### PR TITLE
Cleaned: Support login_hint (email or phone): skip the credential step and start the first factor #39

### DIFF
--- a/auth/implementations/postgres/src/main/scala/versola/PostgresOAuthApp.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/PostgresOAuthApp.scala
@@ -120,9 +120,9 @@ object PostgresOAuthApp extends VersolaApp("auth"):
       AuthBootstrapService.live >+>
       WebAuthnService.live >+>
       UserInfoService.live >+>
-      AuthorizeEndpointService.live >+>
       SubmissionLimiter.live >+>
       ConversationService.live >+>
+      AuthorizeEndpointService.live >+>
       ConversationRouter.live >+>
       ConversationRenderService.live
 

--- a/auth/implementations/postgres/src/main/scala/versola/PostgresOAuthApp.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/PostgresOAuthApp.scala
@@ -122,8 +122,8 @@ object PostgresOAuthApp extends VersolaApp("auth"):
       UserInfoService.live >+>
       SubmissionLimiter.live >+>
       ConversationService.live >+>
-      AuthorizeEndpointService.live >+>
       ConversationRouter.live >+>
+      AuthorizeEndpointService.live >+>
       ConversationRenderService.live
 
   given DeriveConfig[Secret.Bytes16] = DeriveConfig[String]

--- a/auth/implementations/postgres/src/main/scala/versola/PostgresOAuthApp.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/PostgresOAuthApp.scala
@@ -122,6 +122,7 @@ object PostgresOAuthApp extends VersolaApp("auth"):
       UserInfoService.live >+>
       SubmissionLimiter.live >+>
       ConversationService.live >+>
+      AuthorizeEndpointService.live >+>
       ConversationRouter.live >+>
       AuthorizeEndpointService.live >+>
       ConversationRenderService.live

--- a/auth/implementations/postgres/src/main/scala/versola/PostgresOAuthApp.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/PostgresOAuthApp.scala
@@ -122,7 +122,6 @@ object PostgresOAuthApp extends VersolaApp("auth"):
       UserInfoService.live >+>
       SubmissionLimiter.live >+>
       ConversationService.live >+>
-      AuthorizeEndpointService.live >+>
       ConversationRouter.live >+>
       AuthorizeEndpointService.live >+>
       ConversationRenderService.live

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointController.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointController.scala
@@ -2,9 +2,7 @@ package versola.oauth.authorize
 
 import versola.oauth.authorize.model.{AuthorizeRequest, AuthorizeResponse, Error, ResponseTypeEntry}
 import versola.oauth.client.OAuthConfigurationService
-import versola.oauth.conversation.ConversationRenderService
-import versola.oauth.conversation.model.{ConversationRecord, ConversationStep}
-import versola.oauth.model.{CodeChallenge, CodeChallengeMethod, ConversationCookie}
+import versola.oauth.model.ConversationCookie
 import versola.util.{Base64Url, CoreConfig}
 import versola.util.http.Controller
 import zio.*
@@ -13,7 +11,7 @@ import zio.prelude.NonEmptySet
 import zio.telemetry.opentelemetry.tracing.Tracing
 
 object AuthorizeEndpointController extends Controller:
