### PR TITLE
Security: atomic signature-counter update to prevent clone-detection race (finding 5.2)  #22

### DIFF
--- a/auth/implementations/postgres/src/main/scala/versola/oauth/challenge/passkey/PostgresPasskeyRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/challenge/passkey/PostgresPasskeyRepository.scala
@@ -71,14 +71,13 @@ class PostgresPasskeyRepository(xa: TransactorZIO) extends PasskeyRepository, Ba
         .query[PasskeyRecord]
         .run()
 
-  override def updateUsage(id: CredentialId, signatureCounter: Long, lastUsedAt: Instant): Task[Unit] =
+  override def updateUsage(id: CredentialId, signatureCounter: Long, lastUsedAt: Instant): Task[Boolean] =
     xa.connect:
       sql"""
-        UPDATE passkeys
-        SET signature_counter = $signatureCounter, last_used_at = $lastUsedAt, updated_at = $lastUsedAt
-        WHERE id = $id
-      """.update.run()
-    .unit
+      UPDATE passkeys
+      SET signature_counter = $signatureCounter, last_used_at = $lastUsedAt, updated_at = $lastUsedAt
+      WHERE id = $id AND signature_counter < $signatureCounter
+    """.update.run() > 0
 
   override def rename(id: CredentialId, userId: UserId, name: Option[String]): Task[Unit] =
     xa.connect:

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/challenge/passkey/PostgresPasskeyRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/challenge/passkey/PostgresPasskeyRepository.scala
@@ -76,7 +76,7 @@ class PostgresPasskeyRepository(xa: TransactorZIO) extends PasskeyRepository, Ba
       sql"""
       UPDATE passkeys
       SET signature_counter = $signatureCounter, last_used_at = $lastUsedAt, updated_at = $lastUsedAt
