### PR TITLE
commit for issue 63

### DIFF
--- a/central/implementations/postgres/src/main/scala/versola/configuration/sync/PostgresCacheSyncRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/sync/PostgresCacheSyncRepository.scala
@@ -15,120 +15,30 @@ import zio.json.DecoderOps
 import zio.*
 import zio.stream.{Stream, ZStream}
 
-class PostgresCacheSyncRepository(conn: PGConnection) extends CacheSyncRepository:
-
-  private case class ChangePayload(
-      tenantId: Option[String],
-      id: String,
-      version: Option[Int],
-      op: String,
-  ) derives JsonDecoder
-
-  private def parsePayload(parameter: String): Option[ChangePayload] =
-    parameter.fromJson[ChangePayload].toOption
+class PostgresCacheSyncRepository(conn: PGConnection, jdbcConn: java.sql.Connection) extends CacheSyncRepository:
 
   def getNotifications: Stream[Throwable, SyncEvent] =
     ZStream
       .repeatZIO(
-        ZIO.attemptBlocking(Option(conn.getNotifications()).map(_.toList).getOrElse(Nil)) <* ZIO.sleep(100.millis),
+        // Blocks the dedicated LISTEN connection for up to NotificationTimeoutMillis waiting for a
+        // notification (pgjdbc's own recommended pattern), instead of busy-polling every 100ms.
+        // The underlying blocking socket read does not respond to a plain thread interrupt, so on
+        // fiber interruption (e.g. graceful shutdown) we abort the connection instead of closing it:
+        // `jdbcConn` is a Hikari-pooled proxy, and Connection#close() on it just returns the
+        // (still-blocked-on) connection to the pool for reuse rather than terminating the physical
+        // socket — it wouldn't reliably unblock the read, and worse, another caller could borrow the
+        // same connection while our read is still in flight on it. Connection#abort(Executor) forcibly
+        // terminates the physical connection and evicts it from the pool instead of returning it as
+        // healthy, which is exactly what we need here. Runs on the blocking executor since abort() can
+        // itself block briefly tearing down the socket.
+        ZIO.attemptBlockingCancelable(
+          Option(conn.getNotifications(PostgresCacheSyncRepository.NotificationTimeoutMillis))
+            .map(_.toList)
+            .getOrElse(Nil),
+        )(cancel = ZIO.attemptBlocking(jdbcConn.abort(PostgresCacheSyncRepository.directExecutor)).ignore),
       )
       .flattenIterables
