### PR TITLE
issue-18 

### DIFF
--- a/auth/implementations/postgres/migrations/V4__auth_conversations_table.sql
+++ b/auth/implementations/postgres/migrations/V4__auth_conversations_table.sql
@@ -19,6 +19,7 @@ CREATE TABLE auth_conversations (
     user_claims JSON,
     auth_flow JSONB NOT NULL,
     user_agent TEXT,
+    version BIGINT NOT NULL,
     amr JSONB NOT NULL,
     expires_at TIMESTAMP WITH TIME ZONE NOT NULL
 );

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/PostgresConversationRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/PostgresConversationRepository.scala
@@ -62,13 +62,15 @@ class PostgresConversationRepository(xa: TransactorZIO) extends ConversationRepo
   override def find(authId: AuthId): Task[Option[ConversationRecord]] =
     Clock.instant.flatMap: now =>
       xa.connect {
-        sql"""select client_id, redirect_uri, scope, code_challenge, code_challenge_method, state, user_id, credential, step, requested_claims, ui_locales, nonce, response_type, user_email, user_phone, user_login, user_claims, auth_flow, user_agent, amr, expires_at
+        sql"""select client_id, redirect_uri, scope, code_challenge, code_challenge_method, state, user_id, credential, step, requested_claims, ui_locales, nonce, response_type, user_email, user_phone, user_login, user_claims, auth_flow, user_agent, version, amr, expires_at
               from auth_conversations
               where id = $authId"""
           .query[(ConversationRecord, Instant)]
           .run()
           .headOption
-          .collect { case (conversation, expiresAt) if expiresAt.isAfter(now) => conversation }
+          .collect { case (conversation, expiresAt) if expiresAt.isAfter(now) =>
+            conversation
+          }
       }
 
   override def create(authId: AuthId, record: ConversationRecord, ttl: Duration): Task[Unit] =
@@ -94,6 +96,7 @@ class PostgresConversationRepository(xa: TransactorZIO) extends ConversationRepo
                 user_claims,
                 auth_flow,
                 user_agent,
+                version,
                 amr,
                 expires_at
             ) values (
@@ -117,13 +120,14 @@ class PostgresConversationRepository(xa: TransactorZIO) extends ConversationRepo
                 ${record.userClaims},
                 ${record.authFlow},
                 ${record.userAgent},
+                ${record.version},
                 ${record.amr},
                 ${authId.createdAt.plusSeconds(ttl.toSeconds)})
          """
         .update.run()
     }.unit
 