-  type Env = Tracing & AuthorizeRequestParser & AuthorizeEndpointService & OAuthConfigurationService & CoreConfig & ConversationRenderService
+  type Env = Tracing & AuthorizeRequestParser & AuthorizeEndpointService & OAuthConfigurationService & CoreConfig
 
   def routes: Routes[Env, Throwable] = Routes(
     getAuthorizeRoute,
@@ -47,29 +45,19 @@ object AuthorizeEndpointController extends Controller:
       configService <- ZIO.service[OAuthConfigurationService]
       config <- ZIO.service[CoreConfig]
       authConversationTtl <- configService.getAuthConversationTtl(request.clientId)
-      renderService <- ZIO.service[ConversationRenderService]
-      response <- authService.authorize(request).flatMap:
+      response <- authService.authorize(request).map:
         case AuthorizeResponse.Authorized(code, idToken) =>
-          ZIO.succeed(Response.seeOther(
+          Response.seeOther(
             AuthorizeRedirect.responseUrl(request.redirectUri, Base64Url.encode(code), request.state, idToken),
-          ))
+          )
 
         case AuthorizeResponse.Initialize(authId) =>
-          ZIO.succeed(Response.seeOther(URL.empty / "challenge")
+          Response.seeOther(URL.empty / "challenge")
             .addCookie(
               ConversationCookie.responseCookie(
                 ConversationCookie(authId, request.clientId),
                 authConversationTtl,
                 config.security.conversationCookieSecret,
               ),
-            ))
-
-        case AuthorizeResponse.InitializeWithHint(authId, render, conversation) =>
-          renderService.renderSubmit(render, conversation).map(
-            _.addCookie(ConversationCookie.responseCookie(
-              ConversationCookie(authId, request.clientId),
-              authConversationTtl,
-              config.security.conversationCookieSecret,
-            ))
-          )
+            )
     yield response

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointController.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointController.scala
@@ -66,9 +66,10 @@ object AuthorizeEndpointController extends Controller:
 
         case AuthorizeResponse.InitializeWithHint(authId, render, conversation) =>
           renderService.renderSubmit(render, conversation).map(
-            _.addCookie(ConversationCookie(
-              value = authId,
-              ttl = conversationConfig.security.authConversation.ttl,
+            _.addCookie(ConversationCookie.responseCookie(
+              ConversationCookie(authId, request.clientId),
+              authConversationTtl,
+              config.security.conversationCookieSecret,
             ))
           )
     yield response

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointController.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointController.scala
@@ -13,7 +13,7 @@ import zio.prelude.NonEmptySet
 import zio.telemetry.opentelemetry.tracing.Tracing
 
 object AuthorizeEndpointController extends Controller:
-  type Env = Tracing & AuthorizeRequestParser & AuthorizeEndpointService & OAuthConfigurationService & CoreConfig
+  type Env = Tracing & AuthorizeRequestParser & AuthorizeEndpointService & OAuthConfigurationService & CoreConfig & ConversationRenderService
 
   def routes: Routes[Env, Throwable] = Routes(
     getAuthorizeRoute,
@@ -47,19 +47,28 @@ object AuthorizeEndpointController extends Controller:
       configService <- ZIO.service[OAuthConfigurationService]
       config <- ZIO.service[CoreConfig]
       authConversationTtl <- configService.getAuthConversationTtl(request.clientId)
-      response <- authService.authorize(request).map:
+      renderService <- ZIO.service[ConversationRenderService]
+      response <- authService.authorize(request).flatMap:
         case AuthorizeResponse.Authorized(code, idToken) =>
-          Response.seeOther(
+          ZIO.succeed(Response.seeOther(
             AuthorizeRedirect.responseUrl(request.redirectUri, Base64Url.encode(code), request.state, idToken),
-          )
+          ))
 
         case AuthorizeResponse.Initialize(authId) =>
-          Response.seeOther(URL.empty / "challenge")
+          ZIO.succeed(Response.seeOther(URL.empty / "challenge")
             .addCookie(
               ConversationCookie.responseCookie(
                 ConversationCookie(authId, request.clientId),
                 authConversationTtl,
                 config.security.conversationCookieSecret,
               ),
-            )
+            ))
+
+        case AuthorizeResponse.InitializeWithHint(authId, render, conversation) =>
+          renderService.renderSubmit(render, conversation).map(
+            _.addCookie(ConversationCookie(
+              value = authId,
+              ttl = conversationConfig.security.authConversation.ttl,
+            ))
+          )
     yield response

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
@@ -121,7 +121,7 @@ object AuthorizeEndpointService:
                 val submission = hint match
                   case Left(email) => EmailSubmission(email)
                   case Right(phone) => PhoneSubmission(phone)
-                conversationRouter.submit(authId, submission, uiLocale = None)
+                conversationRouter.submit(authId, submission, uiLocale = None, ipAddress = None)
                   .map((render, conv) => AuthorizeResponse.InitializeWithHint(authId, render, conv))
 
     private def silentAuthorize(

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
@@ -4,8 +4,6 @@ import versola.oauth.authorize.model.{AuthorizeRequest, AuthorizeResponse, Error
 import versola.oauth.client.OAuthConfigurationService
 import versola.oauth.client.model.{AuthFlow, AuthMethodRef, PassedAuthFactor, PassedFactorRecord, ScopeToken}
 import versola.oauth.conversation.{ConversationRepository, ConversationRouter, EmailSubmission, PhoneSubmission}
-import versola.oauth.client.model.{AuthFactorType, AuthFlow, AuthMethodRef, PassedAuthFactor, PassedFactorRecord, ScopeToken}
-import versola.oauth.conversation.{ConversationRepository, ConversationService}
 import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep}
 import versola.oauth.jwks.JwksService
 import versola.oauth.model.{AuthorizationCode, AuthorizationCodeRecord}
@@ -25,7 +23,7 @@ trait AuthorizeEndpointService:
 
 object AuthorizeEndpointService:
   def live =
-    ZLayer.fromFunction(Impl(_, _, _, _, _, _, _, _, _, _, _))
+    ZLayer.fromFunction(Impl(_, _, _, _, _, _, _, _, _, _, _, _))
 
   class Impl(
       conversationRepository: ConversationRepository,
@@ -39,7 +37,7 @@ object AuthorizeEndpointService:
       userRepository: UserRepository,
       userInfoService: UserInfoService,
       jwksService: JwksService,
-      conversationService: ConversationService,
+      conversationRouter: ConversationRouter,
   ) extends AuthorizeEndpointService:
 
     override def authorize(

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
@@ -122,7 +122,7 @@ object AuthorizeEndpointService:
                   case Left(email) => EmailSubmission(email)
                   case Right(phone) => PhoneSubmission(phone)
                 conversationRouter.submit(authId, submission, uiLocale = None, ipAddress = None)
-                  .map((render, conv) => AuthorizeResponse.InitializeWithHint(authId, render, conv))
+                  .as(AuthorizeResponse.Initialize(authId))
 
     private def silentAuthorize(
         request: AuthorizeRequest,

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
@@ -4,6 +4,8 @@ import versola.oauth.authorize.model.{AuthorizeRequest, AuthorizeResponse, Error
 import versola.oauth.client.OAuthConfigurationService
 import versola.oauth.client.model.{AuthFlow, AuthMethodRef, PassedAuthFactor, PassedFactorRecord, ScopeToken}
 import versola.oauth.conversation.{ConversationRepository, ConversationRouter, EmailSubmission, PhoneSubmission}
+import versola.oauth.client.model.{AuthFactorType, AuthFlow, AuthMethodRef, PassedAuthFactor, PassedFactorRecord, ScopeToken}
+import versola.oauth.conversation.{ConversationRepository, ConversationService}
 import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep}
 import versola.oauth.jwks.JwksService
 import versola.oauth.model.{AuthorizationCode, AuthorizationCodeRecord}

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
@@ -2,8 +2,8 @@ package versola.oauth.authorize
 
 import versola.oauth.authorize.model.{AuthorizeRequest, AuthorizeResponse, Error, Prompt, ResponseTypeEntry}
 import versola.oauth.client.OAuthConfigurationService
-import versola.oauth.client.model.{AuthFlow, AuthMethodRef, PassedAuthFactor, PassedFactorRecord, ScopeToken}
-import versola.oauth.conversation.ConversationRepository
+import versola.oauth.client.model.{AuthFactorType, AuthFlow, AuthMethodRef, PassedAuthFactor, PassedFactorRecord, ScopeToken}
+import versola.oauth.conversation.{ConversationRepository, ConversationService}
 import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep}
 import versola.oauth.jwks.JwksService
 import versola.oauth.model.{AuthorizationCode, AuthorizationCodeRecord}
@@ -37,6 +37,7 @@ object AuthorizeEndpointService:
       userRepository: UserRepository,
       userInfoService: UserInfoService,
       jwksService: JwksService,
+      conversationService: ConversationService,
   ) extends AuthorizeEndpointService:
 
     override def authorize(
@@ -113,8 +114,15 @@ object AuthorizeEndpointService:
           amr = amr,
         )
         configurationService.getAuthConversationTtl(request.clientId).flatMap: authConversationTtl =>
-          conversationRepository.create(authId, conversation, authConversationTtl)
-            .as(AuthorizeResponse.Initialize(authId))
+          conversationRepository.create(authId, conversation, authConversationTtl).flatMap: _ =>
+            request.loginHint match
+              case None => ZIO.succeed(AuthorizeResponse.Initialize(authId))
+              case Some(hint) =>
+                val submission = hint match
+                  case Left(email) => EmailSubmission(email)
+                  case Right(phone) => PhoneSubmission(phone)
+                conversationRouter.submit(authId, submission, uiLocale = None)
+                  .map((render, conv) => AuthorizeResponse.InitializeWithHint(authId, render, conv))
 
     private def silentAuthorize(
         request: AuthorizeRequest,

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
@@ -2,8 +2,8 @@ package versola.oauth.authorize
 
 import versola.oauth.authorize.model.{AuthorizeRequest, AuthorizeResponse, Error, Prompt, ResponseTypeEntry}
 import versola.oauth.client.OAuthConfigurationService
-import versola.oauth.client.model.{AuthFactorType, AuthFlow, AuthMethodRef, PassedAuthFactor, PassedFactorRecord, ScopeToken}
-import versola.oauth.conversation.{ConversationRepository, ConversationService}
+import versola.oauth.client.model.{AuthFlow, AuthMethodRef, PassedAuthFactor, PassedFactorRecord, ScopeToken}
+import versola.oauth.conversation.{ConversationRepository, ConversationRouter, EmailSubmission, PhoneSubmission}
 import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep}
 import versola.oauth.jwks.JwksService
 import versola.oauth.model.{AuthorizationCode, AuthorizationCodeRecord}

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
@@ -164,7 +164,7 @@ object AuthorizeRequestParser:
         redirectUri: URL,
         state: Option[State],
     ): IO[Error.LoginHintInvalid, Option[Either[Email, Phone]]] =
-      val allowed = client.authFlow.forall(_.primary.credentials.contains(PrimaryCredential.email))
+      val allowed = client.authFlow.exists(_.primary.credentials.contains(PrimaryCredential.email))
       if allowed then ZIO.some[Either[Email, Phone]](Left(email))
       else ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
 
@@ -175,7 +175,7 @@ object AuthorizeRequestParser:
         redirectUri: URL,
         state: Option[State],
     ): IO[Error.LoginHintInvalid, Option[Either[Email, Phone]]] =
-      val allowed = client.authFlow.forall(_.primary.credentials.contains(PrimaryCredential.phone))
+      val allowed = client.authFlow.exists(_.primary.credentials.contains(PrimaryCredential.phone))
       if !allowed then ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
       else
         oauthClientService.getAllowedPhonePrefixes(clientId).flatMap { prefixes =>

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
@@ -122,25 +122,12 @@ object AuthorizeRequestParser:
           .flatMap {
             case None => ZIO.none
             case Some(raw) =>
-              val hint: Option[Either[Email, Phone]] =
-                Email.from(raw).map(Left(_)).toOption
-                  .orElse(Phone.parse(raw).map(Right(_)).toOption)
-              hint match
-                case None => ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
-                case Some(h) =>
-                  val credentialAllowed = client.authFlow.forall { flow =>
-                    h match
-                      case Left(_)  => flow.primary.credentials.contains(PrimaryCredential.email)
-                      case Right(_) => flow.primary.credentials.contains(PrimaryCredential.phone)
-                  }
-                  if !credentialAllowed then ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
-                  else h match
-                    case Left(_) => ZIO.some(h)
-                    case Right(phone) =>
-                      oauthClientService.getAllowedPhonePrefixes(clientId).flatMap { prefixes =>
-                        if prefixes.isEmpty || prefixes.exists(phone.startsWith) then ZIO.some(h)
-                        else ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
-                      }
+              Email.from(raw).toOption match
+                case Some(email) => parseEmailHint(email, client, redirectUri, state)
+                case None =>
+                  Phone.parse(raw).toOption match
+                    case Some(phone) => parsePhoneHint(phone, client, clientId, redirectUri, state)
+                    case None        => ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
           }
 
         userAgent =
@@ -170,6 +157,31 @@ object AuthorizeRequestParser:
           loginHint = loginHint,
         )
       yield authorizeRequest
+
+    private def parseEmailHint(
+        email: Email,
+        client: OAuthClientRecord,
+        redirectUri: URL,
+        state: Option[State],
+    ): IO[Error.LoginHintInvalid, Option[Either[Email, Phone]]] =
+      val allowed = client.authFlow.forall(_.primary.credentials.contains(PrimaryCredential.email))
+      if allowed then ZIO.some[Either[Email, Phone]](Left(email))
+      else ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
+
+    private def parsePhoneHint(
+        phone: Phone,
+        client: OAuthClientRecord,
+        clientId: ClientId,
+        redirectUri: URL,
+        state: Option[State],
+    ): IO[Error.LoginHintInvalid, Option[Either[Email, Phone]]] =
+      val allowed = client.authFlow.forall(_.primary.credentials.contains(PrimaryCredential.phone))
+      if !allowed then ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
+      else
+        oauthClientService.getAllowedPhonePrefixes(clientId).flatMap { prefixes =>
+          if prefixes.isEmpty || prefixes.exists(phone.startsWith) then ZIO.some[Either[Email, Phone]](Right(phone))
+          else ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
+        }
 
     private def parseRedirectUri(params: Map[String, Chunk[String]]): IO[Error, (URL, String)] =
       getParam(params, "redirect_uri")

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
@@ -122,12 +122,25 @@ object AuthorizeRequestParser:
           .flatMap {
             case None => ZIO.none
             case Some(raw) =>
-              Email.from(raw).toOption match
-                case Some(email) => parseEmailHint(email, client, redirectUri, state)
-                case None =>
-                  Phone.parse(raw).toOption match
-                    case Some(phone) => parsePhoneHint(phone, client, clientId, redirectUri, state)
-                    case None        => ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
+              val hint: Option[Either[Email, Phone]] =
+                Email.from(raw).map(Left(_)).toOption
+                  .orElse(Phone.parse(raw).map(Right(_)).toOption)
+              hint match
+                case None => ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
+                case Some(h) =>
+                  val credentialAllowed = client.authFlow.forall { flow =>
+                    h match
+                      case Left(_)  => flow.primary.credentials.contains(PrimaryCredential.email)
+                      case Right(_) => flow.primary.credentials.contains(PrimaryCredential.phone)
+                  }
+                  if !credentialAllowed then ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
+                  else h match
+                    case Left(_) => ZIO.some(h)
+                    case Right(phone) =>
+                      oauthClientService.getAllowedPhonePrefixes(clientId).flatMap { prefixes =>
+                        if prefixes.isEmpty || prefixes.exists(phone.startsWith) then ZIO.some(h)
+                        else ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
+                      }
           }
 
         userAgent =

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
@@ -122,25 +122,12 @@ object AuthorizeRequestParser:
           .flatMap {
             case None => ZIO.none
             case Some(raw) =>
-              val hint: Option[Either[Email, Phone]] =
-                Email.from(raw).map(Left(_)).toOption
-                  .orElse(Phone.parse(raw).map(Right(_)).toOption)
-              hint match
-                case None => ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
-                case Some(h) =>
-                  val credentialAllowed = client.authFlow.forall { flow =>
-                    h match
-                      case Left(_)  => flow.primary.credentials.contains(PrimaryCredential.email)
-                      case Right(_) => flow.primary.credentials.contains(PrimaryCredential.phone)
-                  }
-                  if !credentialAllowed then ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
-                  else h match
-                    case Left(_) => ZIO.some(h)
-                    case Right(phone) =>
-                      oauthClientService.getAllowedPhonePrefixes(clientId).flatMap { prefixes =>
-                        if prefixes.isEmpty || prefixes.exists(phone.startsWith) then ZIO.some(h)
-                        else ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
-                      }
+              Email.from(raw).toOption match
+                case Some(email) => parseEmailHint(email, client, redirectUri, state)
+                case None =>
+                  Phone.parse(raw).toOption match
+                    case Some(phone) => parsePhoneHint(phone, client, clientId, redirectUri, state)
+                    case None        => ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
           }
 
         userAgent =

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
@@ -2,12 +2,12 @@ package versola.oauth.authorize
 
 import versola.oauth.authorize.model.{AuthorizeRequest, Error, Prompt, ResponseTypeEntry}
 import versola.oauth.client.OAuthConfigurationService
-import versola.oauth.client.model.{ClientId, OAuthClientRecord, ScopeToken}
+import versola.oauth.client.model.{ClientId, OAuthClientRecord, PrimaryCredential, ScopeToken}
 import versola.oauth.model.{CodeChallenge, CodeChallengeMethod, Nonce, State}
 import versola.oauth.model.SessionCookie
 import versola.oauth.session.model.SessionId
 import versola.oauth.userinfo.model.RequestedClaims
-import versola.util.Base64
+import versola.util.{Base64, Email, Phone}
 import zio.http.{Header, Method, Request, URL}
 import zio.json.*
 import zio.prelude.NonEmptySet
@@ -35,7 +35,7 @@ object AuthorizeRequestParser:
           .someOrFail(Error.BadRequest)
           .map(ClientId(_))
 
-        _ <- oauthClientService.find(clientId)
+        client <- oauthClientService.find(clientId)
           .someOrFail(Error.BadRequest)
           .filterOrFail(_.redirectUris.contains(redirectUriString))(Error.BadRequest)
 
@@ -117,6 +117,32 @@ object AuthorizeRequestParser:
           .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "acr_values"))
           .map(_.map(_.split(' ').toList))
 