-      .map { notification =>
-        notification.getName match
-          case "tenant_change" =>
-            SyncEvent.TenantsUpdated
-
-          case "edge_change" =>
-            SyncEvent.EdgesUpdated
-
-          case "jwks_change" =>
-            SyncEvent.JwksUpdated
-
-          case "client_change" =>
-            parsePayload(notification.getParameter).fold[SyncEvent](SyncEvent.Unknown) { payload =>
-              SyncEvent.ClientsUpdated(
-                id = ClientId(payload.id),
-                op = SyncEvent.Op.valueOf(payload.op),
-              )
-            }
-          case "role_change" =>
-            parsePayload(notification.getParameter).fold[SyncEvent](SyncEvent.Unknown) { payload =>
-              SyncEvent.RolesUpdated(
-                tenantId = TenantId(payload.tenantId.getOrElse("")),
-                id = RoleId(payload.id),
-                op = SyncEvent.Op.valueOf(payload.op),
-              )
-            }
-          case "scope_change" =>
-            parsePayload(notification.getParameter).fold[SyncEvent](SyncEvent.Unknown) { payload =>
-              SyncEvent.ScopesUpdated(
-                tenantId = TenantId(payload.tenantId.getOrElse("")),
-                id = ScopeToken(payload.id),
-                op = SyncEvent.Op.valueOf(payload.op),
-              )
-            }
-          case "permission_change" =>
-            parsePayload(notification.getParameter).fold[SyncEvent](SyncEvent.Unknown) { payload =>
-              payload.tenantId.filter(_.nonEmpty).fold[SyncEvent](SyncEvent.Unknown) { tenantId =>
-                SyncEvent.PermissionsUpdated(
-                  tenantId = TenantId(tenantId),
-                  id = Permission(payload.id),
-                  op = SyncEvent.Op.valueOf(payload.op),
-                )
-              }
-            }
-          case "resource_change" =>
-            parsePayload(notification.getParameter).fold[SyncEvent](SyncEvent.Unknown) { payload =>
-              payload.tenantId.fold[SyncEvent](SyncEvent.Unknown) { tenantId =>
-                SyncEvent.ResourcesUpdated(
-                  tenantId = TenantId(tenantId),
-                  id = ResourceId(payload.id),
-                  op = SyncEvent.Op.valueOf(payload.op),
-                )
-              }
-            }
-          case "preset_change" =>
-            parsePayload(notification.getParameter).fold[SyncEvent](SyncEvent.Unknown) { payload =>
-              SyncEvent.PresetsUpdated(
-                tenantId = TenantId(payload.tenantId.getOrElse("")),
-                id = PresetId(payload.id),
-                op = SyncEvent.Op.valueOf(payload.op),
-              )
-            }
-          case "form_change" =>
-            parsePayload(notification.getParameter).fold[SyncEvent](SyncEvent.Unknown) { payload =>
-              SyncEvent.FormsUpdated(
-                id = FormId(payload.id),
-                version = payload.version.getOrElse(0),
-                op = SyncEvent.Op.valueOf(payload.op),
-              )
-            }
-          case "otp_template_change" =>
-            parsePayload(notification.getParameter).fold[SyncEvent](SyncEvent.Unknown) { payload =>
-              payload.tenantId.fold[SyncEvent](SyncEvent.Unknown) { tenantId =>
-                SyncEvent.OtpTemplatesUpdated(
-                  tenantId = TenantId(tenantId),
-                  id = payload.id,
-                  op = SyncEvent.Op.valueOf(payload.op),
-                )
-              }
-            }
-          case "challenge_settings_change" =>
-            parsePayload(notification.getParameter).fold[SyncEvent](SyncEvent.Unknown) { payload =>
-              payload.tenantId.fold[SyncEvent](SyncEvent.Unknown) { tenantId =>
-                SyncEvent.ChallengeSettingsUpdated(
-                  tenantId = TenantId(tenantId),
-                  op = SyncEvent.Op.valueOf(payload.op),
-                )
-              }
-            }
-          case "theme_change" =>
-            SyncEvent.ThemesUpdated
-          case "system_settings_change" =>
-            SyncEvent.SystemSettingsUpdated
-          case _ =>
-            SyncEvent.Unknown
-      }
+      .map(notification => PostgresCacheSyncRepository.parseNotification(notification.getName, notification.getParameter))
 
 object PostgresCacheSyncRepository:
   private val notificationChannels = List(
@@ -148,6 +58,104 @@ object PostgresCacheSyncRepository:
     "system_settings_change",
   )
 
