### PR TITLE
fix: Cleanup job for authorization_codes is broken (hardcoded id column) #53

### DIFF
--- a/adr/02_cleanup_manager.md
+++ b/adr/02_cleanup_manager.md
@@ -74,12 +74,13 @@ The following tables have TTL-based expiration and require periodic cleanup:
 
 **Design:**
 ```scala
-def cleanupExpired(table: String, batchSize: Int): Task[Int] =
+def cleanupExpired(table: String, batchSize: Int, keyColumn: String = "id"): Task[Int] =
+  val key = SqlLiteral(keyColumn)
   xa.transact {
     sql"""
       DELETE FROM $table
-      WHERE id IN (
-        SELECT id FROM $table
+      WHERE $key IN (
+        SELECT $key FROM $table
         WHERE expires_at < NOW()
         ORDER BY expires_at
         LIMIT $batchSize
@@ -198,6 +199,7 @@ case class TableCleanupConfig(
   tableName: String,
   batchSize: Int,
   interval: Duration,
+  keyColumn: Option[String] = None, // defaults to "id"; use "ctid" for composite-PK tables
 )
 
 case class CleanupResult(
@@ -220,7 +222,7 @@ abstract class CleanupManager.Base(
   fibers: Ref[List[Fiber.Runtime[Throwable, Long]]],
 ) extends CleanupManager:
 
-  protected def cleanupBatch(tableName: String, batchSize: Int): Task[Int]
+  protected def cleanupBatch(tableName: String, batchSize: Int, keyColumn: String): Task[Int]
 
   override def start(): RIO[Scope, Unit] =
     Semaphore.make(config.maxThreads).flatMap { semaphore =>
@@ -243,9 +245,10 @@ abstract class CleanupManager.Base(
     yield ()
 
   private def cleanupTable(config: TableCleanupConfig): Task[CleanupResult] =
+    val keyColumn = config.keyColumn.getOrElse("id")
     for
       start <- Clock.currentTime(TimeUnit.MILLISECONDS)
-      deleted <- cleanupBatch(config.tableName, config.batchSize)
+      deleted <- cleanupBatch(config.tableName, config.batchSize, keyColumn)
       end <- Clock.currentTime(TimeUnit.MILLISECONDS)
       duration = end - start
       _ <- ZIO.logInfo(s"Cleaned ${config.tableName}: $deleted rows in ${duration}ms")
@@ -262,13 +265,14 @@ class PostgresCleanupManager(
   fibers: Ref[List[Fiber.Runtime[Throwable, Long]]],
 ) extends CleanupManager.Base(config, fibers):
 
-  override protected def cleanupBatch(tableName: String, batchSize: Int): Task[Int] =
+  override protected def cleanupBatch(tableName: String, batchSize: Int, keyColumn: String): Task[Int] =
     val table = SqlLiteral(tableName)
+    val key   = SqlLiteral(keyColumn)
     xa.connect {
       sql"""
         DELETE FROM $table
-        WHERE id IN (
-          SELECT id FROM $table
+        WHERE $key IN (
+          SELECT $key FROM $table
           WHERE expires_at < NOW()
           ORDER BY expires_at
           LIMIT $batchSize
@@ -771,9 +775,10 @@ When compliance requirements are defined, add archive table:
 
 ```scala
 // Copy to archive before deleting
-private def cleanupWithArchive(tableName: String, batchSize: Int): Task[Int] =
+private def cleanupWithArchive(tableName: String, batchSize: Int, keyColumn: String = "id"): Task[Int] =
   val table = SqlLiteral(tableName)
   val archiveTable = SqlLiteral(tableName + "_archive")
