### PR TITLE
commit for issue 60

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -44,6 +44,41 @@ jobs:
       - name: Set up Scala CLI
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: VirtusLab/scala-cli-setup@v1
+      - name: Enforce measured DB access in production code
+        shell: bash
+        run: |
+          set -eo pipefail
+          # Fail the build if production code (src/main) uses the raw transactor methods
+          # xa.connect / xa.transact instead of the measured wrappers
+          # xa.connectMeasured / xa.transactMeasured, so every query is recorded in the
+          # db_client_operation_duration_seconds metric.
+          #
+          # - Scoped to the `xa.` receiver (every TransactorZIO is named `xa` in this codebase),
+          #   so unrelated APIs with a connect/transact method are not flagged.
+          # - POSIX character class instead of `\b` (a GNU-only extension) for portability.
+          # - BasicCodecs.scala (which defines the wrappers) is excluded via a git pathspec, so
+          #   there is no second grep in a pipe: the exit status is git grep's alone, and a real
+          #   git error is surfaced as a failure instead of being masked into a silent pass.
+          status=0
+          matches="$(git grep -nE '(^|[^[:alnum:]_])xa\.(connect|transact)[:(]' \
+            -- '**/src/main/**/*.scala' \
+            ':(exclude)util/implementations/postgres/src/main/scala/versola/util/postgres/BasicCodecs.scala')" \
+            || status=$?
+
+          # git grep exit codes: 0 = matches found, 1 = no matches, >1 = error.
+          if [ "$status" -gt 1 ]; then
+            echo "::error::'git grep' failed with exit code $status while checking DB access; failing the build instead of passing silently."
+            exit 1
+          fi
+
+          if [ -n "$matches" ]; then
+            printf '%s\n' "$matches"
+            echo "::error::Use xa.connectMeasured(...)/xa.transactMeasured(...) instead of raw xa.connect/xa.transact in production code (src/main)."
+            exit 1
+          fi
+
+          echo "OK: no unmeasured xa.connect/xa.transact found in src/main."
+
       - name: Compile
         run: sbt compile
 

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/limit/PostgresChallengeThrottleRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/limit/PostgresChallengeThrottleRepository.scala
@@ -51,7 +51,7 @@ class PostgresChallengeThrottleRepository(xa: TransactorZIO) extends ChallengeTh
       subjects: List[String],
       challengeType: ChallengeType,
   ): Task[List[ChallengeThrottleRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-all-challenge-throttle-for-subjects"):
       sql"""SELECT tenant_id, subject, challenge_type, attempts, banned_until, expires_at
             FROM challenge_throttle
             WHERE tenant_id = $tenantId AND subject = ANY($subjects) AND challenge_type = $challengeType"""

--- a/auth/implementations/postgres/src/main/scala/versola/user/PostgresUserRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/user/PostgresUserRepository.scala
@@ -64,7 +64,7 @@ class PostgresUserRepository(
         .headOption
 
   override def findByLogin(login: Login): Task[Option[UserRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-user-by-login"):
       sql"select id, email, phone, login, claims, ui_locales from users where login = $login"
         .query[UserRecord]
         .run()

--- a/central/implementations/postgres/src/main/scala/versola/configuration/jwks/PostgresJwksRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/jwks/PostgresJwksRepository.scala
@@ -13,14 +13,14 @@ class PostgresJwksRepository(xa: TransactorZIO) extends JwksRepository, BasicCod
   given DbCodec[JwksRecord] = DbCodec.derived
 
   override def getAll: Task[Vector[JwksRecord]] =
-    xa.connect:
+    xa.connectMeasured("get-all-jwks"):
       sql"""
         SELECT kid, jwk
         FROM jwks
       """.query[JwksRecord].run()
 
   override def find(kid: String): Task[Option[JwksRecord]] =
-    xa.connect:
+    xa.connectMeasured("find-jwks"):
       sql"""
         SELECT kid, jwk
         FROM jwks
@@ -28,7 +28,7 @@ class PostgresJwksRepository(xa: TransactorZIO) extends JwksRepository, BasicCod
       """.query[JwksRecord].run().headOption
 
   override def create(kid: String, jwk: Json.Obj): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("create-jwks"):
       sql"""
         INSERT INTO jwks (kid, jwk)
         VALUES ($kid, $jwk)
@@ -36,7 +36,7 @@ class PostgresJwksRepository(xa: TransactorZIO) extends JwksRepository, BasicCod
     .unit
 
   override def update(kid: String, jwk: Json.Obj): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("update-jwks"):
       sql"""
         UPDATE jwks
         SET jwk = $jwk
@@ -45,7 +45,7 @@ class PostgresJwksRepository(xa: TransactorZIO) extends JwksRepository, BasicCod
     .unit
 
   override def delete(kid: String): Task[Unit] =
-    xa.connect:
+    xa.connectMeasured("delete-jwks"):
       sql"""
         DELETE FROM jwks
         WHERE kid = $kid


### PR DESCRIPTION
## Add DB metrics to unmeasured hot-path queries + CI guard against future regressions

Closes #60

### Summary
`PostgresUserRepository.findByLogin` and `PostgresChallengeThrottleRepository.findAllForSubjects` used plain `xa.connect` instead of `xa.connectMeasured`, making them invisible to the `db_client_operation_duration_seconds` metric.

### Changes
- `PostgresUserRepository.findByLogin` → `xa.connectMeasured("find-user-by-login")`
- `PostgresChallengeThrottleRepository.findAllForSubjects` → `xa.connectMeasured("find-all-challenge-throttle-for-subjects")`
- **Bonus find:** while building the CI guard below, discovered `PostgresJwksRepository` was *entirely* unmeasured — all 5 methods (`getAll`, `find`, `create`, `update`, `delete`) used plain `xa.connect`. Fixed all five with descriptive operation names (`get-all-jwks`, `find-jwks`, `create-jwks`, `update-jwks`, `delete-jwks`).
- Added a CI step (`Enforce measured DB access in production code` in `ci-cd.yml`) answering the "can we restrict usage" question from the issue thread: `git grep` over `src/main` for raw `.connect(`/`.connect:`/`.transact(`/`.transact:`, excluding `BasicCodecs.scala` (where the measured wrappers are defined). Scoped to `src/main` only — test fixtures legitimately use plain `connect` for setup/teardown and shouldn't be tagged as operations.
  - Note: the pattern matches both Scala call styles — parens (`.connect(...)`) and the colon/trailing-lambda form (`.connect:`). The `PostgresJwksRepository` violations above were all colon-style, which a naive parens-only pattern would have missed.
