### PR TITLE
Track repository call metrics via trackedConnect/trackedTransact

### DIFF
--- a/auth/implementations/postgres/src/main/scala/versola/oauth/PostgresAuthorizationCodeRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/PostgresAuthorizationCodeRepository.scala
@@ -48,7 +48,7 @@ class PostgresAuthorizationCodeRepository(
   override def find(code: MAC.Of[AuthorizationCode]): Task[Option[AuthorizationCodeRecord]] =
     for
       now <- Clock.instant
-      result <- xa.connect:
+      result <- xa.trackedConnect:
         sql"""
           SELECT session_id, client_id, user_id, redirect_uri,
                  scope, code_challenge, code_challenge_method,
@@ -66,7 +66,7 @@ class PostgresAuthorizationCodeRepository(
       ttl: Duration,
   ): Task[Unit] =
     Clock.instant.flatMap: now =>
-      xa.connect:
+      xa.trackedConnect:
         sql"""
           INSERT INTO authorization_codes (
             code,
@@ -104,12 +104,12 @@ class PostgresAuthorizationCodeRepository(
     .unit
 
   override def delete(code: MAC.Of[AuthorizationCode]): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""DELETE FROM authorization_codes WHERE code = $code""".update.run()
     .unit
 
   override def markAsUsed(code: MAC.Of[AuthorizationCode]): Task[Either[AccessToken, Unit]] =
-    xa.connect:
+    xa.trackedConnect:
       val affectedRows = sql"""
         UPDATE authorization_codes
         SET used = TRUE

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/challenge/password/PostgresPasswordRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/challenge/password/PostgresPasswordRepository.scala
@@ -19,7 +19,7 @@ class PostgresPasswordRepository(xa: TransactorZIO) extends PasswordRepository, 
   given DbCodec[PasswordRecord] = DbCodec.derived[PasswordRecord]
 
   override def list(userId: UserId): Task[Vector[PasswordRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
         SELECT id, user_id, password, salt, created_at, is_current
         FROM user_passwords
@@ -37,7 +37,7 @@ class PostgresPasswordRepository(xa: TransactorZIO) extends PasswordRepository, 
   ): IO[Throwable | PasswordReuseError, Unit] =
     for
       now <- Clock.instant
-      result <- xa.transact {
+      result <- xa.trackedTransact {
         val oldPasswords = sql"""
           SELECT id, user_id, password, salt, created_at, is_current
           FROM user_passwords

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/PostgresConversationRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/PostgresConversationRepository.scala
@@ -59,7 +59,7 @@ class PostgresConversationRepository(xa: TransactorZIO) extends ConversationRepo
 
   override def find(authId: AuthId): Task[Option[ConversationRecord]] =
     Clock.instant.flatMap: now =>
-      xa.connect {
+      xa.trackedConnect {
         sql"""select client_id, redirect_uri, scope, code_challenge, code_challenge_method, state, user_id, credential, step, requested_claims, ui_locales, nonce, response_type, user_email, user_phone, user_login, user_claims, auth_flow, expires_at
               from auth_conversations
               where id = $authId"""
@@ -70,7 +70,7 @@ class PostgresConversationRepository(xa: TransactorZIO) extends ConversationRepo
       }
 
   override def create(authId: AuthId, record: ConversationRecord, ttl: Duration): Task[Unit] =
-    xa.connect {
+    xa.trackedConnect {
       sql"""insert into auth_conversations (
                 id,
                 client_id,
@@ -118,7 +118,7 @@ class PostgresConversationRepository(xa: TransactorZIO) extends ConversationRepo
     }.unit
 
   override def overwrite(authId: AuthId, record: ConversationRecord): Task[Unit] =
-    xa.connect {
+    xa.trackedConnect {
       sql"""update auth_conversations set
               user_id = ${record.userId},
               credential = ${record.credential},
@@ -133,7 +133,7 @@ class PostgresConversationRepository(xa: TransactorZIO) extends ConversationRepo
     }.unit
 
   override def delete(authId: AuthId): Task[Unit] =
-    xa.connect {
+    xa.trackedConnect {
       sql"""delete from auth_conversations where id = $authId"""
         .update.run()
     }.unit

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/limit/PostgresChallengeThrottleRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/limit/PostgresChallengeThrottleRepository.scala
@@ -29,7 +29,7 @@ class PostgresChallengeThrottleRepository(xa: TransactorZIO) extends ChallengeTh
       subject: String,
       challengeType: ChallengeType,
   ): Task[Option[ChallengeThrottleRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""SELECT tenant_id, subject, challenge_type, attempts, banned_until, expires_at
             FROM challenge_throttle
             WHERE tenant_id = $tenantId AND subject = $subject AND challenge_type = $challengeType"""
@@ -41,7 +41,7 @@ class PostgresChallengeThrottleRepository(xa: TransactorZIO) extends ChallengeTh
       subject: String,
       challengeTypes: List[ChallengeType],
   ): Task[List[ChallengeThrottleRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""SELECT tenant_id, subject, challenge_type, attempts, banned_until, expires_at
             FROM challenge_throttle
             WHERE tenant_id = $tenantId AND subject = $subject AND challenge_type = ANY($challengeTypes)"""
@@ -50,7 +50,7 @@ class PostgresChallengeThrottleRepository(xa: TransactorZIO) extends ChallengeTh
 
   override def upsert(record: ChallengeThrottleRecord): Task[Unit] =
     ZIO.succeed(UUID.randomUUID()).flatMap: id =>
-      xa.connect:
+      xa.trackedConnect:
         sql"""
           INSERT INTO challenge_throttle (id, tenant_id, subject, challenge_type, attempts, banned_until, expires_at)
           VALUES ($id, ${record.tenantId}, ${record.subject}, ${record.challengeType}, ${record.attempts}, ${record.bannedUntil}, ${record.expiresAt})
@@ -66,14 +66,14 @@ class PostgresChallengeThrottleRepository(xa: TransactorZIO) extends ChallengeTh
       subject: String,
       challengeType: ChallengeType,
   ): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""DELETE FROM challenge_throttle
             WHERE tenant_id = $tenantId AND subject = $subject AND challenge_type = $challengeType"""
         .update.run()
     .unit
 
   override def deleteAllForSubject(tenantId: TenantId, subject: String): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""DELETE FROM challenge_throttle
             WHERE tenant_id = $tenantId AND subject = $subject"""
         .update.run()

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresRefreshTokenRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresRefreshTokenRepository.scala
@@ -84,7 +84,7 @@ class PostgresRefreshTokenRepository(xa: TransactorZIO) extends RefreshTokenRepo
   override def find(token: MAC.Of[RefreshToken]): Task[Option[RefreshTokenRecord]] =
     for
       now <- Clock.instant
-      result <- xa.connect:
+      result <- xa.trackedConnect:
         sql"""
           SELECT session_id, access_token, user_id, client_id,
                  external_audience, scope, issued_at,
@@ -98,12 +98,12 @@ class PostgresRefreshTokenRepository(xa: TransactorZIO) extends RefreshTokenRepo
     yield result
 
   override def delete(token: MAC.Of[RefreshToken]): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""DELETE FROM refresh_tokens WHERE id = $token""".update.run()
     .unit
 
   override def deleteByAccessToken(token: AccessToken): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""DELETE FROM refresh_tokens WHERE access_token = $token""".update.run()
     .unit
 

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
@@ -26,7 +26,7 @@ class PostgresSessionRepository(xa: TransactorZIO) extends SessionRepository, Ba
       ttl: zio.Duration,
   ): Task[Unit] =
     Clock.instant.flatMap: now =>
-      xa.connect:
+      xa.trackedConnect:
         sql"""
           INSERT INTO sso_sessions (id, client_id, user_id, expires_at)
           VALUES (
@@ -41,7 +41,7 @@ class PostgresSessionRepository(xa: TransactorZIO) extends SessionRepository, Ba
   override def find(id: MAC.Of[SessionId]): Task[Option[SessionRecord]] =
     for
       now <- Clock.instant
-      result <- xa.connect:
+      result <- xa.trackedConnect:
         sql"""
           SELECT user_id, client_id, expires_at
           FROM sso_sessions

--- a/auth/implementations/postgres/src/main/scala/versola/user/PostgresUserRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/user/PostgresUserRepository.scala
@@ -21,7 +21,7 @@ class PostgresUserRepository(
   override def findOrCreate(userId: UserId, credential: Either[Email, Phone]): Task[(UserRecord, WasCreated)] =
     for
       now <- Clock.instant
-      (user, wasCreated) <- xa.connect:
+      (user, wasCreated) <- xa.trackedConnect:
         credential match
           case Left(email) => createByEmailQuery(userId, email, now).run().head
           case Right(phone) => createByPhoneQuery(userId, phone, now).run().head
@@ -30,7 +30,7 @@ class PostgresUserRepository(
   override def create(id: UserId): Task[UserRecord] =
     for
       now <- Clock.instant
-      user <- xa.connect:
+      user <- xa.trackedConnect:
         createQuery(id, now).run().head
     yield user
 
@@ -57,14 +57,14 @@ class PostgresUserRepository(
        """.returning[UserRecord]
 
   override def find(id: UserId): Task[Option[UserRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"select id, email, phone, login, claims, ui_locales from users where id = $id"
         .query[UserRecord]
         .run()
         .headOption
 
   override def findByCredential(credential: Either[Email, Phone]): Task[Option[UserRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       credential match
         case Left(email) => findByEmailQuery(email).run().headOption
         case Right(phone) => findByPhoneQuery(phone).run().headOption
@@ -76,7 +76,7 @@ class PostgresUserRepository(
       phone: Option[Phone],
       login: Option[Login],
   ): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""insert into users (id, email, phone, login, claims, last_version)
             values ($id, $email, $phone, $login, '{}'::jsonb, $version)
             on conflict (id) do update set
@@ -89,7 +89,7 @@ class PostgresUserRepository(
     .unit
 
   override def patchClaims(id: UserId, patch: Json.Obj): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"update users set claims = jsonb_strip_nulls(claims || $patch::jsonb) where id = $id".update.run()
     .unit
 

--- a/auth/implementations/postgres/src/main/scala/versola/user/PostgresUserRolesRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/user/PostgresUserRolesRepository.scala
@@ -17,7 +17,7 @@ class PostgresUserRolesRepository(xa: TransactorZIO) extends UserRolesRepository
   given DbCodec[RoleId] = DbCodec.StringCodec.biMap(RoleId(_), identity[String])
 
   override def findRolesByUser(userId: UserId): Task[List[RoleId]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"SELECT role_id FROM user_roles WHERE user_id = $userId"
         .query[String]
         .run()
@@ -25,7 +25,7 @@ class PostgresUserRolesRepository(xa: TransactorZIO) extends UserRolesRepository
         .toList
 
   override def findRolesByUserAndTenant(userId: UserId, tenantId: TenantId): Task[List[RoleId]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"SELECT role_id FROM user_roles WHERE user_id = $userId AND tenant_id = $tenantId"
         .query[String]
         .run()
@@ -40,7 +40,7 @@ class PostgresUserRolesRepository(xa: TransactorZIO) extends UserRolesRepository
   ): Task[Unit] =
     if add.isEmpty && remove.isEmpty then ZIO.unit
     else
-      xa.transact:
+      xa.trackedTransact:
         if remove.nonEmpty then
           remove.foreach: roleId =>
             sql"DELETE FROM user_roles WHERE user_id = $userId AND tenant_id = $tenantId AND role_id = $roleId"

--- a/central/implementations/postgres/src/main/scala/versola/MockDataService.scala
+++ b/central/implementations/postgres/src/main/scala/versola/MockDataService.scala
@@ -12,6 +12,7 @@ import versola.central.configuration.roles.RoleRepository
 import versola.central.configuration.scopes.OAuthScopeRepository
 import versola.central.configuration.tenants.TenantRepository
 import versola.util.SecureRandom
+import versola.util.postgres.BasicCodecs
 import zio.{Task, ZIO, ZLayer}
 
 import scala.io.Source
@@ -39,10 +40,10 @@ object MockDataService:
       otpChallengeService: OtpChallengeService,
       challengeSettingsService: ChallengeSettingsService,
       edgeRepository: EdgeRepository,
-  ) extends MockDataService:
+  ) extends MockDataService, BasicCodecs:
 
     private def cleanup(): Task[Unit] =
-      xa.connect:
+      xa.trackedConnect:
         // Include themes explicitly so CASCADE from tenants does not silently wipe it.
         sql"""TRUNCATE TABLE tenants, permissions, resources, oauth_scopes, roles, oauth_clients, edges, themes RESTART IDENTITY CASCADE""".update.run()
 
@@ -52,7 +53,7 @@ object MockDataService:
           val src = Source.fromResource("forms/common.css")
           try src.mkString finally src.close()
       .flatMap: css =>
-        xa.connect:
+        xa.trackedConnect:
           sql"""INSERT INTO themes (id, css, tenant_id) VALUES ('default', $css, NULL)""".update.run()
       .unit
 

--- a/central/implementations/postgres/src/main/scala/versola/configuration/challenges/PostgresChallengeSettingsRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/challenges/PostgresChallengeSettingsRepository.scala
@@ -16,18 +16,18 @@ class PostgresChallengeSettingsRepository(xa: TransactorZIO) extends ChallengeSe
   given DbCodec[ChallengeSettingsRecord] = DbCodec.derived
 
   override def getAll: Task[Vector[ChallengeSettingsRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""SELECT tenant_id, allowed_prefixes, password_regex, submission_limits, otp_length, otp_resend_after FROM challenge_settings ORDER BY tenant_id"""
         .query[ChallengeSettingsRecord].run()
 
   override def findByTenant(tenantId: TenantId): Task[Option[ChallengeSettingsRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""SELECT tenant_id, allowed_prefixes, password_regex, submission_limits, otp_length, otp_resend_after FROM challenge_settings WHERE tenant_id = $tenantId"""
         .query[ChallengeSettingsRecord].run()
         .headOption
 
   override def upsert(record: ChallengeSettingsRecord): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
         INSERT INTO challenge_settings (tenant_id, allowed_prefixes, password_regex, submission_limits, otp_length, otp_resend_after)
         VALUES (${record.tenantId}, ${record.allowedPrefixes}, ${record.passwordRegex}, ${record.submissionLimits}, ${record.otpLength}, ${record.otpResendAfter})

--- a/central/implementations/postgres/src/main/scala/versola/configuration/challenges/PostgresOtpChallengeRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/challenges/PostgresOtpChallengeRepository.scala
@@ -13,17 +13,17 @@ class PostgresOtpChallengeRepository(xa: TransactorZIO) extends OtpChallengeRepo
   given DbCodec[OtpTemplateRecord] = DbCodec.derived[OtpTemplateRecord]
 
   override def getAll: Task[Vector[OtpTemplateRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""SELECT id, tenant_id, localizations FROM otp_templates ORDER BY tenant_id, id"""
         .query[OtpTemplateRecord].run()
 
   override def find(id: String, tenantId: TenantId): Task[Option[OtpTemplateRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""SELECT id, tenant_id, localizations FROM otp_templates WHERE id = $id AND tenant_id = $tenantId"""
         .query[OtpTemplateRecord].run().headOption
 
   override def upsertTemplate(record: OtpTemplateRecord): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
         INSERT INTO otp_templates (id, tenant_id, localizations)
         VALUES (${record.id}, ${record.tenantId}, ${record.localizations})
@@ -33,7 +33,7 @@ class PostgresOtpChallengeRepository(xa: TransactorZIO) extends OtpChallengeRepo
     .unit
 
   override def deleteTemplate(id: String, tenantId: TenantId): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""DELETE FROM otp_templates WHERE id = $id AND tenant_id = $tenantId""".update.run()
     .unit
 

--- a/central/implementations/postgres/src/main/scala/versola/configuration/clients/PostgresAuthorizationPresetRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/clients/PostgresAuthorizationPresetRepository.scala
@@ -32,7 +32,7 @@ class PostgresAuthorizationPresetRepository(
   given DbCodec[AuthorizationPreset] = DbCodec.derived
 
   override def find(id: PresetId): Task[Option[AuthorizationPreset]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
         SELECT id, client_id, description, redirect_uri, post_login_redirect_uri, scope, response_type, ui_locales, custom_parameters, cookie_domain, cookie_path
         FROM authorization_presets
@@ -41,7 +41,7 @@ class PostgresAuthorizationPresetRepository(
         .query[AuthorizationPreset].run().headOption
 
   override def replace(clientId: ClientId, presets: Seq[AuthorizationPreset]): Task[Unit] =
-    xa.repeatableRead.transact:
+    xa.repeatableRead.trackedTransact:
       sql"""DELETE FROM authorization_presets WHERE client_id = $clientId""".update.run()
       if presets.nonEmpty then
         batchUpdate(presets): preset =>
@@ -58,7 +58,7 @@ class PostgresAuthorizationPresetRepository(
     .unit
 
   override def getAll: Task[Vector[AuthorizationPreset]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
         SELECT id, client_id, description, redirect_uri, post_login_redirect_uri, scope, response_type, ui_locales, custom_parameters, cookie_domain, cookie_path
         FROM authorization_presets

--- a/central/implementations/postgres/src/main/scala/versola/configuration/clients/PostgresOAuthClientRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/clients/PostgresOAuthClientRepository.scala
@@ -34,7 +34,7 @@ class PostgresOAuthClientRepository(
     """
 
   override def getAll: Task[Vector[OAuthClientRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
         SELECT id, tenant_id, client_name, redirect_uris, scope, external_audience, secret, previous_secret, access_token_ttl, refresh_token_ttl, permissions, theme, auth_flow, otp_template_id
         FROM oauth_clients
@@ -42,11 +42,11 @@ class PostgresOAuthClientRepository(
         .query[OAuthClientRecord].run()
 
   override def find(clientId: ClientId): Task[Option[OAuthClientRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       findClient(clientId).query[OAuthClientRecord].run().headOption
 
   override def createClient(client: OAuthClientRecord): IO[ClientAlreadyExists | Throwable, Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
         INSERT INTO oauth_clients (id, tenant_id, client_name, redirect_uris, scope, external_audience, secret, previous_secret, access_token_ttl, refresh_token_ttl, permissions, theme, auth_flow, otp_template_id)
         VALUES (${client.id}, ${client.tenantId}, ${client.clientName}, ${client.redirectUris}, ${client.scope},
@@ -71,7 +71,7 @@ class PostgresOAuthClientRepository(
       authFlow: Option[AuthFlow],
       otpTemplateId: Option[String],
   ): Task[Unit] =
-    xa.repeatableRead.transact:
+    xa.repeatableRead.trackedTransact:
       val client = findClient(clientId).query[OAuthClientRecord].run().head
       val newClientName = clientName.getOrElse(client.clientName)
       val newRedirectUris = client.redirectUris -- patchRedirectUris.remove ++ patchRedirectUris.add
@@ -98,7 +98,7 @@ class PostgresOAuthClientRepository(
     .unit
 
   override def rotateClientSecret(clientId: ClientId, newSecret: Array[Byte]): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
         UPDATE oauth_clients
         SET previous_secret = secret,
@@ -108,7 +108,7 @@ class PostgresOAuthClientRepository(
     .unit
 
   override def deletePreviousClientSecret(clientId: ClientId): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
         UPDATE oauth_clients
         SET previous_secret = NULL
@@ -117,7 +117,7 @@ class PostgresOAuthClientRepository(
     .unit
 
   override def deleteClient(clientId: ClientId): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""DELETE FROM oauth_clients WHERE id = $clientId""".update.run()
     .unit
 

--- a/central/implementations/postgres/src/main/scala/versola/configuration/edges/PostgresEdgeRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/edges/PostgresEdgeRepository.scala
@@ -14,14 +14,14 @@ class PostgresEdgeRepository(xa: TransactorZIO) extends EdgeRepository, BasicCod
   given DbCodec[EdgeRecord] = DbCodec.derived
 
   override def getAll: Task[Vector[EdgeRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
         SELECT id, public_key_jwk, old_public_key_jwk
         FROM edges
       """.query[EdgeRecord].run()
 
   override def find(id: EdgeId): Task[Option[EdgeRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
         SELECT id, public_key_jwk, old_public_key_jwk
         FROM edges
@@ -29,7 +29,7 @@ class PostgresEdgeRepository(xa: TransactorZIO) extends EdgeRepository, BasicCod
       """.query[EdgeRecord].run().headOption
 
   override def createEdge(id: EdgeId, publicKeyJwk: Json.Obj): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
         INSERT INTO edges (id, public_key_jwk, old_public_key_jwk)
         VALUES ($id, $publicKeyJwk, NULL)
@@ -37,7 +37,7 @@ class PostgresEdgeRepository(xa: TransactorZIO) extends EdgeRepository, BasicCod
     .unit
 
   override def rotateEdgeKey(id: EdgeId, newPublicKeyJwk: Json.Obj): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
         UPDATE edges
         SET old_public_key_jwk = public_key_jwk,
@@ -47,7 +47,7 @@ class PostgresEdgeRepository(xa: TransactorZIO) extends EdgeRepository, BasicCod
     .unit
 
   override def deleteOldEdgeKey(id: EdgeId): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
         UPDATE edges
         SET old_public_key_jwk = NULL
@@ -56,7 +56,7 @@ class PostgresEdgeRepository(xa: TransactorZIO) extends EdgeRepository, BasicCod
     .unit
 
   override def deleteEdge(id: EdgeId): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""DELETE FROM edges WHERE id = $id""".update.run()
     .unit
 

--- a/central/implementations/postgres/src/main/scala/versola/configuration/forms/PostgresFormRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/forms/PostgresFormRepository.scala
@@ -17,13 +17,13 @@ class PostgresFormRepository(xa: TransactorZIO) extends FormRepository, BasicCod
   given DbCodec[FormRecord] = DbCodec.derived
 
   override def getAll: Task[Vector[FormRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""SELECT id, version, active, style, js_source, js_compiled, localizations, properties FROM forms ORDER BY id, version DESC"""
         .query[FormRecord]
         .run()
 
   override def find(id: FormId, version: Int): Task[Option[FormRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""SELECT id, version, active, style, js_source, js_compiled, localizations, properties FROM forms WHERE id = $id AND version = $version"""
         .query[FormRecord]
         .run()
@@ -38,7 +38,7 @@ class PostgresFormRepository(xa: TransactorZIO) extends FormRepository, BasicCod
       properties: Vector[BackendProperty],
       activate: Boolean,
   ): Task[Unit] =
-    xa.repeatableRead.transact:
+    xa.repeatableRead.trackedTransact:
       val versions = sql"""SELECT version FROM forms WHERE id = $id ORDER BY version DESC""".query[Int].run()
       val nextVersion = versions.maxOption.getOrElse(0) + 1
       val makeActive = activate || versions.isEmpty
@@ -52,7 +52,7 @@ class PostgresFormRepository(xa: TransactorZIO) extends FormRepository, BasicCod
       ()
 
   override def setActiveVersion(id: FormId, version: Int): Task[Unit] =
-    xa.transact:
+    xa.trackedTransact:
       sql"""UPDATE forms SET active = false WHERE id = $id""".update.run()
       sql"""UPDATE forms SET active = true WHERE id = $id AND version = $version""".update.run()
     .unit

--- a/central/implementations/postgres/src/main/scala/versola/configuration/locales/PostgresLocaleRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/locales/PostgresLocaleRepository.scala
@@ -11,11 +11,11 @@ class PostgresLocaleRepository(xa: TransactorZIO) extends LocaleRepository, Basi
   given DbCodec[LocaleRecord] = DbCodec.derived
 
   override def getAll: Task[Vector[LocaleRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""SELECT code, name, is_default, active FROM locales ORDER BY code""".query[LocaleRecord].run()
 
   override def update(add: Vector[LocaleRecord], delete: Vector[String]): Task[Unit] =
-    xa.repeatableRead.transact:
+    xa.repeatableRead.trackedTransact:
       delete.foreach { code =>
         sql"""DELETE FROM locales WHERE code = $code""".update.run()
         sql"""UPDATE forms SET localizations = localizations - $code WHERE jsonb_exists(localizations, $code)""".update.run()
@@ -27,7 +27,7 @@ class PostgresLocaleRepository(xa: TransactorZIO) extends LocaleRepository, Basi
       }
 
   override def setDefault(code: String): Task[Unit] =
-    xa.repeatableRead.transact:
+    xa.repeatableRead.trackedTransact:
       sql"""UPDATE locales SET is_default = FALSE WHERE is_default = TRUE""".update.run()
       sql"""UPDATE locales SET is_default = TRUE WHERE code = $code""".update.run()
     .unit

--- a/central/implementations/postgres/src/main/scala/versola/configuration/permissions/PostgresPermissionRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/permissions/PostgresPermissionRepository.scala
@@ -19,7 +19,7 @@ class PostgresPermissionRepository(xa: TransactorZIO) extends PermissionReposito
   given DbCodec[PermissionRecord] = DbCodec.derived
 
   override def getAll: Task[Vector[PermissionRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
         SELECT tenant_id, id, description, endpoint_ids FROM permissions
         ORDER BY tenant_id NULLS FIRST, id
@@ -29,7 +29,7 @@ class PostgresPermissionRepository(xa: TransactorZIO) extends PermissionReposito
     tenantId: Option[TenantId],
     permission: Permission
   ): Task[Option[PermissionRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
         SELECT tenant_id, id, description, endpoint_ids FROM permissions
         WHERE tenant_id IS NOT DISTINCT FROM $tenantId AND id = $permission
@@ -41,7 +41,7 @@ class PostgresPermissionRepository(xa: TransactorZIO) extends PermissionReposito
       description: Map[String, String],
       endpointIds: Set[ResourceEndpointId],
   ): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""INSERT INTO permissions (tenant_id, id, description, endpoint_ids)
             VALUES ($tenantId, $permission, $description, $endpointIds)""".update.run()
     .unit
@@ -52,7 +52,7 @@ class PostgresPermissionRepository(xa: TransactorZIO) extends PermissionReposito
       descriptionPatch: PatchDescription,
       endpointIdsPatch: Option[Set[ResourceEndpointId]],
   ): Task[Unit] =
-    xa.repeatableRead.transact:
+    xa.repeatableRead.trackedTransact:
       val existing = sql"""
         SELECT tenant_id, id, description, endpoint_ids FROM permissions
         WHERE tenant_id IS NOT DISTINCT FROM $tenantId AND id = $permission
@@ -76,7 +76,7 @@ class PostgresPermissionRepository(xa: TransactorZIO) extends PermissionReposito
       tenantId: Option[TenantId],
       permission: Permission,
   ): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""DELETE FROM permissions WHERE tenant_id IS NOT DISTINCT FROM $tenantId AND id = $permission""".update.run()
     .unit
 

--- a/central/implementations/postgres/src/main/scala/versola/configuration/resources/PostgresResourceRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/resources/PostgresResourceRepository.scala
@@ -34,7 +34,7 @@ class PostgresResourceRepository(xa: TransactorZIO) extends ResourceRepository, 
     """.query[ResourceRecord]
 
   override def getAll: Task[Vector[ResourceRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
         SELECT tenant_id, id, alias, resource, endpoints FROM resources
       """.query[ResourceRecord].run()
@@ -42,7 +42,7 @@ class PostgresResourceRepository(xa: TransactorZIO) extends ResourceRepository, 
   override def findResource(
       resourceId: ResourceId,
   ): Task[Option[ResourceRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       findResourceQuery(resourceId).run().headOption
 
   override def createResource(
@@ -51,7 +51,7 @@ class PostgresResourceRepository(xa: TransactorZIO) extends ResourceRepository, 
       resource: ResourceUri,
       endpoints: Vector[ResourceEndpointRecord],
   ): Task[ResourceId] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
         INSERT INTO resources (tenant_id, alias, resource, endpoints)
         VALUES ($tenantId, $alias, $resource, $endpoints)
@@ -65,7 +65,7 @@ class PostgresResourceRepository(xa: TransactorZIO) extends ResourceRepository, 
       addEndpoints: Vector[ResourceEndpointRecord],
       deleteEndpoints: Set[ResourceEndpointId],
   ): Task[Unit] =
-    xa.repeatableRead.transact:
+    xa.repeatableRead.trackedTransact:
       findResourceQuery(id).run().headOption match
         case None => ()
         case Some(resource) =>
@@ -87,7 +87,7 @@ class PostgresResourceRepository(xa: TransactorZIO) extends ResourceRepository, 
   override def deleteResource(
       id: ResourceId,
   ): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""DELETE FROM resources WHERE id = $id""".update.run()
     .unit
 

--- a/central/implementations/postgres/src/main/scala/versola/configuration/roles/PostgresRoleRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/roles/PostgresRoleRepository.scala
@@ -19,7 +19,7 @@ class PostgresRoleRepository(
   given DbCodec[RoleRecord] = DbCodec.derived[RoleRecord]
 
   override def getAll: Task[Vector[RoleRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""SELECT id, tenant_id, description, permissions, active FROM roles"""
         .query[RoleRecord].run()
 
@@ -27,7 +27,7 @@ class PostgresRoleRepository(
       tenantId: TenantId,
       id: RoleId,
   ): Task[Option[RoleRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       getRole(id, tenantId).run().headOption
 
 
@@ -37,7 +37,7 @@ class PostgresRoleRepository(
       description: Map[String, String],
       permissions: List[Permission],
   ): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
           INSERT INTO roles (id, tenant_id, description, permissions, active)
           VALUES ($id, $tenantId, $description, $permissions, TRUE)
@@ -54,7 +54,7 @@ class PostgresRoleRepository(
       descriptionPatch: PatchDescription,
       permissionsPatch: PatchPermissions,
   ): Task[Unit] =
-    xa.repeatableRead.transact:
+    xa.repeatableRead.trackedTransact:
       getRole(id, tenantId).run().headOption match
         case None => ()
         case Some(role) =>
@@ -71,13 +71,13 @@ class PostgresRoleRepository(
 
   override def markRoleInactive(tenantId: TenantId, id: RoleId): Task[Unit] =
     Clock.instant.flatMap { now =>
-      xa.connect:
+      xa.trackedConnect:
         sql"""UPDATE roles SET active = FALSE WHERE tenant_id = $tenantId AND id = $id""".update.run()
       .unit
     }
 
   override def deleteRole(tenantId: TenantId, id: RoleId): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""DELETE FROM roles WHERE tenant_id = $tenantId AND id = $id""".update.run()
     .unit
 

--- a/central/implementations/postgres/src/main/scala/versola/configuration/scopes/PostgresOAuthScopeRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/scopes/PostgresOAuthScopeRepository.scala
@@ -21,7 +21,7 @@ class PostgresOAuthScopeRepository(
   given DbCodec[ScopeRecord] = DbCodec.derived
 
   override def getAll: Task[Vector[ScopeRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
             SELECT tenant_id, id, description, claims FROM oauth_scopes
          """.query[ScopeRecord].run()
@@ -30,7 +30,7 @@ class PostgresOAuthScopeRepository(
       tenantId: TenantId,
       scopeId: ScopeToken,
   ): Task[Option[ScopeRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
         SELECT tenant_id, id, description, claims FROM oauth_scopes
         WHERE tenant_id = $tenantId AND id = $scopeId
@@ -42,7 +42,7 @@ class PostgresOAuthScopeRepository(
       description: Map[String, String],
       claims: List[CreateClaim],
   ): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""
             INSERT INTO oauth_scopes (id, tenant_id, description, claims)
             VALUES ($id, $tenantId, $description, ${claims.map(_.asRecord)}::jsonb[])
@@ -54,7 +54,7 @@ class PostgresOAuthScopeRepository(
       id: ScopeToken,
       patch: PatchScope,
   ): Task[Unit] =
-    xa.repeatableRead.transact:
+    xa.repeatableRead.trackedTransact:
       val scope =
         sql"""SELECT tenant_id, id, description, claims::jsonb[] FROM oauth_scopes WHERE tenant_id = $tenantId AND id = $id"""
           .query[ScopeRecord].run().head
@@ -84,7 +84,7 @@ class PostgresOAuthScopeRepository(
       tenantId: TenantId,
       id: ScopeToken,
   ): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""DELETE FROM oauth_scopes WHERE tenant_id = $tenantId AND id = $id""".update.run()
     .unit
 

--- a/central/implementations/postgres/src/main/scala/versola/configuration/tenants/PostgresTenantRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/tenants/PostgresTenantRepository.scala
@@ -14,7 +14,7 @@ class PostgresTenantRepository(xa: TransactorZIO) extends TenantRepository, Basi
   given DbCodec[TenantRecord] = DbCodec.derived
 
   override def getAll: Task[Vector[TenantRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""SELECT id, description, edge_id FROM tenants ORDER BY id"""
         .query[TenantRecord]
         .run()
@@ -24,7 +24,7 @@ class PostgresTenantRepository(xa: TransactorZIO) extends TenantRepository, Basi
       description: String,
       edgeId: Option[EdgeId],
   ): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""INSERT INTO tenants (id, description, edge_id) VALUES ($id, $description, $edgeId)""".update.run()
     .unit
 
@@ -33,12 +33,12 @@ class PostgresTenantRepository(xa: TransactorZIO) extends TenantRepository, Basi
       description: String,
       edgeId: Option[EdgeId],
   ): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""UPDATE tenants SET description = $description, edge_id = $edgeId WHERE id = $id""".update.run()
     .unit
 
   override def deleteTenant(id: TenantId): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""DELETE FROM tenants WHERE id = $id""".update.run()
     .unit
 

--- a/central/implementations/postgres/src/main/scala/versola/configuration/themes/PostgresThemeRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/themes/PostgresThemeRepository.scala
@@ -13,26 +13,26 @@ class PostgresThemeRepository(xa: TransactorZIO) extends ThemeRepository, BasicC
   given DbCodec[ThemeRecord] = DbCodec.derived
 
   override def getAll: Task[Vector[ThemeRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""SELECT id, css, tenant_id FROM themes ORDER BY id"""
         .query[ThemeRecord]
         .run()
 
   override def create(theme: ThemeRecord): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""INSERT INTO themes (id, css, tenant_id)
             VALUES (${theme.id}, ${theme.css}, ${theme.tenantId})"""
         .update.run()
     .unit
 
   override def update(theme: ThemeRecord): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""UPDATE themes SET css = ${theme.css} WHERE id = ${theme.id}"""
         .update.run()
     .unit
 
   override def delete(id: String): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"""DELETE FROM themes WHERE id = $id"""
         .update.run()
     .unit

--- a/central/implementations/postgres/src/main/scala/versola/users/PostgresUserRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/users/PostgresUserRepository.scala
@@ -27,22 +27,22 @@ class PostgresUserRepository(xa: TransactorZIO, secureRandom: SecureRandom) exte
   given DbCodec[Instant] = DbCodec.InstantCodec
 
   override def findById(id: UserId): Task[Option[UserIndexRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"SELECT id, email, phone, login FROM user_index WHERE id = $id"
         .query[UserIndexRecord].run().headOption
 
   override def findByEmail(email: Email): Task[Option[UserIndexRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"SELECT id, email, phone, login FROM user_index WHERE email = $email"
         .query[UserIndexRecord].run().headOption
 
   override def findByPhone(phone: Phone): Task[Option[UserIndexRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"SELECT id, email, phone, login FROM user_index WHERE phone = $phone"
         .query[UserIndexRecord].run().headOption
 
   override def findByLogin(login: Login): Task[Option[UserIndexRecord]] =
-    xa.connect:
+    xa.trackedConnect:
       sql"SELECT id, email, phone, login FROM user_index WHERE login = $login"
         .query[UserIndexRecord].run().headOption
 
@@ -85,7 +85,7 @@ class PostgresUserRepository(xa: TransactorZIO, secureRandom: SecureRandom) exte
     (for
       version <- secureRandom.nextUUIDv7
       now <- Clock.instant
-      _ <- xa.transact:
+      _ <- xa.trackedTransact:
              upsertSql(id, email, phone, login)
              enqueueEventSql(id, version, OutboxEvent.UpsertUser(id, version, email, phone, login), now)
     yield ()).mapError:
@@ -101,7 +101,7 @@ class PostgresUserRepository(xa: TransactorZIO, secureRandom: SecureRandom) exte
     for
       version <- secureRandom.nextUUIDv7
       now <- Clock.instant
-      _ <- xa.transact:
+      _ <- xa.trackedTransact:
         // Lock the user row to prevent lost updates and serialize events
         sql"SELECT id FROM user_index WHERE id = $id FOR UPDATE".query[UserId].run()
 
@@ -126,7 +126,7 @@ class PostgresUserRepository(xa: TransactorZIO, secureRandom: SecureRandom) exte
     */
   override def claimDueEvents(limit: Int, lease: Duration): Task[Vector[OutboxRecord]] =
     val leaseSeconds = lease.toSeconds
-    xa.connect:
+    xa.trackedConnect:
       sql"""UPDATE user_outbox SET
               next_attempt_at = NOW() + ($leaseSeconds || ' seconds')::interval
             WHERE id IN (
@@ -146,13 +146,13 @@ class PostgresUserRepository(xa: TransactorZIO, secureRandom: SecureRandom) exte
         .run()
 
   override def deleteEvent(id: UUID): Task[Unit] =
-    xa.connect:
+    xa.trackedConnect:
       sql"DELETE FROM user_outbox WHERE id = $id".update.run()
     .unit
 
   override def rescheduleEvent(id: UUID, delay: Duration): Task[Unit] =
     val seconds = delay.toSeconds
-    xa.connect:
+    xa.trackedConnect:
       sql"""UPDATE user_outbox SET
               attempts = attempts + 1,
               next_attempt_at = NOW() + ($seconds || ' seconds')::interval
@@ -160,7 +160,7 @@ class PostgresUserRepository(xa: TransactorZIO, secureRandom: SecureRandom) exte
     .unit
 
   override def moveToDeadLetter(id: UUID, error: String): Task[Unit] =
-    xa.transact:
+    xa.trackedTransact:
       sql"""INSERT INTO user_outbox_dead (id, user_id, event_type, payload, attempts, failed_at, error)
             SELECT id, user_id, event_type, payload, attempts, NOW(), $error
             FROM user_outbox

--- a/edge/implementations/postgres/src/main/scala/versola/edge/PostgresEdgeRefreshTokenRepository.scala
+++ b/edge/implementations/postgres/src/main/scala/versola/edge/PostgresEdgeRefreshTokenRepository.scala
@@ -18,7 +18,7 @@ class PostgresEdgeRefreshTokenRepository(xa: TransactorZIO) extends EdgeRefreshT
       accessTokenId: AccessTokenId,
       record: EdgeRefreshTokenRecord,
   ): Task[Unit] =
-    xa.connect {
+    xa.trackedConnect {
       sql"""
         INSERT INTO edge_refresh_tokens (id, preset_id, refresh_token, expires_at)
         VALUES ($accessTokenId, ${record.presetId}, ${record.encryptedRefreshToken}, ${record.expiresAt})
@@ -31,7 +31,7 @@ class PostgresEdgeRefreshTokenRepository(xa: TransactorZIO) extends EdgeRefreshT
 
   override def find(accessTokenId: AccessTokenId): Task[Option[EdgeRefreshTokenRecord]] =
     Clock.instant.flatMap { now =>
-      xa.connect {
+      xa.trackedConnect {
         sql"""
           SELECT preset_id, refresh_token, expires_at
           FROM edge_refresh_tokens
@@ -44,14 +44,14 @@ class PostgresEdgeRefreshTokenRepository(xa: TransactorZIO) extends EdgeRefreshT
     }
 
   override def delete(accessTokenId: AccessTokenId): Task[Unit] =
-    xa.connect {
+    xa.trackedConnect {
       sql"""
         DELETE FROM edge_refresh_tokens WHERE id = $accessTokenId
       """.update.run()
     }.unit
 
   override def deleteByPresetId(presetId: PresetId): Task[Unit] =
-    xa.connect {
+    xa.trackedConnect {
       sql"""
         DELETE FROM edge_refresh_tokens WHERE preset_id = $presetId
       """.update.run()

--- a/edge/implementations/postgres/src/main/scala/versola/edge/PostgresLoginRepository.scala
+++ b/edge/implementations/postgres/src/main/scala/versola/edge/PostgresLoginRepository.scala
@@ -4,9 +4,10 @@ import com.augustnagro.magnum.*
 import com.augustnagro.magnum.magzio.TransactorZIO
 import versola.edge.login.{LoginRecord, LoginRepository}
 import versola.edge.model.{CodeVerifier, PresetId, State}
+import versola.util.postgres.BasicCodecs
 import zio.{Clock, Duration, Task, ZLayer}
 
-class PostgresLoginRepository(xa: TransactorZIO) extends LoginRepository:
+class PostgresLoginRepository(xa: TransactorZIO) extends LoginRepository, BasicCodecs:
   given DbCodec[CodeVerifier] = DbCodec.StringCodec.biMap(CodeVerifier(_), identity[String])
   given DbCodec[State] = DbCodec.StringCodec.biMap(State(_), identity[String])
   given DbCodec[PresetId] = DbCodec.StringCodec.biMap(PresetId(_), identity[String])
@@ -19,7 +20,7 @@ class PostgresLoginRepository(xa: TransactorZIO) extends LoginRepository:
   ): Task[Unit] =
     Clock.instant.flatMap { now =>
       val expiresAt = now.plusSeconds(ttl.toSeconds)
-      xa.connect {
+      xa.trackedConnect {
         sql"""
           INSERT INTO pending_logins (login_id, state, code_verifier, preset_id, expires_at)
           VALUES ($loginId, ${data.state}, ${data.codeVerifier}, ${data.presetId}, $expiresAt)
@@ -34,7 +35,7 @@ class PostgresLoginRepository(xa: TransactorZIO) extends LoginRepository:
 
   override def find(loginId: String): Task[Option[LoginRecord]] =
     Clock.instant.flatMap { now =>
-      xa.connect {
+      xa.trackedConnect {
         sql"""
           SELECT code_verifier, preset_id, state
           FROM pending_logins
@@ -48,7 +49,7 @@ class PostgresLoginRepository(xa: TransactorZIO) extends LoginRepository:
 
   override def findByState(state: State): Task[Option[LoginRecord]] =
     Clock.instant.flatMap { now =>
-      xa.connect {
+      xa.trackedConnect {
         sql"""
           SELECT code_verifier, preset_id, state
           FROM pending_logins
@@ -61,14 +62,14 @@ class PostgresLoginRepository(xa: TransactorZIO) extends LoginRepository:
     }
 
   override def delete(loginId: String): Task[Unit] =
-    xa.connect {
+    xa.trackedConnect {
       sql"""
         DELETE FROM pending_logins WHERE login_id = $loginId
       """.update.run()
     }.unit
 
   override def deleteByState(state: State): Task[Unit] =
-    xa.connect {
+    xa.trackedConnect {
       sql"""
         DELETE FROM pending_logins WHERE state = $state
       """.update.run()

--- a/util/implementations/postgres/src/main/scala/versola/cleanup/PostgresCleanupManager.scala
+++ b/util/implementations/postgres/src/main/scala/versola/cleanup/PostgresCleanupManager.scala
@@ -2,6 +2,7 @@ package versola.cleanup
 
 import com.augustnagro.magnum.*
 import com.augustnagro.magnum.magzio.TransactorZIO
+import versola.util.postgres.BasicCodecs
 import zio.*
 import zio.config.magnolia.deriveConfig
 
@@ -21,11 +22,11 @@ class PostgresCleanupManager(
     xa: TransactorZIO,
     config: CleanupConfig,
     fibers: Ref[List[Fiber.Runtime[Throwable, Long]]],
-) extends CleanupManager.Base(config, fibers):
+) extends CleanupManager.Base(config, fibers), BasicCodecs:
 
   override protected def cleanupBatch(tableName: String, batchSize: Int): Task[Int] =
     val table = SqlLiteral(tableName)
-    xa.connect {
+    xa.trackedConnect {
       sql"""
         DELETE FROM $table
         WHERE id IN (

--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/BasicCodecs.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/BasicCodecs.scala
@@ -1,13 +1,14 @@
 package versola.util.postgres
 
-import com.augustnagro.magnum.DbCodec
+import com.augustnagro.magnum.{DbCodec, DbCon, DbTx}
 import com.augustnagro.magnum.magzio.TransactorZIO
 import com.augustnagro.magnum.pg.json.JsonBDbCodec
 import com.augustnagro.magnum.pg.{PgCodec, SqlArrayCodec, json}
 import versola.util.Secret
-import zio.NonEmptyChunk
+import zio.{NonEmptyChunk, Task, Trace}
 import zio.json.*
 import zio.json.ast.Json
+import zio.metrics.Metric
 import zio.prelude.NonEmptySet
 
 import java.sql.Connection
@@ -97,3 +98,11 @@ trait BasicCodecs:
 
     def serializable: TransactorZIO =
       xa.withConnectionConfig(_.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE))
+
+    def trackedConnect[A](f: DbCon ?=> A)(using trace: Trace): Task[A] =
+      val name = trace.toString.takeWhile(_ != '(').replaceAll("\\$", "")
+      xa.connect(f) @@ Metric.counter(name).fromConst(1L)
+
+    def trackedTransact[A](f: DbTx ?=> A)(using trace: Trace): Task[A] =
+      val name = trace.toString.takeWhile(_ != '(').replaceAll("\\$", "")
+      xa.transact(f) @@ Metric.counter(name).fromConst(1L)


### PR DESCRIPTION
## What

Adds per-call metrics for every Postgres repository operation, keyed by the fully-qualified method name.

## How

Two new extension methods on `TransactorZIO` in `BasicCodecs`:

```scala
def trackedConnect[A](f: DbCon ?=> A)(using trace: Trace): Task[A] =
  val name = trace.toString.takeWhile(_ != '(').replaceAll("\\$", "")
  xa.connect(f) @@ Metric.counter(name).fromConst(1L)

def trackedTransact[A](f: DbTx ?=> A)(using trace: Trace): Task[A] =
  val name = trace.toString.takeWhile(_ != '(').replaceAll("\\$", "")
  xa.transact(f) @@ Metric.counter(name).fromConst(1L)
```

- The caller's `zio.Trace` is captured at compile time, giving the full call-site path.
- `takeWhile(_ != '(')` drops the `(file:line)` suffix, leaving e.g. `versola.configuration.themes.PostgresThemeRepository.getAll`.
- `replaceAll("\\$", "")` removes any generated `$` signs.
- A `Metric.counter` keyed by that name is incremented once per DB operation.

## Scope

- Migrated all Postgres repository call sites: `xa.connect` → `xa.trackedConnect`, `xa.transact` → `xa.trackedTransact` (including `xa.repeatableRead.transact` → `xa.repeatableRead.trackedTransact`).
- Added the `BasicCodecs` mixin to `PostgresLoginRepository`, `PostgresCleanupManager`, and `MockDataService.Impl`, which previously didn't mix it in.

27 files changed, 110 tracked call sites, no remaining `xa.connect`/`xa.transact` calls in production code.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KVG4SBQG964QZ70XMKATFEWT&panel=chat)