### PR TITLE
Diagnostics server stops immediately on startup — /metrics, /liveness, /readiness unavailable  #42

### DIFF
--- a/util/src/main/scala/versola/util/http/VersolaApp.scala
+++ b/util/src/main/scala/versola/util/http/VersolaApp.scala
@@ -52,7 +52,7 @@ trait VersolaApp(serviceName: String) extends ZIOApp:
     Option(java.lang.System.getenv("PORT")).flatMap(_.toIntOption).getOrElse(8080)
 
   def diagnosticsPort: Int =
-    Option(java.lang.System.getenv("DPORT")).flatMap(_.toIntOption).getOrElse(8080)
+    Option(java.lang.System.getenv("DPORT")).flatMap(_.toIntOption).getOrElse(9090)
 
   def serverConfig: Server.Config =
     Server.Config.default.port(port)
@@ -70,13 +70,17 @@ trait VersolaApp(serviceName: String) extends ZIOApp:
       readinessService <- ReadinessService.make
       client <- ZIO.service[Client]
 
-      _ <- Server.install[MetricsService](serviceRoutes(readinessService))
-        .provide(
-          Server.live,
-          prometheusMetricsService,
-          ZLayer.succeed(MetricsConfig(1.second)),
-          ZLayer.succeed(diagnosticsConfig),
-        )
+      _ <- {
+        for
+          _ <- Server.install[MetricsService](serviceRoutes(readinessService))
+          _ <- ZIO.never
+        yield ()
+      }.provide(
+        Server.live,
+        prometheusMetricsService,
+        ZLayer.succeed(MetricsConfig(1.second)),
+        ZLayer.succeed(diagnosticsConfig),
+      ).forkScoped
 
       _ <- {
         for
@@ -99,7 +103,7 @@ trait VersolaApp(serviceName: String) extends ZIOApp:
         ZLayer.succeed(envConfig),
         ZLayer.succeed(envName),
         ZLayer.succeed(scope),
-        ZLayer.succeed(client)
+        ZLayer.succeed(client),
       )
     yield ()
   }

--- a/util/src/main/scala/versola/util/http/VersolaApp.scala
+++ b/util/src/main/scala/versola/util/http/VersolaApp.scala
@@ -72,7 +72,8 @@ trait VersolaApp(serviceName: String) extends ZIOApp:
 
       _ <- {
         for
-          _ <- Server.install[MetricsService](serviceRoutes(readinessService))
+          port <- Server.install[MetricsService](serviceRoutes(readinessService))
+          _ <- ZIO.logInfo(s"Diagnostics server started on port $port")
           _ <- ZIO.never
         yield ()
       }.provide(

--- a/util/src/main/scala/versola/util/http/VersolaApp.scala
+++ b/util/src/main/scala/versola/util/http/VersolaApp.scala
@@ -52,7 +52,7 @@ trait VersolaApp(serviceName: String) extends ZIOApp:
     Option(java.lang.System.getenv("PORT")).flatMap(_.toIntOption).getOrElse(8080)
 
   def diagnosticsPort: Int =
-    Option(java.lang.System.getenv("DPORT")).flatMap(_.toIntOption).getOrElse(9090)
+    Option(java.lang.System.getenv("DPORT")).flatMap(_.toIntOption).getOrElse(8081)
 
   def serverConfig: Server.Config =
     Server.Config.default.port(port)
@@ -70,18 +70,26 @@ trait VersolaApp(serviceName: String) extends ZIOApp:
       readinessService <- ReadinessService.make
       client <- ZIO.service[Client]
 
-      _ <- {
-        for
-          port <- Server.install[MetricsService](serviceRoutes(readinessService))
-          _ <- ZIO.logInfo(s"Diagnostics server started on port $port")
-          _ <- ZIO.never
-        yield ()
-      }.provide(
-        Server.live,
-        prometheusMetricsService,
-        ZLayer.succeed(MetricsConfig(1.second)),
-        ZLayer.succeed(diagnosticsConfig),
-      ).forkScoped
+      _ <- for
+        ready <- Promise.make[Throwable, Int]
+        _ <- {
+          for
+            port <- Server.install[MetricsService](serviceRoutes(readinessService))
+            _ <- ready.succeed(port)
+            _ <- ZIO.never
+          yield ()
+        }.provide(
+          Server.live,
+          prometheusMetricsService,
+          ZLayer.succeed(MetricsConfig(1.second)),
+          ZLayer.succeed(diagnosticsConfig),
+        ).onExit {
+          case Exit.Failure(cause) => ready.failCause(cause)
+          case _ => ZIO.unit
+        }.forkScoped
+        port <- ready.await
+        _ <- ZIO.logInfo(s"Diagnostics server started on port $port")
+      yield ()
 
       _ <- {
         for


### PR DESCRIPTION
Closes #42 

Fix diagnostics server lifecycle and default port (#42)
Problem
The diagnostics server (/metrics, /liveness, /readiness) was stopping immediately after startup. Server.install returns as soon as the server binds to a port — so the scope created by .provide(Server.live, ...) closed right away, killing the server.
Additionally, diagnosticsPort defaulted to 8080 — same as the main server — causing a port conflict when DPORT was not set.
Changes

Wrapped the diagnostics Server.install in a for block with ZIO.never to keep the scope open, then called .forkScoped so the server runs for the lifetime of the application without blocking the main server startup
Changed default DPORT from 8080 to 8081