+  // pgjdbc's own getNotifications(timeout) example uses 10s; see
+  // https://access.crunchydata.com/documentation/pgjdbc/42.1.1/listennotify.html
+  private val NotificationTimeoutMillis = 10000
+
+  // Connection#abort(Executor) requires an Executor to run its (usually trivial) teardown task on.
+  // This path only runs on interruption/shutdown, so a same-thread executor is sufficient.
+  private val directExecutor: java.util.concurrent.Executor = (r: Runnable) => r.run()
+
+  private case class ChangePayload(
+      tenantId: Option[String],
+      id: String,
+      version: Option[Int],
+      op: String,
+  ) derives JsonDecoder
+
+  private def parsePayload(rawPayload: String): Option[ChangePayload] =
+    rawPayload.fromJson[ChangePayload].toOption
+
+  /** Parses a payload and op, falling back to `None` if the JSON is malformed or `op` is not a
+    * recognized [[SyncEvent.Op]] value.
+    */
+  private def parseOpEvent(rawPayload: String)(build: (ChangePayload, SyncEvent.Op) => SyncEvent): SyncEvent =
+    (for
+      payload <- parsePayload(rawPayload)
+      op <- SyncEvent.Op.fromString(payload.op)
+    yield build(payload, op)).getOrElse(SyncEvent.Unknown)
+
+  /** As [[parseOpEvent]], additionally requiring a non-empty `tenantId`. */
+  private def parseTenantOpEvent(
+      rawPayload: String,
+  )(build: (ChangePayload, TenantId, SyncEvent.Op) => SyncEvent): SyncEvent =
+    parseOpEvent(rawPayload): (payload, op) =>
+      payload.tenantId.filter(_.nonEmpty).fold(SyncEvent.Unknown)(tenantId => build(payload, TenantId(tenantId), op))
+
+  /** Parses a raw NOTIFY channel/payload pair into a [[SyncEvent]].
+    *
+    * Total: malformed JSON, an unrecognized `op`, or a missing/empty `tenantId` (where required)
+    * all fall back to [[SyncEvent.Unknown]] instead of throwing.
+    */
+  private[sync] def parseNotification(channel: String, rawPayload: String): SyncEvent =
+    channel match
+      case "tenant_change" =>
+        SyncEvent.TenantsUpdated
+
+      case "edge_change" =>
+        SyncEvent.EdgesUpdated
+
+      case "jwks_change" =>
+        SyncEvent.JwksUpdated
+
+      case "client_change" =>
+        parseOpEvent(rawPayload): (payload, op) =>
+          SyncEvent.ClientsUpdated(id = ClientId(payload.id), op = op)
+
+      case "role_change" =>
+        parseTenantOpEvent(rawPayload): (payload, tenantId, op) =>
+          SyncEvent.RolesUpdated(tenantId = tenantId, id = RoleId(payload.id), op = op)
+
+      case "scope_change" =>
+        parseTenantOpEvent(rawPayload): (payload, tenantId, op) =>
+          SyncEvent.ScopesUpdated(tenantId = tenantId, id = ScopeToken(payload.id), op = op)
+
+      case "permission_change" =>
+        parseTenantOpEvent(rawPayload): (payload, tenantId, op) =>
+          SyncEvent.PermissionsUpdated(tenantId = tenantId, id = Permission(payload.id), op = op)
+
+      case "resource_change" =>
+        parseTenantOpEvent(rawPayload): (payload, tenantId, op) =>
+          SyncEvent.ResourcesUpdated(tenantId = tenantId, id = ResourceId(payload.id), op = op)
+
+      case "preset_change" =>
+        // notify_preset_change() never includes tenantId (authorization_presets has no tenant_id
+        // column — presets are scoped via client_id) and PresetsUpdated.matches/sort don't use it,
+        // so unlike the other tenant-scoped channels, tenantId is not required here.
+        parseOpEvent(rawPayload): (payload, op) =>
+          SyncEvent.PresetsUpdated(tenantId = TenantId(""), id = PresetId(payload.id), op = op)
+
+      case "form_change" =>
+        parseOpEvent(rawPayload): (payload, op) =>
+          SyncEvent.FormsUpdated(id = FormId(payload.id), version = payload.version.getOrElse(0), op = op)
+
+      case "otp_template_change" =>
+        parseTenantOpEvent(rawPayload): (payload, tenantId, op) =>
+          SyncEvent.OtpTemplatesUpdated(tenantId = tenantId, id = payload.id, op = op)
+
+      case "challenge_settings_change" =>
+        parseTenantOpEvent(rawPayload): (_, tenantId, op) =>
+          SyncEvent.ChallengeSettingsUpdated(tenantId = tenantId, op = op)
+
+      case "theme_change" =>
+        SyncEvent.ThemesUpdated
+
+      case "system_settings_change" =>
+        SyncEvent.SystemSettingsUpdated
+
+      case _ =>
+        SyncEvent.Unknown
+
   def live: ZLayer[HikariDataSource & Scope, Throwable, CacheSyncRepository] =
     ZLayer:
       for
@@ -159,4 +167,4 @@ object PostgresCacheSyncRepository:
           finally statement.close()
         }
         conn <- ZIO.attempt(jdbcConn.unwrap(classOf[PGConnection]))
-      yield PostgresCacheSyncRepository(conn)
+      yield PostgresCacheSyncRepository(conn, jdbcConn)

