### PR TITLE
Locale deletion performs full-table jsonb UPDATEs on forms and otp_templates  #59 

### DIFF
--- a/central/implementations/postgres/migrations/V210__forms_table.sql
+++ b/central/implementations/postgres/migrations/V210__forms_table.sql
@@ -32,3 +32,5 @@ $$ LANGUAGE plpgsql;
 CREATE TRIGGER forms_notify
 AFTER INSERT OR UPDATE OR DELETE ON forms
 FOR EACH ROW EXECUTE FUNCTION notify_form_change();
+
+CREATE INDEX forms_localizations_gin ON forms USING GIN (localizations);

--- a/central/implementations/postgres/migrations/V212__otp_challenges.sql
+++ b/central/implementations/postgres/migrations/V212__otp_challenges.sql
@@ -23,3 +23,5 @@ $$ LANGUAGE plpgsql;
 CREATE TRIGGER otp_templates_notify
 AFTER INSERT OR UPDATE OR DELETE ON otp_templates
 FOR EACH ROW EXECUTE FUNCTION notify_otp_template_change();
+
+CREATE INDEX otp_templates_localizations_gin ON otp_templates USING GIN (localizations);

--- a/central/implementations/postgres/src/main/scala/versola/configuration/locales/PostgresLocaleRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/locales/PostgresLocaleRepository.scala
@@ -16,11 +16,14 @@ class PostgresLocaleRepository(xa: TransactorZIO) extends LocaleRepository, Basi
 
   override def update(add: Vector[LocaleRecord], delete: Vector[String]): Task[Unit] =
     xa.repeatableRead.transactMeasured("update-locales"):