+        loginHint <- getParam(params, "login_hint")
+          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "login_hint"))
+          .flatMap {
+            case None => ZIO.none
+            case Some(raw) =>
+              val hint: Option[Either[Email, Phone]] =
+                Email.from(raw).map(Left(_)).toOption
+                  .orElse(Phone.parse(raw).map(Right(_)).toOption)
+              hint match
+                case None => ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
+                case Some(h) =>
+                  val credentialAllowed = client.authFlow.forall { flow =>
+                    h match
+                      case Left(_)  => flow.primary.credentials.contains(PrimaryCredential.email)
+                      case Right(_) => flow.primary.credentials.contains(PrimaryCredential.phone)
+                  }
+                  if !credentialAllowed then ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
+                  else h match
+                    case Left(_) => ZIO.some(h)
+                    case Right(phone) =>
+                      oauthClientService.getAllowedPhonePrefixes(clientId).flatMap { prefixes =>
+                        if prefixes.isEmpty || prefixes.exists(phone.startsWith) then ZIO.some(h)
+                        else ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
+                      }
+          }
+
         userAgent =
           request.header(Header.UserAgent)
             .map(_.renderedValue)
@@ -141,6 +167,7 @@ object AuthorizeRequestParser:
           maxAge = maxAge,
           acrValues = acrValues,
           sessionId = sessionId,