+  val key = SqlLiteral(keyColumn)
   xa.transact {
     for
       _ <- sql"""
@@ -785,8 +790,8 @@ private def cleanupWithArchive(tableName: String, batchSize: Int): Task[Int] =
 
       deleted <- sql"""
         DELETE FROM $table
-        WHERE id IN (
-          SELECT id FROM $table
+        WHERE $key IN (
+          SELECT $key FROM $table
           WHERE expires_at < NOW()
           LIMIT $batchSize
           FOR UPDATE SKIP LOCKED

--- a/scripts/gen-env.scala
+++ b/scripts/gen-env.scala
@@ -275,6 +275,7 @@ def writeFile(dir: File, name: String, content: String): Unit =
        |      table-name = "authorization_codes"
        |      batch-size = 1000
        |      interval   = "5 minutes"
+       |      key-column = "code"
        |    }
        |    {
        |      table-name = "refresh_tokens"
@@ -290,6 +291,7 @@ def writeFile(dir: File, name: String, content: String): Unit =
        |      table-name = "challenge_throttle"
        |      batch-size = 1000
        |      interval   = "5 minutes"
+       |      key-column = "ctid"
        |    }
        |  ]
        |}
@@ -378,6 +380,7 @@ def writeFile(dir: File, name: String, content: String): Unit =
        |      table-name = "pending_logins"
        |      batch-size = 1000
        |      interval   = "5 minutes"
