### PR TITLE
N+1 writes in PostgresUserRolesRepository.updateRoles  #57

### DIFF
--- a/auth/implementations/postgres/src/main/scala/versola/user/PostgresUserRolesRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/user/PostgresUserRolesRepository.scala
@@ -42,13 +42,13 @@ class PostgresUserRolesRepository(xa: TransactorZIO) extends UserRolesRepository
     else
       xa.transactMeasured("update-roles"):
         if remove.nonEmpty then
-          remove.foreach: roleId =>
-            sql"DELETE FROM user_roles WHERE user_id = $userId AND tenant_id = $tenantId AND role_id = $roleId"
-              .update.run()
+          sql"DELETE FROM user_roles WHERE user_id = $userId AND tenant_id = $tenantId AND role_id = ANY($remove)"
+            .update.run()
         if add.nonEmpty then
-          add.foreach: roleId =>
-            sql"INSERT INTO user_roles (user_id, tenant_id, role_id) VALUES ($userId, $tenantId, $roleId) ON CONFLICT DO NOTHING"
-              .update.run()
+          sql"""INSERT INTO user_roles (user_id, tenant_id, role_id)
+                SELECT $userId, $tenantId, unnest($add)
+                ON CONFLICT DO NOTHING"""
+            .update.run()
       .unit
 
 object PostgresUserRolesRepository:

--- a/auth/implementations/postgres/src/test/scala/versola/user/PostgresUserRolesRepositorySpec.scala
+++ b/auth/implementations/postgres/src/test/scala/versola/user/PostgresUserRolesRepositorySpec.scala
@@ -1,0 +1,24 @@
+package versola.user
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import com.augustnagro.magnum.sql
+import versola.util.postgres.PostgresSpec
+import zio.{ZIO, ZLayer}
+
+import java.util.UUID
+
+object PostgresUserRolesRepositorySpec extends PostgresSpec, UserRolesRepositorySpec:
+
+  override lazy val environment =
+    ZLayer:
+      for
+        xa <- ZIO.service[TransactorZIO]
+      yield UserRolesRepositorySpec.Env(PostgresUserRolesRepository(xa))
+
+  override def beforeEach(env: UserRolesRepositorySpec.Env) =
+    for
+      xa <- ZIO.service[TransactorZIO]
+      _ <- xa.connect:
+        sql"TRUNCATE TABLE users CASCADE".update.run()
+        sql"INSERT INTO users (id, claims) VALUES (${(userId1: UUID)}, '{}'::jsonb)".update.run()
+    yield ()

--- a/auth/src/test/scala/versola/user/UserRolesRepositorySpec.scala
+++ b/auth/src/test/scala/versola/user/UserRolesRepositorySpec.scala
@@ -1,0 +1,70 @@
+package versola.user
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import versola.oauth.client.model.TenantId
+import versola.role.model.RoleId
+import versola.user.model.UserId
+import versola.util.DatabaseSpecBase
+import zio.*
+import zio.test.*
+
+import java.util.UUID
+
+trait UserRolesRepositorySpec extends DatabaseSpecBase[UserRolesRepositorySpec.Env]:
+  self: ZIOSpec[TransactorZIO] =>
+
+  val userId1 = UserId(UUID.fromString("f077fb08-9935-4a6d-8643-bf97c073bf0f"))
+
+  val tenantId1 = TenantId("tenant-1")
+
+  val roleA = RoleId("role-a")
+  val roleB = RoleId("role-b")
+  val roleC = RoleId("role-c")
+
+  override def testCases(env: UserRolesRepositorySpec.Env): List[Spec[UserRolesRepositorySpec.Env & Scope, Any]] =
+    List(
+      test("add roles to user") {
+        for
+          _ <- env.rolesRepository.updateRoles(userId1, tenantId1, add = Set(roleA, roleB), remove = Set.empty)
+          roles <- env.rolesRepository.findRolesByUserAndTenant(userId1, tenantId1)
+        yield assertTrue(roles.toSet == Set(roleA, roleB))
+      },
+      test("remove roles from user") {
+        for
+          _ <- env.rolesRepository.updateRoles(userId1, tenantId1, add = Set(roleA, roleB), remove = Set.empty)
+          _ <- env.rolesRepository.updateRoles(userId1, tenantId1, add = Set.empty, remove = Set(roleA))
+          roles <- env.rolesRepository.findRolesByUserAndTenant(userId1, tenantId1)
+        yield assertTrue(roles == List(roleB))
+      },
+      test("add and remove roles in one call") {
+        for
+          _ <- env.rolesRepository.updateRoles(userId1, tenantId1, add = Set(roleA, roleB), remove = Set.empty)
+          _ <- env.rolesRepository.updateRoles(userId1, tenantId1, add = Set(roleC), remove = Set(roleA))
+          roles <- env.rolesRepository.findRolesByUserAndTenant(userId1, tenantId1)
+        yield assertTrue(roles.toSet == Set(roleB, roleC))
+      },
+      test("empty add and remove is a no-op") {
+        for
+          _ <- env.rolesRepository.updateRoles(userId1, tenantId1, add = Set(roleA), remove = Set.empty)
+          _ <- env.rolesRepository.updateRoles(userId1, tenantId1, add = Set.empty, remove = Set.empty)
+          roles <- env.rolesRepository.findRolesByUserAndTenant(userId1, tenantId1)
+        yield assertTrue(roles == List(roleA))
+      },
+      test("insert is idempotent via ON CONFLICT DO NOTHING") {
+        for
+          _ <- env.rolesRepository.updateRoles(userId1, tenantId1, add = Set(roleA), remove = Set.empty)
+          _ <- env.rolesRepository.updateRoles(userId1, tenantId1, add = Set(roleA), remove = Set.empty)
+          roles <- env.rolesRepository.findRolesByUserAndTenant(userId1, tenantId1)
+        yield assertTrue(roles == List(roleA))
+      },
+      test("remove non-existing role is a no-op") {
+        for
+          _ <- env.rolesRepository.updateRoles(userId1, tenantId1, add = Set(roleA), remove = Set.empty)
+          _ <- env.rolesRepository.updateRoles(userId1, tenantId1, add = Set.empty, remove = Set(roleB))
+          roles <- env.rolesRepository.findRolesByUserAndTenant(userId1, tenantId1)
+        yield assertTrue(roles == List(roleA))
+      },
+    )
+
+object UserRolesRepositorySpec:
+  case class Env(rolesRepository: UserRolesRepository)


### PR DESCRIPTION
Closes #57 

## Summary

Fixes N+1 write issue in `PostgresUserRolesRepository.updateRoles`.

Previously, the method issued one `DELETE` and one `INSERT` per role in a loop, resulting in O(n) round-trips to the database.

## Changes

Replaced per-role loops with batched SQL in `PostgresUserRolesRepository`:

- `DELETE ... WHERE role_id = ANY($remove)` — single statement for all removals
- `INSERT ... SELECT $userId, $tenantId, unnest($add) ON CONFLICT DO NOTHING` — single statement for all additions

Round-trips are now constant (at most 2) regardless of how many roles are being changed.