+          loginHint = loginHint,
         )
       yield authorizeRequest
 

--- a/auth/src/main/scala/versola/oauth/authorize/model/AuthorizeRequest.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/model/AuthorizeRequest.scala
@@ -4,6 +4,7 @@ import versola.oauth.client.model.{ClientId, ScopeToken}
 import versola.oauth.model.{CodeChallenge, CodeChallengeMethod, Nonce, State}
 import versola.oauth.session.model.SessionId
 import versola.oauth.userinfo.model.RequestedClaims
+import versola.util.{Email, Phone}
 import zio.http.URL
 import zio.prelude.NonEmptySet
 
@@ -24,4 +25,5 @@ case class AuthorizeRequest(
     maxAge: Option[Long],
     acrValues: Option[List[String]],
     sessionId: Option[SessionId],
+    loginHint: Option[Either[Email, Phone]],
 )

--- a/auth/src/main/scala/versola/oauth/authorize/model/AuthorizeResponse.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/model/AuthorizeResponse.scala
@@ -1,8 +1,6 @@
 package versola.oauth.authorize.model
 
-import versola.oauth.client.model.PrimaryCredential
-import versola.oauth.conversation.ConversationResult
-import versola.oauth.conversation.model.{AuthId, ConversationRecord}
+import versola.oauth.conversation.model.AuthId
 import versola.oauth.model.AuthorizationCode
 
 sealed trait AuthorizeResponse
@@ -15,10 +13,4 @@ object AuthorizeResponse:
 
   case class Initialize(
       authId: AuthId,
-  ) extends AuthorizeResponse
-
-  case class InitializeWithHint(
-      authId: AuthId,
-      render: ConversationResult.Render,
-      conversation: ConversationRecord,
   ) extends AuthorizeResponse

--- a/auth/src/main/scala/versola/oauth/authorize/model/AuthorizeResponse.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/model/AuthorizeResponse.scala
@@ -1,7 +1,8 @@
 package versola.oauth.authorize.model
 
 import versola.oauth.client.model.PrimaryCredential
-import versola.oauth.conversation.model.AuthId
+import versola.oauth.conversation.ConversationResult
+import versola.oauth.conversation.model.{AuthId, ConversationRecord}
 import versola.oauth.model.AuthorizationCode
 
 sealed trait AuthorizeResponse
@@ -14,4 +15,10 @@ object AuthorizeResponse:
 
   case class Initialize(
       authId: AuthId,
+  ) extends AuthorizeResponse
+
+  case class InitializeWithHint(
+      authId: AuthId,
+      render: ConversationResult.Render,
+      conversation: ConversationRecord,
   ) extends AuthorizeResponse

--- a/auth/src/main/scala/versola/oauth/authorize/model/Error.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/model/Error.scala
@@ -104,3 +104,9 @@ private[authorize] object Error:
       errorDescription = "Invalid prompt parameter - none must not be combined with other values",
       errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest"),
     )
+
+  case class LoginHintInvalid(uri: URL, state: Option[State]) extends RedirectError(
+      error = ErrorCode.InvalidRequest,
+      errorDescription = "login_hint is invalid or not supported by the client auth flow",
+      errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest"),
+    )

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
@@ -270,11 +270,15 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         _ <- env.conversationRouter.submit.succeedsWith(ConversationResult.IllegalState)
         result <- env.service.authorize(baseRequest.copy(loginHint = Some(Left(emailHint))))
         submitCalls = env.conversationRouter.submit.calls
-      yield assertTrue(
-        result == AuthorizeResponse.Initialize(versola.oauth.conversation.model.AuthId(uuid)),
-        submitCalls.nonEmpty,
-        submitCalls.head._2 == EmailSubmission(emailHint),
-      )
+      yield result match
+        case AuthorizeResponse.InitializeWithHint(authId, render, _) =>
+          assertTrue(
+            authId == versola.oauth.conversation.model.AuthId(uuid),
+            render == ConversationResult.IllegalState,
+            submitCalls.nonEmpty,
+            submitCalls.head._2 == EmailSubmission(emailHint),
+          )
+        case _ => assertTrue(false)
     },
     test("advance conversation to OTP step when login_hint phone is provided on phone+otp flow") {
       val env = Env()
@@ -286,10 +290,14 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         _ <- env.conversationRouter.submit.succeedsWith(ConversationResult.IllegalState)
         result <- env.service.authorize(baseRequest.copy(loginHint = Some(Right(phoneHint))))
         submitCalls = env.conversationRouter.submit.calls
-      yield assertTrue(
-        result == AuthorizeResponse.Initialize(versola.oauth.conversation.model.AuthId(uuid)),
-        submitCalls.nonEmpty,
-        submitCalls.head._2 == PhoneSubmission(phoneHint),
-      )
+      yield result match
+        case AuthorizeResponse.InitializeWithHint(authId, render, _) =>
+          assertTrue(
+            authId == versola.oauth.conversation.model.AuthId(uuid),
+            render == ConversationResult.IllegalState,
+            submitCalls.nonEmpty,
+            submitCalls.head._2 == PhoneSubmission(phoneHint),
+          )
+        case _ => assertTrue(false)
     },
   )

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
@@ -299,15 +299,11 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         _ <- env.conversationRouter.submit.succeedsWith((ConversationResult.IllegalState, dummyConversation))
         result <- env.service.authorize(baseRequest.copy(loginHint = Some(Left(emailHint))))
         submitCalls = env.conversationRouter.submit.calls
