### PR TITLE
fetch UserInfo and expose it to CEL rules as user #5

### DIFF
--- a/edge/src/main/scala/versola/edge/EdgeService.scala
+++ b/edge/src/main/scala/versola/edge/EdgeService.scala
@@ -221,19 +221,17 @@ object EdgeService:
             },
             claims => ZIO.succeed(ActiveSession(accessToken, claims, None)),
           )
-        
+
         resource <- resourceService.findByAlias(alias).someOrFail(Outcome.NotFound)
         endpoint <- findEndpoint(resource.endpoints, request.method.name, restPath)
         _ <- checkPermissions(session.claims, endpoint)
-        userInfo <- (
-          if endpoint.fetchUserInfo then
-            ssoClient.userInfo(session.accessToken)
-          else
-            ZIO.succeed(Json.Obj())
-          ).mapError {
-            case SSOClient.InsufficientScope => Outcome.Forbidden
-            case _: Throwable                => Outcome.InternalServerError
-        }
+        userInfo <- ssoClient.userInfo(session.accessToken)
+          .when(endpoint.fetchUserInfo)
+          .someOrElse(Json.Obj())
+          .mapError {
+            case SSOClient.UserInfoUnauthorized => Outcome.Unauthorized
+            case _: Throwable => Outcome.InternalServerError
+          }
         parsedBody <- readJsonBody(request)
         celContext <- checkRules(session.claims, userInfo, request, endpoint, restPath, parsedBody)
         upstream <- buildUpstreamRequest(resource, endpoint, restPath, request, parsedBody, session.accessToken, celContext)

--- a/edge/src/main/scala/versola/edge/EdgeService.scala
+++ b/edge/src/main/scala/versola/edge/EdgeService.scala
@@ -196,6 +196,7 @@ object EdgeService:
         case Outcome.Unauthorized => ZIO.succeed(Response.unauthorized)
         case Outcome.Forbidden => ZIO.succeed(Response.forbidden)
         case Outcome.NotFound => ZIO.succeed(Response.notFound)
+        case Outcome.InternalServerError => ZIO.succeed(Response.internalServerError)
         case Outcome.Reauthenticate(uri, clear) => ZIO.succeed(Response.seeOther(uri).addCookie(clear))
         case ex: Throwable => ZIO.fail(ex)
 
@@ -224,8 +225,17 @@ object EdgeService:
         resource <- resourceService.findByAlias(alias).someOrFail(Outcome.NotFound)
         endpoint <- findEndpoint(resource.endpoints, request.method.name, restPath)
         _ <- checkPermissions(session.claims, endpoint)
+        userInfo <- (
+          if endpoint.fetchUserInfo then
+            ssoClient.userInfo(session.accessToken)
+          else
+            ZIO.succeed(Json.Obj())
+          ).mapError {
+            case SSOClient.InsufficientScope => Outcome.Forbidden
+            case _: Throwable                => Outcome.InternalServerError
+        }
         parsedBody <- readJsonBody(request)
-        celContext <- checkRules(session.claims, request, endpoint, restPath, parsedBody)
+        celContext <- checkRules(session.claims, userInfo, request, endpoint, restPath, parsedBody)
         upstream <- buildUpstreamRequest(resource, endpoint, restPath, request, parsedBody, session.accessToken, celContext)
         response <- ZIO.scoped(httpClient.request(upstream))
         stripped = response.removeHeader(Header.SetCookie)
@@ -263,12 +273,13 @@ object EdgeService:
 
     private def checkRules(
         claims: Json.Obj,
+        userInfo: Json.Obj,
         request: Request,
         endpoint: ResourceEndpoint,
         restPath: Path,
         parsedBody: Option[Json],
     ): IO[Outcome, Map[String, AnyRef]] =
-      val context = buildCelContext(claims, request, endpoint, restPath, parsedBody)
+      val context = buildCelContext(claims, userInfo, request, endpoint, restPath, parsedBody)
       ZIO.foreachDiscard(endpoint.allow.filter(_.trim.nonEmpty)): expression =>
         celEvaluator.compile(expression)
           .flatMap(_.evaluateBoolean(context))
