### PR TITLE
observability: server-side RED metrics (inbound HTTP)

### DIFF
--- a/central-ui/src/components/resources-list.ts
+++ b/central-ui/src/components/resources-list.ts
@@ -331,7 +331,7 @@ export class VersolaResourcesList extends LitElement {
     if (!validation.valid) { this.error = validation.error ?? 'Resource URI is invalid'; return; }
     const invalidEndpoint = this.endpointDrafts.find(endpoint => this.isEndpointPathInvalid(endpoint.path));
     if (invalidEndpoint) {
-      this.error = `Endpoint path must start with “/” and contain no “*” or “:”: ${endpointLabel(invalidEndpoint)}`;
+      this.error = `Endpoint path must start with “/” and contain no “*”, “:” or “{}”: ${endpointLabel(invalidEndpoint)}`;
       return;
     }
     const celIssue = this.findCelIssue();
@@ -373,7 +373,7 @@ export class VersolaResourcesList extends LitElement {
     const trimmed = path.trim();
     if (trimmed.length === 0) return false;
     if (!trimmed.startsWith('/')) return true;
-    if (trimmed.includes('*') || trimmed.includes(':')) return true;
+    if (trimmed.includes('*') || trimmed.includes(':') || trimmed.includes('{')) return true;
     return false;
   }
 

--- a/central-ui/src/components/resources-list.ts
+++ b/central-ui/src/components/resources-list.ts
@@ -331,7 +331,7 @@ export class VersolaResourcesList extends LitElement {
     if (!validation.valid) { this.error = validation.error ?? 'Resource URI is invalid'; return; }
     const invalidEndpoint = this.endpointDrafts.find(endpoint => this.isEndpointPathInvalid(endpoint.path));
     if (invalidEndpoint) {
-      this.error = `Endpoint path must start with “/” and contain no “*”, “:” or “{}”: ${endpointLabel(invalidEndpoint)}`;
+      this.error = `Endpoint path must start with "/" and contain only latin letters, digits, and "-" per segment (no consecutive "/"): ${endpointLabel(invalidEndpoint)}`;
       return;
     }
     const celIssue = this.findCelIssue();
@@ -372,9 +372,7 @@ export class VersolaResourcesList extends LitElement {
   private isEndpointPathInvalid(path: string) {
     const trimmed = path.trim();
     if (trimmed.length === 0) return false;
-    if (!trimmed.startsWith('/')) return true;
-    if (trimmed.includes('*') || trimmed.includes(':') || trimmed.includes('{')) return true;
-    return false;
+    return !/^\/([a-zA-Z0-9-]+(\/[a-zA-Z0-9-]+)*)?$/.test(trimmed);
   }
 
   private findCelIssue(): string | null {

--- a/central-ui/tests/resources.spec.ts
+++ b/central-ui/tests/resources.spec.ts
@@ -112,7 +112,11 @@ test('shows resource validation errors before saving', async ({ page }) => {
   await expect(relativePathField).toHaveClass(/input-error/);
   await expect(relativePathField).toHaveCSS('border-top-color', 'rgb(248, 81, 73)');
   await page.getByRole('button', { name: 'Create Resource', exact: true }).click();
-  await expect(page.getByText('Endpoint path must start with “/” and contain no “*” or “:”: GET users', { exact: true })).toBeVisible();
+  await expect(page.getByText('Endpoint path must start with “/” and contain no “*”, “:” or “{}”: GET users', { exact: true })).toBeVisible();
+
+  await relativePathField.fill('/users/{id}');
+  await page.getByRole('button', { name: 'Create Resource', exact: true }).click();
+  await expect(page.getByText('Endpoint path must start with “/” and contain no “*”, “:” or “{}”: GET /users/{id}', { exact: true })).toBeVisible();
 
   expect(api.requests.some(request => request.method === 'POST' && request.pathname === '/configuration/resources')).toBeFalsy();
 });

--- a/central-ui/tests/resources.spec.ts
+++ b/central-ui/tests/resources.spec.ts
@@ -112,11 +112,11 @@ test('shows resource validation errors before saving', async ({ page }) => {
   await expect(relativePathField).toHaveClass(/input-error/);
   await expect(relativePathField).toHaveCSS('border-top-color', 'rgb(248, 81, 73)');
   await page.getByRole('button', { name: 'Create Resource', exact: true }).click();
-  await expect(page.getByText('Endpoint path must start with “/” and contain no “*”, “:” or “{}”: GET users', { exact: true })).toBeVisible();
+  await expect(page.getByText('Endpoint path must start with “/” and contain only latin letters, digits, and "-" per segment (no consecutive "/"): GET users', { exact: true })).toBeVisible();
 
   await relativePathField.fill('/users/{id}');
   await page.getByRole('button', { name: 'Create Resource', exact: true }).click();
-  await expect(page.getByText('Endpoint path must start with “/” and contain no “*”, “:” or “{}”: GET /users/{id}', { exact: true })).toBeVisible();
+  await expect(page.getByText('Endpoint path must start with “/” and contain only latin letters, digits, and "-" per segment (no consecutive "/"): GET /users/{id}', { exact: true })).toBeVisible();
 
   expect(api.requests.some(request => request.method === 'POST' && request.pathname === '/configuration/resources')).toBeFalsy();
 });

--- a/central/src/main/scala/versola/central/configuration/resources/ResourceService.scala
+++ b/central/src/main/scala/versola/central/configuration/resources/ResourceService.scala
@@ -97,13 +97,13 @@ object ResourceService:
         case (Some(err), _) => ZIO.succeed(Some(err))
         case (None, endpoint) => validateEndpoint(endpoint)
 
+    private val validPathRegex = "^/([a-zA-Z0-9-]+(/[a-zA-Z0-9-]+)*)?$".r
+
     private def validateEndpoint(
         endpoint: CreateResourceEndpointRequest,
     ): Task[Option[ResourceValidationError]] =
-      val hasPathParams = endpoint.path.split('/').exists:
-        case s"{$_}" => true
-        case _ => false
-      if hasPathParams then return ZIO.some(ResourceValidationError.PathParametersNotAllowed(endpoint.id))
+      if !validPathRegex.matches(endpoint.path) then
+        return ZIO.some(ResourceValidationError.InvalidEndpointPath(endpoint.id))
       val allowCheck = endpoint.allow.filter(_.trim.nonEmpty) match
         case None => ZIO.none
         case Some(expression) =>

--- a/central/src/main/scala/versola/central/configuration/resources/ResourceService.scala
+++ b/central/src/main/scala/versola/central/configuration/resources/ResourceService.scala
@@ -102,7 +102,8 @@ object ResourceService:
     private def validateEndpoint(
         endpoint: CreateResourceEndpointRequest,
     ): Task[Option[ResourceValidationError]] =
-      if !validPathRegex.matches(endpoint.path) then
+      val trimmedPath = endpoint.path.trim
+      if !validPathRegex.matches(trimmedPath) then
         return ZIO.some(ResourceValidationError.InvalidEndpointPath(endpoint.id))
       val allowCheck = endpoint.allow.filter(_.trim.nonEmpty) match
         case None => ZIO.none

--- a/central/src/main/scala/versola/central/configuration/resources/ResourceService.scala
+++ b/central/src/main/scala/versola/central/configuration/resources/ResourceService.scala
@@ -100,6 +100,10 @@ object ResourceService:
     private def validateEndpoint(
         endpoint: CreateResourceEndpointRequest,
     ): Task[Option[ResourceValidationError]] =
+      val hasPathParams = endpoint.path.split('/').exists:
+        case s"{$_}" => true
+        case _ => false
+      if hasPathParams then return ZIO.some(ResourceValidationError.PathParametersNotAllowed(endpoint.id))
       val allowCheck = endpoint.allow.filter(_.trim.nonEmpty) match
         case None => ZIO.none
         case Some(expression) =>

--- a/central/src/main/scala/versola/central/configuration/resources/ResourceValidationError.scala
+++ b/central/src/main/scala/versola/central/configuration/resources/ResourceValidationError.scala
@@ -6,3 +6,4 @@ import zio.schema.{Schema, derived}
 enum ResourceValidationError derives JsonCodec, Schema:
   case InvalidAllowExpression(endpointId: ResourceEndpointId, expression: String, message: String)
   case InvalidInjectExpression(endpointId: ResourceEndpointId, ruleName: String, expression: String, message: String)
+  case PathParametersNotAllowed(endpointId: ResourceEndpointId)

--- a/central/src/main/scala/versola/central/configuration/resources/ResourceValidationError.scala
+++ b/central/src/main/scala/versola/central/configuration/resources/ResourceValidationError.scala
@@ -6,4 +6,4 @@ import zio.schema.{Schema, derived}
 enum ResourceValidationError derives JsonCodec, Schema:
   case InvalidAllowExpression(endpointId: ResourceEndpointId, expression: String, message: String)
   case InvalidInjectExpression(endpointId: ResourceEndpointId, ruleName: String, expression: String, message: String)
-  case PathParametersNotAllowed(endpointId: ResourceEndpointId)
+  case InvalidEndpointPath(endpointId: ResourceEndpointId)

--- a/central/src/test/scala/versola/central/configuration/resources/ResourceServiceSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/resources/ResourceServiceSpec.scala
@@ -114,6 +114,19 @@ object ResourceServiceSpec extends ZIOSpecDefault, ZIOStubs:
         env.repository.createResource.calls.isEmpty,
       )
     },
+    test("createResource returns error when endpoint path contains path parameters") {
+      val env = new Env
+      val badRequest = createRequest.copy(
+        endpoints = Vector(
+          CreateResourceEndpointRequest(existingEndpointId, "/users/{id}", "GET", false, None, Vector.empty),
+        ),
+      )
+      for result <- env.service.createResource(badRequest)
+      yield assertTrue(
+        result == Left(ResourceValidationError.PathParametersNotAllowed(existingEndpointId)),
+        env.repository.createResource.calls.isEmpty,
+      )
+    },
     test("createResource returns error when inject expression is invalid CEL") {
       val env = new Env
       val badRequest = createRequest.copy(

--- a/central/src/test/scala/versola/central/configuration/resources/ResourceServiceSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/resources/ResourceServiceSpec.scala
@@ -123,7 +123,33 @@ object ResourceServiceSpec extends ZIOSpecDefault, ZIOStubs:
       )
       for result <- env.service.createResource(badRequest)
       yield assertTrue(
-        result == Left(ResourceValidationError.PathParametersNotAllowed(existingEndpointId)),
+        result == Left(ResourceValidationError.InvalidEndpointPath(existingEndpointId)),
+        env.repository.createResource.calls.isEmpty,
+      )
+    },
+    test("createResource returns error when endpoint path contains consecutive slashes") {
+      val env = new Env
+      val badRequest = createRequest.copy(
+        endpoints = Vector(
+          CreateResourceEndpointRequest(existingEndpointId, "/users//list", "GET", false, None, Vector.empty),
+        ),
+      )
+      for result <- env.service.createResource(badRequest)
+      yield assertTrue(
+        result == Left(ResourceValidationError.InvalidEndpointPath(existingEndpointId)),
+        env.repository.createResource.calls.isEmpty,
+      )
+    },
+    test("createResource returns error when endpoint path contains disallowed characters") {
+      val env = new Env
+      val badRequest = createRequest.copy(
+        endpoints = Vector(
+          CreateResourceEndpointRequest(existingEndpointId, "/users/:id", "GET", false, None, Vector.empty),
+        ),
+      )
+      for result <- env.service.createResource(badRequest)
+      yield assertTrue(
+        result == Left(ResourceValidationError.InvalidEndpointPath(existingEndpointId)),
         env.repository.createResource.calls.isEmpty,
       )
     },

--- a/util/src/main/scala/versola/util/http/Observability.scala
+++ b/util/src/main/scala/versola/util/http/Observability.scala
@@ -35,26 +35,17 @@ object Observability:
   )(zio: ZIO[R, E, A]): ZIO[R, E, A] =
     serverLogging.set(f(HttpObservabilityConfig.Server.default)) *> zio
 
-  // Shared, seconds-based histogram boundaries for inbound HTTP latency. Kept identical across
-  // all services so p50/p90/p99 queries are consistent.
   val durationBoundaries: Boundaries =
     Boundaries.fromChunk(Chunk(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0))
 
-  private val requestsTotal =
-    Metric.counter("http_server_requests_total")
+  private val requestsCount =
+    Metric.counter("server_http_requests_count")
 
   private val requestDuration =
-    Metric.histogram("http_server_request_duration_seconds", durationBoundaries)
+    Metric.histogram("server_http_request_duration_seconds", durationBoundaries)
 
   private val activeRequests =
-    Metric.gauge("http_server_active_requests")
-
-  // Routes are static (query params, not path params), so the raw path is a low-cardinality label.
-  // The only unbounded case is the edge proxy `resources / alias / trailing`, collapsed to a fixed label.
-  private[http] def routeLabel(request: Request): String =
-    request.path.segments match
-      case "resources" +: _ => "/resources/:alias/*"
-      case _ => request.path.encode
+    Metric.gauge("server_http_active_requests")
 
   def handleErrors[Env](routes: Routes[Env, Throwable]): Routes[Env, Nothing] =
     routes.handleErrorZIO {
@@ -126,7 +117,7 @@ object Observability:
                   for
                     startTime <- Clock.instant
                     now <- Clock.nanoTime
-                    route = routeLabel(request)
+                    route = request.path.encode
                     baseTags = Set(
                       MetricLabel("method", request.method.name),
                       MetricLabel("route", route),
@@ -139,7 +130,7 @@ object Observability:
                     after <- Clock.nanoTime
                     status = response.status.code
                     statusClass = s"${status / 100}xx"
-                    _ <- requestsTotal
+                    _ <- requestsCount
                       .tagged(baseTags + MetricLabel("status", status.toString) + MetricLabel("status_class", statusClass))
                       .increment
                     _ <- requestDuration

--- a/util/src/main/scala/versola/util/http/Observability.scala
+++ b/util/src/main/scala/versola/util/http/Observability.scala
@@ -5,6 +5,8 @@ import zio.*
 import zio.http.*
 import zio.json.*
 import zio.logging.LogAnnotation
+import zio.metrics.MetricKeyType.Histogram.Boundaries
+import zio.metrics.{Metric, MetricLabel}
 import zio.telemetry.opentelemetry.context.{IncomingContextCarrier, OutgoingContextCarrier}
 import zio.telemetry.opentelemetry.tracing.Tracing
 import zio.telemetry.opentelemetry.tracing.propagation.TraceContextPropagator
@@ -32,6 +34,27 @@ object Observability:
       f: HttpObservabilityConfig.Server => HttpObservabilityConfig.Server,
   )(zio: ZIO[R, E, A]): ZIO[R, E, A] =
     serverLogging.set(f(HttpObservabilityConfig.Server.default)) *> zio
+
+  // Shared, seconds-based histogram boundaries for inbound HTTP latency. Kept identical across
+  // all services so p50/p90/p99 queries are consistent.
+  val durationBoundaries: Boundaries =
+    Boundaries.fromChunk(Chunk(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0))
+
+  private val requestsTotal =
+    Metric.counter("http_server_requests_total")
+
+  private val requestDuration =
+    Metric.histogram("http_server_request_duration_seconds", durationBoundaries)
+
+  private val activeRequests =
+    Metric.gauge("http_server_active_requests")
+
+  // Routes are static (query params, not path params), so the raw path is a low-cardinality label.
+  // The only unbounded case is the edge proxy `resources / alias / trailing`, collapsed to a fixed label.
+  private[http] def routeLabel(request: Request): String =
+    request.path.segments match
+      case "resources" +: _ => "/resources/:alias/*"
+      case _ => request.path.encode
 
   def handleErrors[Env](routes: Routes[Env, Throwable]): Routes[Env, Nothing] =
     routes.handleErrorZIO {
@@ -103,10 +126,25 @@ object Observability:
                   for
                     startTime <- Clock.instant
                     now <- Clock.nanoTime
-                    response <- handler(request)
+                    route = routeLabel(request)
+                    baseTags = Set(
+                      MetricLabel("method", request.method.name),
+                      MetricLabel("route", route),
+                    )
+                    response <- activeRequests.tagged(baseTags).increment
+                      .zipRight(handler(request))
+                      .ensuring(activeRequests.tagged(baseTags).decrement)
                     masking <- serverLogging.get
                     (requestLog, responseLog) <- toLog(request, masking) <&> toLog(request, response, masking)
                     after <- Clock.nanoTime
+                    status = response.status.code
+                    statusClass = s"${status / 100}xx"
+                    _ <- requestsTotal
+                      .tagged(baseTags + MetricLabel("status", status.toString) + MetricLabel("status_class", statusClass))
+                      .increment
+                    _ <- requestDuration
+                      .tagged(baseTags + MetricLabel("status_class", statusClass))
+                      .update((after - now) / 1e9)
                     log = receiveHttp(
                       ReceiveHttpLog(
                         request = requestLog,

--- a/util/src/main/scala/versola/util/http/Observability.scala
+++ b/util/src/main/scala/versola/util/http/Observability.scala
@@ -36,7 +36,7 @@ object Observability:
     serverLogging.set(f(HttpObservabilityConfig.Server.default)) *> zio
 
   val durationBoundaries: Boundaries =
-    Boundaries.fromChunk(Chunk(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0))
+    Boundaries.fromChunk(Chunk(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 7.5, 10.0, 15.0, 20.0, 25.0, 30.0))
 
   private val requestsCount =
     Metric.counter("server_http_requests_count")

--- a/util/src/main/scala/versola/util/http/VersolaApp.scala
+++ b/util/src/main/scala/versola/util/http/VersolaApp.scala
@@ -17,7 +17,7 @@ import versola.util.{EnvName, PostInitializationService}
 import zio.*
 import zio.config.magnolia.{DeriveConfig, deriveConfig}
 import zio.config.typesafe.FromConfigSourceTypesafe
-import zio.http.{Client, Method, Middleware, Request, RequestStore, Response, Routes, Server, Status, handler}
+import zio.http.{Client, Method, Request, RequestStore, Response, Routes, Server, Status, handler}
 import zio.logging.LogFormat.{cause, fiberId, label, level, line, logAnnotation, quoted, space, text, timestamp}
 import zio.logging.slf4j.bridge.Slf4jBridge
 import zio.logging.{ConsoleLoggerConfig, LogFilter, LogFormat, LoggerNameExtractor}
@@ -84,8 +84,7 @@ trait VersolaApp(serviceName: String) extends ZIOApp:
 
           port <- Server.install {
             Observability.handleErrors(routes) @@
-              Observability.middleware @@
-              Middleware.metrics()
+              Observability.middleware
           }
           _ <- ZIO.logInfo(s"Application server is started and ready to use on $port")
           _ <- readinessService.setReady

--- a/util/src/test/scala/versola/util/http/ObservabilitySpec.scala
+++ b/util/src/test/scala/versola/util/http/ObservabilitySpec.scala
@@ -6,6 +6,7 @@ import zio.http.*
 import zio.json.*
 import zio.logging.LogFilter
 import zio.logging.LogFormat.{cause, label, level, line, logAnnotation, quoted, space}
+import zio.metrics.{Metric, MetricLabel}
 import zio.telemetry.opentelemetry.OpenTelemetry
 import zio.telemetry.opentelemetry.tracing.Tracing
 import zio.test.*
@@ -72,6 +73,22 @@ object ObservabilitySpec extends ZIOSpecDefault:
       ),
     )
 
+  private val proxyRoutes =
+    Observability.middleware(
+      Observability.handleErrors(
+        Routes(
+          Method.GET / "resources" / string("alias") / trailing ->
+            handler((_: String, _: Path, _: Request) => Response.text("proxied")),
+        ),
+      ),
+    )
+
+  private def counterCount(tags: Set[MetricLabel]): UIO[Double] =
+    Metric.counter("http_server_requests_total").tagged(tags).value.map(_.count)
+
+  private def histogramCount(tags: Set[MetricLabel]): UIO[Long] =
+    Metric.histogram("http_server_request_duration_seconds", Observability.durationBoundaries).tagged(tags).value.map(_.count)
+
   def spec = suite("Observability")(
     test("logs a single info entry for successful requests") {
       for
@@ -115,6 +132,77 @@ object ObservabilitySpec extends ZIOSpecDefault:
         rendered.stack_trace.exists(_.contains("RuntimeException: boom")),
       )
     }.provideSomeLayer[Scope](testLayer) @@ TestAspect.silentLogging,
+    suite("server metrics")(
+      test("records counter and histogram for successful requests") {
+        val counterTags = Set(
+          MetricLabel("method", "GET"),
+          MetricLabel("route", "ok"),
+          MetricLabel("status", "200"),
+          MetricLabel("status_class", "2xx"),
+        )
+        val durationTags = Set(
+          MetricLabel("method", "GET"),
+          MetricLabel("route", "ok"),
+          MetricLabel("status_class", "2xx"),
+        )
+        for
+          env <- tracingLayer.build
+          _ <- TestClient.addRoutes(routes.provideEnvironment(env))
+          client <- ZIO.service[Client]
+          response <- client.batched(Request.get(URL.empty / "ok"))
+          requests <- counterCount(counterTags)
+          durations <- histogramCount(durationTags)
+        yield assertTrue(
+          response.status == Status.Ok,
+          requests >= 1.0,
+          durations >= 1L,
+        )
+      }.provideSomeLayer[Scope](testLayer) @@ TestAspect.silentLogging,
+      test("counts 5xx errors via status_class") {
+        val counterTags = Set(
+          MetricLabel("method", "GET"),
+          MetricLabel("route", "boom"),
+          MetricLabel("status", "500"),
+          MetricLabel("status_class", "5xx"),
+        )
+        for
+          env <- tracingLayer.build
+          _ <- TestClient.addRoutes(routes.provideEnvironment(env))
+          client <- ZIO.service[Client]
+          response <- client.batched(Request.get(URL.empty / "boom"))
+          requests <- counterCount(counterTags)
+        yield assertTrue(
+          response.status == Status.InternalServerError,
+          requests >= 1.0,
+        )
+      }.provideSomeLayer[Scope](testLayer) @@ TestAspect.silentLogging,
+      test("collapses the edge resources proxy path to a fixed route label") {
+        val collapsedTags = Set(
+          MetricLabel("method", "GET"),
+          MetricLabel("route", "/resources/:alias/*"),
+          MetricLabel("status", "200"),
+          MetricLabel("status_class", "2xx"),
+        )
+        val rawTags = Set(
+          MetricLabel("method", "GET"),
+          MetricLabel("route", "resources/myalias/extra"),
+          MetricLabel("status", "200"),
+          MetricLabel("status_class", "2xx"),
+        )
+        for
+          env <- tracingLayer.build
+          _ <- TestClient.addRoutes(proxyRoutes.provideEnvironment(env))
+          client <- ZIO.service[Client]
+          response <- client.batched(Request.get(URL.empty / "resources" / "myalias" / "extra"))
+          collapsed <- counterCount(collapsedTags)
+          raw <- counterCount(rawTags)
+        yield assertTrue(
+          response.status == Status.Ok,
+          collapsed >= 1.0,
+          raw == 0.0,
+        )
+      }.provideSomeLayer[Scope](testLayer) @@ TestAspect.silentLogging,
+    ),
     suite("client middleware")(
       test("logs INFO for successful requests") {
         for

--- a/util/src/test/scala/versola/util/http/ObservabilitySpec.scala
+++ b/util/src/test/scala/versola/util/http/ObservabilitySpec.scala
@@ -84,10 +84,10 @@ object ObservabilitySpec extends ZIOSpecDefault:
     )
 
   private def counterCount(tags: Set[MetricLabel]): UIO[Double] =
-    Metric.counter("http_server_requests_total").tagged(tags).value.map(_.count)
+    Metric.counter("server_http_requests_count").tagged(tags).value.map(_.count)
 
   private def histogramCount(tags: Set[MetricLabel]): UIO[Long] =
-    Metric.histogram("http_server_request_duration_seconds", Observability.durationBoundaries).tagged(tags).value.map(_.count)
+    Metric.histogram("server_http_request_duration_seconds", Observability.durationBoundaries).tagged(tags).value.map(_.count)
 
   def spec = suite("Observability")(
     test("logs a single info entry for successful requests") {
@@ -176,14 +176,8 @@ object ObservabilitySpec extends ZIOSpecDefault:
           requests >= 1.0,
         )
       }.provideSomeLayer[Scope](testLayer) @@ TestAspect.silentLogging,
-      test("collapses the edge resources proxy path to a fixed route label") {
-        val collapsedTags = Set(
-          MetricLabel("method", "GET"),
-          MetricLabel("route", "/resources/:alias/*"),
-          MetricLabel("status", "200"),
-          MetricLabel("status_class", "2xx"),
-        )
-        val rawTags = Set(
+      test("uses the raw path as the route label for the resources proxy") {
+        val tags = Set(
           MetricLabel("method", "GET"),
           MetricLabel("route", "resources/myalias/extra"),
           MetricLabel("status", "200"),
@@ -194,12 +188,10 @@ object ObservabilitySpec extends ZIOSpecDefault:
           _ <- TestClient.addRoutes(proxyRoutes.provideEnvironment(env))
           client <- ZIO.service[Client]
           response <- client.batched(Request.get(URL.empty / "resources" / "myalias" / "extra"))
-          collapsed <- counterCount(collapsedTags)
-          raw <- counterCount(rawTags)
+          requests <- counterCount(tags)
         yield assertTrue(
           response.status == Status.Ok,
-          collapsed >= 1.0,
-          raw == 0.0,
+          requests >= 1.0,
         )
       }.provideSomeLayer[Scope](testLayer) @@ TestAspect.silentLogging,
     ),


### PR DESCRIPTION
Closes #7

## Summary

Adds **RED** (Rate, Errors, Duration) metrics for **inbound** HTTP traffic, emitted from the shared `Observability.middleware` so `auth`, `central` and `edge` use identical metric names, labels and buckets.

## What changed

`util/.../Observability.scala`
- Defined shared metrics with a `server_http_*` prefix (allowing future matching `client_http_*` metrics):
  - `server_http_requests_count` — Counter (R + E)
  - `server_http_request_duration_seconds` — Histogram (D), using boundaries up to 30s: `0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 7.5, 10.0, 15.0, 20.0, 25.0, 30.0`.
  - `server_http_active_requests` — Gauge (in-flight concurrency).
- Labels: `method`, `route`, `status`, `status_class`.
- The `route` label uses the raw request path (`request.path.encode`).

`central` (Validation)
- Restricted endpoint registration: resource endpoints can now only contain latin letters, digits, and `-` per segment. No path parameters (`{id}`, `:id`, `*`) or consecutive slashes are allowed. This ensures `route` label cardinality remains bounded while allowing the edge to use the raw path.
- Added `ResourceValidationError.InvalidEndpointPath`.
- Ensured consistent trimming of paths during validation.

`central-ui`
- Added client-side validation for endpoint paths to match backend rules.
- Updated UI error messages and Playwright E2E tests (fixed quote-mismatch issue).

`util/.../VersolaApp.scala`
- Dropped the bare `Middleware.metrics()` from `run` so there is exactly one source of HTTP server metrics.

## Acceptance (PromQL)

- Rate: `sum(rate(server_http_requests_count[5m])) by (route)`
- Errors: `sum(rate(server_http_requests_count{status_class="5xx"}[5m])) by (route)`
- Latency p99: `histogram_quantile(0.99, sum(rate(server_http_request_duration_seconds_bucket[5m])) by (le, route))`

## Testing

- `sbt central/test` — 165 tests pass.
- `sbt util/test` — 45 tests pass.
- `central-ui` — `npm run build` succeeds.