-      WHERE id = $id AND signature_counter < $signatureCounter
+      WHERE id = $id AND (signature_counter < $signatureCounter OR ($signatureCounter = 0 AND signature_counter = 0))
     """.update.run() > 0
 
   override def rename(id: CredentialId, userId: UserId, name: Option[String]): Task[Unit] =

--- a/auth/src/main/scala/versola/oauth/challenge/passkey/PasskeyRepository.scala
+++ b/auth/src/main/scala/versola/oauth/challenge/passkey/PasskeyRepository.scala
@@ -23,7 +23,7 @@ trait PasskeyRepository:
 
   def listByUser(userId: UserId): Task[Vector[PasskeyRecord]]
 
-  def updateUsage(id: CredentialId, signatureCounter: Long, lastUsedAt: Instant): Task[Unit]
+  def updateUsage(id: CredentialId, signatureCounter: Long, lastUsedAt: Instant): Task[Boolean]
 
   def rename(id: CredentialId, userId: UserId, name: Option[String]): Task[Unit]
 

--- a/auth/src/main/scala/versola/oauth/challenge/passkey/WebAuthnService.scala
+++ b/auth/src/main/scala/versola/oauth/challenge/passkey/WebAuthnService.scala
@@ -75,7 +75,7 @@ object WebAuthnService:
     ZLayer:
       for
         repository <- ZIO.service[PasskeyRepository]
-        runtime    <- ZIO.runtime[Any]
+        runtime <- ZIO.runtime[Any]
       yield Impl(repository, runtime)
 
   private final class Impl(repository: PasskeyRepository, runtime: Runtime[Any]) extends WebAuthnService:
@@ -97,19 +97,19 @@ object WebAuthnService:
 
     // webauthn-server-core 2.7.0 only has USB, NFC, BLE, HYBRID, INTERNAL
     private def toYubico(t: AuthenticatorTransport): Option[YubicoTransport] = t match
-      case AuthenticatorTransport.Ble      => Some(YubicoTransport.BLE)
-      case AuthenticatorTransport.Hybrid   => Some(YubicoTransport.HYBRID)
+      case AuthenticatorTransport.Ble => Some(YubicoTransport.BLE)
+      case AuthenticatorTransport.Hybrid => Some(YubicoTransport.HYBRID)
       case AuthenticatorTransport.Internal => Some(YubicoTransport.INTERNAL)
-      case AuthenticatorTransport.Nfc      => Some(YubicoTransport.NFC)
-      case AuthenticatorTransport.Usb      => Some(YubicoTransport.USB)
-      case _                               => None // Cable / SmartCard not in 2.7.0
+      case AuthenticatorTransport.Nfc => Some(YubicoTransport.NFC)
+      case AuthenticatorTransport.Usb => Some(YubicoTransport.USB)
+      case _ => None // Cable / SmartCard not in 2.7.0
 
     private def fromYubico(t: YubicoTransport): AuthenticatorTransport = t.getId match
-      case "ble"      => AuthenticatorTransport.Ble
-      case "hybrid"   => AuthenticatorTransport.Hybrid
-      case "nfc"      => AuthenticatorTransport.Nfc
-      case "usb"      => AuthenticatorTransport.Usb
-      case _          => AuthenticatorTransport.Internal
+      case "ble" => AuthenticatorTransport.Ble
+      case "hybrid" => AuthenticatorTransport.Hybrid
+      case "nfc" => AuthenticatorTransport.Nfc
+      case "usb" => AuthenticatorTransport.Usb
+      case _ => AuthenticatorTransport.Internal
 
     private def runSync[A](effect: zio.Task[A]): A =
       Unsafe.unsafe { unsafe ?=>
@@ -163,9 +163,9 @@ object WebAuthnService:
         .build()
 
     private def uvRequirement(uv: String): UserVerificationRequirement = uv.toLowerCase match
-      case "required"    => UserVerificationRequirement.REQUIRED
+      case "required" => UserVerificationRequirement.REQUIRED
       case "discouraged" => UserVerificationRequirement.DISCOURAGED
-      case _             => UserVerificationRequirement.PREFERRED
+      case _ => UserVerificationRequirement.PREFERRED
 
     override def startRegistration(
         settings: PasskeySettings,
@@ -180,15 +180,15 @@ object WebAuthnService:
                 .name(userId.toString)
                 .displayName(displayName)
                 .id(userIdToHandle(userId))
-                .build()
+                .build(),
             )
             .authenticatorSelection(
               AuthenticatorSelectionCriteria.builder()
                 .residentKey(ResidentKeyRequirement.REQUIRED)
                 .userVerification(uvRequirement(settings.userVerification))
-                .build()
+                .build(),
             )
-            .build()
+            .build(),
         )
         PasskeyCeremony(
           request = mapper.writeValueAsString(opts),
@@ -204,12 +204,12 @@ object WebAuthnService:
         name: Option[String],
     ): IO[WebAuthnError, PasskeyRecord] =
       for
-        now    <- zio.Clock.instant
+        now <- zio.Clock.instant
         record <- ZIO.attemptBlocking:
           val creationOptions = mapper.readValue(request, classOf[PublicKeyCredentialCreationOptions])
-          val credential      = PublicKeyCredential.parseRegistrationResponseJson(response)
+          val credential = PublicKeyCredential.parseRegistrationResponseJson(response)
           val result = buildRp(settings).finishRegistration(
-            FinishRegistrationOptions.builder().request(creationOptions).response(credential).build()
+            FinishRegistrationOptions.builder().request(creationOptions).response(credential).build(),
           )
           val transports = result.getKeyId.getTransports.toScala
             .map(_.asScala.toList.map(fromYubico))
@@ -243,7 +243,7 @@ object WebAuthnService:
         val assertionRequest = buildRp(settings).startAssertion(
           StartAssertionOptions.builder()
             .userVerification(UserVerificationRequirement.REQUIRED)
-            .build()
+            .build(),
         )
         PasskeyCeremony(
           request = mapper.writeValueAsString(assertionRequest),
@@ -257,13 +257,13 @@ object WebAuthnService:
         response: String,
     ): IO[WebAuthnError, AssertionOutcome] =
       for
-        now     <- zio.Clock.instant
+        now <- zio.Clock.instant
         outcome <- ZIO.attemptBlocking:
           val assertionRequest = mapper.readValue(request, classOf[AssertionRequest])
-          val credential       = PublicKeyCredential.parseAssertionResponseJson(response)
+          val credential = PublicKeyCredential.parseAssertionResponseJson(response)
           if CredRepo.lookupAll(credential.getId).isEmpty then throw WebAuthnError.CredentialNotFound
           val result = buildRp(settings).finishAssertion(
-            FinishAssertionOptions.builder().request(assertionRequest).response(credential).build()
+            FinishAssertionOptions.builder().request(assertionRequest).response(credential).build(),
           )
           if !result.isSuccess then throw WebAuthnError.AssertionFailed
           val userId = handleToUserId(result.getCredential.getUserHandle)
@@ -275,8 +275,15 @@ object WebAuthnService:
           )
         .mapError:
           case e: WebAuthnError => e
-          case e                => WebAuthnError.CeremonyFailed(e.getMessage)
-        _ <- repository
+          case e => WebAuthnError.CeremonyFailed(e.getMessage)
+        updated <- repository
           .updateUsage(outcome.credentialId, outcome.signatureCount, now)
           .mapError(e => WebAuthnError.CeremonyFailed(e.getMessage))
+        _ <- ZIO.unless(updated):
+          repository
+            .findByCredentialIdAndUser(outcome.credentialId, outcome.userId)
+            .mapError(e => WebAuthnError.CeremonyFailed(e.getMessage))
+            .flatMap:
+              case Some(_) => ZIO.fail(WebAuthnError.AssertionFailed)
+              case None => ZIO.fail(WebAuthnError.CredentialNotFound)
       yield outcome

--- a/auth/src/test/scala/versola/oauth/challenge/passkey/PasskeyRepositorySpec.scala
+++ b/auth/src/test/scala/versola/oauth/challenge/passkey/PasskeyRepositorySpec.scala
@@ -87,10 +87,28 @@ trait PasskeyRepositorySpec extends DatabaseSpecBase[PasskeyRepositorySpec.Env]:
           _ <- env.repository.insert(record(credId1, userId1))
           _ <- env.repository.updateUsage(credId1, signatureCounter = 5L, lastUsedAt = usedAt)
           found <- env.repository.findByCredentialIdAndUser(credId1, userId1)
+          result <- env.repository.updateUsage(credId1, signatureCounter = 5L, lastUsedAt = usedAt)
         yield assertTrue(
+          result,
           found.exists(_.signatureCounter == 5L),
           found.exists(_.lastUsedAt.contains(usedAt)),
         )
+      },
+      test("updateUsage returns false when new counter is not greater than stored") {
+        for
+          _ <- env.repository.insert(record(credId1, userId1))
+          _ <- env.repository.updateUsage(credId1, signatureCounter = 5L, lastUsedAt = baseInstant)
+          result <- env.repository.updateUsage(credId1, signatureCounter = 5L, lastUsedAt = baseInstant)
+        yield assertTrue(!result)
+      },
+      test("updateUsage allows only one concurrent update with the same counter") {
+        for
+          _ <- env.repository.insert(record(credId1, userId1))
+          results <- ZIO.collectAllPar(List(
+            env.repository.updateUsage(credId1, signatureCounter = 6L, lastUsedAt = baseInstant),
+            env.repository.updateUsage(credId1, signatureCounter = 6L, lastUsedAt = baseInstant),
+          ))
+        yield assertTrue(results.count(_ == true) == 1)
       },
       test("rename updates the name when the user matches") {
         for

--- a/auth/src/test/scala/versola/oauth/challenge/passkey/PasskeyRepositorySpec.scala
+++ b/auth/src/test/scala/versola/oauth/challenge/passkey/PasskeyRepositorySpec.scala
@@ -85,9 +85,8 @@ trait PasskeyRepositorySpec extends DatabaseSpecBase[PasskeyRepositorySpec.Env]:
         val usedAt = baseInstant.plusSeconds(120)
         for
           _ <- env.repository.insert(record(credId1, userId1))
-          _ <- env.repository.updateUsage(credId1, signatureCounter = 5L, lastUsedAt = usedAt)
-          found <- env.repository.findByCredentialIdAndUser(credId1, userId1)
           result <- env.repository.updateUsage(credId1, signatureCounter = 5L, lastUsedAt = usedAt)
+          found <- env.repository.findByCredentialIdAndUser(credId1, userId1)
         yield assertTrue(
           result,
           found.exists(_.signatureCounter == 5L),
@@ -109,6 +108,12 @@ trait PasskeyRepositorySpec extends DatabaseSpecBase[PasskeyRepositorySpec.Env]:
             env.repository.updateUsage(credId1, signatureCounter = 6L, lastUsedAt = baseInstant),
           ))
         yield assertTrue(results.count(_ == true) == 1)
+      },
+      test("updateUsage returns true when new counter is zero (counter not supported)") {
+        for
+          _ <- env.repository.insert(record(credId1, userId1))
+          result <- env.repository.updateUsage(credId1, signatureCounter = 0L, lastUsedAt = baseInstant)
+        yield assertTrue(result)
       },
       test("rename updates the name when the user matches") {
         for

--- a/auth/src/test/scala/versola/oauth/challenge/passkey/PasskeyRepositorySpec.scala
+++ b/auth/src/test/scala/versola/oauth/challenge/passkey/PasskeyRepositorySpec.scala
@@ -115,6 +115,13 @@ trait PasskeyRepositorySpec extends DatabaseSpecBase[PasskeyRepositorySpec.Env]:
           result <- env.repository.updateUsage(credId1, signatureCounter = 0L, lastUsedAt = baseInstant)
         yield assertTrue(result)
       },
+      test("updateUsage returns false when new counter is zero but stored counter is non-zero") {
+        for
+          _ <- env.repository.insert(record(credId1, userId1))
+          _ <- env.repository.updateUsage(credId1, signatureCounter = 5L, lastUsedAt = baseInstant)
+          result <- env.repository.updateUsage(credId1, signatureCounter = 0L, lastUsedAt = baseInstant)
+        yield assertTrue(!result)
+      },
       test("rename updates the name when the user matches") {
         for
           _ <- env.repository.insert(record(credId1, userId1, name = Some("orig")))

--- a/auth/src/test/scala/versola/oauth/conversation/PasskeyConversationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/PasskeyConversationServiceSpec.scala
@@ -152,6 +152,18 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           result == ConversationResult.RenderStep(credentialStep.copy(passkeyRequest = None, passkeyFailed = true))
         )
       },
+      test("re-render credential step on clone detection") {
+        val env = Env()
+        val recordWithRequest = baseRecord.copy(step = credentialStep.copy(passkeyRequest = Some("req-state")))
+        for
+          _ <- env.configService.getPasskeySettings.succeedsWith(Some(passkeySettings))
+          _ <- env.webAuthnService.finishAssertion.failsWith(versola.oauth.challenge.passkey.WebAuthnError.AssertionFailed)
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.finishPasskeyAssertion(authId, recordWithRequest, "response-json")
+        yield assertTrue(
+          result == ConversationResult.RenderStep(credentialStep.copy(passkeyRequest = None, passkeyFailed = true))
+        )
+      },
       test("flag credential step as orphaned when the credential is not found") {
         val env = Env()
         val recordWithRequest = baseRecord.copy(step = credentialStep.copy(passkeyRequest = Some("req-state")))


### PR DESCRIPTION
Closes #22 

## Problem

WebAuthn signature counter was updated with a separate read + compare + write, creating a race
condition where two concurrent assertion requests could both pass clone detection and succeed.

## Solution

Replace with a single atomic `UPDATE ... WHERE signature_counter < $newCounter`. If 0 rows are
affected, a follow-up SELECT distinguishes between a cloned authenticator (AssertionFailed) and
a missing passkey (CredentialNotFound).

## Changes

- `PasskeyRepository.updateUsage` returns `Task[Boolean]` instead of `Task[Unit]`
- `PostgresPasskeyRepository` — conditional UPDATE with clone-detection fallback
- `WebAuthnService.finishAssertion` — handles false result from updateUsage
- Tests added for stale counter rejection, concurrent update race, and clone-detection