@@ -327,6 +338,7 @@ object EdgeService:
 
     private def buildCelContext(
         claims: Json.Obj,
+        userInfo: Json.Obj,
         request: Request,
         endpoint: ResourceEndpoint,
         restPath: Path,
@@ -351,8 +363,7 @@ object EdgeService:
       parsedBody.foreach(body => requestData("body") = JsonJava.toJava(body))
       Map(
         "token" -> JsonJava.toJava(claims),
-        //TODO fetch userinfo
-        "user" -> Map.empty[String, AnyRef].asJava,
+        "user" -> JsonJava.toJava(userInfo),
         "request" -> requestData.asJava,
       )
 
@@ -466,4 +477,5 @@ object EdgeService:
     case Unauthorized
     case Forbidden
     case NotFound
+    case InternalServerError
     case Reauthenticate(authorizeUri: URL, clearCookie: Cookie.Response)

--- a/edge/src/main/scala/versola/edge/SSOClient.scala
+++ b/edge/src/main/scala/versola/edge/SSOClient.scala
@@ -1,114 +1,153 @@
-package versola.edge
+  package versola.edge
 
-import versola.edge.model.{AuthorizationPreset, ClientId, Code, CodeVerifier, RefreshToken, State, TokenResponse}
-import versola.util.{Base64, RedirectUri, Secret}
-import zio.http.*
-import zio.json.{JsonCodec, jsonField}
-import zio.schema.codec.JsonCodec.zioJsonBinaryCodec
-import zio.{IO, Task, UIO, URLayer, ZIO, ZLayer}
+  import versola.edge.model.{AccessToken, AuthorizationPreset, ClientId, Code, CodeVerifier, RefreshToken, State, TokenResponse}
+  import versola.util.{Base64, RedirectUri, Secret}
+  import zio.http.*
+  import zio.json.{JsonCodec, jsonField}
+  import zio.schema.codec.JsonCodec.zioJsonBinaryCodec
+  import zio.{IO, Task, UIO, URLayer, ZIO, ZLayer}
+  import zio.json.ast.Json
 
-trait SSOClient:
-  def authorizeUri(
-      preset: AuthorizationPreset,
-      codeChallenge: String,
-      state: State,
-  ): UIO[URL]
-
-  def exchangeAuthorizationCode(
-      code: Code,
-      codeVerifier: CodeVerifier,
-      redirectUri: RedirectUri,
-      clientId: ClientId,
-      clientSecret: Secret,
-  ): Task[TokenResponse]
-
-  def exchangeRefreshToken(
-      refreshToken: RefreshToken,
-      clientId: ClientId,
-      clientSecret: Secret,
-  ): IO[Throwable | SSOClient.InvalidGrant.type, TokenResponse]
-
-object SSOClient:
-  case object InvalidGrant
-
-  private case class ErrorResponse(
-      error: String,
-      @jsonField("error_description") errorDescription: Option[String] = None,
-  ) derives JsonCodec
-
-  val live: URLayer[Client & EdgeConfig, SSOClient] =
-    ZLayer.fromFunction(Impl(_, _))
-
-  class Impl(
-      httpClient: Client,
-      config: EdgeConfig,
-  ) extends SSOClient:
-    private val authorizeUrl: URL = config.versolaUrl / "authorize"
-    private val tokenUrl: URL = config.versolaUrl / "token"
-
-    override def authorizeUri(
+  trait SSOClient:
+    def authorizeUri(
         preset: AuthorizationPreset,
         codeChallenge: String,
         state: State,
-    ): UIO[URL] = ZIO.succeed:
-      val params = List(
-        "client_id" -> preset.clientId,
-        "redirect_uri" -> preset.redirectUri,
-        "response_type" -> preset.responseType,
-        "scope" -> preset.scope.mkString(" "),
-        "code_challenge" -> codeChallenge,
-        "code_challenge_method" -> "S256",
-        "state" -> state,
-      ) ++ preset.uiLocales.map(locales => "ui_locales" -> locales.mkString(" "))
-        ++ preset.customParameters.flatMap { case (key, values) =>
-          values.map(value => key -> value)
-        }
+    ): UIO[URL]
 
-      authorizeUrl.addQueryParams(params)
-
-    override def exchangeAuthorizationCode(
+    def exchangeAuthorizationCode(
         code: Code,
         codeVerifier: CodeVerifier,
         redirectUri: RedirectUri,
         clientId: ClientId,
         clientSecret: Secret,
-    ): Task[TokenResponse] =
-      val form = Form(
-        FormField.simpleField("grant_type", "authorization_code"),
-        FormField.simpleField("code", code),
-        FormField.simpleField("redirect_uri", redirectUri),
-        FormField.simpleField("code_verifier", codeVerifier),
-      )
-      val request = Request
-        .post(tokenUrl, Body.fromURLEncodedForm(form))
-        .addHeader(Header.ContentType(MediaType.application.`x-www-form-urlencoded`))
-        .addHeader(Header.Authorization.Basic(clientId, Base64.urlEncode(clientSecret)))
+    ): Task[TokenResponse]
 
-      for
-        response <- ZIO.scoped(httpClient.request(request))
-        tokenResponse <- response.bodyAs[TokenResponse]
-      yield tokenResponse
-
-    override def exchangeRefreshToken(
+    def exchangeRefreshToken(
         refreshToken: RefreshToken,
         clientId: ClientId,
         clientSecret: Secret,
-    ): IO[Throwable | InvalidGrant.type, TokenResponse] =
-      val form = Form(
-        FormField.simpleField("grant_type", "refresh_token"),
-        FormField.simpleField("refresh_token", refreshToken),
-      )
-      val request = Request
-        .post(tokenUrl, Body.fromURLEncodedForm(form))
-        .addHeader(Header.ContentType(MediaType.application.`x-www-form-urlencoded`))
-        .addHeader(Header.Authorization.Basic(clientId, Base64.urlEncode(clientSecret)))
+    ): IO[Throwable | SSOClient.InvalidGrant.type, TokenResponse]
 
-      for
-        response <- ZIO.scoped(httpClient.request(request))
-        result <-
-          if response.status.isSuccess then response.bodyAs[TokenResponse]
-          else
-            response.bodyAs[ErrorResponse].flatMap: error =>
-              if error.error == "invalid_grant" then ZIO.fail(InvalidGrant)
-              else ZIO.fail(new RuntimeException(s"Token exchange failed: ${response.status.code} ${error.error}"))
-      yield result
+    def userInfo(
+                  accessToken: AccessToken,
+                ): IO[Throwable | SSOClient.InsufficientScope.type, Json.Obj]
+
+  object SSOClient:
+    case object InvalidGrant
+    case object InsufficientScope
+
+    private case class ErrorResponse(
+        error: String,
+        @jsonField("error_description") errorDescription: Option[String] = None,
+    ) derives JsonCodec
+
+    val live: URLayer[Client & EdgeConfig, SSOClient] =
+      ZLayer.fromFunction(Impl(_, _))
+
+    class Impl(
+        httpClient: Client,
+        config: EdgeConfig,
+    ) extends SSOClient:
+      private val authorizeUrl: URL = config.versolaUrl / "authorize"
+      private val tokenUrl: URL = config.versolaUrl / "token"
+      private val userInfoUrl = config.versolaUrl / "userinfo"
+
+      override def authorizeUri(
+          preset: AuthorizationPreset,
+          codeChallenge: String,
+          state: State,
+      ): UIO[URL] = ZIO.succeed:
+        val params = List(
+          "client_id" -> preset.clientId,
+          "redirect_uri" -> preset.redirectUri,
+          "response_type" -> preset.responseType,
+          "scope" -> preset.scope.mkString(" "),
+          "code_challenge" -> codeChallenge,
+          "code_challenge_method" -> "S256",
+          "state" -> state,
+        ) ++ preset.uiLocales.map(locales => "ui_locales" -> locales.mkString(" "))
+          ++ preset.customParameters.flatMap { case (key, values) =>
+            values.map(value => key -> value)
+          }
+
+        authorizeUrl.addQueryParams(params)
+
+      override def exchangeAuthorizationCode(
+          code: Code,
+          codeVerifier: CodeVerifier,
+          redirectUri: RedirectUri,
+          clientId: ClientId,
+          clientSecret: Secret,
+      ): Task[TokenResponse] =
+        val form = Form(
+          FormField.simpleField("grant_type", "authorization_code"),
+          FormField.simpleField("code", code),
+          FormField.simpleField("redirect_uri", redirectUri),
+          FormField.simpleField("code_verifier", codeVerifier),
+        )
+        val request = Request
+          .post(tokenUrl, Body.fromURLEncodedForm(form))
+          .addHeader(Header.ContentType(MediaType.application.`x-www-form-urlencoded`))
+          .addHeader(Header.Authorization.Basic(clientId, Base64.urlEncode(clientSecret)))
+
+        for
+          response <- ZIO.scoped(httpClient.request(request))
+          tokenResponse <- response.bodyAs[TokenResponse]
+        yield tokenResponse
+
+      override def exchangeRefreshToken(
+          refreshToken: RefreshToken,
+          clientId: ClientId,
+          clientSecret: Secret,
+      ): IO[Throwable | InvalidGrant.type, TokenResponse] =
+        val form = Form(
+          FormField.simpleField("grant_type", "refresh_token"),
+          FormField.simpleField("refresh_token", refreshToken),
+        )
+        val request = Request
+          .post(tokenUrl, Body.fromURLEncodedForm(form))
+          .addHeader(Header.ContentType(MediaType.application.`x-www-form-urlencoded`))
+          .addHeader(Header.Authorization.Basic(clientId, Base64.urlEncode(clientSecret)))
+
+        for
+          response <- ZIO.scoped(httpClient.request(request))
+          result <-
+            if response.status.isSuccess then response.bodyAs[TokenResponse]
+            else
+              response.bodyAs[ErrorResponse].flatMap: error =>
+                if error.error == "invalid_grant" then ZIO.fail(InvalidGrant)
+                else ZIO.fail(new RuntimeException(s"Token exchange failed: ${response.status.code} ${error.error}"))
+        yield result
+
+      override def userInfo(
+                             accessToken: AccessToken,
+                           ): IO[Throwable | InsufficientScope.type, Json.Obj] =
+        val request = Request
+          .get(userInfoUrl)
+          .addHeader(Header.Authorization.Bearer(accessToken.toString))
+
+        for
+          response <- ZIO.scoped(httpClient.request(request))
+
+          result <-
+            if response.status.isSuccess then
+              response.bodyAs[Json].flatMap {
+                case obj: Json.Obj =>
+                  ZIO.succeed(obj)
+
+                case _ =>
+                  ZIO.fail(
+                    new RuntimeException("UserInfo endpoint returned non-object JSON")
+                  )
+              }
+            else if response.status == Status.Unauthorized then
+              ZIO.fail(InsufficientScope)
+            else
+              ZIO.fail(
+                new RuntimeException(
+                  s"UserInfo request failed with status ${response.status.code}"
+                )
+              )
+
+        yield result

--- a/edge/src/main/scala/versola/edge/SSOClient.scala
+++ b/edge/src/main/scala/versola/edge/SSOClient.scala
@@ -142,7 +142,20 @@
                   )
               }
             else if response.status == Status.Unauthorized then
