### PR TITLE
ci: build central admin forms before packaging Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+﻿central-ui/node_modules
+central-ui/dist

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -166,6 +166,17 @@ jobs:
         id: version
         run: echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12'
+
+      - name: Build central admin forms
+        working-directory: central-ui
+        run: |
+          npm install
+          npm run build:forms
+
       - name: Build and push central image
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
central was crashing with FileNotFoundException: forms/common.css — the resources never made it into the classpath, because central/src/main/resources/forms/ is in .gitignore and gets generated by npm run build:forms, and CI never ran that step.