### PR TITLE
fix: store raw SessionId in SSO_SESSION cookie instead of MAC

### DIFF
--- a/auth/src/main/scala/versola/oauth/conversation/ConversationResult.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationResult.scala
@@ -5,7 +5,7 @@ import versola.oauth.conversation.model.{AuthId, ConversationStep}
 import versola.oauth.model.{AuthorizationCode, State}
 import versola.oauth.session.model.SessionId
 import versola.user.model.UserId
-import versola.util.{Base64Url, MAC}
+import versola.util.Base64Url
 import zio.http.URL
 import zio.json.ast.Json
 
@@ -33,7 +33,7 @@ object ConversationResult:
       redirectUri: URL,
       state: Option[State],
       code: AuthorizationCode,
-      sessionId: MAC.Of[SessionId],
+      sessionId: SessionId,
       idTokenData: Option[IdTokenData],
   ) extends Render
 

--- a/auth/src/main/scala/versola/oauth/conversation/ConversationService.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationService.scala
@@ -354,7 +354,7 @@ object ConversationService:
         redirectUri = conversation.redirectUri,
         state = conversation.state,
         code = code,
-        sessionId = sessionIdMac,
+        sessionId = sessionId,
         idTokenData = idTokenData,
       )
 

--- a/auth/src/main/scala/versola/oauth/model/cookies.scala
+++ b/auth/src/main/scala/versola/oauth/model/cookies.scala
@@ -2,7 +2,7 @@ package versola.oauth.model
 
 import versola.oauth.conversation.model.AuthId
 import versola.oauth.session.model.SessionId
-import versola.util.{Base64Url, MAC}
+import versola.util.Base64Url
 import zio.Duration
 import zio.http.{Cookie, Path}
 
@@ -23,7 +23,7 @@ object ConversationCookie:
 object SessionCookie:
   val name = "SSO_SESSION"
 
-  inline def apply(value: MAC.Of[SessionId], ttl: Duration): Cookie.Response = Cookie.Response(
+  inline def apply(value: SessionId, ttl: Duration): Cookie.Response = Cookie.Response(
     name = name,
     content = Base64Url.encode(value),
     domain = None,


### PR DESCRIPTION
The SSO_SESSION cookie was previously populated with MAC.Of[SessionId], which is also the primary key stored in sso_sessions. This means an attacker with DB read access could directly use the stored MACs as session credentials.

Fix:
- ConversationResult.Complete.sessionId is now SessionId (raw)
- ConversationService.finish returns raw sessionId in the result
- SessionCookie now accepts SessionId instead of MAC.Of[SessionId]

The DB continues to store MAC.Of[SessionId]. When SSO session validation is implemented, middleware must MAC the incoming cookie value before looking it up in SessionRepository.

Closes #19