### PR TITLE
Unindexed foreign keys cause sequential scans on cascade deletes  #55

### DIFF
--- a/central/implementations/postgres/migrations/V201__oauth_clients_table.sql
+++ b/central/implementations/postgres/migrations/V201__oauth_clients_table.sql
@@ -13,3 +13,5 @@ CREATE TABLE oauth_clients (
     auth_flow         JSONB,
     otp_template_id   TEXT NOT NULL
 );
+
+CREATE INDEX idx_oauth_clients_tenant_id ON oauth_clients (tenant_id);

--- a/central/implementations/postgres/migrations/V207__edges_table.sql
+++ b/central/implementations/postgres/migrations/V207__edges_table.sql
@@ -7,6 +7,8 @@ CREATE TABLE edges (
 ALTER TABLE tenants
     ADD COLUMN edge_id TEXT REFERENCES edges(id) ON DELETE SET NULL;
 
+CREATE INDEX idx_tenants_edge_id ON tenants (edge_id);
+
 -- edge_change — empty payload, reload all
 CREATE OR REPLACE FUNCTION notify_edge_change()
 RETURNS trigger AS $$

--- a/central/implementations/postgres/migrations/V211__themes_table.sql
+++ b/central/implementations/postgres/migrations/V211__themes_table.sql
@@ -5,3 +5,6 @@ CREATE TABLE themes (
 );
 
 ALTER TABLE oauth_clients ADD COLUMN theme TEXT NOT NULL REFERENCES themes(id);
+
+CREATE INDEX idx_themes_tenant_id ON themes (tenant_id);
+CREATE INDEX idx_oauth_clients_theme ON oauth_clients (theme);


### PR DESCRIPTION
Closes #55 

Add indexes on unindexed FK columns (#55)

Several FK columns lacked a supporting index, causing sequential scans on ON DELETE CASCADE/SET NULL operations and tenant-scoped lookups.

Added indexes:
- `idx_oauth_clients_tenant_id` on `oauth_clients(tenant_id)` (V201)
- `idx_tenants_edge_id` on `tenants(edge_id)` (V207)
- `idx_themes_tenant_id` on `themes(tenant_id)` (V211)
- `idx_oauth_clients_theme` on `oauth_clients(theme)` (V211)

Note: during review I noticed that `otp_templates` has `PRIMARY KEY (id, tenant_id)` — PK is prefixed by `id`, not `tenant_id`, so it does not cover lookups by `tenant_id` alone. This is the same class of problem but left out of scope here — worth a separate issue.