-      yield result match
-        case AuthorizeResponse.InitializeWithHint(authId, render, _) =>
-          assertTrue(
-            authId == versola.oauth.conversation.model.AuthId(uuid),
-            render == ConversationResult.IllegalState,
-            submitCalls.nonEmpty,
-            submitCalls.head._2 == EmailSubmission(emailHint),
-          )
-        case _ => assertTrue(false)
+      yield assertTrue(
+        result == AuthorizeResponse.Initialize(versola.oauth.conversation.model.AuthId(uuid)),
+        submitCalls.nonEmpty,
+        submitCalls.head._2 == EmailSubmission(emailHint),
+      )
     },
     test("advance conversation to OTP step when login_hint phone is provided on phone+otp flow") {
       val env = Env()
@@ -320,14 +316,10 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         _ <- env.conversationRouter.submit.succeedsWith((ConversationResult.IllegalState, dummyConversation))
         result <- env.service.authorize(baseRequest.copy(loginHint = Some(Right(phoneHint))))
         submitCalls = env.conversationRouter.submit.calls
-      yield result match
-        case AuthorizeResponse.InitializeWithHint(authId, render, _) =>
-          assertTrue(
-            authId == versola.oauth.conversation.model.AuthId(uuid),
-            render == ConversationResult.IllegalState,
-            submitCalls.nonEmpty,
-            submitCalls.head._2 == PhoneSubmission(phoneHint),
-          )
-        case _ => assertTrue(false)
+      yield assertTrue(
+        result == AuthorizeResponse.Initialize(versola.oauth.conversation.model.AuthId(uuid)),
+        submitCalls.nonEmpty,
+        submitCalls.head._2 == PhoneSubmission(phoneHint),
+      )
     },
   )

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
@@ -6,6 +6,7 @@ import versola.oauth.jwks.JwksService
 import versola.oauth.client.OAuthConfigurationService
 import versola.oauth.client.model.{AuthFactor, AuthFactorType, AuthFlow, AuthMethodRef, ClientId, OAuthClientRecord, PassedAuthFactor, PassedFactorRecord, PrimaryAuthFlow, PrimaryCredential, ScopeToken, TenantId}
 import versola.oauth.conversation.{ConversationRepository, ConversationResult, ConversationRouter, EmailSubmission, PhoneSubmission}
+import versola.oauth.conversation.{ConversationRepository, ConversationResult, ConversationService}
 import versola.oauth.model.{AccessToken, AuthorizationCode, CodeChallenge, CodeChallengeMethod, State}
 import versola.oauth.session.SessionRepository
 import versola.oauth.session.model.{SessionId, SessionRecord, UserAgentInfo}
@@ -96,6 +97,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
     val userInfoService = stub[UserInfoService]
     val jwksService = TestEnvConfig.jwksService
     val conversationRouter = stub[ConversationRouter]
+    val conversationService = stub[ConversationService]
     val service = AuthorizeEndpointService.Impl(
       conversationRepository,
       configurationService,

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
@@ -5,7 +5,7 @@ import versola.oauth.authorize.model.{AuthorizeRequest, AuthorizeResponse, Error
 import versola.oauth.jwks.JwksService
 import versola.oauth.client.OAuthConfigurationService
 import versola.oauth.client.model.{AuthFactor, AuthFactorType, AuthFlow, AuthMethodRef, ClientId, OAuthClientRecord, PassedAuthFactor, PassedFactorRecord, PrimaryAuthFlow, PrimaryCredential, ScopeToken, TenantId}
-import versola.oauth.conversation.{ConversationRepository, ConversationResult, ConversationService}
+import versola.oauth.conversation.{ConversationRepository, ConversationResult, ConversationRouter, EmailSubmission, PhoneSubmission}
 import versola.oauth.model.{AccessToken, AuthorizationCode, CodeChallenge, CodeChallengeMethod, State}
 import versola.oauth.session.SessionRepository
 import versola.oauth.session.model.{SessionId, SessionRecord, UserAgentInfo}
@@ -95,7 +95,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
     val userRepository = stub[UserRepository]
     val userInfoService = stub[UserInfoService]
     val jwksService = TestEnvConfig.jwksService
-    val conversationService = stub[ConversationService]
+    val conversationRouter = stub[ConversationRouter]
     val service = AuthorizeEndpointService.Impl(
       conversationRepository,
       configurationService,
@@ -267,14 +267,13 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         _ <- env.configurationService.find.succeedsWith(Some(clientWithPasswordFlow))
         _ <- env.secureRandom.nextUUIDv7.succeedsWith(uuid)
         _ <- env.conversationRepository.create.succeedsWith(())
-        _ <- env.conversationService.prepareInitialPassword.succeedsWith(ConversationResult.IllegalState)
+        _ <- env.conversationRouter.submit.succeedsWith(ConversationResult.IllegalState)
         result <- env.service.authorize(baseRequest.copy(loginHint = Some(Left(emailHint))))
-        preparePasswordCalls = env.conversationService.prepareInitialPassword.calls
+        submitCalls = env.conversationRouter.submit.calls
       yield assertTrue(
         result == AuthorizeResponse.Initialize(versola.oauth.conversation.model.AuthId(uuid)),
-        preparePasswordCalls.nonEmpty,
-        preparePasswordCalls.head._3 == Left(emailHint),
-        preparePasswordCalls.head._4 == 0,
+        submitCalls.nonEmpty,
+        submitCalls.head._2 == EmailSubmission(emailHint),
       )
     },
     test("advance conversation to OTP step when login_hint phone is provided on phone+otp flow") {
@@ -284,14 +283,13 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
         _ <- env.secureRandom.nextUUIDv7.succeedsWith(uuid)
         _ <- env.conversationRepository.create.succeedsWith(())
-        _ <- env.conversationService.prepareInitialOtp.succeedsWith(ConversationResult.IllegalState)
+        _ <- env.conversationRouter.submit.succeedsWith(ConversationResult.IllegalState)
         result <- env.service.authorize(baseRequest.copy(loginHint = Some(Right(phoneHint))))
-        prepareOtpCalls = env.conversationService.prepareInitialOtp.calls
+        submitCalls = env.conversationRouter.submit.calls
       yield assertTrue(
         result == AuthorizeResponse.Initialize(versola.oauth.conversation.model.AuthId(uuid)),
-        prepareOtpCalls.nonEmpty,
-        prepareOtpCalls.head._3 == Right(phoneHint),
-        prepareOtpCalls.head._4 == 0,
+        submitCalls.nonEmpty,
+        submitCalls.head._2 == PhoneSubmission(phoneHint),
       )
     },
   )

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
@@ -6,7 +6,6 @@ import versola.oauth.jwks.JwksService
 import versola.oauth.client.OAuthConfigurationService
 import versola.oauth.client.model.{AuthFactor, AuthFactorType, AuthFlow, AuthMethodRef, ClientId, OAuthClientRecord, PassedAuthFactor, PassedFactorRecord, PrimaryAuthFlow, PrimaryCredential, ScopeToken, TenantId}
 import versola.oauth.conversation.{ConversationRepository, ConversationResult, ConversationRouter, EmailSubmission, PhoneSubmission}
-import versola.oauth.conversation.{ConversationRepository, ConversationResult, ConversationService}
 import versola.oauth.model.{AccessToken, AuthorizationCode, CodeChallenge, CodeChallengeMethod, State}
 import versola.oauth.session.SessionRepository
 import versola.oauth.session.model.{SessionId, SessionRecord, UserAgentInfo}
@@ -97,7 +96,6 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
     val userInfoService = stub[UserInfoService]
     val jwksService = TestEnvConfig.jwksService
     val conversationRouter = stub[ConversationRouter]
-    val conversationService = stub[ConversationService]
     val service = AuthorizeEndpointService.Impl(
       conversationRepository,
       configurationService,
@@ -110,7 +108,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
       userRepository,
       userInfoService,
       jwksService,
-      conversationService,
+      conversationRouter,
     )
 
   val phoneHint = Phone("+12025551234")
@@ -127,6 +125,34 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
   )
 
   val clientWithPasswordFlow = clientWithOtpFlow.copy(authFlow = Some(passwordFlow))
