### PR TITLE
commit for issue 64

### DIFF
--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresConfig.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresConfig.scala
@@ -1,6 +1,8 @@
 package versola.util.postgres
 
+import versola.util.Secret
 import zio.Duration
+import zio.config.magnolia.DeriveConfig
 
 /** Configuration for the PostgreSQL HikariCP connection pool.
   *
@@ -13,7 +15,8 @@ import zio.Duration
   * @param user
   *   Database user
   * @param password
-  *   Database password
+  *   Database password. Wrapped in [[Secret]] (an opaque `Array[Byte]` newtype) so it
+  *   doesn't leak through `toString`/logging of the config object.
   * @param maximumPoolSize
   *   Maximum number of connections in the pool (HikariCP `maximumPoolSize`)
   * @param minimumIdle
@@ -34,10 +37,19 @@ import zio.Duration
 case class PostgresConfig(
     url: String,
     user: String,
-    password: String,
+    password: Secret,
     maximumPoolSize: Int,
     minimumIdle: Int,
     connectionTimeout: Duration,
     maxLifetime: Duration,
     leakDetectionThreshold: Duration,
 )
+
+/** The DB password is a plain string in HOCON (not base64), so it's decoded via
+  * `Secret.fromString` rather than the base64url decoders used elsewhere for other secrets.
+  *
+  * Declared top-level (not inside `object PostgresConfig`) so every file in this package —
+  * `PostgresHikariDataSource` and the test specs — picks it up via ordinary same-package
+  * visibility, without needing an explicit import.
+  */
+given DeriveConfig[Secret] = DeriveConfig[String].map(Secret.fromString)

--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresHikariDataSource.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresHikariDataSource.scala
@@ -6,6 +6,7 @@ import org.flywaydb.core.Flyway
 import zio.*
 import zio.config.magnolia.deriveConfig
 
+import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Paths}
 import java.util.concurrent.locks.ReentrantLock
 
@@ -46,7 +47,9 @@ object PostgresHikariDataSource:
             config.setDriverClassName("org.postgresql.Driver")
             config.setJdbcUrl(postgres.url)
             config.setUsername(postgres.user)
-            config.setPassword(postgres.password)
+            // Secret is an opaque Array[Byte] newtype (kept out of toString/logging); HikariConfig
+            // needs a plain String, so it's decoded back here at the point of use only.
+            config.setPassword(new String(postgres.password, StandardCharsets.UTF_8))
             config.setMaximumPoolSize(postgres.maximumPoolSize)
             config.setMinimumIdle(postgres.minimumIdle)
             config.setConnectionTimeout(postgres.connectionTimeout.toMillis)

--- a/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresConfigSpec.scala
+++ b/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresConfigSpec.scala
@@ -1,8 +1,10 @@
 package versola.util.postgres
 
+import versola.util.Secret
 import zio.*
 import zio.config.magnolia.deriveConfig
 import zio.config.typesafe.TypesafeConfigProvider
+import zio.prelude.EqualOps
 import zio.test.*
 
 /** Pure config-parsing and pool-validation tests (no database required).
@@ -30,7 +32,7 @@ object PostgresConfigSpec extends ZIOSpecDefault:
   private val validConfig = PostgresConfig(
     url = "jdbc:postgresql://localhost:5432/auth",
     user = "dev",
-    password = "1234",
+    password = Secret.fromString("1234"),
     maximumPoolSize = 10,
     minimumIdle = 10,
     connectionTimeout = 30.seconds,
@@ -45,7 +47,7 @@ object PostgresConfigSpec extends ZIOSpecDefault:
         yield assertTrue(
           config.url == "jdbc:postgresql://localhost:5432/auth",
           config.user == "dev",
-          config.password == "1234",
+          config.password === Secret.fromString("1234"),
           config.maximumPoolSize == 15,
           config.minimumIdle == 15,
           config.connectionTimeout == 30.seconds,
@@ -62,6 +64,10 @@ object PostgresConfigSpec extends ZIOSpecDefault:
             |}""".stripMargin
         for result <- TypesafeConfigProvider.fromHoconString(incompleteHocon).kebabCase.load(postgresConfig).exit
         yield assertTrue(result.isFailure)
+      },
+      test("does not leak the raw password through toString (regression for #64)") {
+        for config <- TypesafeConfigProvider.fromHoconString(fullHocon).kebabCase.load(postgresConfig)
+        yield assertTrue(!config.toString.contains("1234"))
       },
     ),
     suite("PostgresHikariDataSource.validate")(

--- a/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresSpec.scala
+++ b/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresSpec.scala
@@ -1,6 +1,7 @@
 package versola.util.postgres
 
 import com.augustnagro.magnum.magzio.TransactorZIO
+import versola.util.Secret
 import zio.*
 import zio.test.ZIOSpec
 
@@ -18,7 +19,7 @@ object PostgresSpec:
           PostgresConfig(
             url = s"jdbc:postgresql://$host/auth",
             user = "dev",
-            password = "1234",
+            password = Secret.fromString("1234"),
             maximumPoolSize = 4,
             minimumIdle = 1,
             connectionTimeout = 30.seconds,


### PR DESCRIPTION
## Summary

Wraps `PostgresConfig.password` in the existing `Secret` newtype (opaque `Array[Byte]`) instead of a plain `String`, so it no longer leaks through `toString`/config-object logging. Mirrors how other secrets in the codebase are already protected.

Closes #64

## Changes

- `PostgresConfig.scala`: `password: String` → `password: Secret`; added a `given DeriveConfig[Secret]` (plain-string decoder via `Secret.fromString`, as opposed to the base64url decoders used for other `Secret`/`Secret.Bytes16/32` fields elsewhere).
- `PostgresHikariDataSource.scala`: decodes `Secret` back to `String` at the single point of use (`HikariConfig.setPassword`), via UTF-8.
- `PostgresConfigSpec.scala`: updated assertions to compare `Secret` via `===` (`zio.prelude.EqualOps`) instead of `==`, which would compare `Array[Byte]` by reference. Added a regression test asserting `config.toString` does not contain the raw password.
- `PostgresSpec.scala`: test fixture updated to construct `password` via `Secret.fromString`.

## Notes

- No migration/schema changes — this is a Scala-only type change.
- `scripts/gen-env.scala`'s weak dev defaults (`dev`/`1234`) are out of scope for this PR (dev-only, unrelated to the logging risk).
- Verified `DeriveConfig[Secret]` is declared top-level (not nested in `object PostgresConfig`) so it's automatically in scope for every `deriveConfig[PostgresConfig]` call site in this package, without extra imports.