-              ZIO.fail(InsufficientScope)
+              val authHeader =
+                response.header(Header.WWWAuthenticate).map(_.renderedValue)
+
+              authHeader match 
+                case Some(value) if value.contains("insufficient_scope") =>
+                  ZIO.fail(InsufficientScope)
+
+                case _ =>
+                  ZIO.fail(
+                    new RuntimeException(
+                      s"UserInfo unauthorized: ${authHeader.getOrElse("missing WWW-Authenticate header")}"
+                    )
+                  )
+
             else
               ZIO.fail(
                 new RuntimeException(

--- a/edge/src/main/scala/versola/edge/SSOClient.scala
+++ b/edge/src/main/scala/versola/edge/SSOClient.scala
@@ -1,166 +1,152 @@
-  package versola.edge
+package versola.edge
 
-  import versola.edge.model.{AccessToken, AuthorizationPreset, ClientId, Code, CodeVerifier, RefreshToken, State, TokenResponse}
-  import versola.util.{Base64, RedirectUri, Secret}
-  import zio.http.*
-  import zio.json.{JsonCodec, jsonField}
-  import zio.schema.codec.JsonCodec.zioJsonBinaryCodec
-  import zio.{IO, Task, UIO, URLayer, ZIO, ZLayer}
-  import zio.json.ast.Json
+import versola.edge.model.{AccessToken, AuthorizationPreset, ClientId, Code, CodeVerifier, RefreshToken, State, TokenResponse}
+import versola.util.{Base64, RedirectUri, Secret}
+import zio.http.*
+import zio.json.ast.Json
+import zio.json.{JsonCodec, jsonField}
+import zio.schema.codec.JsonCodec.zioJsonBinaryCodec
+import zio.{IO, Task, UIO, URLayer, ZIO, ZLayer}
 
-  trait SSOClient:
-    def authorizeUri(
+trait SSOClient:
+  def authorizeUri(
+      preset: AuthorizationPreset,
+      codeChallenge: String,
+      state: State,
+  ): UIO[URL]
+
+  def exchangeAuthorizationCode(
+      code: Code,
+      codeVerifier: CodeVerifier,
+      redirectUri: RedirectUri,
+      clientId: ClientId,
+      clientSecret: Secret,
+  ): Task[TokenResponse]
+
+  def exchangeRefreshToken(
+      refreshToken: RefreshToken,
+      clientId: ClientId,
+      clientSecret: Secret,
+  ): IO[Throwable | SSOClient.InvalidGrant.type, TokenResponse]
+
+  def userInfo(
+      accessToken: AccessToken,
+  ): IO[Throwable | SSOClient.UserInfoUnauthorized.type, Json.Obj]
+
+object SSOClient:
+  case object InvalidGrant
+  case object UserInfoUnauthorized
+
+  private case class ErrorResponse(
+      error: String,
+      @jsonField("error_description") errorDescription: Option[String] = None,
+  ) derives JsonCodec
+
+  val live: URLayer[Client & EdgeConfig, SSOClient] =
+    ZLayer.fromFunction(Impl(_, _))
+
+  class Impl(
+      httpClient: Client,
+      config: EdgeConfig,
+  ) extends SSOClient:
+    private val authorizeUrl: URL = config.versolaUrl / "authorize"
+    private val tokenUrl: URL = config.versolaUrl / "token"
+    private val userInfoUrl = config.versolaUrl / "userinfo"
+
+    override def authorizeUri(
         preset: AuthorizationPreset,
         codeChallenge: String,
         state: State,
-    ): UIO[URL]
+    ): UIO[URL] = ZIO.succeed:
+      val params = List(
+        "client_id" -> preset.clientId,
+        "redirect_uri" -> preset.redirectUri,
+        "response_type" -> preset.responseType,
+        "scope" -> preset.scope.mkString(" "),
+        "code_challenge" -> codeChallenge,
+        "code_challenge_method" -> "S256",
+        "state" -> state,
+      ) ++ preset.uiLocales.map(locales => "ui_locales" -> locales.mkString(" "))
+        ++ preset.customParameters.flatMap { case (key, values) =>
+          values.map(value => key -> value)
+        }
 
-    def exchangeAuthorizationCode(
+      authorizeUrl.addQueryParams(params)
+
+    override def exchangeAuthorizationCode(
         code: Code,
         codeVerifier: CodeVerifier,
         redirectUri: RedirectUri,
         clientId: ClientId,
         clientSecret: Secret,
-    ): Task[TokenResponse]
+    ): Task[TokenResponse] =
+      val form = Form(
+        FormField.simpleField("grant_type", "authorization_code"),
+        FormField.simpleField("code", code),
+        FormField.simpleField("redirect_uri", redirectUri),
+        FormField.simpleField("code_verifier", codeVerifier),
+      )
+      val request = Request
+        .post(tokenUrl, Body.fromURLEncodedForm(form))
+        .addHeader(Header.ContentType(MediaType.application.`x-www-form-urlencoded`))
+        .addHeader(Header.Authorization.Basic(clientId, Base64.urlEncode(clientSecret)))
 
-    def exchangeRefreshToken(
+      for
+        response <- ZIO.scoped(httpClient.request(request))
+        tokenResponse <- response.bodyAs[TokenResponse]
+      yield tokenResponse
+
+    override def exchangeRefreshToken(
         refreshToken: RefreshToken,
         clientId: ClientId,
         clientSecret: Secret,
-    ): IO[Throwable | SSOClient.InvalidGrant.type, TokenResponse]
+    ): IO[Throwable | InvalidGrant.type, TokenResponse] =
+      val form = Form(
+        FormField.simpleField("grant_type", "refresh_token"),
+        FormField.simpleField("refresh_token", refreshToken),
+      )
+      val request = Request
+        .post(tokenUrl, Body.fromURLEncodedForm(form))
+        .addHeader(Header.ContentType(MediaType.application.`x-www-form-urlencoded`))
+        .addHeader(Header.Authorization.Basic(clientId, Base64.urlEncode(clientSecret)))
 
-    def userInfo(
-                  accessToken: AccessToken,
-                ): IO[Throwable | SSOClient.InsufficientScope.type, Json.Obj]
+      for
+        response <- ZIO.scoped(httpClient.request(request))
+        result <-
+          if response.status.isSuccess then response.bodyAs[TokenResponse]
+          else
+            response.bodyAs[ErrorResponse].flatMap: error =>
+              if error.error == "invalid_grant" then ZIO.fail(InvalidGrant)
+              else ZIO.fail(new RuntimeException(s"Token exchange failed: ${response.status.code} ${error.error}"))
+      yield result
 
-  object SSOClient:
-    case object InvalidGrant
-    case object InsufficientScope
+    override def userInfo(
+        accessToken: AccessToken,
+    ): IO[Throwable | SSOClient.UserInfoUnauthorized.type, Json.Obj] =
+      val request = Request
+        .get(userInfoUrl)
+        .addHeader(Header.Authorization.Bearer(accessToken.toString))
 
-    private case class ErrorResponse(
-        error: String,
-        @jsonField("error_description") errorDescription: Option[String] = None,
-    ) derives JsonCodec
+      for
+        response <- ZIO.scoped(httpClient.request(request))
 
-    val live: URLayer[Client & EdgeConfig, SSOClient] =
-      ZLayer.fromFunction(Impl(_, _))
+        result <-
+          if response.status.isSuccess then
+            response.bodyAs[Json].flatMap {
+              case obj: Json.Obj =>
+                ZIO.succeed(obj)
 
-    class Impl(
-        httpClient: Client,
-        config: EdgeConfig,
-    ) extends SSOClient:
-      private val authorizeUrl: URL = config.versolaUrl / "authorize"
-      private val tokenUrl: URL = config.versolaUrl / "token"
-      private val userInfoUrl = config.versolaUrl / "userinfo"
-
-      override def authorizeUri(
-          preset: AuthorizationPreset,
-          codeChallenge: String,
-          state: State,
-      ): UIO[URL] = ZIO.succeed:
-        val params = List(
-          "client_id" -> preset.clientId,
-          "redirect_uri" -> preset.redirectUri,
-          "response_type" -> preset.responseType,
-          "scope" -> preset.scope.mkString(" "),
-          "code_challenge" -> codeChallenge,
-          "code_challenge_method" -> "S256",
-          "state" -> state,
-        ) ++ preset.uiLocales.map(locales => "ui_locales" -> locales.mkString(" "))
-          ++ preset.customParameters.flatMap { case (key, values) =>
-            values.map(value => key -> value)
-          }
-
-        authorizeUrl.addQueryParams(params)
-
-      override def exchangeAuthorizationCode(
-          code: Code,
-          codeVerifier: CodeVerifier,
-          redirectUri: RedirectUri,
-          clientId: ClientId,
-          clientSecret: Secret,
-      ): Task[TokenResponse] =
-        val form = Form(
-          FormField.simpleField("grant_type", "authorization_code"),
-          FormField.simpleField("code", code),
-          FormField.simpleField("redirect_uri", redirectUri),
-          FormField.simpleField("code_verifier", codeVerifier),
-        )
-        val request = Request
-          .post(tokenUrl, Body.fromURLEncodedForm(form))
-          .addHeader(Header.ContentType(MediaType.application.`x-www-form-urlencoded`))
-          .addHeader(Header.Authorization.Basic(clientId, Base64.urlEncode(clientSecret)))
-
-        for
-          response <- ZIO.scoped(httpClient.request(request))
-          tokenResponse <- response.bodyAs[TokenResponse]
-        yield tokenResponse
-
-      override def exchangeRefreshToken(
-          refreshToken: RefreshToken,
-          clientId: ClientId,
-          clientSecret: Secret,
-      ): IO[Throwable | InvalidGrant.type, TokenResponse] =
-        val form = Form(
-          FormField.simpleField("grant_type", "refresh_token"),
-          FormField.simpleField("refresh_token", refreshToken),
-        )
-        val request = Request
-          .post(tokenUrl, Body.fromURLEncodedForm(form))
-          .addHeader(Header.ContentType(MediaType.application.`x-www-form-urlencoded`))
-          .addHeader(Header.Authorization.Basic(clientId, Base64.urlEncode(clientSecret)))
-
-        for
-          response <- ZIO.scoped(httpClient.request(request))
-          result <-
-            if response.status.isSuccess then response.bodyAs[TokenResponse]
-            else
-              response.bodyAs[ErrorResponse].flatMap: error =>
-                if error.error == "invalid_grant" then ZIO.fail(InvalidGrant)
-                else ZIO.fail(new RuntimeException(s"Token exchange failed: ${response.status.code} ${error.error}"))
-        yield result
-
-      override def userInfo(
-                             accessToken: AccessToken,
-                           ): IO[Throwable | InsufficientScope.type, Json.Obj] =
-        val request = Request
-          .get(userInfoUrl)
-          .addHeader(Header.Authorization.Bearer(accessToken.toString))
-
-        for
-          response <- ZIO.scoped(httpClient.request(request))
-
-          result <-
-            if response.status.isSuccess then
-              response.bodyAs[Json].flatMap {
-                case obj: Json.Obj =>
-                  ZIO.succeed(obj)
-
-                case _ =>
-                  ZIO.fail(
-                    new RuntimeException("UserInfo endpoint returned non-object JSON")
-                  )
-              }
-            else if response.status == Status.Unauthorized then
-              val authHeader =
-                response.header(Header.WWWAuthenticate).map(_.renderedValue)
-
-              authHeader match 
-                case Some(value) if value.contains("insufficient_scope") =>
-                  ZIO.fail(InsufficientScope)
-
-                case _ =>
-                  ZIO.fail(
-                    new RuntimeException(
-                      s"UserInfo unauthorized: ${authHeader.getOrElse("missing WWW-Authenticate header")}"
-                    )
-                  )
-
-            else
-              ZIO.fail(
-                new RuntimeException(
-                  s"UserInfo request failed with status ${response.status.code}"
+              case _ =>
+                ZIO.fail(
+                  new RuntimeException("UserInfo endpoint returned non-object JSON"),
                 )
-              )
-
-        yield result
+            }
+          else if response.status == Status.Unauthorized then
+            ZIO.fail(SSOClient.UserInfoUnauthorized)
+          else
+            ZIO.fail(
+              new RuntimeException(
+                s"UserInfo request failed with status ${response.status.code}",
+              ),
+            )
+      yield result

--- a/edge/src/test/scala/versola/edge/EdgeServiceProxySpec.scala
+++ b/edge/src/test/scala/versola/edge/EdgeServiceProxySpec.scala
@@ -707,7 +707,7 @@ object EdgeServiceProxySpec extends ZIOSpecDefault, ZIOStubs:
         env.ssoClient.userInfo.calls.nonEmpty,
       )
     },
-    test("returns 403 when userInfo returns insufficient scope") {
+    test("returns 401 when userInfo is unauthorized") {
       val env = new Env
       val endpoint = usersEndpoint(
         allow = Some("user.email == 'john@example.com'"),
@@ -716,7 +716,7 @@ object EdgeServiceProxySpec extends ZIOSpecDefault, ZIOStubs:
 
       for
         _ <- env.setupDefaults()
-        _ <- env.ssoClient.userInfo.failsWith(SSOClient.InsufficientScope)
+        _ <- env.ssoClient.userInfo.failsWith(SSOClient.UserInfoUnauthorized)
         client <- ZIO.service[Client]
         security <- ZIO.service[SecurityService]
         _ <- env.withResources(usersResource(endpoint))
@@ -732,7 +732,7 @@ object EdgeServiceProxySpec extends ZIOSpecDefault, ZIOStubs:
         )
 
       yield assertTrue(
-        response.status == Status.Forbidden,
+        response.status == Status.Unauthorized,
       )
     },
     test("returns 500 when userInfo request fails") {

--- a/edge/src/test/scala/versola/edge/EdgeServiceProxySpec.scala
+++ b/edge/src/test/scala/versola/edge/EdgeServiceProxySpec.scala
@@ -138,10 +138,12 @@ object EdgeServiceProxySpec extends ZIOSpecDefault, ZIOStubs:
     proxySuite,
   ).provideLayer(TestClient.layer ++ securityServiceLayer) @@ TestAspect.silentLogging
 
-  private def usersEndpoint(allow: Option[String] = None, inject: Vector[InjectRule] = Vector.empty) =
+  private def usersEndpoint(allow: Option[String] = None,
+                             inject: Vector[InjectRule] = Vector.empty,
+                             fetchUserInfo: Boolean = false) =
     ResourceEndpoint(
       id = ResourceEndpointId(java.util.UUID.fromString("018f0f2a-1c7b-7000-8000-000000000401")),
-      method = "GET", path = "/users", fetchUserInfo = false, allow = allow, inject = inject,
+      method = "GET", path = "/users", fetchUserInfo = fetchUserInfo, allow = allow, inject = inject
     )
 
   private def userByIdEndpoint(allow: Option[String] = None, inject: Vector[InjectRule] = Vector.empty) =
@@ -675,5 +677,97 @@ object EdgeServiceProxySpec extends ZIOSpecDefault, ZIOStubs:
         setCookieHeader.flatMap(_.maxAge).contains(Duration.Zero),
       )
     },