-      delete.foreach { code =>
-        sql"""DELETE FROM locales WHERE code = $code""".update.run()
-        sql"""UPDATE forms SET localizations = localizations - $code WHERE jsonb_exists(localizations, $code)""".update.run()
-        sql"""UPDATE otp_templates SET localizations = localizations - $code WHERE jsonb_exists(localizations, $code)""".update.run()
-      }
+      if delete.nonEmpty then
+        sql"""DELETE FROM locales WHERE code = ANY($delete)""".update.run()
+        sql"""UPDATE forms
+              SET localizations = localizations - $delete
+              WHERE jsonb_exists_any(localizations, $delete)""".update.run()
+        sql"""UPDATE otp_templates
+              SET localizations = localizations - $delete
+              WHERE jsonb_exists_any(localizations, $delete)""".update.run()
       add.foreach { locale =>
         sql"""INSERT INTO locales (code, name, is_default, active) VALUES (${locale.code}, ${locale.name}, ${locale.isDefault}, ${locale.active})
               ON CONFLICT (code) DO UPDATE SET name = EXCLUDED.name, active = EXCLUDED.active""".update.run()

--- a/central/implementations/postgres/src/test/scala/versola/configuration/locales/PostgresLocaleRepositorySpec.scala
+++ b/central/implementations/postgres/src/test/scala/versola/configuration/locales/PostgresLocaleRepositorySpec.scala
@@ -11,9 +11,9 @@ object PostgresLocaleRepositorySpec extends PostgresSpec, LocaleRepositorySpec:
   override lazy val environment =
     ZLayer:
       for xa <- ZIO.service[TransactorZIO]
-      yield LocaleRepositorySpec.Env(PostgresLocaleRepository(xa))
+      yield LocaleRepositorySpec.Env(PostgresLocaleRepository(xa), xa)
 
   override def beforeEach(env: LocaleRepositorySpec.Env) =
     ZIO.serviceWithZIO[TransactorZIO] { xa =>
-      xa.connect(sql"TRUNCATE TABLE locales RESTART IDENTITY CASCADE".update.run())
+      xa.connect(sql"TRUNCATE TABLE tenants, locales, forms RESTART IDENTITY CASCADE".update.run())
     }.unit

--- a/central/src/test/scala/versola/central/configuration/locales/LocaleRepositorySpec.scala
+++ b/central/src/test/scala/versola/central/configuration/locales/LocaleRepositorySpec.scala
@@ -1,6 +1,7 @@
 package versola.central.configuration.locales
 
 import com.augustnagro.magnum.magzio.TransactorZIO
+import com.augustnagro.magnum.sql
 import versola.util.DatabaseSpecBase
 import zio.test.*
 
@@ -25,6 +26,47 @@ trait LocaleRepositorySpec extends DatabaseSpecBase[LocaleRepositorySpec.Env]:
           _ <- env.repository.update(add = Vector.empty, delete = Vector("ru"))
           all <- env.repository.getAll
         yield assertTrue(all.map(_.code) == Vector("en", "fr"))
+      },
+      test("update delete removes locale key from forms localizations") {
+        for
+          _ <- env.repository.update(add = Vector(en, ru), delete = Vector.empty)
+          _ <- env.xa.connect:
+            sql"""INSERT INTO forms (id, version, active, style, js_source, js_compiled, localizations, properties)
+                  VALUES ('credential', 1, true, '', null, null, '{"en":{"title":"Sign in"},"ru":{"title":"Вход"}}', '{}')""".update.run()
+          _ <- env.repository.update(add = Vector.empty, delete = Vector("ru"))
+          locs <- env.xa.connect:
+            sql"""SELECT localizations::text FROM forms WHERE id = 'credential' AND version = 1""".query[String].run()
+        yield assertTrue(
+          locs.headOption.exists(l => l.contains(""""en"""") && !l.contains(""""ru"""")),
+        )
+      },
+      test("update delete removes locale key from otp_templates localizations") {
+        for
+          _ <- env.repository.update(add = Vector(en, ru), delete = Vector.empty)
+          _ <- env.xa.connect:
+            sql"""INSERT INTO tenants (id, description) VALUES ('t1', 'Test Tenant')""".update.run()
+          _ <- env.xa.connect:
+            sql"""INSERT INTO otp_templates (id, tenant_id, localizations)
+                  VALUES ('email', 't1', '{"en":{"subject":"Code"},"ru":{"subject":"Код"}}')""".update.run()
+          _ <- env.repository.update(add = Vector.empty, delete = Vector("ru"))
+          locs <- env.xa.connect:
+            sql"""SELECT localizations::text FROM otp_templates WHERE id = 'email' AND tenant_id = 't1'""".query[String].run()
+        yield assertTrue(
+          locs.headOption.exists(l => l.contains(""""en"""") && !l.contains(""""ru"""")),
+        )
+      },
+      test("update batch-deletes multiple locale keys from forms localizations") {
+        for
+          _ <- env.repository.update(add = Vector(en, ru, fr), delete = Vector.empty)
+          _ <- env.xa.connect:
+            sql"""INSERT INTO forms (id, version, active, style, js_source, js_compiled, localizations, properties)
+                  VALUES ('credential', 1, true, '', null, null, '{"en":{"title":"Sign in"},"ru":{"title":"Вход"},"fr":{"title":"Connexion"}}', '{}')""".update.run()
+          _ <- env.repository.update(add = Vector.empty, delete = Vector("ru", "fr"))
+          locs <- env.xa.connect:
+            sql"""SELECT localizations::text FROM forms WHERE id = 'credential' AND version = 1""".query[String].run()
+        yield assertTrue(
+          locs.headOption.exists(l => l.contains(""""en"""") && !l.contains(""""ru"""") && !l.contains(""""fr"""")),
+        )
       },
       test("setDefault marks only the given locale as default") {
         for
@@ -59,4 +101,4 @@ trait LocaleRepositorySpec extends DatabaseSpecBase[LocaleRepositorySpec.Env]:
     )
 
 object LocaleRepositorySpec:
-  case class Env(repository: LocaleRepository)
+  case class Env(repository: LocaleRepository, xa: TransactorZIO)


### PR DESCRIPTION
Closes #59 

Fix locale deletion full-table scans on forms and otp_templates (#59)
Problem
PostgresLocaleRepository.update iterated over deleted locale codes in a Scala loop, issuing 3 SQL statements per code — resulting in O(rows × deleted-codes) sequential scans with no index support on the localizations JSONB column.
Changes

Replaced the delete.foreach loop with three batched statements using ANY($codes) for the locales delete, jsonb_exists_any for the WHERE predicate, and the jsonb - text[] operator to strip multiple keys in a single pass. Used jsonb_exists_any instead of the ?| operator to avoid conflicts with JDBC parameter placeholders.
Added a nonEmpty guard so no statements are issued when there is nothing to delete.
Added GIN indexes on forms.localizations and otp_templates.localizations so the WHERE predicate hits the index rather than doing a sequential scan.
Added integration tests verifying that locale deletion removes the corresponding key from forms.localizations, from otp_templates.localizations, and that batch deletion of multiple codes works correctly in a single call.

Files changed

PostgresLocaleRepository.scala — batched delete logic
V210__forms_table.sql — GIN index on forms.localizations
V212__otp_challenges.sql — GIN index on otp_templates.localizations
LocaleRepositorySpec.scala — three new integration tests; Env extended with xa: TransactorZIO for raw SQL setup
PostgresLocaleRepositorySpec.scala — updated Env construction and beforeEach TRUNCATE to cover tenants, forms, and cascade to otp_templates