### PR TITLE
Database client metrics  #3

### DIFF
--- a/auth/implementations/postgres/src/main/scala/versola/oauth/PostgresAuthorizationCodeRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/PostgresAuthorizationCodeRepository.scala
@@ -49,7 +49,7 @@ class PostgresAuthorizationCodeRepository(
   override def find(code: MAC.Of[AuthorizationCode]): Task[Option[AuthorizationCodeRecord]] =
     for
       now <- Clock.instant
-      result <- xa.connect:
+      result <- xa.connectMeasured("find-authorization-code"):
         sql"""
           SELECT session_id, client_id, user_id, redirect_uri,
                  scope, code_challenge, code_challenge_method,
@@ -68,7 +68,7 @@ class PostgresAuthorizationCodeRepository(
       ttl: Duration,
   ): Task[Unit] =
     Clock.instant.flatMap: now =>
-      xa.connect:
+      xa.connectMeasured("create-authorization-code"):
         sql"""
           INSERT INTO authorization_codes (
             code,
@@ -110,12 +110,12 @@ class PostgresAuthorizationCodeRepository(
     .unit
 
   override def delete(code: MAC.Of[AuthorizationCode]): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-authorization-code"):
       sql"""DELETE FROM authorization_codes WHERE code = $code""".update.run()
     .unit
 
   override def markAsUsed(code: MAC.Of[AuthorizationCode]): Task[Either[AccessToken, Unit]] =
-    xa.connect:
+    xa.connectMeasured("mark-authorization-code-used"):
       val affectedRows = sql"""
         UPDATE authorization_codes
         SET used = TRUE

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/challenge/passkey/PostgresPasskeyRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/challenge/passkey/PostgresPasskeyRepository.scala
@@ -28,7 +28,7 @@ class PostgresPasskeyRepository(xa: TransactorZIO) extends PasskeyRepository, Ba
   given DbCodec[PasskeyRecord] = DbCodec.derived[PasskeyRecord]
 
   override def insert(record: PasskeyRecord): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("insert-passkey"):
       sql"""
         INSERT INTO passkeys (
           id, user_id, public_key, signature_counter, device_type,
@@ -44,7 +44,7 @@ class PostgresPasskeyRepository(xa: TransactorZIO) extends PasskeyRepository, Ba
     .unit
 
   override def findByCredentialIdAndUser(id: CredentialId, userId: UserId): Task[Option[PasskeyRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-passkey-by-credential-and-user"):
       sql"""SELECT id, user_id, public_key, signature_counter, device_type,
               backed_up, backup_eligible, transports, attestation_object, client_data_json,
               aaguid, name, last_used_at, created_at, updated_at
@@ -54,7 +54,7 @@ class PostgresPasskeyRepository(xa: TransactorZIO) extends PasskeyRepository, Ba
         .headOption
 
   override def findByCredentialId(id: CredentialId): Task[Vector[PasskeyRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-passkey-by-credential"):
       sql"""SELECT id, user_id, public_key, signature_counter, device_type,
               backed_up, backup_eligible, transports, attestation_object, client_data_json,
               aaguid, name, last_used_at, created_at, updated_at
@@ -63,7 +63,7 @@ class PostgresPasskeyRepository(xa: TransactorZIO) extends PasskeyRepository, Ba
         .run()
 
   override def listByUser(userId: UserId): Task[Vector[PasskeyRecord]] =
-    xa.connect:
+    xa.connectMeasured("list-passkeys-by-user"):
       sql"""SELECT id, user_id, public_key, signature_counter, device_type,
               backed_up, backup_eligible, transports, attestation_object, client_data_json,
               aaguid, name, last_used_at, created_at, updated_at
@@ -72,7 +72,7 @@ class PostgresPasskeyRepository(xa: TransactorZIO) extends PasskeyRepository, Ba
         .run()
 
   override def updateUsage(id: CredentialId, signatureCounter: Long, lastUsedAt: Instant): Task[Boolean] =
-    xa.connect:
+    xa.connectMeasured("update-passkey-usage"):
       sql"""
       UPDATE passkeys
       SET signature_counter = $signatureCounter, last_used_at = $lastUsedAt, updated_at = $lastUsedAt
@@ -80,7 +80,7 @@ class PostgresPasskeyRepository(xa: TransactorZIO) extends PasskeyRepository, Ba
     """.update.run() > 0
 
   override def rename(id: CredentialId, userId: UserId, name: Option[String]): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("rename-passkey"):
       sql"""
         UPDATE passkeys
         SET name = $name
@@ -89,12 +89,12 @@ class PostgresPasskeyRepository(xa: TransactorZIO) extends PasskeyRepository, Ba
     .unit
 
   override def deleteByUser(id: CredentialId, userId: UserId): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-passkey-by-user"):
       sql"DELETE FROM passkeys WHERE id = $id AND user_id = $userId".update.run()
     .unit
 
   override def delete(id: CredentialId): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-passkey"):
       sql"DELETE FROM passkeys WHERE id = $id".update.run()
     .unit
 

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/challenge/password/PostgresPasswordRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/challenge/password/PostgresPasswordRepository.scala
@@ -19,7 +19,7 @@ class PostgresPasswordRepository(xa: TransactorZIO) extends PasswordRepository, 
   given DbCodec[PasswordRecord] = DbCodec.derived[PasswordRecord]
 
   override def list(userId: UserId): Task[Vector[PasswordRecord]] =
-    xa.connect:
+    xa.connectMeasured("list-passwords"):
       sql"""
         SELECT id, user_id, password, salt, created_at, is_current
         FROM user_passwords
@@ -37,7 +37,7 @@ class PostgresPasswordRepository(xa: TransactorZIO) extends PasswordRepository, 
   ): IO[Throwable | PasswordReuseError, Unit] =
     for
       now <- Clock.instant
-      result <- xa.transact {
+      result <- xa.transactMeasured("create-password") {
         val oldPasswords = sql"""
           SELECT id, user_id, password, salt, created_at, is_current
           FROM user_passwords

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/PostgresConversationRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/PostgresConversationRepository.scala
@@ -61,7 +61,7 @@ class PostgresConversationRepository(xa: TransactorZIO) extends ConversationRepo
 
   override def find(authId: AuthId): Task[Option[ConversationRecord]] =
     Clock.instant.flatMap: now =>
-      xa.connect {
+      xa.connectMeasured("find-conversation") {
         sql"""select client_id, redirect_uri, scope, code_challenge, code_challenge_method, state, user_id, credential, step, requested_claims, ui_locales, nonce, response_type, user_email, user_phone, user_login, user_claims, auth_flow, user_agent, version, amr, expires_at
               from auth_conversations
               where id = $authId"""
@@ -74,7 +74,7 @@ class PostgresConversationRepository(xa: TransactorZIO) extends ConversationRepo
       }
 
   override def create(authId: AuthId, record: ConversationRecord, ttl: Duration): Task[Unit] =
-    xa.connect {
+    xa.connectMeasured("create-conversation") {
       sql"""insert into auth_conversations (
                 id,
                 client_id,
@@ -128,7 +128,7 @@ class PostgresConversationRepository(xa: TransactorZIO) extends ConversationRepo
     }.unit
 
   override def overwrite(authId: AuthId, record: ConversationRecord): Task[Boolean] =
-    xa.connect {
+    xa.connectMeasured("overwrite-conversation") {
       sql"""update auth_conversations set
               user_id = ${record.userId},
               credential = ${record.credential},
@@ -145,7 +145,7 @@ class PostgresConversationRepository(xa: TransactorZIO) extends ConversationRepo
     }.map(_ > 0)
 
   override def delete(authId: AuthId, version: Long): Task[Boolean] =
-    xa.connect {
+    xa.connectMeasured("delete-conversation") {
       sql"""delete from auth_conversations where id = $authId and version = $version"""
         .update.run()
     }.map(_ > 0)

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/limit/PostgresChallengeThrottleRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/limit/PostgresChallengeThrottleRepository.scala
@@ -29,7 +29,7 @@ class PostgresChallengeThrottleRepository(xa: TransactorZIO) extends ChallengeTh
       subject: String,
       challengeType: ChallengeType,
   ): Task[Option[ChallengeThrottleRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-challenge-throttle"):
       sql"""SELECT tenant_id, subject, challenge_type, attempts, banned_until, expires_at
             FROM challenge_throttle
             WHERE tenant_id = $tenantId AND subject = $subject AND challenge_type = $challengeType"""
@@ -41,7 +41,7 @@ class PostgresChallengeThrottleRepository(xa: TransactorZIO) extends ChallengeTh
       subject: String,
       challengeTypes: List[ChallengeType],
   ): Task[List[ChallengeThrottleRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-all-challenge-throttle"):
       sql"""SELECT tenant_id, subject, challenge_type, attempts, banned_until, expires_at
             FROM challenge_throttle
             WHERE tenant_id = $tenantId AND subject = $subject AND challenge_type = ANY($challengeTypes)"""
@@ -50,7 +50,7 @@ class PostgresChallengeThrottleRepository(xa: TransactorZIO) extends ChallengeTh
 
   override def upsert(record: ChallengeThrottleRecord): Task[Unit] =
     ZIO.succeed(UUID.randomUUID()).flatMap: id =>
-      xa.connect:
+      xa.connectMeasured("upsert-challenge-throttle"):
         sql"""
           INSERT INTO challenge_throttle (id, tenant_id, subject, challenge_type, attempts, banned_until, expires_at)
           VALUES ($id, ${record.tenantId}, ${record.subject}, ${record.challengeType}, ${record.attempts}, ${record.bannedUntil}, ${record.expiresAt})
@@ -66,14 +66,14 @@ class PostgresChallengeThrottleRepository(xa: TransactorZIO) extends ChallengeTh
       subject: String,
       challengeType: ChallengeType,
   ): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-challenge-throttle"):
       sql"""DELETE FROM challenge_throttle
             WHERE tenant_id = $tenantId AND subject = $subject AND challenge_type = $challengeType"""
         .update.run()
     .unit
 
   override def deleteAllForSubject(tenantId: TenantId, subject: String): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-challenge-throttle-for-subject"):
       sql"""DELETE FROM challenge_throttle
             WHERE tenant_id = $tenantId AND subject = $subject"""
         .update.run()

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresRefreshTokenRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresRefreshTokenRepository.scala
@@ -40,7 +40,7 @@ class PostgresRefreshTokenRepository(xa: TransactorZIO) extends RefreshTokenRepo
   ): IO[Throwable | RefreshAlreadyExchanged, Unit] =
     xa.withConnectionConfig(
       _.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ),
-    ).transact {
+    ).transactMeasured("create-refresh-token") {
       record.previousRefreshToken
         .foreach { oldToken => sql"""DELETE FROM refresh_tokens WHERE id = $oldToken""".update.run() }
 
@@ -89,7 +89,7 @@ class PostgresRefreshTokenRepository(xa: TransactorZIO) extends RefreshTokenRepo
   override def find(token: MAC.Of[RefreshToken]): Task[Option[RefreshTokenRecord]] =
     for
       now <- Clock.instant
-      result <- xa.connect:
+      result <- xa.connectMeasured("find-refresh-token"):
         sql"""
           SELECT session_id, access_token, user_id, client_id,
                  external_audience, scope, issued_at,
@@ -104,12 +104,12 @@ class PostgresRefreshTokenRepository(xa: TransactorZIO) extends RefreshTokenRepo
     yield result
 
   override def delete(token: MAC.Of[RefreshToken]): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-refresh-token"):
       sql"""DELETE FROM refresh_tokens WHERE id = $token""".update.run()
     .unit
 
   override def deleteByAccessToken(token: AccessToken): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-refresh-token-by-access-token"):
       sql"""DELETE FROM refresh_tokens WHERE access_token = $token""".update.run()
     .unit
 

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
@@ -62,7 +62,7 @@ class PostgresSessionRepository(xa: TransactorZIO) extends SessionRepository, Ba
   ): Task[List[SessionRecord]] =
     for
       now <- Clock.instant
-      result <- xa.connect:
+      result <- xa.connectMeasured("find-sessions-by-user"):
         sql"""
         SELECT user_id, client_id, user_agent, created_at, amr
         FROM sso_sessions
@@ -78,7 +78,7 @@ class PostgresSessionRepository(xa: TransactorZIO) extends SessionRepository, Ba
   ): Task[Unit] =
     for
       now <- Clock.instant
-      _ <- xa.connect:
+      _ <- xa.connectMeasured("invalidate-sessions-by-user"):
         sql"""
           UPDATE sso_sessions
           SET expires_at = $now

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
@@ -30,7 +30,7 @@ class PostgresSessionRepository(xa: TransactorZIO) extends SessionRepository, Ba
       ttl: zio.Duration,
   ): Task[Unit] =
     Clock.instant.flatMap: now =>
-      xa.connect:
+      xa.connectMeasured("create-session"):
         sql"""
           INSERT INTO sso_sessions (id, client_id, user_id, user_agent, created_at, amr, expires_at)
           VALUES (
@@ -48,7 +48,7 @@ class PostgresSessionRepository(xa: TransactorZIO) extends SessionRepository, Ba
   override def find(id: MAC.Of[SessionId]): Task[Option[SessionRecord]] =
     for
       now <- Clock.instant
-      result <- xa.connect:
+      result <- xa.connectMeasured("find-session"):
         sql"""
           SELECT user_id, client_id, user_agent, created_at, amr, expires_at
           FROM sso_sessions

--- a/auth/implementations/postgres/src/main/scala/versola/user/PostgresUserRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/user/PostgresUserRepository.scala
@@ -21,7 +21,7 @@ class PostgresUserRepository(
   override def findOrCreate(userId: UserId, credential: Either[Email, Phone]): Task[(UserRecord, WasCreated)] =
     for
       now <- Clock.instant
-      (user, wasCreated) <- xa.connect:
+      (user, wasCreated) <- xa.connectMeasured("find-or-create-user"):
         credential match
           case Left(email) => createByEmailQuery(userId, email, now).run().head
           case Right(phone) => createByPhoneQuery(userId, phone, now).run().head
@@ -30,7 +30,7 @@ class PostgresUserRepository(
   override def create(id: UserId): Task[UserRecord] =
     for
       now <- Clock.instant
-      user <- xa.connect:
+      user <- xa.connectMeasured("create-user"):
         createQuery(id, now).run().head
     yield user
 
@@ -57,14 +57,14 @@ class PostgresUserRepository(
        """.returning[UserRecord]
 
   override def find(id: UserId): Task[Option[UserRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-user"):
       sql"select id, email, phone, login, claims, ui_locales from users where id = $id"
         .query[UserRecord]
         .run()
         .headOption
 
   override def findByCredential(credential: Either[Email, Phone]): Task[Option[UserRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-user-by-credential"):
       credential match
         case Left(email) => findByEmailQuery(email).run().headOption
         case Right(phone) => findByPhoneQuery(phone).run().headOption
@@ -76,7 +76,7 @@ class PostgresUserRepository(
       phone: Option[Phone],
       login: Option[Login],
   ): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("upsert-user"):
       sql"""insert into users (id, email, phone, login, claims, last_version)
             values ($id, $email, $phone, $login, '{}'::jsonb, $version)
             on conflict (id) do update set
@@ -89,7 +89,7 @@ class PostgresUserRepository(
     .unit
 
   override def patchClaims(id: UserId, patch: Json.Obj): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("patch-user-claims"):
       sql"update users set claims = jsonb_strip_nulls(claims || $patch::jsonb) where id = $id".update.run()
     .unit
 

--- a/auth/implementations/postgres/src/main/scala/versola/user/PostgresUserRolesRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/user/PostgresUserRolesRepository.scala
@@ -17,7 +17,7 @@ class PostgresUserRolesRepository(xa: TransactorZIO) extends UserRolesRepository
   given DbCodec[RoleId] = DbCodec.StringCodec.biMap(RoleId(_), identity[String])
 
   override def findRolesByUser(userId: UserId): Task[List[RoleId]] =
-    xa.connect:
+    xa.connectMeasured("find-roles-by-user"):
       sql"SELECT role_id FROM user_roles WHERE user_id = $userId"
         .query[String]
         .run()
@@ -25,7 +25,7 @@ class PostgresUserRolesRepository(xa: TransactorZIO) extends UserRolesRepository
         .toList
 
   override def findRolesByUserAndTenant(userId: UserId, tenantId: TenantId): Task[List[RoleId]] =
-    xa.connect:
+    xa.connectMeasured("find-roles-by-user-and-tenant"):
       sql"SELECT role_id FROM user_roles WHERE user_id = $userId AND tenant_id = $tenantId"
         .query[String]
         .run()
@@ -40,7 +40,7 @@ class PostgresUserRolesRepository(xa: TransactorZIO) extends UserRolesRepository
   ): Task[Unit] =
     if add.isEmpty && remove.isEmpty then ZIO.unit
     else
-      xa.transact:
+      xa.transactMeasured("update-roles"):
         if remove.nonEmpty then
           remove.foreach: roleId =>
             sql"DELETE FROM user_roles WHERE user_id = $userId AND tenant_id = $tenantId AND role_id = $roleId"

--- a/central/implementations/postgres/src/main/scala/versola/configuration/challenges/PostgresChallengeSettingsRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/challenges/PostgresChallengeSettingsRepository.scala
@@ -17,18 +17,18 @@ class PostgresChallengeSettingsRepository(xa: TransactorZIO) extends ChallengeSe
   given DbCodec[ChallengeSettingsRecord] = DbCodec.derived
 
   override def getAll: Task[Vector[ChallengeSettingsRecord]] =
-    xa.connect:
+    xa.connectMeasured("get-all-challenge-settings"):
       sql"""SELECT tenant_id, allowed_prefixes, password_regex, submission_limits, otp_length, otp_resend_after, passkey_settings FROM challenge_settings ORDER BY tenant_id"""
         .query[ChallengeSettingsRecord].run()
 
   override def findByTenant(tenantId: TenantId): Task[Option[ChallengeSettingsRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-challenge-settings-by-tenant"):
       sql"""SELECT tenant_id, allowed_prefixes, password_regex, submission_limits, otp_length, otp_resend_after, passkey_settings FROM challenge_settings WHERE tenant_id = $tenantId"""
         .query[ChallengeSettingsRecord].run()
         .headOption
 
   override def upsert(record: ChallengeSettingsRecord): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("upsert-challenge-settings"):
       sql"""
         INSERT INTO challenge_settings (tenant_id, allowed_prefixes, password_regex, submission_limits, otp_length, otp_resend_after, passkey_settings)
         VALUES (${record.tenantId}, ${record.allowedPrefixes}, ${record.passwordRegex}, ${record.submissionLimits}, ${record.otpLength}, ${record.otpResendAfter}, ${record.passkeySettings})

--- a/central/implementations/postgres/src/main/scala/versola/configuration/challenges/PostgresOtpChallengeRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/challenges/PostgresOtpChallengeRepository.scala
@@ -13,17 +13,17 @@ class PostgresOtpChallengeRepository(xa: TransactorZIO) extends OtpChallengeRepo
   given DbCodec[OtpTemplateRecord] = DbCodec.derived[OtpTemplateRecord]
 
   override def getAll: Task[Vector[OtpTemplateRecord]] =
-    xa.connect:
+    xa.connectMeasured("get-all-otp-templates"):
       sql"""SELECT id, tenant_id, localizations FROM otp_templates ORDER BY tenant_id, id"""
         .query[OtpTemplateRecord].run()
 
   override def find(id: String, tenantId: TenantId): Task[Option[OtpTemplateRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-otp-template"):
       sql"""SELECT id, tenant_id, localizations FROM otp_templates WHERE id = $id AND tenant_id = $tenantId"""
         .query[OtpTemplateRecord].run().headOption
 
   override def upsertTemplate(record: OtpTemplateRecord): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("upsert-otp-template"):
       sql"""
         INSERT INTO otp_templates (id, tenant_id, localizations)
         VALUES (${record.id}, ${record.tenantId}, ${record.localizations})
@@ -33,7 +33,7 @@ class PostgresOtpChallengeRepository(xa: TransactorZIO) extends OtpChallengeRepo
     .unit
 
   override def deleteTemplate(id: String, tenantId: TenantId): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-otp-template"):
       sql"""DELETE FROM otp_templates WHERE id = $id AND tenant_id = $tenantId""".update.run()
     .unit
 

--- a/central/implementations/postgres/src/main/scala/versola/configuration/clients/PostgresAuthorizationPresetRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/clients/PostgresAuthorizationPresetRepository.scala
@@ -32,7 +32,7 @@ class PostgresAuthorizationPresetRepository(
   given DbCodec[AuthorizationPreset] = DbCodec.derived
 
   override def find(id: PresetId): Task[Option[AuthorizationPreset]] =
-    xa.connect:
+    xa.connectMeasured("find-preset"):
       sql"""
         SELECT id, client_id, description, redirect_uri, post_login_redirect_uri, scope, response_type, ui_locales, custom_parameters, cookie_domain, cookie_path
         FROM authorization_presets
@@ -41,7 +41,7 @@ class PostgresAuthorizationPresetRepository(
         .query[AuthorizationPreset].run().headOption
 
   override def replace(clientId: ClientId, presets: Seq[AuthorizationPreset]): Task[Unit] =
-    xa.repeatableRead.transact:
+    xa.repeatableRead.transactMeasured("replace-presets"):
       sql"""DELETE FROM authorization_presets WHERE client_id = $clientId""".update.run()
       if presets.nonEmpty then
         batchUpdate(presets): preset =>
@@ -58,7 +58,7 @@ class PostgresAuthorizationPresetRepository(
     .unit
 
   override def getAll: Task[Vector[AuthorizationPreset]] =
-    xa.connect:
+    xa.connectMeasured("get-all-presets"):
       sql"""
         SELECT id, client_id, description, redirect_uri, post_login_redirect_uri, scope, response_type, ui_locales, custom_parameters, cookie_domain, cookie_path
         FROM authorization_presets

--- a/central/implementations/postgres/src/main/scala/versola/configuration/clients/PostgresOAuthClientRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/clients/PostgresOAuthClientRepository.scala
@@ -34,7 +34,7 @@ class PostgresOAuthClientRepository(
     """
 
   override def getAll: Task[Vector[OAuthClientRecord]] =
-    xa.connect:
+    xa.connectMeasured("get-all-clients"):
       sql"""
         SELECT id, tenant_id, client_name, redirect_uris, scope, external_audience, secret, previous_secret, access_token_ttl, refresh_token_ttl, permissions, theme, auth_flow, otp_template_id
         FROM oauth_clients
@@ -42,11 +42,11 @@ class PostgresOAuthClientRepository(
         .query[OAuthClientRecord].run()
 
   override def find(clientId: ClientId): Task[Option[OAuthClientRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-client"):
       findClient(clientId).query[OAuthClientRecord].run().headOption
 
   override def createClient(client: OAuthClientRecord): IO[ClientAlreadyExists | Throwable, Unit] =
-    xa.connect:
+    xa.connectMeasured("create-client"):
       sql"""
         INSERT INTO oauth_clients (id, tenant_id, client_name, redirect_uris, scope, external_audience, secret, previous_secret, access_token_ttl, refresh_token_ttl, permissions, theme, auth_flow, otp_template_id)
         VALUES (${client.id}, ${client.tenantId}, ${client.clientName}, ${client.redirectUris}, ${client.scope},
@@ -71,7 +71,7 @@ class PostgresOAuthClientRepository(
       authFlow: Option[AuthFlow],
       otpTemplateId: Option[String],
   ): Task[Unit] =
-    xa.repeatableRead.transact:
+    xa.repeatableRead.transactMeasured("update-client"):
       val client = findClient(clientId).query[OAuthClientRecord].run().head
       val newClientName = clientName.getOrElse(client.clientName)
       val newRedirectUris = client.redirectUris -- patchRedirectUris.remove ++ patchRedirectUris.add
@@ -98,7 +98,7 @@ class PostgresOAuthClientRepository(
     .unit
 
   override def rotateClientSecret(clientId: ClientId, newSecret: Array[Byte]): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("rotate-client-secret"):
       sql"""
         UPDATE oauth_clients
         SET previous_secret = secret,
@@ -108,7 +108,7 @@ class PostgresOAuthClientRepository(
     .unit
 
   override def deletePreviousClientSecret(clientId: ClientId): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-previous-client-secret"):
       sql"""
         UPDATE oauth_clients
         SET previous_secret = NULL
@@ -117,7 +117,7 @@ class PostgresOAuthClientRepository(
     .unit
 
   override def deleteClient(clientId: ClientId): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-client"):
       sql"""DELETE FROM oauth_clients WHERE id = $clientId""".update.run()
     .unit
 

--- a/central/implementations/postgres/src/main/scala/versola/configuration/edges/PostgresEdgeRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/edges/PostgresEdgeRepository.scala
@@ -14,14 +14,14 @@ class PostgresEdgeRepository(xa: TransactorZIO) extends EdgeRepository, BasicCod
   given DbCodec[EdgeRecord] = DbCodec.derived
 
   override def getAll: Task[Vector[EdgeRecord]] =
-    xa.connect:
+    xa.connectMeasured("get-all-edges"):
       sql"""
         SELECT id, public_key_jwk, old_public_key_jwk
         FROM edges
       """.query[EdgeRecord].run()
 
   override def find(id: EdgeId): Task[Option[EdgeRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-edge"):
       sql"""
         SELECT id, public_key_jwk, old_public_key_jwk
         FROM edges
@@ -29,7 +29,7 @@ class PostgresEdgeRepository(xa: TransactorZIO) extends EdgeRepository, BasicCod
       """.query[EdgeRecord].run().headOption
 
   override def createEdge(id: EdgeId, publicKeyJwk: Json.Obj): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("create-edge"):
       sql"""
         INSERT INTO edges (id, public_key_jwk, old_public_key_jwk)
         VALUES ($id, $publicKeyJwk, NULL)
@@ -37,7 +37,7 @@ class PostgresEdgeRepository(xa: TransactorZIO) extends EdgeRepository, BasicCod
     .unit
 
   override def rotateEdgeKey(id: EdgeId, newPublicKeyJwk: Json.Obj): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("rotate-edge-key"):
       sql"""
         UPDATE edges
         SET old_public_key_jwk = public_key_jwk,
@@ -47,7 +47,7 @@ class PostgresEdgeRepository(xa: TransactorZIO) extends EdgeRepository, BasicCod
     .unit
 
   override def deleteOldEdgeKey(id: EdgeId): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-old-edge-key"):
       sql"""
         UPDATE edges
         SET old_public_key_jwk = NULL
@@ -56,7 +56,7 @@ class PostgresEdgeRepository(xa: TransactorZIO) extends EdgeRepository, BasicCod
     .unit
 
   override def deleteEdge(id: EdgeId): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-edge"):
       sql"""DELETE FROM edges WHERE id = $id""".update.run()
     .unit
 

--- a/central/implementations/postgres/src/main/scala/versola/configuration/forms/PostgresFormRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/forms/PostgresFormRepository.scala
@@ -17,13 +17,13 @@ class PostgresFormRepository(xa: TransactorZIO) extends FormRepository, BasicCod
   given DbCodec[FormRecord] = DbCodec.derived
 
   override def getAll: Task[Vector[FormRecord]] =
-    xa.connect:
+    xa.connectMeasured("get-all-forms"):
       sql"""SELECT id, version, active, style, js_source, js_compiled, localizations, properties FROM forms ORDER BY id, version DESC"""
         .query[FormRecord]
         .run()
 
   override def find(id: FormId, version: Int): Task[Option[FormRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-form"):
       sql"""SELECT id, version, active, style, js_source, js_compiled, localizations, properties FROM forms WHERE id = $id AND version = $version"""
         .query[FormRecord]
         .run()
@@ -38,7 +38,7 @@ class PostgresFormRepository(xa: TransactorZIO) extends FormRepository, BasicCod
       properties: Vector[BackendProperty],
       activate: Boolean,
   ): Task[Unit] =
-    xa.repeatableRead.transact:
+    xa.repeatableRead.transactMeasured("upsert-form"):
       val versions = sql"""SELECT version FROM forms WHERE id = $id ORDER BY version DESC""".query[Int].run()
       val nextVersion = versions.maxOption.getOrElse(0) + 1
       val makeActive = activate || versions.isEmpty
@@ -52,7 +52,7 @@ class PostgresFormRepository(xa: TransactorZIO) extends FormRepository, BasicCod
       ()
 
   override def setActiveVersion(id: FormId, version: Int): Task[Unit] =
-    xa.transact:
+    xa.transactMeasured("set-active-form-version"):
       sql"""UPDATE forms SET active = false WHERE id = $id""".update.run()
       sql"""UPDATE forms SET active = true WHERE id = $id AND version = $version""".update.run()
     .unit

--- a/central/implementations/postgres/src/main/scala/versola/configuration/locales/PostgresLocaleRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/locales/PostgresLocaleRepository.scala
@@ -11,11 +11,11 @@ class PostgresLocaleRepository(xa: TransactorZIO) extends LocaleRepository, Basi
   given DbCodec[LocaleRecord] = DbCodec.derived
 
   override def getAll: Task[Vector[LocaleRecord]] =
-    xa.connect:
+    xa.connectMeasured("get-all-locales"):
       sql"""SELECT code, name, is_default, active FROM locales ORDER BY code""".query[LocaleRecord].run()
 
   override def update(add: Vector[LocaleRecord], delete: Vector[String]): Task[Unit] =
-    xa.repeatableRead.transact:
+    xa.repeatableRead.transactMeasured("update-locales"):
       delete.foreach { code =>
         sql"""DELETE FROM locales WHERE code = $code""".update.run()
         sql"""UPDATE forms SET localizations = localizations - $code WHERE jsonb_exists(localizations, $code)""".update.run()
@@ -27,7 +27,7 @@ class PostgresLocaleRepository(xa: TransactorZIO) extends LocaleRepository, Basi
       }
 
   override def setDefault(code: String): Task[Unit] =
-    xa.repeatableRead.transact:
+    xa.repeatableRead.transactMeasured("set-default-locale"):
       sql"""UPDATE locales SET is_default = FALSE WHERE is_default = TRUE""".update.run()
       sql"""UPDATE locales SET is_default = TRUE WHERE code = $code""".update.run()
     .unit

--- a/central/implementations/postgres/src/main/scala/versola/configuration/permissions/PostgresPermissionRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/permissions/PostgresPermissionRepository.scala
@@ -19,7 +19,7 @@ class PostgresPermissionRepository(xa: TransactorZIO) extends PermissionReposito
   given DbCodec[PermissionRecord] = DbCodec.derived
 
   override def getAll: Task[Vector[PermissionRecord]] =
-    xa.connect:
+    xa.connectMeasured("get-all-permissions"):
       sql"""
         SELECT tenant_id, id, description, endpoint_ids FROM permissions
         ORDER BY tenant_id NULLS FIRST, id
@@ -29,7 +29,7 @@ class PostgresPermissionRepository(xa: TransactorZIO) extends PermissionReposito
     tenantId: Option[TenantId],
     permission: Permission
   ): Task[Option[PermissionRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-permission"):
       sql"""
         SELECT tenant_id, id, description, endpoint_ids FROM permissions
         WHERE tenant_id IS NOT DISTINCT FROM $tenantId AND id = $permission
@@ -41,7 +41,7 @@ class PostgresPermissionRepository(xa: TransactorZIO) extends PermissionReposito
       description: Map[String, String],
       endpointIds: Set[ResourceEndpointId],
   ): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("create-permission"):
       sql"""INSERT INTO permissions (tenant_id, id, description, endpoint_ids)
             VALUES ($tenantId, $permission, $description, $endpointIds)""".update.run()
     .unit
@@ -52,7 +52,7 @@ class PostgresPermissionRepository(xa: TransactorZIO) extends PermissionReposito
       descriptionPatch: PatchDescription,
       endpointIdsPatch: Option[Set[ResourceEndpointId]],
   ): Task[Unit] =
-    xa.repeatableRead.transact:
+    xa.repeatableRead.transactMeasured("update-permission"):
       val existing = sql"""
         SELECT tenant_id, id, description, endpoint_ids FROM permissions
         WHERE tenant_id IS NOT DISTINCT FROM $tenantId AND id = $permission
@@ -76,7 +76,7 @@ class PostgresPermissionRepository(xa: TransactorZIO) extends PermissionReposito
       tenantId: Option[TenantId],
       permission: Permission,
   ): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-permission"):
       sql"""DELETE FROM permissions WHERE tenant_id IS NOT DISTINCT FROM $tenantId AND id = $permission""".update.run()
     .unit
 

--- a/central/implementations/postgres/src/main/scala/versola/configuration/resources/PostgresResourceRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/resources/PostgresResourceRepository.scala
@@ -34,7 +34,7 @@ class PostgresResourceRepository(xa: TransactorZIO) extends ResourceRepository, 
     """.query[ResourceRecord]
 
   override def getAll: Task[Vector[ResourceRecord]] =
-    xa.connect:
+    xa.connectMeasured("get-all-resources"):
       sql"""
         SELECT tenant_id, id, alias, resource, endpoints FROM resources
       """.query[ResourceRecord].run()
@@ -42,7 +42,7 @@ class PostgresResourceRepository(xa: TransactorZIO) extends ResourceRepository, 
   override def findResource(
       resourceId: ResourceId,
   ): Task[Option[ResourceRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-resource"):
       findResourceQuery(resourceId).run().headOption
 
   override def createResource(
@@ -51,7 +51,7 @@ class PostgresResourceRepository(xa: TransactorZIO) extends ResourceRepository, 
       resource: ResourceUri,
       endpoints: Vector[ResourceEndpointRecord],
   ): Task[ResourceId] =
-    xa.connect:
+    xa.connectMeasured("create-resource"):
       sql"""
         INSERT INTO resources (tenant_id, alias, resource, endpoints)
         VALUES ($tenantId, $alias, $resource, $endpoints)
@@ -65,7 +65,7 @@ class PostgresResourceRepository(xa: TransactorZIO) extends ResourceRepository, 
       addEndpoints: Vector[ResourceEndpointRecord],
       deleteEndpoints: Set[ResourceEndpointId],
   ): Task[Unit] =
-    xa.repeatableRead.transact:
+    xa.repeatableRead.transactMeasured("update-resource"):
       findResourceQuery(id).run().headOption match
         case None => ()
         case Some(resource) =>
@@ -87,7 +87,7 @@ class PostgresResourceRepository(xa: TransactorZIO) extends ResourceRepository, 
   override def deleteResource(
       id: ResourceId,
   ): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-resource"):
       sql"""DELETE FROM resources WHERE id = $id""".update.run()
     .unit
 

--- a/central/implementations/postgres/src/main/scala/versola/configuration/roles/PostgresRoleRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/roles/PostgresRoleRepository.scala
@@ -19,7 +19,7 @@ class PostgresRoleRepository(
   given DbCodec[RoleRecord] = DbCodec.derived[RoleRecord]
 
   override def getAll: Task[Vector[RoleRecord]] =
-    xa.connect:
+    xa.connectMeasured("get-all-roles"):
       sql"""SELECT id, tenant_id, description, permissions, active FROM roles"""
         .query[RoleRecord].run()
 
@@ -27,7 +27,7 @@ class PostgresRoleRepository(
       tenantId: TenantId,
       id: RoleId,
   ): Task[Option[RoleRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-role"):
       getRole(id, tenantId).run().headOption
 
 
@@ -37,7 +37,7 @@ class PostgresRoleRepository(
       description: Map[String, String],
       permissions: List[Permission],
   ): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("create-role"):
       sql"""
           INSERT INTO roles (id, tenant_id, description, permissions, active)
           VALUES ($id, $tenantId, $description, $permissions, TRUE)
@@ -54,7 +54,7 @@ class PostgresRoleRepository(
       descriptionPatch: PatchDescription,
       permissionsPatch: PatchPermissions,
   ): Task[Unit] =
-    xa.repeatableRead.transact:
+    xa.repeatableRead.transactMeasured("update-role"):
       getRole(id, tenantId).run().headOption match
         case None => ()
         case Some(role) =>
@@ -71,13 +71,13 @@ class PostgresRoleRepository(
 
   override def markRoleInactive(tenantId: TenantId, id: RoleId): Task[Unit] =
     Clock.instant.flatMap { now =>
-      xa.connect:
+      xa.connectMeasured("mark-role-inactive"):
         sql"""UPDATE roles SET active = FALSE WHERE tenant_id = $tenantId AND id = $id""".update.run()
       .unit
     }
 
   override def deleteRole(tenantId: TenantId, id: RoleId): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-role"):
       sql"""DELETE FROM roles WHERE tenant_id = $tenantId AND id = $id""".update.run()
     .unit
 

--- a/central/implementations/postgres/src/main/scala/versola/configuration/scopes/PostgresOAuthScopeRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/scopes/PostgresOAuthScopeRepository.scala
@@ -21,7 +21,7 @@ class PostgresOAuthScopeRepository(
   given DbCodec[ScopeRecord] = DbCodec.derived
 
   override def getAll: Task[Vector[ScopeRecord]] =
-    xa.connect:
+    xa.connectMeasured("get-all-scopes"):
       sql"""
             SELECT tenant_id, id, description, claims FROM oauth_scopes
          """.query[ScopeRecord].run()
@@ -30,7 +30,7 @@ class PostgresOAuthScopeRepository(
       tenantId: TenantId,
       scopeId: ScopeToken,
   ): Task[Option[ScopeRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-scope"):
       sql"""
         SELECT tenant_id, id, description, claims FROM oauth_scopes
         WHERE tenant_id = $tenantId AND id = $scopeId
@@ -42,7 +42,7 @@ class PostgresOAuthScopeRepository(
       description: Map[String, String],
       claims: List[CreateClaim],
   ): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("create-scope"):
       sql"""
             INSERT INTO oauth_scopes (id, tenant_id, description, claims)
             VALUES ($id, $tenantId, $description, ${claims.map(_.asRecord)}::jsonb[])
@@ -54,7 +54,7 @@ class PostgresOAuthScopeRepository(
       id: ScopeToken,
       patch: PatchScope,
   ): Task[Unit] =
-    xa.repeatableRead.transact:
+    xa.repeatableRead.transactMeasured("update-scope"):
       val scope =
         sql"""SELECT tenant_id, id, description, claims::jsonb[] FROM oauth_scopes WHERE tenant_id = $tenantId AND id = $id"""
           .query[ScopeRecord].run().head
@@ -84,7 +84,7 @@ class PostgresOAuthScopeRepository(
       tenantId: TenantId,
       id: ScopeToken,
   ): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-scope"):
       sql"""DELETE FROM oauth_scopes WHERE tenant_id = $tenantId AND id = $id""".update.run()
     .unit
 

--- a/central/implementations/postgres/src/main/scala/versola/configuration/tenants/PostgresTenantRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/tenants/PostgresTenantRepository.scala
@@ -14,7 +14,7 @@ class PostgresTenantRepository(xa: TransactorZIO) extends TenantRepository, Basi
   given DbCodec[TenantRecord] = DbCodec.derived
 
   override def getAll: Task[Vector[TenantRecord]] =
-    xa.connect:
+    xa.connectMeasured("get-all-tenants"):
       sql"""SELECT id, description, edge_id FROM tenants ORDER BY id"""
         .query[TenantRecord]
         .run()
@@ -24,7 +24,7 @@ class PostgresTenantRepository(xa: TransactorZIO) extends TenantRepository, Basi
       description: String,
       edgeId: Option[EdgeId],
   ): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("create-tenant"):
       sql"""INSERT INTO tenants (id, description, edge_id) VALUES ($id, $description, $edgeId)""".update.run()
     .unit
 
@@ -33,12 +33,12 @@ class PostgresTenantRepository(xa: TransactorZIO) extends TenantRepository, Basi
       description: String,
       edgeId: Option[EdgeId],
   ): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("update-tenant"):
       sql"""UPDATE tenants SET description = $description, edge_id = $edgeId WHERE id = $id""".update.run()
     .unit
 
   override def deleteTenant(id: TenantId): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-tenant"):
       sql"""DELETE FROM tenants WHERE id = $id""".update.run()
     .unit
 

--- a/central/implementations/postgres/src/main/scala/versola/configuration/themes/PostgresThemeRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/themes/PostgresThemeRepository.scala
@@ -13,26 +13,26 @@ class PostgresThemeRepository(xa: TransactorZIO) extends ThemeRepository, BasicC
   given DbCodec[ThemeRecord] = DbCodec.derived
 
   override def getAll: Task[Vector[ThemeRecord]] =
-    xa.connect:
+    xa.connectMeasured("get-all-themes"):
       sql"""SELECT id, css, tenant_id FROM themes ORDER BY id"""
         .query[ThemeRecord]
         .run()
 
   override def create(theme: ThemeRecord): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("create-theme"):
       sql"""INSERT INTO themes (id, css, tenant_id)
             VALUES (${theme.id}, ${theme.css}, ${theme.tenantId})"""
         .update.run()
     .unit
 
   override def update(theme: ThemeRecord): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("update-theme"):
       sql"""UPDATE themes SET css = ${theme.css} WHERE id = ${theme.id}"""
         .update.run()
     .unit
 
   override def delete(id: String): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-theme"):
       sql"""DELETE FROM themes WHERE id = $id"""
         .update.run()
     .unit

--- a/central/implementations/postgres/src/main/scala/versola/users/PostgresUserRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/users/PostgresUserRepository.scala
@@ -27,22 +27,22 @@ class PostgresUserRepository(xa: TransactorZIO, secureRandom: SecureRandom) exte
   given DbCodec[Instant] = DbCodec.InstantCodec
 
   override def findById(id: UserId): Task[Option[UserIndexRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-user-by-id"):
       sql"SELECT id, email, phone, login FROM user_index WHERE id = $id"
         .query[UserIndexRecord].run().headOption
 
   override def findByEmail(email: Email): Task[Option[UserIndexRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-user-by-email"):
       sql"SELECT id, email, phone, login FROM user_index WHERE email = $email"
         .query[UserIndexRecord].run().headOption
 
   override def findByPhone(phone: Phone): Task[Option[UserIndexRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-user-by-phone"):
       sql"SELECT id, email, phone, login FROM user_index WHERE phone = $phone"
         .query[UserIndexRecord].run().headOption
 
   override def findByLogin(login: Login): Task[Option[UserIndexRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-user-by-login"):
       sql"SELECT id, email, phone, login FROM user_index WHERE login = $login"
         .query[UserIndexRecord].run().headOption
 
@@ -85,7 +85,7 @@ class PostgresUserRepository(xa: TransactorZIO, secureRandom: SecureRandom) exte
     (for
       version <- secureRandom.nextUUIDv7
       now <- Clock.instant
-      _ <- xa.transact:
+      _ <- xa.transactMeasured("create-user"):
              upsertSql(id, email, phone, login)
              enqueueEventSql(id, version, OutboxEvent.UpsertUser(id, version, email, phone, login), now)
     yield ()).mapError:
@@ -101,7 +101,7 @@ class PostgresUserRepository(xa: TransactorZIO, secureRandom: SecureRandom) exte
     for
       version <- secureRandom.nextUUIDv7
       now <- Clock.instant
-      _ <- xa.transact:
+      _ <- xa.transactMeasured("patch-user"):
         // Lock the user row to prevent lost updates and serialize events
         sql"SELECT id FROM user_index WHERE id = $id FOR UPDATE".query[UserId].run()
 
@@ -126,7 +126,7 @@ class PostgresUserRepository(xa: TransactorZIO, secureRandom: SecureRandom) exte
     */
   override def claimDueEvents(limit: Int, lease: Duration): Task[Vector[OutboxRecord]] =
     val leaseSeconds = lease.toSeconds
-    xa.connect:
+    xa.connectMeasured("claim-due-events"):
       sql"""UPDATE user_outbox SET
               next_attempt_at = NOW() + ($leaseSeconds || ' seconds')::interval
             WHERE id IN (
@@ -146,13 +146,13 @@ class PostgresUserRepository(xa: TransactorZIO, secureRandom: SecureRandom) exte
         .run()
 
   override def deleteEvent(id: UUID): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-event"):
       sql"DELETE FROM user_outbox WHERE id = $id".update.run()
     .unit
 
   override def rescheduleEvent(id: UUID, delay: Duration): Task[Unit] =
     val seconds = delay.toSeconds
-    xa.connect:
+    xa.connectMeasured("reschedule-event"):
       sql"""UPDATE user_outbox SET
               attempts = attempts + 1,
               next_attempt_at = NOW() + ($seconds || ' seconds')::interval
@@ -160,7 +160,7 @@ class PostgresUserRepository(xa: TransactorZIO, secureRandom: SecureRandom) exte
     .unit
 
   override def moveToDeadLetter(id: UUID, error: String): Task[Unit] =
-    xa.transact:
+    xa.transactMeasured("move-event-to-dead-letter"):
       sql"""INSERT INTO user_outbox_dead (id, user_id, event_type, payload, attempts, failed_at, error)
             SELECT id, user_id, event_type, payload, attempts, NOW(), $error
             FROM user_outbox

--- a/edge/implementations/postgres/src/main/scala/versola/edge/PostgresEdgeRefreshTokenRepository.scala
+++ b/edge/implementations/postgres/src/main/scala/versola/edge/PostgresEdgeRefreshTokenRepository.scala
@@ -18,7 +18,7 @@ class PostgresEdgeRefreshTokenRepository(xa: TransactorZIO) extends EdgeRefreshT
       accessTokenId: AccessTokenId,
       record: EdgeRefreshTokenRecord,
   ): Task[Unit] =
-    xa.connect {
+    xa.connectMeasured("create-edge-refresh-token") {
       sql"""
         INSERT INTO edge_refresh_tokens (id, preset_id, refresh_token, expires_at)
         VALUES ($accessTokenId, ${record.presetId}, ${record.encryptedRefreshToken}, ${record.expiresAt})
@@ -31,7 +31,7 @@ class PostgresEdgeRefreshTokenRepository(xa: TransactorZIO) extends EdgeRefreshT
 
   override def find(accessTokenId: AccessTokenId): Task[Option[EdgeRefreshTokenRecord]] =
     Clock.instant.flatMap { now =>
-      xa.connect {
+      xa.connectMeasured("find-edge-refresh-token") {
         sql"""
           SELECT preset_id, refresh_token, expires_at
           FROM edge_refresh_tokens
@@ -44,14 +44,14 @@ class PostgresEdgeRefreshTokenRepository(xa: TransactorZIO) extends EdgeRefreshT
     }
 
   override def delete(accessTokenId: AccessTokenId): Task[Unit] =
-    xa.connect {
+    xa.connectMeasured("delete-edge-refresh-token") {
       sql"""
         DELETE FROM edge_refresh_tokens WHERE id = $accessTokenId
       """.update.run()
     }.unit
 
   override def deleteByPresetId(presetId: PresetId): Task[Unit] =
-    xa.connect {
+    xa.connectMeasured("delete-edge-refresh-token-by-preset") {
       sql"""
         DELETE FROM edge_refresh_tokens WHERE preset_id = $presetId
       """.update.run()

--- a/edge/implementations/postgres/src/main/scala/versola/edge/PostgresLoginRepository.scala
+++ b/edge/implementations/postgres/src/main/scala/versola/edge/PostgresLoginRepository.scala
@@ -4,9 +4,10 @@ import com.augustnagro.magnum.*
 import com.augustnagro.magnum.magzio.TransactorZIO
 import versola.edge.login.{LoginRecord, LoginRepository}
 import versola.edge.model.{CodeVerifier, PresetId, State}
+import versola.util.postgres.BasicCodecs
 import zio.{Clock, Duration, Task, ZLayer}
 
-class PostgresLoginRepository(xa: TransactorZIO) extends LoginRepository:
+class PostgresLoginRepository(xa: TransactorZIO) extends LoginRepository, BasicCodecs:
   given DbCodec[CodeVerifier] = DbCodec.StringCodec.biMap(CodeVerifier(_), identity[String])
   given DbCodec[State] = DbCodec.StringCodec.biMap(State(_), identity[String])
   given DbCodec[PresetId] = DbCodec.StringCodec.biMap(PresetId(_), identity[String])
@@ -19,7 +20,7 @@ class PostgresLoginRepository(xa: TransactorZIO) extends LoginRepository:
   ): Task[Unit] =
     Clock.instant.flatMap { now =>
       val expiresAt = now.plusSeconds(ttl.toSeconds)
-      xa.connect {
+      xa.connectMeasured("create-login") {
         sql"""
           INSERT INTO pending_logins (login_id, state, code_verifier, preset_id, expires_at)
           VALUES ($loginId, ${data.state}, ${data.codeVerifier}, ${data.presetId}, $expiresAt)
@@ -34,7 +35,7 @@ class PostgresLoginRepository(xa: TransactorZIO) extends LoginRepository:
 
   override def find(loginId: String): Task[Option[LoginRecord]] =
     Clock.instant.flatMap { now =>
-      xa.connect {
+      xa.connectMeasured("find-login") {
         sql"""
           SELECT code_verifier, preset_id, state
           FROM pending_logins
@@ -48,7 +49,7 @@ class PostgresLoginRepository(xa: TransactorZIO) extends LoginRepository:
 
   override def findByState(state: State): Task[Option[LoginRecord]] =
     Clock.instant.flatMap { now =>
-      xa.connect {
+      xa.connectMeasured("find-login-by-state") {
         sql"""
           SELECT code_verifier, preset_id, state
           FROM pending_logins
@@ -61,14 +62,14 @@ class PostgresLoginRepository(xa: TransactorZIO) extends LoginRepository:
     }
 
   override def delete(loginId: String): Task[Unit] =
-    xa.connect {
+    xa.connectMeasured("delete-login") {
       sql"""
         DELETE FROM pending_logins WHERE login_id = $loginId
       """.update.run()
     }.unit
 
   override def deleteByState(state: State): Task[Unit] =
-    xa.connect {
+    xa.connectMeasured("delete-login-by-state") {
       sql"""
         DELETE FROM pending_logins WHERE state = $state
       """.update.run()

--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/BasicCodecs.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/BasicCodecs.scala
@@ -1,11 +1,11 @@
 package versola.util.postgres
 
-import com.augustnagro.magnum.DbCodec
+import com.augustnagro.magnum.{DbCodec, DbCon, DbTx}
 import com.augustnagro.magnum.magzio.TransactorZIO
 import com.augustnagro.magnum.pg.json.JsonBDbCodec
 import com.augustnagro.magnum.pg.{PgCodec, SqlArrayCodec, json}
 import versola.util.Secret
-import zio.NonEmptyChunk
+import zio.{NonEmptyChunk, Task, Trace}
 import zio.json.*
 import zio.json.ast.Json
 import zio.prelude.NonEmptySet
@@ -97,3 +97,9 @@ trait BasicCodecs:
 
     def serializable: TransactorZIO =
       xa.withConnectionConfig(_.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE))
+
+    def connectMeasured[A](operation: String)(f: DbCon ?=> A)(using Trace): Task[A] =
+      DbMetrics.measured(operation)(xa.connect(f))
+
+    def transactMeasured[A](operation: String)(f: DbTx ?=> A)(using Trace): Task[A] =
+      DbMetrics.measured(operation)(xa.transact(f))

--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/DbMetrics.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/DbMetrics.scala
@@ -1,0 +1,41 @@
+package versola.util.postgres
+
+import zio.*
+import zio.metrics.*
+
+object DbMetrics:
+
+  private[postgres] val boundaries: MetricKeyType.Histogram.Boundaries =
+    MetricKeyType.Histogram.Boundaries.fromChunk(
+      Chunk(0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0),
+    )
+
+  private def histogram(repository: String, operation: String, outcome: String) =
+    Metric
+      .histogram("db_client_operation_duration_seconds", boundaries)
+      .tagged(
+        MetricLabel("repository", repository),
+        MetricLabel("operation", operation),
+        MetricLabel("db_system", "postgresql"),
+        MetricLabel("outcome", outcome),
+      )
+
+  /** Derives the simple repository class name from the call-site trace. */
+  def repositoryName(trace: Trace): String =
+    trace match
+      case Trace(location, _, _) =>
+        val lastDot = location.lastIndexOf('.')
+        val owner = if lastDot >= 0 then location.substring(0, lastDot) else location
+        owner.substring(owner.lastIndexOf('.') + 1).stripSuffix("$")
+      case _ => "unknown"
+
+  /** Measures a database effect, recording its latency on both success and
+    * failure paths under the `db_client_operation_duration_seconds` histogram.
+    * The original exit is re-raised unchanged.
+    */
+  def measured[A](operation: String)(zio: Task[A])(using trace: Trace): Task[A] =
+    val repository = repositoryName(trace)
+    zio.exit.timed.flatMap: (elapsed, exit) =>
+      val outcome = if exit.isSuccess then "success" else "failure"
+      val seconds = elapsed.toNanos.toDouble / 1e9
+      histogram(repository, operation, outcome).update(seconds) *> exit

--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/DbMetrics.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/DbMetrics.scala
@@ -24,9 +24,7 @@ object DbMetrics:
   def repositoryName(trace: Trace): String =
     trace match
       case Trace(location, _, _) =>
-        val lastDot = location.lastIndexOf('.')
-        val owner = if lastDot >= 0 then location.substring(0, lastDot) else location
-        owner.substring(owner.lastIndexOf('.') + 1).stripSuffix("$")
+        location.replace("$.", ".").stripSuffix("$")
       case _ => "unknown"
 
   /** Measures a database effect, recording its latency on both success and

--- a/util/implementations/postgres/src/test/scala/versola/util/postgres/DbMetricsSpec.scala
+++ b/util/implementations/postgres/src/test/scala/versola/util/postgres/DbMetricsSpec.scala
@@ -1,0 +1,61 @@
+package versola.util.postgres
+
+import zio.*
+import zio.metrics.*
+import zio.test.*
+
+object DbMetricsSpec extends ZIOSpecDefault:
+
+  private def histogramCount(repository: String, operation: String, outcome: String): UIO[Long] =
+    Metric
+      .histogram("db_client_operation_duration_seconds", DbMetrics.boundaries)
+      .tagged(
+        MetricLabel("repository", repository),
+        MetricLabel("operation", operation),
+        MetricLabel("db_system", "postgresql"),
+        MetricLabel("outcome", outcome),
+      )
+      .value
+      .map(_.count)
+
+  // Repo-shaped helper: the call-site trace must resolve `repository` to this object's simple name.
+  private def autoDerivedOp: Task[Int] =
+    DbMetrics.measured("auto-op")(ZIO.succeed(1))
+
+  def spec = suite("DbMetrics")(
+    suite("repositoryName")(
+      test("derives the simple class name from a method location") {
+        val trace =
+          Trace.apply("versola.configuration.themes.PostgresThemeRepository.getAll", "PostgresThemeRepository.scala", 10)
+        assertTrue(DbMetrics.repositoryName(trace) == "PostgresThemeRepository")
+      },
+      test("strips a trailing $ from object owners") {
+        val trace = Trace.apply("versola.configuration.themes.ThemeQueries$.getAll", "ThemeQueries.scala", 5)
+        assertTrue(DbMetrics.repositoryName(trace) == "ThemeQueries")
+      },
+      test("falls back to unknown for the empty trace") {
+        assertTrue(DbMetrics.repositoryName(Trace.empty) == "unknown")
+      },
+    ),
+    test("records a success outcome with the derived repository and given operation") {
+      val trace = Trace.apply("versola.test.SuccessRepo.run", "SuccessRepo.scala", 1)
+      for
+        _ <- DbMetrics.measured("success-op")(ZIO.succeed(()))(using trace)
+        count <- histogramCount("SuccessRepo", "success-op", "success")
+      yield assertTrue(count == 1L)
+    },
+    test("records a failure outcome and re-raises the original error") {
+      val trace = Trace.apply("versola.test.FailureRepo.run", "FailureRepo.scala", 1)
+      val boom = new RuntimeException("boom")
+      for
+        exit <- DbMetrics.measured("failure-op")(ZIO.fail(boom))(using trace).exit
+        count <- histogramCount("FailureRepo", "failure-op", "failure")
+      yield assertTrue(exit == Exit.fail(boom), count == 1L)
+    },
+    test("auto-derives the repository from the enclosing class") {
+      for
+        result <- autoDerivedOp
+        count <- histogramCount("DbMetricsSpec", "auto-op", "success")
+      yield assertTrue(result == 1, count == 1L)
+    },
+  )

--- a/util/implementations/postgres/src/test/scala/versola/util/postgres/DbMetricsSpec.scala
+++ b/util/implementations/postgres/src/test/scala/versola/util/postgres/DbMetricsSpec.scala
@@ -27,11 +27,11 @@ object DbMetricsSpec extends ZIOSpecDefault:
       test("derives the simple class name from a method location") {
         val trace =
           Trace.apply("versola.configuration.themes.PostgresThemeRepository.getAll", "PostgresThemeRepository.scala", 10)
-        assertTrue(DbMetrics.repositoryName(trace) == "PostgresThemeRepository")
+        assertTrue(DbMetrics.repositoryName(trace) == "versola.configuration.themes.PostgresThemeRepository.getAll")
       },
       test("strips a trailing $ from object owners") {
         val trace = Trace.apply("versola.configuration.themes.ThemeQueries$.getAll", "ThemeQueries.scala", 5)
-        assertTrue(DbMetrics.repositoryName(trace) == "ThemeQueries")
+        assertTrue(DbMetrics.repositoryName(trace) == "versola.configuration.themes.ThemeQueries.getAll")
       },
       test("falls back to unknown for the empty trace") {
         assertTrue(DbMetrics.repositoryName(Trace.empty) == "unknown")
@@ -41,7 +41,7 @@ object DbMetricsSpec extends ZIOSpecDefault:
       val trace = Trace.apply("versola.test.SuccessRepo.run", "SuccessRepo.scala", 1)
       for
         _ <- DbMetrics.measured("success-op")(ZIO.succeed(()))(using trace)
-        count <- histogramCount("SuccessRepo", "success-op", "success")
+        count <- histogramCount("versola.test.SuccessRepo.run", "success-op", "success")
       yield assertTrue(count == 1L)
     },
     test("records a failure outcome and re-raises the original error") {
@@ -49,13 +49,13 @@ object DbMetricsSpec extends ZIOSpecDefault:
       val boom = new RuntimeException("boom")
       for
         exit <- DbMetrics.measured("failure-op")(ZIO.fail(boom))(using trace).exit
-        count <- histogramCount("FailureRepo", "failure-op", "failure")
+        count <- histogramCount("versola.test.FailureRepo.run", "failure-op", "failure")
       yield assertTrue(exit == Exit.fail(boom), count == 1L)
     },
     test("auto-derives the repository from the enclosing class") {
       for
         result <- autoDerivedOp
-        count <- histogramCount("DbMetricsSpec", "auto-op", "success")
+        count <- histogramCount("versola.util.postgres.DbMetricsSpec.autoDerivedOp", "auto-op", "success")
       yield assertTrue(result == 1, count == 1L)
     },
   )


### PR DESCRIPTION
What's changed
Cherry-picked and adapted the DB metrics implementation from PR #14.

Added DbMetrics.scala — ZIO histogram db_client_operation_duration_seconds with labels: repository, operation, db_system, outcome. Repository name is auto-derived from Trace.
Added connectMeasured / transactMeasured extensions to BasicCodecs.scala.
Instrumented PostgresPasskeyRepository (8 methods) and PostgresSessionRepository (4 methods).
Added DbMetricsSpec — 6 unit tests covering trace parsing, success/failure recording, label derivation.

Verification

sbt compile ✅
DbMetricsSpec 6/6 ✅

Closes #3