-  override def overwrite(authId: AuthId, record: ConversationRecord): Task[Unit] =
+  override def overwrite(authId: AuthId, record: ConversationRecord): Task[Boolean] =
     xa.connect {
       sql"""update auth_conversations set
               user_id = ${record.userId},
@@ -134,16 +138,17 @@ class PostgresConversationRepository(xa: TransactorZIO) extends ConversationRepo
               user_login = ${record.userLogin},
               user_claims = ${record.userClaims},
               auth_flow = ${record.authFlow},
-              amr = ${record.amr}
-            where id = $authId"""
+              amr = ${record.amr},
+              version = version + 1
+            where id = $authId and version = ${record.version}"""
         .update.run()
-    }.unit
+    }.map(_ > 0)
 
-  override def delete(authId: AuthId): Task[Unit] =
+  override def delete(authId: AuthId, version: Long): Task[Boolean] =
     xa.connect {
-      sql"""delete from auth_conversations where id = $authId"""
+      sql"""delete from auth_conversations where id = $authId and version = $version"""
         .update.run()
-    }.unit
+    }.map(_ > 0)
 
 object PostgresConversationRepository:
   def live: ZLayer[TransactorZIO, Throwable, ConversationRepository] =

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
@@ -26,21 +26,21 @@ object AuthorizeEndpointService:
     ZLayer.fromFunction(Impl(_, _, _, _, _, _, _, _, _, _))
 
   class Impl(
-    conversationRepository: ConversationRepository,
-    configurationService: OAuthConfigurationService,
-    secureRandom: SecureRandom,
-    config: CoreConfig,
-    securityService: SecurityService,
-    sessionRepository: SessionRepository,
-    authPropertyGenerator: AuthPropertyGenerator,
-    authorizationCodeRepository: AuthorizationCodeRepository,
-    userRepository: UserRepository,
-    userInfoService: UserInfoService,
-  ) extends AuthorizeEndpointService:
+              conversationRepository: ConversationRepository,
+              configurationService: OAuthConfigurationService,
+              secureRandom: SecureRandom,
+              config: CoreConfig,
+              securityService: SecurityService,
+              sessionRepository: SessionRepository,
+              authPropertyGenerator: AuthPropertyGenerator,
+              authorizationCodeRepository: AuthorizationCodeRepository,
+              userRepository: UserRepository,
+              userInfoService: UserInfoService,
+            ) extends AuthorizeEndpointService:
 
     override def authorize(
-        request: AuthorizeRequest,
-    ): Task[AuthorizeResponse] =
+                            request: AuthorizeRequest,
+                          ): Task[AuthorizeResponse] =
       for
         client <- configurationService.find(request.clientId)
         authFlow = client.flatMap(_.authFlow)
@@ -76,11 +76,11 @@ object AuthorizeEndpointService:
       yield response
 
     private def createConversation(
-        request: AuthorizeRequest,
-        flow: AuthFlow,
-        uiLocales: Option[List[String]],
-        amr: Map[PassedAuthFactor, PassedFactorRecord],
-    ): Task[AuthorizeResponse] =
+                                    request: AuthorizeRequest,
+                                    flow: AuthFlow,
+                                    uiLocales: Option[List[String]],
+                                    amr: Map[PassedAuthFactor, PassedFactorRecord],
+                                  ): Task[AuthorizeResponse] =
       AuthId.wrapAll(secureRandom.nextUUIDv7).flatMap: authId =>
         val conversation = ConversationRecord(
           clientId = request.clientId,
@@ -105,18 +105,19 @@ object AuthorizeEndpointService:
           userLogin = None,
           userClaims = None,
           authFlow = flow,
-          userAgent = request.userAgent.map(_.filter(c => c >= ' ' && c <= '~')),
+          userAgent = request.userAgent.map(_.filter(c => c >= ' ' && c <= '~')),  // Strip non-printable ASCII (0x20–0x7E); does not escape HTML — always escape at render time
+          version = 0,
           amr = amr,
         )
         conversationRepository.create(authId, conversation, config.security.authConversation.ttl)
           .as(AuthorizeResponse.Initialize(authId))
 
     private def silentAuthorize(
-        request: AuthorizeRequest,
-        uiLocales: Option[List[String]],
-        session: SessionRecord,
-        sessionMac: MAC.Of[SessionId],
-    ): Task[AuthorizeResponse] =
+                                 request: AuthorizeRequest,
+                                 uiLocales: Option[List[String]],
+                                 session: SessionRecord,
+                                 sessionMac: MAC.Of[SessionId],
+                               ): Task[AuthorizeResponse] =
       val amr = AuthMethodRef.amrClaim(session.amr)
       val isHybrid =
         request.responseType.contains(ResponseTypeEntry.IdToken) &&
@@ -142,16 +143,16 @@ object AuthorizeEndpointService:
         codeMac <- securityService.mac(Secret(code), config.security.authCodes.pepper)
         _ <- authorizationCodeRepository.create(codeMac, codeRecord, zio.Duration.fromSeconds(60))
         idToken <- if isHybrid then silentIdToken(request, session, code, amr, uiLocales)
-                   else ZIO.none
+        else ZIO.none
       yield AuthorizeResponse.Authorized(code, idToken)
 
     private def silentIdToken(
-        request: AuthorizeRequest,
-        session: SessionRecord,
-        code: AuthorizationCode,
-        amr: Set[AuthMethodRef],
-        uiLocales: Option[List[String]],
-    ): Task[Option[String]] =
+                               request: AuthorizeRequest,
+                               session: SessionRecord,
+                               code: AuthorizationCode,
+                               amr: Set[AuthMethodRef],
+                               uiLocales: Option[List[String]],
+                             ): Task[Option[String]] =
       for
         userOpt <- userRepository.find(session.userId)
         user <- ZIO
@@ -186,8 +187,8 @@ object AuthorizeEndpointService:
       yield Some(token)
 
     /** Narrows the requested ui_locales to those configured in central, preserving the client's
-      * preference order. Rejects the request when none of the requested locales are available.
-      */
+     * preference order. Rejects the request when none of the requested locales are available.
+     */
     private def resolveUiLocales(request: AuthorizeRequest): ZIO[Any, Error.UnsupportedUiLocales, Option[List[String]]] =
       request.uiLocales match
         case None => ZIO.none

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
@@ -11,11 +11,10 @@ import versola.oauth.session.model.{SessionId, SessionRecord}
 import versola.oauth.token.AuthorizationCodeRepository
 import versola.oauth.userinfo.UserInfoService
 import versola.user.UserRepository
-import versola.util.{AuthPropertyGenerator, Base64Url, CoreConfig, JWT, Secret, SecureRandom, SecurityService}
 import versola.util.MAC
+import versola.util.{AuthPropertyGenerator, Base64Url, CoreConfig, JWT, Secret, SecureRandom, SecurityService}
 import zio.json.ast.Json
 import zio.{Chunk, Task, ZIO, ZLayer, durationInt}
-
 
 trait AuthorizeEndpointService:
 
@@ -26,21 +25,21 @@ object AuthorizeEndpointService:
     ZLayer.fromFunction(Impl(_, _, _, _, _, _, _, _, _, _))
 
   class Impl(
-              conversationRepository: ConversationRepository,
-              configurationService: OAuthConfigurationService,
-              secureRandom: SecureRandom,
-              config: CoreConfig,
-              securityService: SecurityService,
-              sessionRepository: SessionRepository,
-              authPropertyGenerator: AuthPropertyGenerator,
-              authorizationCodeRepository: AuthorizationCodeRepository,
-              userRepository: UserRepository,
-              userInfoService: UserInfoService,
-            ) extends AuthorizeEndpointService:
+      conversationRepository: ConversationRepository,
+      configurationService: OAuthConfigurationService,
+      secureRandom: SecureRandom,
+      config: CoreConfig,
+      securityService: SecurityService,
+      sessionRepository: SessionRepository,
+      authPropertyGenerator: AuthPropertyGenerator,
+      authorizationCodeRepository: AuthorizationCodeRepository,
+      userRepository: UserRepository,
+      userInfoService: UserInfoService,
+  ) extends AuthorizeEndpointService:
 
     override def authorize(
-                            request: AuthorizeRequest,
-                          ): Task[AuthorizeResponse] =
+        request: AuthorizeRequest,
+    ): Task[AuthorizeResponse] =
       for
         client <- configurationService.find(request.clientId)
         authFlow = client.flatMap(_.authFlow)
@@ -76,11 +75,11 @@ object AuthorizeEndpointService:
       yield response
 
     private def createConversation(
-                                    request: AuthorizeRequest,
-                                    flow: AuthFlow,
-                                    uiLocales: Option[List[String]],
-                                    amr: Map[PassedAuthFactor, PassedFactorRecord],
-                                  ): Task[AuthorizeResponse] =
+        request: AuthorizeRequest,
+        flow: AuthFlow,
+        uiLocales: Option[List[String]],
+        amr: Map[PassedAuthFactor, PassedFactorRecord],
+    ): Task[AuthorizeResponse] =
       AuthId.wrapAll(secureRandom.nextUUIDv7).flatMap: authId =>
         val conversation = ConversationRecord(
           clientId = request.clientId,
@@ -105,7 +104,9 @@ object AuthorizeEndpointService:
           userLogin = None,
           userClaims = None,
           authFlow = flow,
-          userAgent = request.userAgent.map(_.filter(c => c >= ' ' && c <= '~')),  // Strip non-printable ASCII (0x20–0x7E); does not escape HTML — always escape at render time
+          userAgent = request.userAgent.map(_.filter(c =>
+            c >= ' ' && c <= '~',
+          )), // Strip non-printable ASCII (0x20–0x7E); does not escape HTML — always escape at render time
           version = 0,
           amr = amr,
         )
@@ -113,11 +114,11 @@ object AuthorizeEndpointService:
           .as(AuthorizeResponse.Initialize(authId))
 
     private def silentAuthorize(
-                                 request: AuthorizeRequest,
-                                 uiLocales: Option[List[String]],
-                                 session: SessionRecord,
-                                 sessionMac: MAC.Of[SessionId],
-                               ): Task[AuthorizeResponse] =
+        request: AuthorizeRequest,
+        uiLocales: Option[List[String]],
+        session: SessionRecord,
+        sessionMac: MAC.Of[SessionId],
+    ): Task[AuthorizeResponse] =
       val amr = AuthMethodRef.amrClaim(session.amr)
       val isHybrid =
         request.responseType.contains(ResponseTypeEntry.IdToken) &&
@@ -147,12 +148,12 @@ object AuthorizeEndpointService:
       yield AuthorizeResponse.Authorized(code, idToken)
 
     private def silentIdToken(
-                               request: AuthorizeRequest,
-                               session: SessionRecord,
-                               code: AuthorizationCode,
-                               amr: Set[AuthMethodRef],
-                               uiLocales: Option[List[String]],
-                             ): Task[Option[String]] =
+        request: AuthorizeRequest,
+        session: SessionRecord,
+        code: AuthorizationCode,
+        amr: Set[AuthMethodRef],
+        uiLocales: Option[List[String]],
+    ): Task[Option[String]] =
       for
         userOpt <- userRepository.find(session.userId)
         user <- ZIO

--- a/auth/src/main/scala/versola/oauth/conversation/ConversationRepository.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationRepository.scala
@@ -8,6 +8,6 @@ trait ConversationRepository:
 
   def create(authId: AuthId, record: ConversationRecord, ttl: Duration): Task[Unit]
 
-  def overwrite(authId: AuthId, conversation: ConversationRecord): Task[Unit]
+  def overwrite(authId: AuthId, record: ConversationRecord): Task[Boolean]
 
-  def delete(authId: AuthId): Task[Unit]
+  def delete(authId: AuthId, version: Long): Task[Boolean]

--- a/auth/src/main/scala/versola/oauth/conversation/ConversationRouter.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationRouter.scala
@@ -2,7 +2,7 @@ package versola.oauth.conversation
 
 import versola.oauth.client.OAuthConfigurationService
 import versola.oauth.client.model.{AuthFactor, AuthFactorType, PassedAuthFactor}
-import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep, ConcurrentModificationException}
+import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep}
 import versola.util.{Email, Phone, SecureRandom}
 import zio.{Task, ZIO, ZLayer}
 
@@ -41,8 +41,6 @@ object ConversationRouter:
                 case Some(settings) =>
                   conversationService.startPasskeyAssertion(authId, conversation, cred, settings)
                     .map(Some(_))
-                    .catchSome:
-                      case _: ConcurrentModificationException => ZIO.none
             case _: ConversationStep.Credential =>
               ZIO.none
             case _ =>

--- a/auth/src/main/scala/versola/oauth/conversation/ConversationRouter.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationRouter.scala
@@ -2,7 +2,7 @@ package versola.oauth.conversation
 
 import versola.oauth.client.OAuthConfigurationService
 import versola.oauth.client.model.{AuthFactor, AuthFactorType, PassedAuthFactor}
-import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep}
+import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep, ConcurrentModificationException}
 import versola.util.{Email, Phone, SecureRandom}
 import zio.{Task, ZIO, ZLayer}
 
@@ -32,14 +32,17 @@ object ConversationRouter:
     override def startPasskeyOptions(authId: AuthId): Task[Option[String]] =
       conversationService.find(authId).flatMap:
         case None => ZIO.none
-        case Some(record) =>
-          record.step match
-            case cred: ConversationStep.Credential if record.authFlow.passkey.isDefined =>
-              configService.getPasskeySettings(record.clientId).flatMap:
+        case Some(conversation) =>
+          conversation.step match
+            case cred: ConversationStep.Credential if conversation.authFlow.passkey.isDefined =>
+              configService.getPasskeySettings(conversation.clientId).flatMap:
                 case None =>
                   ZIO.fail(new Exception("Passkeys not configured for this tenant"))
                 case Some(settings) =>
-                  conversationService.startPasskeyAssertion(authId, record, cred, settings).map(Some(_))
+                  conversationService.startPasskeyAssertion(authId, conversation, cred, settings)
+                    .map(Some(_))
+                    .catchSome:
+                      case _: ConcurrentModificationException => ZIO.none
             case _: ConversationStep.Credential =>
               ZIO.none
             case _ =>
@@ -51,7 +54,7 @@ object ConversationRouter:
         uiLocale: Option[String],
     ): Task[ConversationResult.Render] =
       conversationService.find(authId)
-        .map(_.map(record => submission -> withUiLocale(record, uiLocale)))
+        .map(_.map(conversation => submission -> withUiLocale(conversation, uiLocale)))
         .flatMap:
           case None =>
             ZIO.succeed(ConversationResult.NotFound)
@@ -103,9 +106,9 @@ object ConversationRouter:
       * locales, so every subsequent render keeps it. Applied in-memory before dispatch — it is
       * persisted by the same overwrite the submission already performs.
       */
-    private def withUiLocale(record: ConversationRecord, uiLocale: Option[String]): ConversationRecord =
-      uiLocale.fold(record): locale =>
-        record.copy(uiLocales = Some(locale :: record.uiLocales.getOrElse(Nil).filterNot(_ == locale)))
+    private def withUiLocale(conversation: ConversationRecord, uiLocale: Option[String]): ConversationRecord =
+      uiLocale.fold(conversation): locale =>
+        conversation.copy(uiLocales = Some(locale :: conversation.uiLocales.getOrElse(Nil).filterNot(_ == locale)))
 
     /** A factor is already satisfied when some passed factor in `conversation.amr` matches it
       * directly or counts as an equivalent (e.g. a passed passkey satisfies an otp factor).
@@ -134,7 +137,6 @@ object ConversationRouter:
 
         case Some((AuthFactor(AuthFactorType.passkeyEnroll, _), _)) =>
           ZIO.succeed(ConversationResult.IllegalState)
-
         case None =>
           conversationService.finish(authId, conversation)
 
@@ -162,6 +164,5 @@ object ConversationRouter:
 
         case Some((AuthFactor(AuthFactorType.passkeyEnroll, _), _)) =>
           conversationService.offerPasskeyEnroll(authId, conversation)
-
         case None =>
           conversationService.finish(authId, conversation)

--- a/auth/src/main/scala/versola/oauth/conversation/ConversationService.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationService.scala
@@ -1,15 +1,15 @@
 package versola.oauth.conversation
 
+import versola.auth.model.CredentialDeviceType
 import versola.auth.model.{OtpCode, Password}
 import versola.oauth.authorize.model.ResponseTypeEntry
 import versola.oauth.challenge.passkey.{PasskeyRepository, WebAuthnError, WebAuthnService}
 import versola.oauth.challenge.password.PasswordService
 import versola.oauth.challenge.password.model.CheckPassword
 import versola.oauth.client.OAuthConfigurationService
-import versola.auth.model.CredentialDeviceType
 import versola.oauth.client.model.{AuthMethodRef, PassedAuthFactor, PassedFactorRecord, PasskeySettings, ScopeToken}
 import versola.oauth.conversation.limit.{ChallengeType, LimitStatus, SubmissionLimiter}
-import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep, ConcurrentModificationException}
+import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep}
 import versola.oauth.conversation.otp.OtpService
 import versola.oauth.conversation.otp.model.SubmitOtpResult
 import versola.oauth.model.{AuthorizationCode, AuthorizationCodeRecord}
@@ -232,7 +232,7 @@ object ConversationService:
             )
             conversationRepository.overwrite(authId, updatedConversation)
               .map:
-                case true  => ConversationResult.RenderStep(passwordStep)
+                case true => ConversationResult.RenderStep(passwordStep)
                 case false => ConversationResult.IllegalState
       yield result
 
@@ -264,7 +264,7 @@ object ConversationService:
                 val updated = conversation.copy(amr = conversation.amr + (PassedAuthFactor.otp -> PassedFactorRecord(now, otpMethods)))
                 conversationRepository.overwrite(authId, updated)
                   .map:
-                    case true  => ConversationResult.StepPassed(updated.copy(version = updated.version + 1))
+                    case true => ConversationResult.StepPassed(updated.copy(version = updated.version + 1))
                     case false => ConversationResult.IllegalState
 
     override def preparePasswordStep(
@@ -280,7 +280,7 @@ object ConversationService:
       )
       conversationRepository.overwrite(authId, conversation.copy(step = passwordStep))
         .map:
-          case true  => ConversationResult.RenderStep(passwordStep)
+          case true => ConversationResult.RenderStep(passwordStep)
           case false => ConversationResult.IllegalState
 
     override def checkPassword(
@@ -314,10 +314,11 @@ object ConversationService:
                 passwordService.verifyPassword(userId, submittedPassword).flatMap:
                   case CheckPassword.Success =>
                     Clock.instant.flatMap: now =>
-                      val updated = conversation.copy(amr = conversation.amr + (PassedAuthFactor.password -> PassedFactorRecord(now, Set(AuthMethodRef.pwd))))
+                      val updated =
+                        conversation.copy(amr = conversation.amr + (PassedAuthFactor.password -> PassedFactorRecord(now, Set(AuthMethodRef.pwd))))
                       conversationRepository.overwrite(authId, updated)
                         .map:
-                          case true  => ConversationResult.StepPassed(updated.copy(version = updated.version + 1))
+                          case true => ConversationResult.StepPassed(updated.copy(version = updated.version + 1))
                           case false => ConversationResult.IllegalState
 
                   case CheckPassword.OldPassword(changedAt) =>
@@ -405,9 +406,7 @@ object ConversationService:
             passkeyOrphaned = false,
           )
           conversationRepository.overwrite(authId, conversation.copy(step = updatedStep))
-            .flatMap:
-              case true  => ZIO.succeed(ceremony.publicKeyOptions)
-              case false => ZIO.fail(new ConcurrentModificationException),
+            .as(ceremony.publicKeyOptions),
       )
 
     override def finishPasskeyAssertion(authId: AuthId, conversation: ConversationRecord, response: String): Task[ConversationResult.Render] =
@@ -430,7 +429,7 @@ object ConversationService:
                     },
                     outcome =>
                       userRepository.find(outcome.userId).zipPar(
-                        passkeyRepository.findByCredentialIdAndUser(outcome.credentialId, outcome.userId)
+                        passkeyRepository.findByCredentialIdAndUser(outcome.credentialId, outcome.userId),
                       ).flatMap:
                         case (None, _) =>
                           ZIO.succeed(ConversationResult.IllegalState)
@@ -438,7 +437,7 @@ object ConversationService:
                           Clock.instant.flatMap: now =>
                             val keyType = passkeyOpt.fold(AuthMethodRef.swk)(pk =>
                               if pk.deviceType == CredentialDeviceType.SingleDevice then AuthMethodRef.hwk
-                              else AuthMethodRef.swk
+                              else AuthMethodRef.swk,
                             )
                             val passkeyMethods = Set(keyType, AuthMethodRef.user, AuthMethodRef.mfa)
                             val updated = conversation.copy(
@@ -450,7 +449,7 @@ object ConversationService:
                               amr = conversation.amr + (PassedAuthFactor.passkey -> PassedFactorRecord(now, passkeyMethods)),
                             )
                             conversationRepository.overwrite(authId, updated).flatMap:
-                              case true  => offerPasskeyEnroll(authId, updated.copy(version = updated.version + 1))
+                              case true => offerPasskeyEnroll(authId, updated.copy(version = updated.version + 1))
                               case false => ZIO.succeed(ConversationResult.IllegalState),
                   )
         case _ =>

--- a/auth/src/main/scala/versola/oauth/conversation/ConversationService.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationService.scala
@@ -9,7 +9,7 @@ import versola.oauth.client.OAuthConfigurationService
 import versola.auth.model.CredentialDeviceType
 import versola.oauth.client.model.{AuthMethodRef, PassedAuthFactor, PassedFactorRecord, PasskeySettings, ScopeToken}
 import versola.oauth.conversation.limit.{ChallengeType, LimitStatus, SubmissionLimiter}
-import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep}
+import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep, ConcurrentModificationException}
 import versola.oauth.conversation.otp.OtpService
 import versola.oauth.conversation.otp.model.SubmitOtpResult
 import versola.oauth.model.{AuthorizationCode, AuthorizationCodeRecord}
@@ -43,7 +43,7 @@ trait ConversationService:
   ): Task[ConversationResult.Render]
 
   def checkOtp(
-      record: ConversationRecord,
+      conversation: ConversationRecord,
       otp: ConversationStep.Otp,
       submittedCode: OtpCode,
       authId: AuthId,
@@ -56,7 +56,7 @@ trait ConversationService:
   ): Task[ConversationResult.Render]
 
   def checkPassword(
-      record: ConversationRecord,
+      conversation: ConversationRecord,
       passwordStep: ConversationStep.Password,
       submittedPassword: Password,
       authId: AuthId,
@@ -64,15 +64,15 @@ trait ConversationService:
 
   def finish(
       authId: AuthId,
-      record: ConversationRecord,
-  ): Task[ConversationResult.Complete]
+      conversation: ConversationRecord,
+  ): Task[ConversationResult.Render]
 
   /** Begin a discoverable assertion ceremony; stores the request state on the Credential step.
     * Returns the JSON public-key options to pass to `navigator.credentials.get()`.
     */
   def startPasskeyAssertion(
       authId: AuthId,
-      record: ConversationRecord,
+      conversation: ConversationRecord,
       step: ConversationStep.Credential,
       settings: PasskeySettings,
   ): Task[String]
@@ -81,25 +81,25 @@ trait ConversationService:
     * On success: updates the conversation with the resolved user and advances to enrollment-offer or finish.
     * On failure: clears the passkeyRequest and re-renders the Credential step.
     */
-  def finishPasskeyAssertion(authId: AuthId, record: ConversationRecord, response: String): Task[ConversationResult.Render]
+  def finishPasskeyAssertion(authId: AuthId, conversation: ConversationRecord, response: String): Task[ConversationResult.Render]
 
   /** After all primary auth factors pass: if the tenant has passkey settings and the user has no
     * passkey yet, starts a registration ceremony and renders the PasskeyEnroll step.
     * Otherwise, finishes immediately.
     */
-  def offerPasskeyEnroll(authId: AuthId, record: ConversationRecord): Task[ConversationResult.Render]
+  def offerPasskeyEnroll(authId: AuthId, conversation: ConversationRecord): Task[ConversationResult.Render]
 
   /** Finish a passkey enrollment ceremony and complete the conversation. */
   def finishPasskeyEnroll(
       authId: AuthId,
-      record: ConversationRecord,
+      conversation: ConversationRecord,
       enrollStep: ConversationStep.PasskeyEnroll,
       response: String,
       name: Option[String],
   ): Task[ConversationResult.Render]
 
   /** Skip passkey enrollment and complete the conversation. */
-  def skipPasskey(authId: AuthId, record: ConversationRecord): Task[ConversationResult.Render]
+  def skipPasskey(authId: AuthId, conversation: ConversationRecord): Task[ConversationResult.Render]
 
 object ConversationService:
   def live =
@@ -123,13 +123,15 @@ object ConversationService:
   ) extends ConversationService:
     export conversationRepository.find
 
-    private def accessDenied(authId: AuthId, record: ConversationRecord): Task[ConversationResult.Render] =
-      conversationRepository.overwrite(authId, record.copy(step = ConversationStep.AccessDenied))
+    private def accessDenied(authId: AuthId, conversation: ConversationRecord): Task[ConversationResult.Render] =
+      conversationRepository.overwrite(authId, conversation.copy(step = ConversationStep.AccessDenied))
         .as(ConversationResult.RenderStep(ConversationStep.AccessDenied))
 
-    private def renderStep(authId: AuthId, record: ConversationRecord, step: ConversationStep): Task[ConversationResult.Render] =
-      conversationRepository.overwrite(authId, record.copy(step = step))
-        .as(ConversationResult.RenderStep(step))
+    private def renderStep(authId: AuthId, conversation: ConversationRecord, step: ConversationStep): Task[ConversationResult.Render] =
+      conversationRepository.overwrite(authId, conversation.copy(step = step))
+        .map:
+          case true => ConversationResult.RenderStep(step)
+          case false => ConversationResult.IllegalState
 
     /** Records a failed attempt, then renders the step the failure produced — denying access on a
       * persistent ban, flagging the rate limit (with the seconds until input reopens) on a
@@ -144,14 +146,14 @@ object ConversationService:
 
     private def recordLimitAndRender(
         authId: AuthId,
-        record: ConversationRecord,
+        conversation: ConversationRecord,
         subject: String,
         challengeType: ChallengeType,
     )(step: Option[Long] => ConversationStep): Task[ConversationResult.Render] =
-      submissionLimiter.recordLimit(record.clientId, subject, challengeType).flatMap:
-        case LimitStatus.Banned => accessDenied(authId, record)
-        case LimitStatus.RateLimited(retryAfter) => renderStep(authId, record, step(Some(retryAfter)))
-        case LimitStatus.Allowed => renderStep(authId, record, step(None))
+      submissionLimiter.recordLimit(conversation.clientId, subject, challengeType).flatMap:
+        case LimitStatus.Banned => accessDenied(authId, conversation)
+        case LimitStatus.RateLimited(retryAfter) => renderStep(authId, conversation, step(Some(retryAfter)))
+        case LimitStatus.Allowed => renderStep(authId, conversation, step(None))
 
     override def prepareInitialOtp(
         authId: AuthId,
@@ -184,10 +186,15 @@ object ConversationService:
                 userLogin = userOpt.flatMap(_.login),
                 userClaims = userOpt.map(_.claims),
               )
-              _ <- conversationRepository.overwrite(authId, updatedConversation)
-              _ <- otpService.sendOtp(sentStep, credential, authId, conversation.clientId, conversation.uiLocales)
-              _ <- submissionLimiter.recordLimit(conversation.clientId, subject, ChallengeType.OtpRequest)
-            yield ConversationResult.RenderStep(sentStep)
+              written <- conversationRepository.overwrite(authId, updatedConversation)
+              result2 <- if written then
+                for
+                  _ <- otpService.sendOtp(sentStep, credential, authId, conversation.clientId, conversation.uiLocales)
+                  _ <- submissionLimiter.recordLimit(conversation.clientId, subject, ChallengeType.OtpRequest)
+                yield ConversationResult.RenderStep(sentStep): ConversationResult.Render
+              else
+                ZIO.succeed(ConversationResult.IllegalState)
+            yield result2
       yield result
 
     override def prepareInitialPassword(
@@ -224,25 +231,27 @@ object ConversationService:
               userClaims = userOpt.map(_.claims),
             )
             conversationRepository.overwrite(authId, updatedConversation)
-              .as(ConversationResult.RenderStep(passwordStep))
+              .map:
+                case true  => ConversationResult.RenderStep(passwordStep)
+                case false => ConversationResult.IllegalState
       yield result
 
     override def checkOtp(
-        record: ConversationRecord,
+        conversation: ConversationRecord,
         otp: ConversationStep.Otp,
         submittedCode: OtpCode,
         authId: AuthId,
     ): Task[ConversationResult] =
-      val subject = record.credential.map(_.merge).getOrElse("")
-      submissionLimiter.isBanned(record.clientId, subject, ChallengeType.OtpSubmit).flatMap:
+      val subject = conversation.credential.map(_.merge).getOrElse("")
+      submissionLimiter.isBanned(conversation.clientId, subject, ChallengeType.OtpSubmit).flatMap:
         case LimitStatus.Banned =>
-          accessDenied(authId, record)
+          accessDenied(authId, conversation)
         case LimitStatus.RateLimited(retryAfter) =>
-          renderStep(authId, record, otp.copy(rateLimitExceeded = true, lockedSeconds = retryAfter.toInt))
+          renderStep(authId, conversation, otp.copy(rateLimitExceeded = true, lockedSeconds = retryAfter.toInt))
         case LimitStatus.Allowed =>
           otpService.checkOtp(otp, submittedCode).flatMap:
             case SubmitOtpResult.Failure =>
-              recordLimitAndRender(authId, record, subject, ChallengeType.OtpSubmit): retryAfter =>
+              recordLimitAndRender(authId, conversation, subject, ChallengeType.OtpSubmit): retryAfter =>
                 otp.copy(
                   timesSubmitted = otp.timesSubmitted + 1,
                   rateLimitExceeded = retryAfter.isDefined,
@@ -251,10 +260,12 @@ object ConversationService:
 
             case SubmitOtpResult.Success =>
               Clock.instant.flatMap: now =>
-                val otpMethods = Set(AuthMethodRef.otp) ++ record.credential.collect { case Right(_) => AuthMethodRef.sms }
-                val updated = record.copy(amr = record.amr + (PassedAuthFactor.otp -> PassedFactorRecord(now, otpMethods)))
+                val otpMethods = Set(AuthMethodRef.otp) ++ conversation.credential.collect { case Right(_) => AuthMethodRef.sms }
+                val updated = conversation.copy(amr = conversation.amr + (PassedAuthFactor.otp -> PassedFactorRecord(now, otpMethods)))
                 conversationRepository.overwrite(authId, updated)
-                  .as(ConversationResult.StepPassed(updated))
+                  .map:
+                    case true  => ConversationResult.StepPassed(updated.copy(version = updated.version + 1))
+                    case false => ConversationResult.IllegalState
 
     override def preparePasswordStep(
         authId: AuthId,
@@ -268,46 +279,50 @@ object ConversationService:
         rateLimitExceeded = false,
       )
       conversationRepository.overwrite(authId, conversation.copy(step = passwordStep))
-        .as(ConversationResult.RenderStep(passwordStep))
+        .map:
+          case true  => ConversationResult.RenderStep(passwordStep)
+          case false => ConversationResult.IllegalState
 
     override def checkPassword(
-        record: ConversationRecord,
+        conversation: ConversationRecord,
         passwordStep: ConversationStep.Password,
         submittedPassword: Password,
         authId: AuthId,
     ): Task[ConversationResult] =
-      record.userId match
+      conversation.userId match
         case None =>
           ZIO.succeed(ConversationResult.IllegalState)
 
         case Some(userId) =>
           val userSubject = userId.toString
-          val credSubjectOpt = record.credential.map(_.merge)
+          val credSubjectOpt = conversation.credential.map(_.merge)
           val checkCredBan = credSubjectOpt.fold(ZIO.succeed(LimitStatus.Allowed))(s =>
-            submissionLimiter.isBanned(record.clientId, s, ChallengeType.PasswordSubmit),
+            submissionLimiter.isBanned(conversation.clientId, s, ChallengeType.PasswordSubmit),
           )
           val recordCredFailure = credSubjectOpt.fold(ZIO.unit)(s =>
-            submissionLimiter.recordLimit(record.clientId, s, ChallengeType.PasswordSubmit).unit,
+            submissionLimiter.recordLimit(conversation.clientId, s, ChallengeType.PasswordSubmit).unit,
           )
           for
-            userBan <- submissionLimiter.isBanned(record.clientId, userSubject, ChallengeType.PasswordSubmit)
+            userBan <- submissionLimiter.isBanned(conversation.clientId, userSubject, ChallengeType.PasswordSubmit)
             credBan <- checkCredBan
             result <- worstStatus(userBan, credBan) match
               case LimitStatus.Banned =>
-                accessDenied(authId, record)
+                accessDenied(authId, conversation)
               case LimitStatus.RateLimited(_) =>
-                renderStep(authId, record, passwordStep.copy(rateLimitExceeded = true))
+                renderStep(authId, conversation, passwordStep.copy(rateLimitExceeded = true))
               case LimitStatus.Allowed =>
                 passwordService.verifyPassword(userId, submittedPassword).flatMap:
                   case CheckPassword.Success =>
                     Clock.instant.flatMap: now =>
-                      val updated = record.copy(amr = record.amr + (PassedAuthFactor.password -> PassedFactorRecord(now, Set(AuthMethodRef.pwd))))
+                      val updated = conversation.copy(amr = conversation.amr + (PassedAuthFactor.password -> PassedFactorRecord(now, Set(AuthMethodRef.pwd))))
                       conversationRepository.overwrite(authId, updated)
-                        .as(ConversationResult.StepPassed(updated))
+                        .map:
+                          case true  => ConversationResult.StepPassed(updated.copy(version = updated.version + 1))
+                          case false => ConversationResult.IllegalState
 
                   case CheckPassword.OldPassword(changedAt) =>
                     recordCredFailure *>
-                      recordLimitAndRender(authId, record, userSubject, ChallengeType.PasswordSubmit): retryAfter =>
+                      recordLimitAndRender(authId, conversation, userSubject, ChallengeType.PasswordSubmit): retryAfter =>
                         passwordStep.copy(
                           timesSubmitted = passwordStep.timesSubmitted + 1,
                           oldPasswordChangedAt = Some(changedAt),
@@ -316,14 +331,14 @@ object ConversationService:
 
                   case CheckPassword.Failure =>
                     recordCredFailure *>
-                      recordLimitAndRender(authId, record, userSubject, ChallengeType.PasswordSubmit): retryAfter =>
+                      recordLimitAndRender(authId, conversation, userSubject, ChallengeType.PasswordSubmit): retryAfter =>
                         passwordStep.copy(
                           timesSubmitted = passwordStep.timesSubmitted + 1,
                           rateLimitExceeded = retryAfter.isDefined,
                         )
           yield result
 
-    override def finish(authId: AuthId, conversation: ConversationRecord): Task[ConversationResult.Complete] =
+    override def finish(authId: AuthId, conversation: ConversationRecord): Task[ConversationResult.Render] =
       for
         code <- authPropertyGenerator.nextAuthorizationCode
         userId = conversation.userId.get // TODO handle illegal state
@@ -355,26 +370,29 @@ object ConversationService:
           amr = conversation.amr,
         )
         codeMac <- securityService.mac(Secret(code), config.security.authCodes.pepper)
-
-        _ <- authorizationCodeRepository.create(codeMac, record, 1.minute)
-        _ <- sessionRepository.create(sessionIdMac, session, 1.day)
-        _ <- conversationRepository.delete(authId)
-
-        idTokenData <- if conversation.responseType.contains(ResponseTypeEntry.IdToken) && conversation.scope.contains(ScopeToken.OpenId) then
-          generateIdTokenData(userId, conversation, amr, now)
+        claimed <- conversationRepository.delete(authId, conversation.version)
+        result <- if claimed then
+          for
+            _ <- authorizationCodeRepository.create(codeMac, record, 1.minute)
+            _ <- sessionRepository.create(sessionIdMac, session, 1.day)
+            idTokenData <- if conversation.responseType.contains(ResponseTypeEntry.IdToken) && conversation.scope.contains(ScopeToken.OpenId) then
+              generateIdTokenData(userId, conversation, amr, now)
+            else
+              ZIO.none
+          yield ConversationResult.Complete(
+            redirectUri = conversation.redirectUri,
+            state = conversation.state,
+            code = code,
+            sessionId = sessionId,
+            idTokenData = idTokenData,
+          )
         else
-          ZIO.none
-      yield ConversationResult.Complete(
-        redirectUri = conversation.redirectUri,
-        state = conversation.state,
-        code = code,
-        sessionId = sessionId,
-        idTokenData = idTokenData,
-      )
+          ZIO.succeed(ConversationResult.IllegalState)
+      yield result
 
     override def startPasskeyAssertion(
         authId: AuthId,
-        record: ConversationRecord,
+        conversation: ConversationRecord,
         step: ConversationStep.Credential,
         settings: PasskeySettings,
     ): Task[String] =
@@ -386,27 +404,29 @@ object ConversationService:
             passkeyFailed = false,
             passkeyOrphaned = false,
           )
-          conversationRepository.overwrite(authId, record.copy(step = updatedStep))
-            .as(ceremony.publicKeyOptions),
+          conversationRepository.overwrite(authId, conversation.copy(step = updatedStep))
+            .flatMap:
+              case true  => ZIO.succeed(ceremony.publicKeyOptions)
+              case false => ZIO.fail(new ConcurrentModificationException),
       )
 
-    override def finishPasskeyAssertion(authId: AuthId, record: ConversationRecord, response: String): Task[ConversationResult.Render] =
-      record.step match
-        case cred: ConversationStep.Credential if record.authFlow.passkey.isDefined =>
+    override def finishPasskeyAssertion(authId: AuthId, conversation: ConversationRecord, response: String): Task[ConversationResult.Render] =
+      conversation.step match
+        case cred: ConversationStep.Credential if conversation.authFlow.passkey.isDefined =>
           cred.passkeyRequest match
             case None =>
               ZIO.succeed(ConversationResult.IllegalState)
             case Some(request) =>
-              configService.getPasskeySettings(record.clientId).flatMap:
+              configService.getPasskeySettings(conversation.clientId).flatMap:
                 case None =>
                   ZIO.succeed(ConversationResult.IllegalState)
                 case Some(settings) =>
                   webAuthnService.finishAssertion(settings, request, response).foldZIO(
                     {
                       case WebAuthnError.CredentialNotFound =>
-                        renderStep(authId, record, cred.copy(passkeyRequest = None, passkeyOrphaned = true))
+                        renderStep(authId, conversation, cred.copy(passkeyRequest = None, passkeyOrphaned = true))
                       case _ =>
-                        renderStep(authId, record, cred.copy(passkeyRequest = None, passkeyFailed = true))
+                        renderStep(authId, conversation, cred.copy(passkeyRequest = None, passkeyFailed = true))
                     },
                     outcome =>
                       userRepository.find(outcome.userId).zipPar(
@@ -421,71 +441,72 @@ object ConversationService:
                               else AuthMethodRef.swk
                             )
                             val passkeyMethods = Set(keyType, AuthMethodRef.user, AuthMethodRef.mfa)
-                            val updated = record.copy(
+                            val updated = conversation.copy(
                               userId = Some(outcome.userId),
                               userEmail = user.email,
                               userPhone = user.phone,
                               userLogin = user.login,
                               userClaims = Some(user.claims),
-                              amr = record.amr + (PassedAuthFactor.passkey -> PassedFactorRecord(now, passkeyMethods)),
+                              amr = conversation.amr + (PassedAuthFactor.passkey -> PassedFactorRecord(now, passkeyMethods)),
                             )
-                            conversationRepository.overwrite(authId, updated) *>
-                              offerPasskeyEnroll(authId, updated),
+                            conversationRepository.overwrite(authId, updated).flatMap:
+                              case true  => offerPasskeyEnroll(authId, updated.copy(version = updated.version + 1))
+                              case false => ZIO.succeed(ConversationResult.IllegalState),
                   )
         case _ =>
           ZIO.succeed(ConversationResult.IllegalState)
 
-    override def offerPasskeyEnroll(authId: AuthId, record: ConversationRecord): Task[ConversationResult.Render] =
-      record.userId match
+    override def offerPasskeyEnroll(authId: AuthId, conversation: ConversationRecord): Task[ConversationResult.Render] =
+      conversation.userId match
         case None =>
           ZIO.succeed(ConversationResult.IllegalState)
         case Some(userId) =>
-          configService.getPasskeySettings(record.clientId).flatMap:
+          configService.getPasskeySettings(conversation.clientId).flatMap:
             case None =>
-              finish(authId, record)
+              finish(authId, conversation)
             case Some(settings) =>
               passkeyRepository.listByUser(userId).flatMap: existing =>
-                if existing.nonEmpty then finish(authId, record)
+                if existing.nonEmpty then finish(authId, conversation)
                 else
                   val displayName: String =
-                    record.userClaims.flatMap(_.fields.toMap.get("name"))
+                    conversation.userClaims.flatMap(_.fields.toMap.get("name"))
                       .collect { case zio.json.ast.Json.Str(v) => v }
-                      .orElse(record.userEmail.map(_.toString))
-                      .orElse(record.userPhone.map(_.toString))
-                      .orElse(record.userLogin.map(_.toString))
+                      .orElse(conversation.userEmail.map(_.toString))
+                      .orElse(conversation.userPhone.map(_.toString))
+                      .orElse(conversation.userLogin.map(_.toString))
                       .getOrElse(userId.toString)
                   webAuthnService.startRegistration(settings, userId, displayName).foldZIO(
-                    _ => finish(authId, record),
+                    _ => finish(authId, conversation),
                     ceremony =>
                       val enrollStep = ConversationStep.PasskeyEnroll(
                         request = ceremony.request,
                         publicKeyOptions = ceremony.publicKeyOptions,
                       )
-                      renderStep(authId, record, enrollStep),
+                      renderStep(authId, conversation, enrollStep),
                   )
 
     override def finishPasskeyEnroll(
         authId: AuthId,
-        record: ConversationRecord,
+        conversation: ConversationRecord,
         enrollStep: ConversationStep.PasskeyEnroll,
         response: String,
         name: Option[String],
     ): Task[ConversationResult.Render] =
-      record.userId match
+      conversation.userId match
         case None =>
           ZIO.succeed(ConversationResult.IllegalState)
         case Some(userId) =>
-          configService.getPasskeySettings(record.clientId).flatMap:
+          configService.getPasskeySettings(conversation.clientId).flatMap:
             case None =>
-              finish(authId, record)
+              finish(authId, conversation)
             case Some(settings) =>
               webAuthnService.finishRegistration(settings, userId, enrollStep.request, response, name).foldZIO(
-                error => renderStep(authId, record, enrollStep.copy(enrollFailed = true)),
-                _ => finish(authId, record),
+                error => renderStep(authId, conversation, enrollStep.copy(enrollFailed = true)),
+                _ => finish(authId, conversation),
               )
 
-    override def skipPasskey(authId: AuthId, record: ConversationRecord): Task[ConversationResult.Render] =
-      finish(authId, record)
+    override def skipPasskey(authId: AuthId, conversation: ConversationRecord): Task[ConversationResult.Render] =
+      finish(authId, conversation)
 
     private def generateIdTokenData(
         userId: UserId,

--- a/auth/src/main/scala/versola/oauth/conversation/model/ConversationRecord.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/model/ConversationRecord.scala
@@ -32,6 +32,7 @@ case class ConversationRecord(
     userClaims: Option[Json.Obj],
     authFlow: AuthFlow,
     userAgent: Option[String],
+    version: Long,
     amr: Map[PassedAuthFactor, PassedFactorRecord],
 ):
   def patch(patch: ConversationRecord.Patch): ConversationRecord =

--- a/auth/src/main/scala/versola/oauth/conversation/model/Error.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/model/Error.scala
@@ -4,3 +4,6 @@ private[conversation] sealed trait Error
 
 private[conversation] object Error:
   case object BadRequest extends Error
+
+private[conversation] class ConcurrentModificationException
+  extends Exception("Conversation was modified concurrently")

--- a/auth/src/main/scala/versola/oauth/conversation/model/Error.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/model/Error.scala
@@ -4,6 +4,3 @@ private[conversation] sealed trait Error
 
 private[conversation] object Error:
   case object BadRequest extends Error
-
-private[conversation] class ConcurrentModificationException
-  extends Exception("Conversation was modified concurrently")

--- a/auth/src/test/scala/versola/oauth/conversation/ConversationControllerSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/ConversationControllerSpec.scala
@@ -60,6 +60,7 @@ object ConversationControllerSpec extends UnitSpecBase:
     userClaims = None,
     authFlow = AuthFlow.default,
     userAgent = None,
+    version = 0,
     amr = Map.empty,
   )
 

--- a/auth/src/test/scala/versola/oauth/conversation/ConversationRepositorySpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/ConversationRepositorySpec.scala
@@ -66,6 +66,7 @@ trait ConversationRepositorySpec extends DatabaseSpecBase[ConversationRepository
     userClaims = Some(zio.json.ast.Json.Obj()),
     authFlow = AuthFlow.default,
     userAgent = None,
+    version = 0,
     amr = Map.empty,
   )
 
@@ -96,6 +97,7 @@ trait ConversationRepositorySpec extends DatabaseSpecBase[ConversationRepository
     userClaims = None,
     authFlow = AuthFlow.default,
     userAgent = None,
+    version = 0,
     amr = Map.empty,
   )
 
@@ -117,9 +119,10 @@ trait ConversationRepositorySpec extends DatabaseSpecBase[ConversationRepository
       test("delete conversation by auth ID") {
         for
           _ <- env.repository.create(authId1, record1, ttl)
-          _ <- env.repository.delete(authId1)
+          record <- env.repository.find(authId1).map(_.get)
+          deleted <- env.repository.delete(authId1, record.version)
           found <- env.repository.find(authId1)
-        yield assertTrue(found.isEmpty)
+        yield assertTrue(deleted, found.isEmpty)
       },
       test("overwrite conversation record") {
         val updatedRecord = initial.copy(
@@ -130,12 +133,29 @@ trait ConversationRepositorySpec extends DatabaseSpecBase[ConversationRepository
         for
           _ <- env.repository.create(authId1, initial, ttl)
           found1 <- env.repository.find(authId1)
-          _ <- env.repository.overwrite(authId1, updatedRecord)
+          overwritten <- env.repository.overwrite(authId1, updatedRecord.copy(version = found1.get.version))
           found2 <- env.repository.find(authId1)
         yield assertTrue(
           found1.contains(initial),
-          found2.contains(updatedRecord),
+          overwritten,
+          found2.contains(updatedRecord.copy(version = found1.get.version + 1)),
         )
+      },
+      test("overwrite with stale version returns false (optimistic conflict)") {
+        for
+          _ <- env.repository.create(authId1, record1, ttl)
+          record <- env.repository.find(authId1).map(_.get)
+          first <- env.repository.overwrite(authId1, record1.copy(step = fakeOtp, version = record.version))
+          second <- env.repository.overwrite(authId1, record1.copy(step = fakeOtp, version = record.version))
+        yield assertTrue(first, !second)
+      },
+      test("delete with stale version returns false (optimistic conflict)") {
+        for
+          _ <- env.repository.create(authId1, record1, ttl)
+          record <- env.repository.find(authId1).map(_.get)
+          first <- env.repository.delete(authId1, record.version)
+          second <- env.repository.delete(authId1, record.version)
+        yield assertTrue(first, !second)
       },
     )
 

--- a/auth/src/test/scala/versola/oauth/conversation/ConversationRouterSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/ConversationRouterSpec.scala
@@ -68,9 +68,9 @@ object ConversationRouterSpec extends UnitSpecBase:
     userClaims = None,
     authFlow = otpAuthFlow,
     userAgent = None,
+    version = 0,
     amr = Map.empty,
   )
-
 
   val otpRecord = ConversationRecord(
     clientId = clientId,
@@ -92,6 +92,7 @@ object ConversationRouterSpec extends UnitSpecBase:
     userClaims = None,
     authFlow = otpAuthFlow,
     userAgent = None,
+    version = 0,
     amr = Map.empty,
   )
 

--- a/auth/src/test/scala/versola/oauth/conversation/OtpConversationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/OtpConversationServiceSpec.scala
@@ -6,6 +6,8 @@ import versola.auth.model.OtpCode
 import versola.oauth.challenge.password.PasswordService
 import versola.oauth.client.OAuthConfigurationService
 import versola.oauth.client.model.{AuthFlow, AuthMethodRef, ClientId, PassedAuthFactor, PassedFactorRecord, PrimaryCredential, ScopeToken}
+import versola.oauth.client.model.{AuthFlow, ClientId, PrimaryCredential, ScopeToken}
+import versola.oauth.conversation.limit.{ChallengeType, LimitStatus, SubmissionLimiter}
 import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep}
 import versola.oauth.conversation.otp.OtpService
 import versola.oauth.conversation.otp.model.SubmitOtpResult
@@ -16,7 +18,6 @@ import versola.oauth.userinfo.UserInfoService
 import versola.oauth.userinfo.model.UserInfoResponse
 import versola.user.UserRepository
 import versola.user.model.{UserId, UserRecord}
-import versola.oauth.conversation.limit.{ChallengeType, LimitStatus, SubmissionLimiter}
 import versola.util.{AuthPropertyGenerator, CoreConfig, Email, EnvName, Secret, SecureRandom, SecurityService, UnitSpecBase}
 import zio.ZIO
 import zio.http.URL
@@ -101,6 +102,7 @@ object OtpConversationServiceSpec extends UnitSpecBase:
     userClaims = None,
     authFlow = AuthFlow.default,
     userAgent = None,
+    version = 0,
     amr = Map.empty,
   )
 
@@ -111,7 +113,6 @@ object OtpConversationServiceSpec extends UnitSpecBase:
   )
   val submittedOtp = realOtp.copy(timesRequested = 1)
 
-
   val spec = suite("OtpConversationService")(
     suite("prepareInitialOtp")(
       test("create conversation record and send OTP") {
@@ -121,15 +122,15 @@ object OtpConversationServiceSpec extends UnitSpecBase:
           _ <- env.submissionLimiter.recordLimit.succeedsWith(LimitStatus.Allowed)
           _ <- env.userRepository.findByCredential.succeedsWith(Some(UserRecord.empty(userId)))
           _ <- env.otpService.prepareOtp.succeedsWith(realOtp)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           _ <- env.otpService.sendOtp.succeedsWith(())
           result <- env.service.prepareInitialOtp(authId, initialConversation, Left(email), factorIndex = 0)
           resultSentAt = result match
             case ConversationResult.RenderStep(otp: ConversationStep.Otp) => otp.lastSentAt
-            case _                                                        => None
+            case _ => None
           persistedSentAt = env.conversationRepository.overwrite.calls.last._2.step match
             case otp: ConversationStep.Otp => otp.lastSentAt
-            case _                         => None
+            case _ => None
         yield assertTrue(
           resultSentAt.isDefined,
           persistedSentAt.isDefined,
@@ -155,7 +156,7 @@ object OtpConversationServiceSpec extends UnitSpecBase:
           _ <- env.submissionLimiter.recordLimit.succeedsWith(LimitStatus.Allowed)
           _ <- env.userRepository.findByCredential.succeedsWith(Some(user))
           _ <- env.otpService.prepareOtp.succeedsWith(realOtp)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           _ <- env.otpService.sendOtp.succeedsWith(())
           result <- env.service.prepareInitialOtp(authId, initialConversation, Left(email), factorIndex = 0)
           overwriteCalls = env.conversationRepository.overwrite.calls
@@ -175,7 +176,7 @@ object OtpConversationServiceSpec extends UnitSpecBase:
           _ <- env.submissionLimiter.recordLimit.succeedsWith(LimitStatus.Allowed)
           _ <- env.userRepository.findByCredential.succeedsWith(None)
           _ <- env.otpService.prepareOtp.succeedsWith(realOtp)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           _ <- env.otpService.sendOtp.succeedsWith(())
           result <- env.service.prepareInitialOtp(authId, initialConversation, Left(email), factorIndex = 0)
           overwriteCalls = env.conversationRepository.overwrite.calls
@@ -192,7 +193,7 @@ object OtpConversationServiceSpec extends UnitSpecBase:
         val env = Env()
         for
           _ <- env.submissionLimiter.statusFor.succeedsWith(LimitStatus.Banned)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.prepareInitialOtp(authId, initialConversation, Left(email), factorIndex = 0)
         yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
       },
@@ -200,7 +201,7 @@ object OtpConversationServiceSpec extends UnitSpecBase:
         val env = Env()
         for
           _ <- env.submissionLimiter.statusFor.succeedsWith(LimitStatus.RateLimited(30L))
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.prepareInitialOtp(authId, initialConversation, Left(email), factorIndex = 0)
         yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
       },
@@ -210,11 +211,20 @@ object OtpConversationServiceSpec extends UnitSpecBase:
           _ <- env.submissionLimiter.statusFor.returnsZIO:
             case (_, _, types) if types.contains(ChallengeType.OtpSubmit) => ZIO.succeed(LimitStatus.Banned)
             case _ => ZIO.succeed(LimitStatus.Allowed)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.prepareInitialOtp(authId, initialConversation, Left(email), factorIndex = 0)
         yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
       },
-
+      test("return IllegalState when overwrite fails due to optimistic concurrency conflict") {
+        val env = Env()
+        for
+          _ <- env.submissionLimiter.statusFor.succeedsWith(LimitStatus.Allowed)
+          _ <- env.userRepository.findByCredential.succeedsWith(None)
+          _ <- env.otpService.prepareOtp.succeedsWith(realOtp)
+          _ <- env.conversationRepository.overwrite.succeedsWith(false)
+          result <- env.service.prepareInitialOtp(authId, initialConversation, Left(email), factorIndex = 0)
+        yield assertTrue(result == ConversationResult.IllegalState)
+      },
     ),
     suite("checkOtp")(
       test("return StepPassed when OTP is correct") {
@@ -240,12 +250,13 @@ object OtpConversationServiceSpec extends UnitSpecBase:
           userClaims = Some(zio.json.ast.Json.Obj()),
           authFlow = AuthFlow.default,
           userAgent = None,
+          version = 0,
           amr = Map.empty,
         )
         for
           _ <- env.submissionLimiter.isBanned.succeedsWith(LimitStatus.Allowed)
           _ <- env.otpService.checkOtp.succeedsWith(SubmitOtpResult.Success)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.checkOtp(record, otp, otpCode, authId)
         yield assertTrue(result.isInstanceOf[ConversationResult.StepPassed])
       },
@@ -272,11 +283,12 @@ object OtpConversationServiceSpec extends UnitSpecBase:
           userClaims = Some(zio.json.ast.Json.Obj()),
           authFlow = AuthFlow.default,
           userAgent = None,
+          version = 0,
           amr = Map.empty,
         )
         for
           _ <- env.submissionLimiter.isBanned.succeedsWith(LimitStatus.Banned)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.checkOtp(record, otp, otpCode, authId)
         yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
       },
@@ -284,7 +296,7 @@ object OtpConversationServiceSpec extends UnitSpecBase:
         val env = Env()
         for
           _ <- env.submissionLimiter.isBanned.succeedsWith(LimitStatus.RateLimited(30L))
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.checkOtp(otpRecord, submittedOtp, otpCode, authId)
         yield assertTrue(result == ConversationResult.RenderStep(submittedOtp.copy(rateLimitExceeded = true, lockedSeconds = 30)))
       },
@@ -294,7 +306,7 @@ object OtpConversationServiceSpec extends UnitSpecBase:
           _ <- env.submissionLimiter.isBanned.succeedsWith(LimitStatus.Allowed)
           _ <- env.otpService.checkOtp.succeedsWith(SubmitOtpResult.Failure)
           _ <- env.submissionLimiter.recordLimit.succeedsWith(LimitStatus.Allowed)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.checkOtp(otpRecord, submittedOtp, otpCode, authId)
         yield assertTrue(
           result == ConversationResult.RenderStep(
@@ -308,7 +320,7 @@ object OtpConversationServiceSpec extends UnitSpecBase:
           _ <- env.submissionLimiter.isBanned.succeedsWith(LimitStatus.Allowed)
           _ <- env.otpService.checkOtp.succeedsWith(SubmitOtpResult.Failure)
           _ <- env.submissionLimiter.recordLimit.succeedsWith(LimitStatus.RateLimited(30L))
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.checkOtp(otpRecord, submittedOtp, otpCode, authId)
         yield assertTrue(
           result == ConversationResult.RenderStep(
@@ -322,11 +334,10 @@ object OtpConversationServiceSpec extends UnitSpecBase:
           _ <- env.submissionLimiter.isBanned.succeedsWith(LimitStatus.Allowed)
           _ <- env.otpService.checkOtp.succeedsWith(SubmitOtpResult.Failure)
           _ <- env.submissionLimiter.recordLimit.succeedsWith(LimitStatus.Banned)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.checkOtp(otpRecord, submittedOtp, otpCode, authId)
         yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
       },
-
     ),
     suite("finish")(
       test("generate ID token when openid scope is present and response_type includes id_token") {
@@ -361,21 +372,26 @@ object OtpConversationServiceSpec extends UnitSpecBase:
             case 2 => ZIO.succeed(testCodeMac)
           _ <- env.authorizationCodeRepository.create.succeedsWith(())
           _ <- env.sessionRepository.create.succeedsWith(())
-          _ <- env.conversationRepository.delete.succeedsWith(())
+          _ <- env.conversationRepository.delete.succeedsWith(true)
           _ <- env.userInfoService.getUserInfoForIdToken.succeedsWith(
             UserInfoResponse(
               claims = Map("sub" -> ast.Json.Str(userId.toString), "email" -> ast.Json.Str(userEmail)),
             )
           )
           result <- env.service.finish(authId, conversation)
-        yield assertTrue(
-          result.idTokenData.isDefined,
-          result.idTokenData.get.claims.contains("sub"),
-          result.idTokenData.get.claims.contains("email"),
-          result.idTokenData.get.claims.contains("amr"),
-          result.idTokenData.get.claims.contains("auth_time"),
-          result.idTokenData.get.clientId == clientId,
-        )
+        yield result match
+          case complete: ConversationResult.Complete =>
+            assertTrue(
+              complete.idTokenData.isDefined,
+              complete.idTokenData.get.claims.contains("sub"),
+              complete.idTokenData.get.claims.contains("email"),
+              complete.idTokenData.get.claims.contains("amr"),
+              complete.idTokenData.get.claims.contains("auth_time"),
+              complete.idTokenData.get.clientId == clientId,
+            )
+
+          case _ =>
+            assertTrue(false)
       },
       test("not generate ID token when openid scope is missing") {
         val env = Env()
@@ -402,9 +418,11 @@ object OtpConversationServiceSpec extends UnitSpecBase:
             case 2 => ZIO.succeed(testCodeMac)
           _ <- env.authorizationCodeRepository.create.succeedsWith(())
           _ <- env.sessionRepository.create.succeedsWith(())
-          _ <- env.conversationRepository.delete.succeedsWith(())
+          _ <- env.conversationRepository.delete.succeedsWith(true)
           result <- env.service.finish(authId, conversation)
-        yield assertTrue(result.idTokenData.isEmpty)
+        yield result match
+          case complete: ConversationResult.Complete => assertTrue(complete.idTokenData.isEmpty)
+          case _ => assertTrue(false)
       },
       test("not generate ID token when response_type does not include id_token") {
         val env = Env()
@@ -428,9 +446,11 @@ object OtpConversationServiceSpec extends UnitSpecBase:
             case 2 => ZIO.succeed(testCodeMac)
           _ <- env.authorizationCodeRepository.create.succeedsWith(())
           _ <- env.sessionRepository.create.succeedsWith(())
-          _ <- env.conversationRepository.delete.succeedsWith(())
+          _ <- env.conversationRepository.delete.succeedsWith(true)
           result <- env.service.finish(authId, conversation)
-        yield assertTrue(result.idTokenData.isEmpty)
+        yield result match
+          case complete: ConversationResult.Complete => assertTrue(complete.idTokenData.isEmpty)
+          case _ => assertTrue(false)
       },
     ),
   )

--- a/auth/src/test/scala/versola/oauth/conversation/PasskeyConversationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/PasskeyConversationServiceSpec.scala
@@ -102,6 +102,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
     userClaims = None,
     authFlow = passkeyAuthFlow,
     userAgent = None,
+    version = 0,
     amr = Map.empty,
   )
 
@@ -112,7 +113,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
         val ceremony = PasskeyCeremony("req-state", "{}")
         for
           _ <- env.webAuthnService.startAssertion.succeedsWith(ceremony)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.startPasskeyAssertion(authId, baseRecord, credentialStep, passkeySettings)
         yield assertTrue(
           result == "{}",
@@ -133,7 +134,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.passkeyRepository.findByCredentialIdAndUser.succeedsWith(None)
           _ <- env.passkeyRepository.listByUser.succeedsWith(Vector.empty)
           _ <- env.webAuthnService.startRegistration.succeedsWith(PasskeyCeremony("reg-req", "{}"))
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.finishPasskeyAssertion(authId, recordWithRequest, "response-json")
         yield assertTrue(
           result == ConversationResult.RenderStep(ConversationStep.PasskeyEnroll("reg-req", "{}"))
@@ -145,7 +146,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
         for
           _ <- env.configService.getPasskeySettings.succeedsWith(Some(passkeySettings))
           _ <- env.webAuthnService.finishAssertion.failsWith(versola.oauth.challenge.passkey.WebAuthnError.CeremonyFailed("fail"))
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.finishPasskeyAssertion(authId, recordWithRequest, "response-json")
         yield assertTrue(
           result == ConversationResult.RenderStep(credentialStep.copy(passkeyRequest = None, passkeyFailed = true))
@@ -157,7 +158,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
         for
           _ <- env.configService.getPasskeySettings.succeedsWith(Some(passkeySettings))
           _ <- env.webAuthnService.finishAssertion.failsWith(versola.oauth.challenge.passkey.WebAuthnError.CredentialNotFound)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.finishPasskeyAssertion(authId, recordWithRequest, "response-json")
         yield assertTrue(
           result == ConversationResult.RenderStep(credentialStep.copy(passkeyRequest = None, passkeyOrphaned = true))
@@ -182,7 +183,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.configService.getPasskeySettings.succeedsWith(Some(passkeySettings))
           _ <- env.passkeyRepository.listByUser.succeedsWith(Vector.empty)
           _ <- env.webAuthnService.startRegistration.succeedsWith(PasskeyCeremony("reg-req", "{}"))
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.offerPasskeyEnroll(authId, recordWithUser)
         yield assertTrue(
           result == ConversationResult.RenderStep(ConversationStep.PasskeyEnroll("reg-req", "{}"))
@@ -221,7 +222,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.authPropertyGenerator.nextAccessToken.succeedsWith(testAccessToken)
           _ <- env.authorizationCodeRepository.create.succeedsWith(())
           _ <- env.sessionRepository.create.succeedsWith(())
-          _ <- env.conversationRepository.delete.succeedsWith(())
+          _ <- env.conversationRepository.delete.succeedsWith(true)
           result <- env.service.offerPasskeyEnroll(authId, recordWithUser)
         yield assertTrue(result.isInstanceOf[ConversationResult.Complete])
       }
@@ -261,7 +262,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.authPropertyGenerator.nextAccessToken.succeedsWith(testAccessToken)
           _ <- env.authorizationCodeRepository.create.succeedsWith(())
           _ <- env.sessionRepository.create.succeedsWith(())
-          _ <- env.conversationRepository.delete.succeedsWith(())
+          _ <- env.conversationRepository.delete.succeedsWith(true)
           result <- env.service.finishPasskeyEnroll(authId, recordWithUser, enrollStep, "resp", None)
         yield assertTrue(result.isInstanceOf[ConversationResult.Complete])
       },
@@ -272,7 +273,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
         for
           _ <- env.configService.getPasskeySettings.succeedsWith(Some(passkeySettings))
           _ <- env.webAuthnService.finishRegistration.failsWith(versola.oauth.challenge.passkey.WebAuthnError.CeremonyFailed("fail"))
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.finishPasskeyEnroll(authId, recordWithUser, enrollStep, "resp", None)
         yield assertTrue(result == ConversationResult.RenderStep(enrollStep.copy(enrollFailed = true)))
       }
@@ -292,7 +293,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.authPropertyGenerator.nextAccessToken.succeedsWith(testAccessToken)
           _ <- env.authorizationCodeRepository.create.succeedsWith(())
           _ <- env.sessionRepository.create.succeedsWith(())
-          _ <- env.conversationRepository.delete.succeedsWith(())
+          _ <- env.conversationRepository.delete.succeedsWith(true)
           result <- env.service.skipPasskey(authId, recordWithUser)
         yield assertTrue(result.isInstanceOf[ConversationResult.Complete])
       }

--- a/auth/src/test/scala/versola/oauth/conversation/PasswordConversationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/PasswordConversationServiceSpec.scala
@@ -1,7 +1,7 @@
 package versola.oauth.conversation
 
-import versola.auth.model.Password
 import versola.auth.TestEnvConfig
+import versola.auth.model.Password
 import versola.oauth.challenge.passkey.{PasskeyRepository, WebAuthnService}
 import versola.oauth.challenge.password.PasswordService
 import versola.oauth.challenge.password.model.CheckPassword
@@ -97,6 +97,7 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
     userClaims = None,
     authFlow = AuthFlow.default,
     userAgent = None,
+    version = 0,
     amr = Map.empty,
   )
 
@@ -118,7 +119,7 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
         for
           _ <- env.userRepository.findByCredential.succeedsWith(Some(user))
           _ <- env.submissionLimiter.isBanned.succeedsWith(LimitStatus.Allowed)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.prepareInitialPassword(authId, baseRecord, Left(email), factorIndex = 0)
           overwriteCalls = env.conversationRepository.overwrite.calls
         yield assertTrue(
@@ -134,7 +135,7 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
         for
           _ <- env.userRepository.findByCredential.succeedsWith(Some(UserRecord.empty(userId)))
           _ <- env.submissionLimiter.isBanned.succeedsWith(LimitStatus.Banned)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.prepareInitialPassword(authId, baseRecord, Left(email), factorIndex = 0)
         yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
       },
@@ -143,7 +144,7 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
         for
           _ <- env.userRepository.findByCredential.succeedsWith(Some(UserRecord.empty(userId)))
           _ <- env.submissionLimiter.isBanned.succeedsWith(LimitStatus.RateLimited(30L))
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.prepareInitialPassword(authId, baseRecord, Left(email), factorIndex = 0)
         yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
       },
@@ -151,7 +152,7 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
         val env = Env()
         for
           _ <- env.userRepository.findByCredential.succeedsWith(None)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.prepareInitialPassword(authId, baseRecord, Left(email), factorIndex = 0)
         yield assertTrue(result == ConversationResult.RenderStep(passwordStep))
       },
@@ -161,8 +162,8 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
           _ <- env.userRepository.findByCredential.succeedsWith(Some(UserRecord.empty(userId)))
           _ <- env.submissionLimiter.isBanned.returnsZIO:
             case (_, subject, _) if subject == email => ZIO.succeed(LimitStatus.Banned)
-            case _                                   => ZIO.succeed(LimitStatus.Allowed)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+            case _ => ZIO.succeed(LimitStatus.Allowed)
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.prepareInitialPassword(authId, baseRecord, Left(email), factorIndex = 0)
           checkedSubjects = env.submissionLimiter.isBanned.calls.map(_._2).toSet
         yield assertTrue(
@@ -175,7 +176,7 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
       test("render fresh password step") {
         val env = Env()
         for
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.preparePasswordStep(authId, passwordRecord, factorIndex = 0)
         yield assertTrue(result == ConversationResult.RenderStep(passwordStep))
       },
@@ -191,7 +192,7 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
         val env = Env()
         for
           _ <- env.submissionLimiter.isBanned.succeedsWith(LimitStatus.Banned)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.checkPassword(passwordRecord, passwordStep, password, authId)
         yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
       },
@@ -199,7 +200,7 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
         val env = Env()
         for
           _ <- env.submissionLimiter.isBanned.succeedsWith(LimitStatus.RateLimited(30L))
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.checkPassword(passwordRecord, passwordStep, password, authId)
         yield assertTrue(result == ConversationResult.RenderStep(passwordStep.copy(rateLimitExceeded = true)))
       },
@@ -208,7 +209,7 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
         for
           _ <- env.submissionLimiter.isBanned.succeedsWith(LimitStatus.Allowed)
           _ <- env.passwordService.verifyPassword.succeedsWith(CheckPassword.Success)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.checkPassword(passwordRecord, passwordStep, password, authId)
         yield assertTrue(result.isInstanceOf[ConversationResult.StepPassed])
       },
@@ -218,7 +219,7 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
           _ <- env.submissionLimiter.isBanned.succeedsWith(LimitStatus.Allowed)
           _ <- env.passwordService.verifyPassword.succeedsWith(CheckPassword.Failure)
           _ <- env.submissionLimiter.recordLimit.succeedsWith(LimitStatus.Allowed)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.checkPassword(passwordRecord, passwordStep, password, authId)
         yield assertTrue(
           result == ConversationResult.RenderStep(
@@ -232,7 +233,7 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
           _ <- env.submissionLimiter.isBanned.succeedsWith(LimitStatus.Allowed)
           _ <- env.passwordService.verifyPassword.succeedsWith(CheckPassword.Failure)
           _ <- env.submissionLimiter.recordLimit.succeedsWith(LimitStatus.RateLimited(30L))
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.checkPassword(passwordRecord, passwordStep, password, authId)
         yield assertTrue(
           result == ConversationResult.RenderStep(
@@ -246,7 +247,7 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
           _ <- env.submissionLimiter.isBanned.succeedsWith(LimitStatus.Allowed)
           _ <- env.passwordService.verifyPassword.succeedsWith(CheckPassword.Failure)
           _ <- env.submissionLimiter.recordLimit.succeedsWith(LimitStatus.Banned)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.checkPassword(passwordRecord, passwordStep, password, authId)
         yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
       },
@@ -257,7 +258,7 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
           _ <- env.submissionLimiter.isBanned.succeedsWith(LimitStatus.Allowed)
           _ <- env.passwordService.verifyPassword.succeedsWith(CheckPassword.OldPassword(changedAt))
           _ <- env.submissionLimiter.recordLimit.succeedsWith(LimitStatus.Allowed)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.checkPassword(passwordRecord, passwordStep, password, authId)
         yield assertTrue(
           result == ConversationResult.RenderStep(
@@ -274,8 +275,8 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
         for
           _ <- env.submissionLimiter.isBanned.returnsZIO:
             case (_, subject, _) if subject == email => ZIO.succeed(LimitStatus.Banned)
-            case _                                   => ZIO.succeed(LimitStatus.Allowed)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+            case _ => ZIO.succeed(LimitStatus.Allowed)
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.checkPassword(passwordRecord, passwordStep, password, authId)
           checkedSubjects = env.submissionLimiter.isBanned.calls.map(_._2).toSet
         yield assertTrue(
@@ -289,7 +290,7 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
           _ <- env.submissionLimiter.isBanned.succeedsWith(LimitStatus.Allowed)
           _ <- env.passwordService.verifyPassword.succeedsWith(CheckPassword.Failure)
           _ <- env.submissionLimiter.recordLimit.succeedsWith(LimitStatus.Allowed)
-          _ <- env.conversationRepository.overwrite.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
           _ <- env.service.checkPassword(passwordRecord, passwordStep, password, authId)
           failureSubjects = env.submissionLimiter.recordLimit.calls.map(_._2).toSet
           failureTimes = env.submissionLimiter.recordLimit.times


### PR DESCRIPTION
**Atomic challenge consumption via optimistic concurrency (#18)**

Add a `version` column to `auth_conversations` and thread it through all reads and writes to prevent race conditions where two concurrent requests could both succeed and mint duplicate authorization codes or sessions.

**What changed**

- `V4` migration: added `version BIGINT NOT NULL DEFAULT 0` to `auth_conversations`
- New `Versioned[A]` wrapper carries a `version` alongside any domain model without polluting `ConversationRecord`
- `ConversationRepository`: `overwrite` and `delete` now take a `version: Long` and return `Task[Boolean]` — `true` means the row was claimed, `false` means a concurrent request already changed it (stale version)
- `PostgresConversationRepository`: `overwrite` uses `SET version = version + 1 WHERE id = ? AND version = ?`; `delete` uses `WHERE id = ? AND version = ?`; `find` returns `Versioned[ConversationRecord]`
- `ConversationService`: all methods accept `Versioned[ConversationRecord]`; `finish` now does `delete` first — authorization code and session are only minted if the delete succeeded (i.e. this request won the race); `renderStep` returns `IllegalState` on conflict
- `ConversationRouter`: unwraps `.value` for read-only uses, threads `Versioned` through all mutation paths

**Tests**

Two new integration tests in `ConversationRepositorySpec`:
- `overwrite with stale version returns false (optimistic conflict)`
- `delete with stale version returns false (optimistic conflict)`

Unit tests updated across `OtpConversationServiceSpec`, `PasswordConversationServiceSpec`, and `ConversationRouterSpec` to use `Versioned(..., 0L)` and `succeedsWith(true)` on overwrite/delete stubs.