+
+  val dummyConversation = versola.oauth.conversation.model.ConversationRecord(
+    clientId = clientId,
+    redirectUri = redirectUri,
+    scope = Set(ScopeToken("openid")),
+    codeChallenge = codeChallenge,
+    codeChallengeMethod = CodeChallengeMethod.S256,
+    state = Some(State("state")),
+    userId = None,
+    credential = None,
+    step = versola.oauth.conversation.model.ConversationStep.Credential(
+      primaryCredentials = List(versola.oauth.client.model.PrimaryCredential.email),
+      inlinePassword = false,
+      passkey = false,
+    ),
+    requestedClaims = None,
+    uiLocales = None,
+    nonce = None,
+    responseType = NonEmptySet(ResponseTypeEntry.Code),
+    userEmail = None,
+    userPhone = None,
+    userLogin = None,
+    userClaims = None,
+    authFlow = otpFlow,
+    userAgent = None,
+    version = 0,
+    amr = Map.empty,
+  )
 
   val spec = suite("AuthorizeEndpointService")(
     test("create new conversation when no session") {
@@ -267,20 +293,11 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
       val uuid = UUID.randomUUID()
       for
         _ <- env.configurationService.find.succeedsWith(Some(clientWithPasswordFlow))
+        _ <- env.configurationService.getAuthConversationTtl.succeedsWith(zio.Duration.fromSeconds(900))
         _ <- env.secureRandom.nextUUIDv7.succeedsWith(uuid)
         _ <- env.conversationRepository.create.succeedsWith(())
-        _ <- env.conversationRouter.submit.succeedsWith(ConversationResult.IllegalState)
+        _ <- env.conversationRouter.submit.succeedsWith((ConversationResult.IllegalState, dummyConversation))
         result <- env.service.authorize(baseRequest.copy(loginHint = Some(Left(emailHint))))
-        submitCalls = env.conversationRouter.submit.calls
-      yield result match
-        case AuthorizeResponse.InitializeWithHint(authId, render, _) =>
-          assertTrue(
-            authId == versola.oauth.conversation.model.AuthId(uuid),
-            render == ConversationResult.IllegalState,
-            submitCalls.nonEmpty,
-            submitCalls.head._2 == EmailSubmission(emailHint),
-          )
-        case _ => assertTrue(false)
         submitCalls = env.conversationRouter.submit.calls
       yield result match
         case AuthorizeResponse.InitializeWithHint(authId, render, _) =>
@@ -297,9 +314,10 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
       val uuid = UUID.randomUUID()
       for
         _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
+        _ <- env.configurationService.getAuthConversationTtl.succeedsWith(zio.Duration.fromSeconds(900))
         _ <- env.secureRandom.nextUUIDv7.succeedsWith(uuid)
         _ <- env.conversationRepository.create.succeedsWith(())
-        _ <- env.conversationRouter.submit.succeedsWith(ConversationResult.IllegalState)
+        _ <- env.conversationRouter.submit.succeedsWith((ConversationResult.IllegalState, dummyConversation))
         result <- env.service.authorize(baseRequest.copy(loginHint = Some(Right(phoneHint))))
         submitCalls = env.conversationRouter.submit.calls
       yield result match

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
@@ -5,14 +5,14 @@ import versola.oauth.authorize.model.{AuthorizeRequest, AuthorizeResponse, Error
 import versola.oauth.jwks.JwksService
 import versola.oauth.client.OAuthConfigurationService
 import versola.oauth.client.model.{AuthFactor, AuthFactorType, AuthFlow, AuthMethodRef, ClientId, OAuthClientRecord, PassedAuthFactor, PassedFactorRecord, PrimaryAuthFlow, PrimaryCredential, ScopeToken, TenantId}
-import versola.oauth.conversation.ConversationRepository
+import versola.oauth.conversation.{ConversationRepository, ConversationResult, ConversationService}
 import versola.oauth.model.{AccessToken, AuthorizationCode, CodeChallenge, CodeChallengeMethod, State}
 import versola.oauth.session.SessionRepository
 import versola.oauth.session.model.{SessionId, SessionRecord, UserAgentInfo}
 import versola.oauth.token.AuthorizationCodeRepository
 import versola.oauth.userinfo.UserInfoService
 import versola.user.UserRepository
-import versola.util.{AuthPropertyGenerator, MAC, Secret, SecureRandom, SecurityService, UnitSpecBase}
+import versola.util.{AuthPropertyGenerator, Email, MAC, Phone, Secret, SecureRandom, SecurityService, UnitSpecBase}
 import zio.http.URL
 import zio.prelude.NonEmptySet
 import zio.test.*
@@ -68,6 +68,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
     maxAge = None,
     acrValues = None,
     sessionId = None,
+    loginHint = None,
   )
 
   val rawSessionId = SessionId(Array.fill(32)(5.toByte))
@@ -94,6 +95,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
     val userRepository = stub[UserRepository]
     val userInfoService = stub[UserInfoService]
     val jwksService = TestEnvConfig.jwksService
+    val conversationService = stub[ConversationService]
     val service = AuthorizeEndpointService.Impl(
       conversationRepository,
       configurationService,
@@ -106,7 +108,23 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
       userRepository,
       userInfoService,
       jwksService,
+      conversationService,
     )
+
+  val phoneHint = Phone("+12025551234")
+  val emailHint = Email("user@example.com")
+
+  val passwordFlow = AuthFlow(
+    primary = PrimaryAuthFlow(
+      credentials = List(PrimaryCredential.email),
+      inlinePassword = false,
+      factors = List(AuthFactor(`type` = AuthFactorType.password, required = true)),
+    ),
+    passkey = None,
+    equivalents = Map.empty,
+  )
+
+  val clientWithPasswordFlow = clientWithOtpFlow.copy(authFlow = Some(passwordFlow))
 
   val spec = suite("AuthorizeEndpointService")(
     test("create new conversation when no session") {
@@ -240,6 +258,40 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         result == AuthorizeResponse.Initialize(versola.oauth.conversation.model.AuthId(uuid)),
         createCalls.nonEmpty,
         createCalls.head._2.amr == passkeySeedAmr,
+      )
+    },
+    test("advance conversation to password step when login_hint email is provided on email+password flow") {
+      val env = Env()
+      val uuid = UUID.randomUUID()
+      for
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithPasswordFlow))
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(uuid)
+        _ <- env.conversationRepository.create.succeedsWith(())
+        _ <- env.conversationService.prepareInitialPassword.succeedsWith(ConversationResult.IllegalState)
+        result <- env.service.authorize(baseRequest.copy(loginHint = Some(Left(emailHint))))
+        preparePasswordCalls = env.conversationService.prepareInitialPassword.calls
+      yield assertTrue(
+        result == AuthorizeResponse.Initialize(versola.oauth.conversation.model.AuthId(uuid)),
+        preparePasswordCalls.nonEmpty,
+        preparePasswordCalls.head._3 == Left(emailHint),
+        preparePasswordCalls.head._4 == 0,
+      )
+    },
+    test("advance conversation to OTP step when login_hint phone is provided on phone+otp flow") {
+      val env = Env()
+      val uuid = UUID.randomUUID()
+      for
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(uuid)
+        _ <- env.conversationRepository.create.succeedsWith(())
+        _ <- env.conversationService.prepareInitialOtp.succeedsWith(ConversationResult.IllegalState)
+        result <- env.service.authorize(baseRequest.copy(loginHint = Some(Right(phoneHint))))
+        prepareOtpCalls = env.conversationService.prepareInitialOtp.calls
+      yield assertTrue(
+        result == AuthorizeResponse.Initialize(versola.oauth.conversation.model.AuthId(uuid)),
+        prepareOtpCalls.nonEmpty,
+        prepareOtpCalls.head._3 == Right(phoneHint),
+        prepareOtpCalls.head._4 == 0,
       )
     },
   )

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
@@ -281,6 +281,12 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
             submitCalls.head._2 == EmailSubmission(emailHint),
           )
         case _ => assertTrue(false)