+       |      key-column = "login_id"
        |    }
        |    {
        |      table-name = "edge_refresh_tokens"

--- a/util/implementations/postgres/src/main/scala/versola/cleanup/PostgresCleanupManager.scala
+++ b/util/implementations/postgres/src/main/scala/versola/cleanup/PostgresCleanupManager.scala
@@ -23,13 +23,14 @@ class PostgresCleanupManager(
     fibers: Ref[List[Fiber.Runtime[Throwable, Long]]],
 ) extends CleanupManager.Base(config, fibers):
 
-  override protected def cleanupBatch(tableName: String, batchSize: Int): Task[Int] =
+  override protected def cleanupBatch(tableName: String, batchSize: Int, keyColumn: String): Task[Int] =
     val table = SqlLiteral(tableName)
+    val key   = SqlLiteral(keyColumn)
     xa.connect {
       sql"""
         DELETE FROM $table
-        WHERE id IN (
-          SELECT id FROM $table
+        WHERE $key IN (
+          SELECT $key FROM $table
           WHERE expires_at < NOW()
           ORDER BY expires_at
           LIMIT $batchSize

--- a/util/implementations/postgres/src/test/scala/versola/cleanup/PostgresCleanupManagerSpec.scala
+++ b/util/implementations/postgres/src/test/scala/versola/cleanup/PostgresCleanupManagerSpec.scala
@@ -1,0 +1,107 @@
+package versola.cleanup
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import com.augustnagro.magnum.sql
+import versola.util.postgres.PostgresSpec
+import zio.*
+import zio.test.*
+
+object PostgresCleanupManagerSpec extends PostgresSpec:
+
+  /** Exposes the protected cleanupBatch method for testing. */
+  private class TestableCleanupManager(
+      xa: TransactorZIO,
+      fibers: Ref[List[Fiber.Runtime[Throwable, Long]]],
+  ) extends PostgresCleanupManager(xa, CleanupConfig(maxThreads = 1, tables = List.empty), fibers):
+    def runBatch(tableName: String, batchSize: Int, keyColumn: String): Task[Int] =
+      cleanupBatch(tableName, batchSize, keyColumn)
+
+  private def makeManager(xa: TransactorZIO): UIO[TestableCleanupManager] =
+    Ref.make(List.empty[Fiber.Runtime[Throwable, Long]]).map(TestableCleanupManager(xa, _))
+
+  override val spec: Spec[TransactorZIO & TestEnvironment & Scope, Any] =
+    suite("PostgresCleanupManagerSpec")(
+      test("deletes expired rows and keeps active ones (keyColumn=id, auth_conversations)") {
+        for
+          xa      <- ZIO.service[TransactorZIO]
+          _       <- xa.connect(sql"TRUNCATE TABLE auth_conversations".update.run())
+          manager <- makeManager(xa)
+          id1      = java.util.UUID.randomUUID()
+          id2      = java.util.UUID.randomUUID()
+          _ <- xa.connect:
+            sql"""
+              INSERT INTO auth_conversations
+                (id, client_id, redirect_uri, scope, code_challenge, code_challenge_method,
+                 step, response_type, auth_flow, version, amr, expires_at)
+              VALUES
+                ($id1, 'c1', 'https://x.com', ARRAY['openid'], 'ch', 'S256',
+                 '{"type":"start"}'::json, 'code', '{"type":"pwd"}'::jsonb, 1, '[]'::jsonb,
+                 NOW() - INTERVAL '2 minutes'),
+                ($id2, 'c1', 'https://x.com', ARRAY['openid'], 'ch', 'S256',
+                 '{"type":"start"}'::json, 'code', '{"type":"pwd"}'::jsonb, 1, '[]'::jsonb,
+                 NOW() + INTERVAL '5 minutes')
+            """.update.run()
+          deleted   <- manager.runBatch("auth_conversations", 1000, "id")
+          remaining <- xa.connect(sql"SELECT COUNT(*) FROM auth_conversations".query[Long].run().head)
+        yield assertTrue(deleted == 1, remaining == 1L)
+      },
+      test("deletes expired authorization_codes (keyColumn=code)") {
+        for
+          xa      <- ZIO.service[TransactorZIO]
+          _       <- xa.connect(sql"TRUNCATE TABLE authorization_codes".update.run())
+          manager <- makeManager(xa)
+          userId1  = java.util.UUID.randomUUID()
+          userId2  = java.util.UUID.randomUUID()
+          _ <- xa.connect:
+            sql"""
+              INSERT INTO authorization_codes
+                (code, client_id, user_id, session_id, redirect_uri, scope,
+                 code_challenge, code_challenge_method, expires_at,
+                 used, access_token, amr, auth_time)
+              VALUES
+                (decode('0101', 'hex'), 'c1', $userId1, decode('02', 'hex'), 'https://x.com', ARRAY['openid'],
+                 'ch', 'S256', NOW() - INTERVAL '1 minute',
+                 false, decode('03', 'hex'), '[]'::jsonb, NOW()),
+                (decode('0202', 'hex'), 'c1', $userId2, decode('02', 'hex'), 'https://x.com', ARRAY['openid'],
+                 'ch', 'S256', NOW() + INTERVAL '5 minutes',
+                 false, decode('04', 'hex'), '[]'::jsonb, NOW())
+            """.update.run()
+          deleted   <- manager.runBatch("authorization_codes", 1000, "code")
+          remaining <- xa.connect(sql"SELECT COUNT(*) FROM authorization_codes".query[Long].run().head)
+        yield assertTrue(deleted == 1, remaining == 1L)
+      },
+      test("deletes expired challenge_throttle rows (keyColumn=ctid, composite PK)") {
+        for
+          xa      <- ZIO.service[TransactorZIO]
+          _       <- xa.connect(sql"TRUNCATE TABLE challenge_throttle".update.run())
+          manager <- makeManager(xa)
+          _ <- xa.connect:
+            sql"""
+              INSERT INTO challenge_throttle (subject, tenant_id, challenge_type, attempts, expires_at)
+              VALUES
+                ('u1', 't1', 'otp', '[]'::jsonb, NOW() - INTERVAL '1 minute'),
+                ('u2', 't1', 'otp', '[]'::jsonb, NOW() - INTERVAL '2 minutes'),
+                ('u3', 't1', 'otp', '[]'::jsonb, NOW() + INTERVAL '5 minutes')
+            """.update.run()
+          deleted   <- manager.runBatch("challenge_throttle", 1000, "ctid")
+          remaining <- xa.connect(sql"SELECT COUNT(*) FROM challenge_throttle".query[Long].run().head)
+        yield assertTrue(deleted == 2, remaining == 1L)
+      },
+      test("respects batch size limit") {
+        for
+          xa      <- ZIO.service[TransactorZIO]
+          _       <- xa.connect(sql"TRUNCATE TABLE challenge_throttle".update.run())
+          manager <- makeManager(xa)
+          _ <- xa.connect:
+            sql"""
+              INSERT INTO challenge_throttle (subject, tenant_id, challenge_type, attempts, expires_at)
+              VALUES
+                ('u1', 't1', 'otp', '[]'::jsonb, NOW() - INTERVAL '3 minutes'),
+                ('u2', 't1', 'otp', '[]'::jsonb, NOW() - INTERVAL '2 minutes'),
+                ('u3', 't1', 'otp', '[]'::jsonb, NOW() - INTERVAL '1 minute')
+            """.update.run()
+          deleted   <- manager.runBatch("challenge_throttle", 2, "ctid")
+          remaining <- xa.connect(sql"SELECT COUNT(*) FROM challenge_throttle".query[Long].run().head)
+        yield assertTrue(deleted == 2, remaining == 1L)
+      },
+    ) @@ TestAspect.sequential

--- a/util/src/main/scala/versola/cleanup/CleanupConfig.scala
+++ b/util/src/main/scala/versola/cleanup/CleanupConfig.scala
@@ -24,9 +24,13 @@ case class CleanupConfig(
  *   Number of rows to delete in a single batch
  * @param interval
  *   How often to run cleanup for this table
+ * @param keyColumn
+ *   The column used to identify rows for deletion. Defaults to `id` if not specified.
+ *   Use `ctid` for tables with composite primary keys.
  */
 case class TableCleanupConfig(
     tableName: String,
     batchSize: Int,
     interval: Duration,
+    keyColumn: Option[String] = None,
 )

--- a/util/src/main/scala/versola/cleanup/CleanupManager.scala
+++ b/util/src/main/scala/versola/cleanup/CleanupManager.scala
@@ -53,10 +53,12 @@ object CleanupManager:
       *   The name of the table to clean up
       * @param batchSize
       *   Maximum number of rows to delete in this batch
+      * @param keyColumn
+      *   The column used to identify rows for deletion
       * @return
       *   Number of rows deleted
       */
-    protected def cleanupBatch(tableName: String, batchSize: Int): Task[Int]
+    protected def cleanupBatch(tableName: String, batchSize: Int, keyColumn: String): Task[Int]
 
     override def start(): RIO[Scope, Unit] =
       Semaphore.make(config.maxThreads).flatMap { semaphore =>
@@ -79,9 +81,10 @@ object CleanupManager:
       yield ()
 
     private def cleanupTable(config: TableCleanupConfig): Task[CleanupResult] =
+      val keyColumn = config.keyColumn.getOrElse("id")
       for
         start <- Clock.currentTime(TimeUnit.MILLISECONDS)
-        deleted <- cleanupBatch(config.tableName, config.batchSize)
+        deleted <- cleanupBatch(config.tableName, config.batchSize, keyColumn)
         end <- Clock.currentTime(TimeUnit.MILLISECONDS)
         duration = end - start
         _ <- ZIO.logInfo(s"Cleaned ${config.tableName}: $deleted rows in ${duration}ms")


### PR DESCRIPTION
## Problem

`PostgresCleanupManager.cleanupBatch` hardcoded `id` as the primary key column in the DELETE query. This broke cleanup for tables whose PK is not `id`:

- `authorization_codes` — PK is `code`
- `challenge_throttle` — composite PK `(subject, tenant_id, challenge_type)`
- `pending_logins` — PK is `login_id`

These tables were producing `column "id" does not exist` errors on every cleanup cycle, leaving expired rows undeleted.

## Solution

Added `keyColumn: Option[String]` to `TableCleanupConfig`. Defaults to `"id"` when not specified, so existing tables are unaffected. Updated `gen-env.scala` to set the correct key column for affected tables (`ctid` is used for `challenge_throttle` as a safe row identifier for composite-PK tables).

## Changes

- `CleanupConfig.scala` — added `keyColumn: Option[String]` to `TableCleanupConfig`
- `CleanupManager.scala` — pass `keyColumn` to `cleanupBatch`; resolve default `"id"` in `cleanupTable`
- `PostgresCleanupManager.scala` — use `keyColumn` as `SqlLiteral` in the DELETE query
- `gen-env.scala` — added `key-column` for `authorization_codes`, `challenge_throttle`, `pending_logins`

Closes #53