### PR TITLE
Security: enforce enrollment ordering — passkey offered only after all primary factors complete (finding 1.2)

### DIFF
--- a/auth/src/main/scala/versola/oauth/conversation/ConversationService.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationService.scala
@@ -1,12 +1,12 @@
 package versola.oauth.conversation
 
+import versola.auth.model.CredentialDeviceType
 import versola.auth.model.{OtpCode, Password}
 import versola.oauth.authorize.model.ResponseTypeEntry
 import versola.oauth.challenge.passkey.{PasskeyRepository, WebAuthnError, WebAuthnService}
 import versola.oauth.challenge.password.PasswordService
 import versola.oauth.challenge.password.model.CheckPassword
 import versola.oauth.client.OAuthConfigurationService
-import versola.auth.model.CredentialDeviceType
 import versola.oauth.client.model.{AuthMethodRef, PassedAuthFactor, PassedFactorRecord, PasskeySettings, ScopeToken}
 import versola.oauth.conversation.limit.{ChallengeType, LimitStatus, SubmissionLimiter}
 import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep}
@@ -410,7 +410,7 @@ object ConversationService:
                     },
                     outcome =>
                       userRepository.find(outcome.userId).zipPar(
-                        passkeyRepository.findByCredentialIdAndUser(outcome.credentialId, outcome.userId)
+                        passkeyRepository.findByCredentialIdAndUser(outcome.credentialId, outcome.userId),
                       ).flatMap:
                         case (None, _) =>
                           ZIO.succeed(ConversationResult.IllegalState)