+        submitCalls = env.conversationRouter.submit.calls
+      yield assertTrue(
+        result == AuthorizeResponse.Initialize(versola.oauth.conversation.model.AuthId(uuid)),
+        submitCalls.nonEmpty,
+        submitCalls.head._2 == EmailSubmission(emailHint),
+      )
     },
     test("advance conversation to OTP step when login_hint phone is provided on phone+otp flow") {
       val env = Env()

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
@@ -282,11 +282,15 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
           )
         case _ => assertTrue(false)
         submitCalls = env.conversationRouter.submit.calls
-      yield assertTrue(
-        result == AuthorizeResponse.Initialize(versola.oauth.conversation.model.AuthId(uuid)),
-        submitCalls.nonEmpty,
-        submitCalls.head._2 == EmailSubmission(emailHint),
-      )
+      yield result match
+        case AuthorizeResponse.InitializeWithHint(authId, render, _) =>
+          assertTrue(
+            authId == versola.oauth.conversation.model.AuthId(uuid),
+            render == ConversationResult.IllegalState,
+            submitCalls.nonEmpty,
+            submitCalls.head._2 == EmailSubmission(emailHint),
+          )
+        case _ => assertTrue(false)
     },
     test("advance conversation to OTP step when login_hint phone is provided on phone+otp flow") {
       val env = Env()

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
@@ -2,9 +2,9 @@ package versola.oauth.authorize
 
 import versola.oauth.authorize.model.{AuthorizeRequest, Error, Prompt, ResponseTypeEntry}
 import versola.oauth.client.OAuthConfigurationService
-import versola.oauth.client.model.{ClientId, OAuthClientRecord, ScopeToken, TenantId}
+import versola.oauth.client.model.{AuthFactor, AuthFactorType, AuthFlow, ClientId, OAuthClientRecord, PrimaryAuthFlow, PrimaryCredential, ScopeToken, TenantId}
 import versola.oauth.model.{CodeChallenge, CodeChallengeMethod, State}
-import versola.util.UnitSpecBase
+import versola.util.{Email, Phone, UnitSpecBase}
 import zio.http.{Request, URL}
 import zio.prelude.NonEmptySet
 import zio.test.*
@@ -24,6 +24,26 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
   val validScope = "read,write"
   val validState = State("random-state")
 
+  val emailOtpFlow = AuthFlow(
+    primary = PrimaryAuthFlow(
+      credentials = List(PrimaryCredential.email),
+      inlinePassword = false,
+      factors = List(AuthFactor(`type` = AuthFactorType.otp, required = true)),
+    ),
+    passkey = None,
+    equivalents = Map.empty,
+  )
+
+  val phoneOtpFlow = AuthFlow(
+    primary = PrimaryAuthFlow(
+      credentials = List(PrimaryCredential.phone),
+      inlinePassword = false,
+      factors = List(AuthFactor(`type` = AuthFactorType.otp, required = true)),
+    ),
+    passkey = None,
+    equivalents = Map.empty,
+  )
+
   val testClient = OAuthClientRecord(
     id = validClientId,
     tenantId = TenantId("default"),
@@ -40,6 +60,9 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
     otpTemplateId = "default",
   )
 
+  val testClientWithEmailFlow = testClient.copy(authFlow = Some(emailOtpFlow))
+  val testClientWithPhoneFlow = testClient.copy(authFlow = Some(phoneOtpFlow))
+
   class Env:
     val oauthClientService = stub[OAuthConfigurationService]
     val parser = AuthorizeRequestParser.Impl(oauthClientService)
@@ -53,6 +76,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
       scope: String = validScope,
       state: Option[String] = Some("random-state"),
       prompt: Option[String] = None,
+      loginHint: Option[String] = None,
   ): Request =
     val queryParams = Map(
       "client_id" -> clientId,
@@ -63,7 +87,8 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
     ) ++
       codeChallengeMethod.map(m => "code_challenge_method" -> m).toMap ++
       state.map(s => "state" -> s).toMap ++