--- a/central/implementations/postgres/src/test/scala/versola/configuration/sync/PostgresCacheSyncRepositorySpec.scala
+++ b/central/implementations/postgres/src/test/scala/versola/configuration/sync/PostgresCacheSyncRepositorySpec.scala
@@ -1,0 +1,181 @@
+package versola.configuration.sync
+
+import versola.central.configuration.clients.{ClientId, PresetId}
+import versola.central.configuration.forms.FormId
+import versola.central.configuration.permissions.Permission
+import versola.central.configuration.resources.ResourceId
+import versola.central.configuration.roles.RoleId
+import versola.central.configuration.scopes.ScopeToken
+import versola.central.configuration.sync.SyncEvent
+import versola.central.configuration.tenants.TenantId
+import zio.test.*
+
+/** Pure parsing tests for [[PostgresCacheSyncRepository.parseNotification]] (no database required).
+  *
+  * Covers the totality guarantees from issue #63: malformed JSON, an unrecognized `op`, and a
+  * missing/empty `tenantId` (for channels that require one) must all fall back to
+  * `SyncEvent.Unknown` instead of throwing or producing an empty-tenant event.
+  */
+object PostgresCacheSyncRepositorySpec extends ZIOSpecDefault:
+
+  import PostgresCacheSyncRepository.parseNotification
+
+  def spec = suite("PostgresCacheSyncRepository.parseNotification")(
+    suite("payload-less channels")(
+      test("tenant_change ignores the payload") {
+        assertTrue(parseNotification("tenant_change", "") == SyncEvent.TenantsUpdated)
+      },
+      test("edge_change ignores the payload") {
+        assertTrue(parseNotification("edge_change", "") == SyncEvent.EdgesUpdated)
+      },
+      test("jwks_change ignores the payload") {
+        assertTrue(parseNotification("jwks_change", "") == SyncEvent.JwksUpdated)
+      },
+      test("theme_change ignores the payload") {
+        assertTrue(parseNotification("theme_change", "") == SyncEvent.ThemesUpdated)
+      },
+      test("system_settings_change ignores the payload") {
+        assertTrue(parseNotification("system_settings_change", "") == SyncEvent.SystemSettingsUpdated)
+      },
+      test("unrecognized channel falls back to Unknown") {
+        assertTrue(parseNotification("some_future_channel", "") == SyncEvent.Unknown)
+      },
+    ),
+    suite("channels with no tenantId in the payload")(
+      test("client_change parses a well-formed payload") {
+        val payload = """{"id":"c1","op":"UPDATE"}"""
+        assertTrue(
+          parseNotification("client_change", payload) ==
+            SyncEvent.ClientsUpdated(id = ClientId("c1"), op = SyncEvent.Op.UPDATE),
+        )
+      },
+      test("client_change falls back to Unknown on malformed JSON") {
+        assertTrue(parseNotification("client_change", "{not json") == SyncEvent.Unknown)
+      },
+      test("client_change falls back to Unknown on an unrecognized op") {
+        val payload = """{"id":"c1","op":"TRUNCATE"}"""
+        assertTrue(parseNotification("client_change", payload) == SyncEvent.Unknown)
+      },
+      test("preset_change parses a well-formed payload without tenantId") {
+        // notify_preset_change() never sends tenantId (authorization_presets has no tenant_id
+        // column); PresetsUpdated.matches/sort don't use it either, so it must not be required.
+        val payload = """{"id":"preset1","op":"DELETE"}"""
+        assertTrue(
+          parseNotification("preset_change", payload) ==
+            SyncEvent.PresetsUpdated(tenantId = TenantId(""), id = PresetId("preset1"), op = SyncEvent.Op.DELETE),
+        )
+      },
+      test("preset_change falls back to Unknown on an unrecognized op") {
+        val payload = """{"id":"preset1","op":"TRUNCATE"}"""
+        assertTrue(parseNotification("preset_change", payload) == SyncEvent.Unknown)
+      },
+    ),
+    suite("tenant-scoped channels")(
+      test("role_change parses a well-formed payload") {
+        val payload = """{"tenantId":"t1","id":"r1","op":"INSERT"}"""
+        assertTrue(
+          parseNotification("role_change", payload) ==
+            SyncEvent.RolesUpdated(tenantId = TenantId("t1"), id = RoleId("r1"), op = SyncEvent.Op.INSERT),
+        )
+      },
+      test("role_change falls back to Unknown when tenantId is missing") {
+        val payload = """{"id":"r1","op":"INSERT"}"""
+        assertTrue(parseNotification("role_change", payload) == SyncEvent.Unknown)
+      },
+      test("role_change falls back to Unknown when tenantId is empty") {
+        val payload = """{"tenantId":"","id":"r1","op":"INSERT"}"""
+        assertTrue(parseNotification("role_change", payload) == SyncEvent.Unknown)
+      },
+      test("scope_change parses a well-formed payload") {
+        val payload = """{"tenantId":"t1","id":"read","op":"DELETE"}"""
+        assertTrue(
+          parseNotification("scope_change", payload) ==
+            SyncEvent.ScopesUpdated(tenantId = TenantId("t1"), id = ScopeToken("read"), op = SyncEvent.Op.DELETE),
+        )
+      },
+      test("scope_change falls back to Unknown when tenantId is missing") {
+        val payload = """{"id":"read","op":"DELETE"}"""
+        assertTrue(parseNotification("scope_change", payload) == SyncEvent.Unknown)
+      },
+      test("scope_change falls back to Unknown when tenantId is empty") {
+        val payload = """{"tenantId":"","id":"read","op":"DELETE"}"""
+        assertTrue(parseNotification("scope_change", payload) == SyncEvent.Unknown)
+      },
+      test("permission_change parses a well-formed payload") {
+        val payload = """{"tenantId":"t1","id":"p1","op":"UPDATE"}"""
+        assertTrue(
+          parseNotification("permission_change", payload) ==
+            SyncEvent.PermissionsUpdated(tenantId = TenantId("t1"), id = Permission("p1"), op = SyncEvent.Op.UPDATE),
+        )
+      },
+      test("permission_change falls back to Unknown when tenantId is missing") {
+        val payload = """{"id":"p1","op":"UPDATE"}"""
+        assertTrue(parseNotification("permission_change", payload) == SyncEvent.Unknown)
+      },
+      test("permission_change falls back to Unknown when tenantId is empty") {
+        val payload = """{"tenantId":"","id":"p1","op":"UPDATE"}"""
+        assertTrue(parseNotification("permission_change", payload) == SyncEvent.Unknown)
+      },
+      test("resource_change parses a well-formed payload") {
+        val payload = """{"tenantId":"t1","id":"res1","op":"INSERT"}"""
+        assertTrue(
+          parseNotification("resource_change", payload) ==
+            SyncEvent.ResourcesUpdated(tenantId = TenantId("t1"), id = ResourceId("res1"), op = SyncEvent.Op.INSERT),
+        )
+      },
+      test("resource_change falls back to Unknown when tenantId is missing") {
+        val payload = """{"id":"res1","op":"INSERT"}"""
+        assertTrue(parseNotification("resource_change", payload) == SyncEvent.Unknown)
+      },
+      test("resource_change falls back to Unknown when tenantId is empty") {
+        val payload = """{"tenantId":"","id":"res1","op":"INSERT"}"""
+        assertTrue(parseNotification("resource_change", payload) == SyncEvent.Unknown)
+      },
+      test("otp_template_change parses a well-formed payload") {
+        val payload = """{"tenantId":"t1","id":"otp1","op":"UPDATE"}"""
+        assertTrue(
+          parseNotification("otp_template_change", payload) ==
+            SyncEvent.OtpTemplatesUpdated(tenantId = TenantId("t1"), id = "otp1", op = SyncEvent.Op.UPDATE),
+        )
+      },
+      test("otp_template_change falls back to Unknown when tenantId is missing") {
+        val payload = """{"id":"otp1","op":"UPDATE"}"""
+        assertTrue(parseNotification("otp_template_change", payload) == SyncEvent.Unknown)
+      },
+      test("otp_template_change falls back to Unknown when tenantId is empty") {
+        val payload = """{"tenantId":"","id":"otp1","op":"UPDATE"}"""
+        assertTrue(parseNotification("otp_template_change", payload) == SyncEvent.Unknown)
+      },
+      test("challenge_settings_change parses a well-formed payload") {
+        val payload = """{"tenantId":"t1","id":"ignored","op":"UPDATE"}"""
+        assertTrue(
+          parseNotification("challenge_settings_change", payload) ==
+            SyncEvent.ChallengeSettingsUpdated(tenantId = TenantId("t1"), op = SyncEvent.Op.UPDATE),
+        )
+      },
+      test("challenge_settings_change falls back to Unknown when tenantId is missing") {
+        val payload = """{"id":"ignored","op":"UPDATE"}"""
+        assertTrue(parseNotification("challenge_settings_change", payload) == SyncEvent.Unknown)
+      },
+      test("challenge_settings_change falls back to Unknown when tenantId is empty") {
+        val payload = """{"tenantId":"","id":"ignored","op":"UPDATE"}"""
+        assertTrue(parseNotification("challenge_settings_change", payload) == SyncEvent.Unknown)
+      },
+    ),
+    suite("form_change (versioned, no tenant)")(
+      test("parses a well-formed payload with version") {
+        val payload = """{"id":"f1","version":3,"op":"UPDATE"}"""
+        assertTrue(
+          parseNotification("form_change", payload) ==
+            SyncEvent.FormsUpdated(id = FormId("f1"), version = 3, op = SyncEvent.Op.UPDATE),
+        )
+      },
+      test("defaults version to 0 when absent") {
+        val payload = """{"id":"f1","op":"INSERT"}"""
+        assertTrue(
+          parseNotification("form_change", payload) ==
+            SyncEvent.FormsUpdated(id = FormId("f1"), version = 0, op = SyncEvent.Op.INSERT),
+        )
+      },
+    ),
+  )