@@ -418,7 +418,7 @@ object ConversationService:
                           Clock.instant.flatMap: now =>
                             val keyType = passkeyOpt.fold(AuthMethodRef.swk)(pk =>
                               if pk.deviceType == CredentialDeviceType.SingleDevice then AuthMethodRef.hwk
-                              else AuthMethodRef.swk
+                              else AuthMethodRef.swk,
                             )
                             val passkeyMethods = Set(keyType, AuthMethodRef.user, AuthMethodRef.mfa)
                             val updated = record.copy(
@@ -436,33 +436,35 @@ object ConversationService:
           ZIO.succeed(ConversationResult.IllegalState)
 
     override def offerPasskeyEnroll(authId: AuthId, record: ConversationRecord): Task[ConversationResult.Render] =
-      record.userId match
-        case None =>
-          ZIO.succeed(ConversationResult.IllegalState)
-        case Some(userId) =>
-          configService.getPasskeySettings(record.clientId).flatMap:
-            case None =>
-              finish(authId, record)
-            case Some(settings) =>
-              passkeyRepository.listByUser(userId).flatMap: existing =>
-                if existing.nonEmpty then finish(authId, record)
-                else
-                  val displayName: String =
-                    record.userClaims.flatMap(_.fields.toMap.get("name"))
-                      .collect { case zio.json.ast.Json.Str(v) => v }
-                      .orElse(record.userEmail.map(_.toString))
-                      .orElse(record.userPhone.map(_.toString))
-                      .orElse(record.userLogin.map(_.toString))
-                      .getOrElse(userId.toString)
-                  webAuthnService.startRegistration(settings, userId, displayName).foldZIO(
-                    _ => finish(authId, record),
-                    ceremony =>
-                      val enrollStep = ConversationStep.PasskeyEnroll(
-                        request = ceremony.request,
-                        publicKeyOptions = ceremony.publicKeyOptions,
-                      )
-                      renderStep(authId, record, enrollStep),
-                  )
+      if !record.primaryFactorsDone then ZIO.succeed(ConversationResult.IllegalState)
+      else
+        record.userId match
+          case None =>
+            ZIO.succeed(ConversationResult.IllegalState)
+          case Some(userId) =>
+            configService.getPasskeySettings(record.clientId).flatMap:
+              case None =>
+                finish(authId, record)
+              case Some(settings) =>
+                passkeyRepository.listByUser(userId).flatMap: existing =>
+                  if existing.nonEmpty then finish(authId, record)
+                  else
+                    val displayName: String =
+                      record.userClaims.flatMap(_.fields.toMap.get("name"))
+                        .collect { case zio.json.ast.Json.Str(v) => v }
+                        .orElse(record.userEmail.map(_.toString))
+                        .orElse(record.userPhone.map(_.toString))
+                        .orElse(record.userLogin.map(_.toString))
+                        .getOrElse(userId.toString)
+                    webAuthnService.startRegistration(settings, userId, displayName).foldZIO(
+                      _ => finish(authId, record),
+                      ceremony =>
+                        val enrollStep = ConversationStep.PasskeyEnroll(
+                          request = ceremony.request,
+                          publicKeyOptions = ceremony.publicKeyOptions,
+                        )
+                        renderStep(authId, record, enrollStep),
+                    )
 
     override def finishPasskeyEnroll(
         authId: AuthId,

--- a/auth/src/main/scala/versola/oauth/conversation/model/ConversationRecord.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/model/ConversationRecord.scala
@@ -35,11 +35,13 @@ case class ConversationRecord(
     amr: Map[PassedAuthFactor, PassedFactorRecord],
 ):
   def primaryFactorsDone: Boolean =
-    authFlow.primary.factors.forall: factor =>
-      PassedAuthFactor.fromFactorType(factor.`type`) match
-        case None => true
-        case Some(required) => amr.keySet.exists(_.satisfies(required, authFlow.equivalents))
-        
+    authFlow.primary.factors
+      .filter(_.required)
+      .forall: factor =>
+        PassedAuthFactor.fromFactorType(factor.`type`) match
+          case None => true
+          case Some(required) => amr.keySet.exists(_.satisfies(required, authFlow.equivalents))
+
   def patch(patch: ConversationRecord.Patch): ConversationRecord =
     this.copy(
       userId = patch.userId.getOrElse(userId),

--- a/auth/src/main/scala/versola/oauth/conversation/model/ConversationRecord.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/model/ConversationRecord.scala
@@ -34,6 +34,12 @@ case class ConversationRecord(
     userAgent: Option[String],
     amr: Map[PassedAuthFactor, PassedFactorRecord],
 ):
+  def primaryFactorsDone: Boolean =
+    authFlow.primary.factors.forall: factor =>
+      PassedAuthFactor.fromFactorType(factor.`type`) match
+        case None => true
+        case Some(required) => amr.keySet.exists(_.satisfies(required, authFlow.equivalents))
+        
   def patch(patch: ConversationRecord.Patch): ConversationRecord =
     this.copy(
       userId = patch.userId.getOrElse(userId),

--- a/auth/src/test/scala/versola/oauth/conversation/PasskeyConversationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/PasskeyConversationServiceSpec.scala
@@ -5,8 +5,18 @@ import versola.auth.model.{AuthenticatorTransport, CredentialDeviceType, Credent
 import versola.oauth.challenge.passkey.{AssertionOutcome, PasskeyCeremony, PasskeyRepository, WebAuthnService}
 import versola.oauth.challenge.password.PasswordService
 import versola.oauth.client.OAuthConfigurationService
-import versola.oauth.client.model.{AuthFlow, ClientId, PasskeyAuthFlow, PasskeySettings, PrimaryCredential, ScopeToken}
-import versola.oauth.conversation.limit.{SubmissionLimiter}
+import versola.oauth.client.model.{
+  AuthFlow,
+  AuthMethodRef,
+  ClientId,
+  PassedAuthFactor,
+  PassedFactorRecord,
+  PasskeyAuthFlow,
+  PasskeySettings,
+  PrimaryCredential,
+  ScopeToken,
+}
+import versola.oauth.conversation.limit.SubmissionLimiter
 import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep}
 import versola.oauth.conversation.otp.OtpService
 import versola.oauth.model.{CodeChallenge, CodeChallengeMethod}
@@ -36,12 +46,14 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
     rpId = "localhost",
     rpName = "Versola",
     origins = List("http://localhost:3000"),
-    userVerification = "preferred"
+    userVerification = "preferred",
   )
 
   // Passkey login enabled at the client level, mirroring what AuthorizeEndpointService persists.
-  val passkeyAuthFlow = AuthFlow.default.copy(passkey = Some(PasskeyAuthFlow(factors = Nil)))
-
+  val passkeyAuthFlow = AuthFlow.default.copy(
+    passkey = Some(PasskeyAuthFlow(factors = Nil)),
+    equivalents = Map(PassedAuthFactor.passkey -> Set(PassedAuthFactor.otp)),
+  )
   class Env:
     val otpService = stub[OtpService]
     val passwordService = stub[PasswordService]
@@ -79,7 +91,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
     primaryCredentials = List(PrimaryCredential.email),
     inlinePassword = false,
     passkey = true,
-    passkeyRequest = None
+    passkeyRequest = None,
   )
 
   val baseRecord = ConversationRecord(
@@ -105,6 +117,11 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
     amr = Map.empty,
   )
 
+  val recordWithOtpPassed = baseRecord.copy(
+    userId = Some(userId),
+    amr = Map(PassedAuthFactor.otp -> PassedFactorRecord(Instant.now(), Set(AuthMethodRef.otp))),
+  )
+
   def spec = suite("PasskeyConversationServiceSpec")(
     suite("startPasskeyAssertion")(
       test("return publicKeyOptions and update step with request") {
@@ -116,9 +133,9 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           result <- env.service.startPasskeyAssertion(authId, baseRecord, credentialStep, passkeySettings)
         yield assertTrue(
           result == "{}",
-          env.conversationRepository.overwrite.calls.head._2.step == credentialStep.copy(passkeyRequest = Some("req-state"))
+          env.conversationRepository.overwrite.calls.head._2.step == credentialStep.copy(passkeyRequest = Some("req-state")),
         )
-      }
+      },
     ),
     suite("finishPasskeyAssertion")(
       test("succeed and move to enrollment check") {
@@ -136,7 +153,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.conversationRepository.overwrite.succeedsWith(())
           result <- env.service.finishPasskeyAssertion(authId, recordWithRequest, "response-json")
         yield assertTrue(
-          result == ConversationResult.RenderStep(ConversationStep.PasskeyEnroll("reg-req", "{}"))
+          result == ConversationResult.RenderStep(ConversationStep.PasskeyEnroll("reg-req", "{}")),
         )
       },
       test("re-render credential step on assertion failure") {
@@ -148,7 +165,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.conversationRepository.overwrite.succeedsWith(())
           result <- env.service.finishPasskeyAssertion(authId, recordWithRequest, "response-json")
         yield assertTrue(
-          result == ConversationResult.RenderStep(credentialStep.copy(passkeyRequest = None, passkeyFailed = true))
+          result == ConversationResult.RenderStep(credentialStep.copy(passkeyRequest = None, passkeyFailed = true)),
         )
       },
       test("flag credential step as orphaned when the credential is not found") {
@@ -160,7 +177,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.conversationRepository.overwrite.succeedsWith(())
           result <- env.service.finishPasskeyAssertion(authId, recordWithRequest, "response-json")
         yield assertTrue(
-          result == ConversationResult.RenderStep(credentialStep.copy(passkeyRequest = None, passkeyOrphaned = true))
+          result == ConversationResult.RenderStep(credentialStep.copy(passkeyRequest = None, passkeyOrphaned = true)),
         )
       },
       test("return IllegalState when passkey login is not enabled for the client") {
@@ -172,12 +189,12 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
         for
           result <- env.service.finishPasskeyAssertion(authId, record, "response-json")
         yield assertTrue(result == ConversationResult.IllegalState)
-      }
+      },
     ),
     suite("offerPasskeyEnroll")(
       test("render enrollment step if user has no passkeys") {
         val env = Env()
-        val recordWithUser = baseRecord.copy(userId = Some(userId))
+        val recordWithUser = recordWithOtpPassed
         for
           _ <- env.configService.getPasskeySettings.succeedsWith(Some(passkeySettings))
           _ <- env.passkeyRepository.listByUser.succeedsWith(Vector.empty)
@@ -185,28 +202,28 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.conversationRepository.overwrite.succeedsWith(())
           result <- env.service.offerPasskeyEnroll(authId, recordWithUser)
         yield assertTrue(
-          result == ConversationResult.RenderStep(ConversationStep.PasskeyEnroll("reg-req", "{}"))
+          result == ConversationResult.RenderStep(ConversationStep.PasskeyEnroll("reg-req", "{}")),
         )
       },
       test("finish conversation if user already has passkeys") {
         val env = Env()
-        val recordWithUser = baseRecord.copy(userId = Some(userId))
+        val recordWithUser = recordWithOtpPassed
         val existingPasskey = PasskeyRecord(
-           id = CredentialId(Array.empty),
-           userId = userId,
-           publicKey = Array.empty,
-           signatureCounter = 0,
-           deviceType = CredentialDeviceType.SingleDevice,
-           backedUp = true,
-           backupEligible = true,
-           transports = Nil,
-           attestationObject = None,
-           clientDataJson = None,
-           aaguid = None,
-           name = None,
-           lastUsedAt = None,
-           createdAt = Instant.now(),
-           updatedAt = Instant.now()
+          id = CredentialId(Array.empty),
+          userId = userId,
+          publicKey = Array.empty,
+          signatureCounter = 0,
+          deviceType = CredentialDeviceType.SingleDevice,
+          backedUp = true,
+          backupEligible = true,
+          transports = Nil,
+          attestationObject = None,
+          clientDataJson = None,
+          aaguid = None,
+          name = None,
+          lastUsedAt = None,
+          createdAt = Instant.now(),
+          updatedAt = Instant.now(),
         )
         val testCode = versola.oauth.model.AuthorizationCode(Array.fill(32)(1.toByte))
         val testSessionId = versola.oauth.session.model.SessionId(Array.fill(32)(2.toByte))
@@ -224,7 +241,14 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.conversationRepository.delete.succeedsWith(())
           result <- env.service.offerPasskeyEnroll(authId, recordWithUser)
         yield assertTrue(result.isInstanceOf[ConversationResult.Complete])
-      }
+      },
+      test("return IllegalState when primary factors are not yet complete") {
+        val env = Env()
+        val recordWithUser = baseRecord.copy(userId = Some(userId))
+        for
+          result <- env.service.offerPasskeyEnroll(authId, recordWithUser)
+        yield assertTrue(result == ConversationResult.IllegalState)
+      },
     ),
     suite("finishPasskeyEnroll")(
       test("finish conversation on success") {
@@ -275,7 +299,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.conversationRepository.overwrite.succeedsWith(())
           result <- env.service.finishPasskeyEnroll(authId, recordWithUser, enrollStep, "resp", None)
         yield assertTrue(result == ConversationResult.RenderStep(enrollStep.copy(enrollFailed = true)))
-      }
+      },
     ),
     suite("skipPasskey")(
       test("finish conversation") {
@@ -295,6 +319,6 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.conversationRepository.delete.succeedsWith(())
           result <- env.service.skipPasskey(authId, recordWithUser)
         yield assertTrue(result.isInstanceOf[ConversationResult.Complete])
-      }
-    )
+      },
+    ),
   )


### PR DESCRIPTION
Closes #21 

feat: guard offerPasskeyEnroll against incomplete primary auth factors

Security finding 1.2: passkey enrollment could be reached before all
required primary factors were satisfied.

- Add ConversationRecord.primaryFactorsDone to check that all primary
  factors (excluding passkeyEnroll) are present in amr, respecting
  equivalents
- Guard offerPasskeyEnroll with primaryFactorsDone check
- Update PasskeyConversationServiceSpec: use recordWithOtpPassed for
  happy-path tests, add equivalents to passkeyAuthFlow, add rejection
  test