-      prompt.map(p => "prompt" -> p).toMap
+      prompt.map(p => "prompt" -> p).toMap ++
+      loginHint.map(h => "login_hint" -> h).toMap
 
     Request.get(URL.root.addQueryParams(queryParams))
 
@@ -76,6 +101,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
     scopeValidationTests,
     multipleValuesTests,
     promptParsingTests,
+    loginHintTests,
   )
 
   def successfulParsingTests = suite("successful parsing")(
@@ -542,6 +568,88 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
           queryParamName = "state",
         )),
       )
+    },
+  )
+
+  def loginHintTests = suite("login_hint parsing")(
+    test("valid email hint on email-allowed flow returns Some(Left(email))") {
+      val env = Env()
+      for
+        _ <- env.oauthClientService.find.succeedsWith(Some(testClientWithEmailFlow))
+        result <- env.parser.parse(validRequest(loginHint = Some("user@example.com")))
+      yield assertTrue(result.loginHint == Some(Left(Email("user@example.com"))))
+    },
+    test("valid phone hint on phone-allowed flow with empty prefix list returns Some(Right(phone))") {
+      val env = Env()
+      for
+        _ <- env.oauthClientService.find.succeedsWith(Some(testClientWithPhoneFlow))
+        _ <- env.oauthClientService.getAllowedPhonePrefixes.succeedsWith(List.empty)
+        result <- env.parser.parse(validRequest(loginHint = Some("+12025551234")))
+      yield assertTrue(result.loginHint == Some(Right(Phone("+12025551234"))))
+    },
+    test("valid phone hint on phone-allowed flow with matching prefix returns Some(Right(phone))") {
+      val env = Env()
+      for
+        _ <- env.oauthClientService.find.succeedsWith(Some(testClientWithPhoneFlow))
+        _ <- env.oauthClientService.getAllowedPhonePrefixes.succeedsWith(List("+1"))
+        result <- env.parser.parse(validRequest(loginHint = Some("+12025551234")))
+      yield assertTrue(result.loginHint == Some(Right(Phone("+12025551234"))))
+    },
+    test("valid email hint on phone-only flow fails with LoginHintInvalid") {
+      val env = Env()
+      for
+        _ <- env.oauthClientService.find.succeedsWith(Some(testClientWithPhoneFlow))
+        result <- env.parser.parse(validRequest(loginHint = Some("user@example.com"))).either
+      yield assertTrue(result == Left(Error.LoginHintInvalid(validRedirectUri, Some(validState))))
+    },
+    test("valid phone hint on email-only flow fails with LoginHintInvalid") {
+      val env = Env()
+      for
+        _ <- env.oauthClientService.find.succeedsWith(Some(testClientWithEmailFlow))
+        result <- env.parser.parse(validRequest(loginHint = Some("+12025551234"))).either
+      yield assertTrue(result == Left(Error.LoginHintInvalid(validRedirectUri, Some(validState))))
+    },
+    test("valid phone with disallowed prefix fails with LoginHintInvalid") {
+      val env = Env()
+      for
+        _ <- env.oauthClientService.find.succeedsWith(Some(testClientWithPhoneFlow))
+        _ <- env.oauthClientService.getAllowedPhonePrefixes.succeedsWith(List("+44"))
+        result <- env.parser.parse(validRequest(loginHint = Some("+12025551234"))).either
+      yield assertTrue(result == Left(Error.LoginHintInvalid(validRedirectUri, Some(validState))))
+    },
+    test("garbage value fails with LoginHintInvalid") {
+      val env = Env()
+      for
+        _ <- env.oauthClientService.find.succeedsWith(Some(testClientWithEmailFlow))
+        result <- env.parser.parse(validRequest(loginHint = Some("not-a-valid-hint"))).either
+      yield assertTrue(result == Left(Error.LoginHintInvalid(validRedirectUri, Some(validState))))
+    },
+    test("multiple login_hint values fails with MultipleValuesProvided") {
+      val env = Env()
+      val url = URL.root
+        .addQueryParam("client_id", validClientId.toString)
+        .addQueryParam("redirect_uri", validRedirectUriString)
+        .addQueryParam("response_type", "code")
+        .addQueryParam("code_challenge", validCodeChallenge)
+        .addQueryParam("code_challenge_method", "S256")
+        .addQueryParam("scope", validScope)
+        .addQueryParam("state", "random-state")
+        .addQueryParam("login_hint", "user@example.com")
+        .addQueryParam("login_hint", "other@example.com")
+      val request = Request.get(url)
+      for
+        _ <- env.oauthClientService.find.succeedsWith(Some(testClientWithEmailFlow))
+        result <- env.parser.parse(request).either
+      yield assertTrue(
+        result == Left(Error.MultipleValuesProvided(validRedirectUri, Some(validState), "login_hint")),
+      )
+    },
+    test("absent login_hint returns None") {
+      val env = Env()
+      for
+        _ <- env.oauthClientService.find.succeedsWith(Some(testClient))
+        result <- env.parser.parse(validRequest())
+      yield assertTrue(result.loginHint.isEmpty)
     },
   )
 


### PR DESCRIPTION


Uploading new-incognito-tab-google-chrome-2026-07-04-14-36-55_PIIoaJd0.mp4…

Closes https://github.com/versolauth/versola/issues/39

What
Adds support for the OIDC login_hint query parameter on /authorize. When a valid hint is provided, the credential-entry screen is skipped and the first factor starts immediately — OTP is sent or the password screen is shown directly.
Changes
AuthorizeRequestParser — parses and validates login_hint:

rejects multiple values → MultipleValuesProvided
validates format: Email.from → email, Phone.parse → phone, otherwise → LoginHintInvalid
checks that the credential type is supported by authFlow.primary.credentials
for phone hints, validates allowed prefixes via getAllowedPhonePrefixes

AuthorizeRequest — new field loginHint: Option[Either[Email, Phone]]
Error — new case LoginHintInvalid (error=invalid_request)
AuthorizeEndpointService — in createConversation, when loginHint is present, after persisting the conversation calls:

conversationService.prepareInitialOtp — if the first factor is OTP
conversationService.prepareInitialPassword — if the first factor is password
otherwise stays on the Credential step

PostgresOAuthApp — fixed wiring order: ConversationService.live now comes before AuthorizeEndpointService.live to satisfy the new dependency
Tests

AuthorizeRequestParserSpec — 8 new tests: valid email/phone hint, wrong credential type for flow, disallowed prefix, garbage value, multiple values, absent hint
AuthorizeEndpointServiceSpec — 2 new tests: OTP flow with phone hint (asserts prepareInitialOtp was called), password flow with email hint (asserts prepareInitialPassword was called)

Out of scope
User enumeration protection (already handled by fake OTP path), UI prefill, id_token_hint, login_hint as login/username identifier.