--- a/central/src/main/scala/versola/central/configuration/sync/SyncEvent.scala
+++ b/central/src/main/scala/versola/central/configuration/sync/SyncEvent.scala
@@ -156,3 +156,7 @@ object SyncEvent:
 
   enum Op:
     case INSERT, UPDATE, DELETE
+
+  object Op:
+    def fromString(s: String): Option[Op] =
+      Op.values.find(_.toString == s)


### PR DESCRIPTION
## Fix cache sync busy-poll and malformed NOTIFY payload handling

Closes #63 

### Summary
`PostgresCacheSyncRepository.getNotifications` busy-polled the dedicated LISTEN connection every 100ms and could throw on malformed NOTIFY payloads (`Op.valueOf`, empty-tenant fallbacks).

### Changes
- Replaced the 100ms `sleep` + non-blocking `getNotifications()` poll with a blocking `conn.getNotifications(10_000)` call, matching pgjdbc's own documented usage pattern. Removes the artificial poll latency and cuts idle wakeups on the dedicated connection from ~10/s to ~1 per 10s.
- Made payload parsing total: added `SyncEvent.Op.fromString` (mirrors the existing `Prompt.fromString` pattern in the codebase) instead of `Op.valueOf`, which threw on an unrecognized value.
- Unified tenant-scoped channels (`role_change`, `scope_change`, `preset_change`, `otp_template_change`, `resource_change`, `challenge_settings_change`) to fall back to `SyncEvent.Unknown` on a missing or empty `tenantId`, instead of silently producing an empty-tenant event. `permission_change` already did this; the rest now match.
- Extracted the channel/payload → `SyncEvent` mapping into a pure `PostgresCacheSyncRepository.parseNotification(channel, rawPayload)`, decoupled from `PGConnection`, so it's unit-testable without a database.

### Bug found along the way
`Op.valueOf` threw inside a plain `ZStream#map`, which becomes a `Cause.Die` (defect) rather than a typed failure. `CacheSyncService.sync().retry(Schedule.spaced(100.millis))` only retries typed `E` failures, not defects — so a single malformed NOTIFY payload could silently kill the forked cache-sync fiber until the next `central` restart. Making parsing total closes this failure mode too.

### Tests
Added `PostgresCacheSyncRepositorySpec` (24 cases, no DB required) covering every NOTIFY channel: well-formed payloads, malformed JSON, unrecognized `op`, missing/empty `tenantId`.