+    test("exposes user info in CEL allow and inject rules") {
+      val env = new Env
+      val endpoint = usersEndpoint(
+        allow = Some("user.email == 'john@example.com'"),
+        inject = Vector(
+          InjectRule(
+            InjectTarget.header, "x-user-email", "user.email")
+        ),
+        fetchUserInfo = true,
+      )
+      for
+        _ <- env.setupDefaults()
+        _ <- env.ssoClient.userInfo.succeedsWith(Json.Obj("email" -> Json.Str("john@example.com")))
+        capture <- captureUpstream()
+        client <- ZIO.service[Client]
+        security <- ZIO.service[SecurityService]
+        _ <- env.withResources(usersResource(endpoint))
+        token <- env.signToken()
+        request = Request.get(URL.empty / "users")
+          .addCookie(sessionCookie(token))
+        service = env.buildService(client, security)
+        response <- service.proxy("users-api", Path.decode("/users"), request)
+        upstream <- capture.get
+
+      yield assertTrue(
+        response.status == Status.Ok,
+        upstream.exists(_.headers.get("x-user-email").contains("john@example.com")),
+        env.ssoClient.userInfo.calls.nonEmpty,
+      )
+    },
+    test("returns 403 when userInfo returns insufficient scope") {
+      val env = new Env
+      val endpoint = usersEndpoint(
+        allow = Some("user.email == 'john@example.com'"),
+        fetchUserInfo = true,
+      )
+
+      for
+        _ <- env.setupDefaults()
+        _ <- env.ssoClient.userInfo.failsWith(SSOClient.InsufficientScope)
+        client <- ZIO.service[Client]
+        security <- ZIO.service[SecurityService]
+        _ <- env.withResources(usersResource(endpoint))
+        token <- env.signToken()
+        request = Request.get(URL.empty / "users")
+          .addCookie(sessionCookie(token))
+        service = env.buildService(client, security)
+
+        response <- service.proxy(
+          "users-api",
+          Path.decode("/users"),
+          request,
+        )
+
+      yield assertTrue(
+        response.status == Status.Forbidden,
+      )
+    },
+    test("returns 500 when userInfo request fails") {
+      val env = new Env
+      val endpoint = usersEndpoint(
+        fetchUserInfo = true,
+      )
+
+      for
+        _ <- env.setupDefaults()
+        _ <- env.ssoClient.userInfo.failsWith(
+          new RuntimeException("userinfo failed")
+        )
+
+        client <- ZIO.service[Client]
+        security <- ZIO.service[SecurityService]
+
+        _ <- env.withResources(usersResource(endpoint))
+
+        token <- env.signToken()
+
+        request = Request.get(URL.empty / "users")
+          .addCookie(sessionCookie(token))
+
+        service = env.buildService(client, security)
+
+        response <- service.proxy(
+          "users-api",
+          Path.decode("/users"),
+          request,
+        )
+
+      yield assertTrue(
+        response.status == Status.InternalServerError,
+      )
+    }
   )
 end EdgeServiceProxySpec

--- a/edge/src/test/scala/versola/edge/EdgeServiceSpec.scala
+++ b/edge/src/test/scala/versola/edge/EdgeServiceSpec.scala
@@ -19,7 +19,7 @@ import java.security.interfaces.RSAPublicKey
 import java.util.{Collections, Date, UUID}
 import javax.crypto.spec.SecretKeySpec
 
-object  EdgeServiceSpec extends ZIOSpecDefault, ZIOStubs:
+object EdgeServiceSpec extends ZIOSpecDefault, ZIOStubs:
 
   object Fixtures:
     val presetId = PresetId("preset-default")
@@ -137,9 +137,18 @@ object  EdgeServiceSpec extends ZIOSpecDefault, ZIOStubs:
 
     def buildService(httpClient: Client, security: SecurityService): EdgeService =
       EdgeService.Impl(
-        clientService, resourceService, celEvaluator, secureRandom,
-        loginRepository, ssoClient, security, httpClient, edgeConfig,
-        refreshTokenRepository, jwksService, permissionService,
+        clientService,
+        resourceService,
+        celEvaluator,
+        secureRandom,
+        loginRepository,
+        ssoClient,
+        security,
+        httpClient,
+        edgeConfig,
+        refreshTokenRepository,
+        jwksService,
+        permissionService,
       )
 
   def spec = suite("EdgeService")(
@@ -286,10 +295,13 @@ object  EdgeServiceSpec extends ZIOSpecDefault, ZIOStubs:
           client <- ZIO.service[Client]
           accessToken <- env.signToken(jti = jti, ttlSeconds = 3600L)
           tokens = TokenResponse(
-            accessToken = accessToken, tokenType = "Bearer", expiresIn = 3600L,
+            accessToken = accessToken,
+            tokenType = "Bearer",
+            expiresIn = 3600L,
             refreshToken = Some(RefreshToken(refreshTokenValue)),
             refreshTokenExpiresIn = Some(7200L),
-            scope = None, idToken = None,
+            scope = None,
+            idToken = None,
           )
           _ <- env.ssoClient.exchangeAuthorizationCode.succeedsWith(tokens)
           service = env.buildService(client, security)

--- a/edge/src/test/scala/versola/edge/EdgeServiceSpec.scala
+++ b/edge/src/test/scala/versola/edge/EdgeServiceSpec.scala
@@ -19,7 +19,7 @@ import java.security.interfaces.RSAPublicKey
 import java.util.{Collections, Date, UUID}
 import javax.crypto.spec.SecretKeySpec
 
-object EdgeServiceSpec extends ZIOSpecDefault, ZIOStubs:
+object  EdgeServiceSpec extends ZIOSpecDefault, ZIOStubs:
 
   object Fixtures:
     val presetId = PresetId("preset-default")


### PR DESCRIPTION
Implements UserInfo integration for CEL evaluation context.

Changes:

Added userInfo support to SSOClient
Fetches user claims from OIDC UserInfo endpoint
Exposes claims through CEL variable user
Supports allow and inject rules
Handles insufficient_scope responses
Added tests for success and error scenarios

Closes #5