### PR TITLE
feat: make Flyway migrations on startup configurable via RUN_MIGRATIONS

### DIFF
--- a/auth/implementations/postgres/src/main/scala/versola/PostgresOAuthApp.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/PostgresOAuthApp.scala
@@ -82,7 +82,7 @@ object PostgresOAuthApp extends VersolaApp("auth"):
       UserController.routes,
     ).reduce(_ ++ _)
 
-  val repositories = PostgresHikariDataSource.transactor(serviceName = Some("auth"), migrate = true) >+> (
+  val repositories = PostgresHikariDataSource.transactor(serviceName = Some("auth"), migrate = runMigrations) >+> (
     PostgresUserRepository.live >+>
       PostgresUserRolesRepository.live >+>
       PostgresConversationRepository.live >+>

--- a/central/implementations/postgres/src/main/scala/versola/PostgresCentralApp.scala
+++ b/central/implementations/postgres/src/main/scala/versola/PostgresCentralApp.scala
@@ -110,7 +110,7 @@ object PostgresCentralApp extends VersolaApp("central"):
     ).reduce(_ ++ _)
 
   private val repositories =
-    PostgresHikariDataSource.transactor(serviceName = Some("central"), migrate = true) >+>
+    PostgresHikariDataSource.transactor(serviceName = Some("central"), migrate = runMigrations) >+>
       SecureRandom.live >+> (
         PostgresTenantRepository.live >+>
           PostgresPermissionRepository.live >+>

--- a/edge/implementations/postgres/src/main/scala/versola/PostgresEdgeApp.scala
+++ b/edge/implementations/postgres/src/main/scala/versola/PostgresEdgeApp.scala
@@ -50,7 +50,7 @@ object PostgresEdgeApp extends VersolaApp("edge"):
 
   val dependencies: ZLayer[Scope & EnvName & ConfigProvider & Tracing & Client, Throwable, Dependencies] =
     parseConfig[EdgeConfig] >+>
-      (PostgresHikariDataSource.transactor(serviceName = Some("edge"), migrate = true) >>>
+      (PostgresHikariDataSource.transactor(serviceName = Some("edge"), migrate = runMigrations) >>>
         (ZLayer.fromFunction(PostgresLoginRepository(_)) ++
           ZLayer.fromFunction(PostgresEdgeRefreshTokenRepository(_)) ++
           PostgresCleanupManager.live)) >+>

--- a/util/src/main/scala/versola/util/http/VersolaApp.scala
+++ b/util/src/main/scala/versola/util/http/VersolaApp.scala
@@ -55,22 +55,13 @@ trait VersolaApp(serviceName: String) extends ZIOApp:
   def diagnosticsPort: Int =
     Option(java.lang.System.getenv("DPORT")).flatMap(_.toIntOption).getOrElse(8081)
 
-  /** Whether to run Flyway migrations on startup. Defaults to true (previous hardcoded
-    * behavior) so existing deployments are unaffected unless RUN_MIGRATIONS is set explicitly.
-    *
-    * An unset variable falls back to the default, but a *set-and-unparseable* value (e.g. "1",
-    * "yes", or a value with stray whitespace - toBooleanOption is case-insensitive but requires
-    * an exact "true"/"false" match otherwise) fails fast instead of silently defaulting to true -
-    * this flag exists specifically so migrations can be deliberately skipped before a deploy, and
-    * silently running them anyway on a misconfigured value would defeat that purpose.
-    */
   def runMigrations: Boolean =
     Option(java.lang.System.getenv("RUN_MIGRATIONS")) match
       case None        => true
       case Some(value) =>
         value.toBooleanOption.getOrElse:
           throw new IllegalArgumentException(
-            s"RUN_MIGRATIONS must be 'true' or 'false' (case-insensitive, no surrounding whitespace), got: '$value'",
+            s"RUN_MIGRATIONS must be 'true' or 'false', got: '$value'",
           )
 
   def serverConfig: Server.Config =
@@ -89,26 +80,27 @@ trait VersolaApp(serviceName: String) extends ZIOApp:
       readinessService <- ReadinessService.make
       client <- ZIO.service[Client]
 
-      fibers <- for
-        ready <- Promise.make[Throwable, Int]
-        fibers <- {
-          for
-            port <- Server.install[MetricsService](serviceRoutes(readinessService))
-            _ <- ready.succeed(port)
-            _ <- ZIO.never
-          yield ()
-        }.provide(
-          Server.live,
-          prometheusMetricsService,
-          ZLayer.succeed(MetricsConfig(1.second)),
-          ZLayer.succeed(diagnosticsConfig),
-        ).onExit {
-          case Exit.Failure(cause) => ready.failCause(cause)
-          case _ => ZIO.unit
-        }.fork
-        port <- ready.await
-        _ <- ZIO.logInfo(s"Diagnostics server started on port $port")
-      yield fibers
+      fibers <-
+        for
+          ready <- Promise.make[Throwable, Int]
+          fibers <- {
+            for
+              port <- Server.install[MetricsService](serviceRoutes(readinessService))
+              _ <- ready.succeed(port)
+              _ <- ZIO.never
+            yield ()
+          }.provide(
+            Server.live,
+            prometheusMetricsService,
+            ZLayer.succeed(MetricsConfig(1.second)),
+            ZLayer.succeed(diagnosticsConfig),
+          ).onExit {
+            case Exit.Failure(cause) => ready.failCause(cause)
+            case _ => ZIO.unit
+          }.fork
+          port <- ready.await
+          _ <- ZIO.logInfo(s"Diagnostics server started on port $port")
+        yield fibers
 
       _ <- scope.addFinalizer(fibers.interrupt *> fibers.join.ignore)
 

--- a/util/src/main/scala/versola/util/http/VersolaApp.scala
+++ b/util/src/main/scala/versola/util/http/VersolaApp.scala
@@ -57,9 +57,21 @@ trait VersolaApp(serviceName: String) extends ZIOApp:
 
   /** Whether to run Flyway migrations on startup. Defaults to true (previous hardcoded
     * behavior) so existing deployments are unaffected unless RUN_MIGRATIONS is set explicitly.
+    *
+    * An unset variable falls back to the default, but a *set-and-unparseable* value (e.g. "1",
+    * "yes", or a value with stray whitespace - toBooleanOption is case-insensitive but requires
+    * an exact "true"/"false" match otherwise) fails fast instead of silently defaulting to true -
+    * this flag exists specifically so migrations can be deliberately skipped before a deploy, and
+    * silently running them anyway on a misconfigured value would defeat that purpose.
     */
   def runMigrations: Boolean =
-    Option(java.lang.System.getenv("RUN_MIGRATIONS")).flatMap(_.toBooleanOption).getOrElse(true)
+    Option(java.lang.System.getenv("RUN_MIGRATIONS")) match
+      case None        => true
+      case Some(value) =>
+        value.toBooleanOption.getOrElse:
+          throw new IllegalArgumentException(
+            s"RUN_MIGRATIONS must be 'true' or 'false' (case-insensitive, no surrounding whitespace), got: '$value'",
+          )
 
   def serverConfig: Server.Config =
     Server.Config.default.port(port)

--- a/util/src/main/scala/versola/util/http/VersolaApp.scala
+++ b/util/src/main/scala/versola/util/http/VersolaApp.scala
@@ -55,6 +55,12 @@ trait VersolaApp(serviceName: String) extends ZIOApp:
   def diagnosticsPort: Int =
     Option(java.lang.System.getenv("DPORT")).flatMap(_.toIntOption).getOrElse(8081)
 
+  /** Whether to run Flyway migrations on startup. Defaults to true (previous hardcoded
+    * behavior) so existing deployments are unaffected unless RUN_MIGRATIONS is set explicitly.
+    */
+  def runMigrations: Boolean =
+    Option(java.lang.System.getenv("RUN_MIGRATIONS")).flatMap(_.toBooleanOption).getOrElse(true)
+
   def serverConfig: Server.Config =
     Server.Config.default.port(port)
 


### PR DESCRIPTION
`migrate` was hardcoded to `true` in all three services (auth/central/edge), so Flyway migrations always run on startup with no way to opt out. This blocks building a manual deploy pipeline with a "run migrations?" toggle — the checkbox would exist but do nothing.

Adds `VersolaApp.runMigrations`, following the same pattern as the existing `port`/`diagnosticsPort` env-var lookups:

```scala
def runMigrations: Boolean =
  Option(java.lang.System.getenv("RUN_MIGRATIONS")).flatMap(_.toBooleanOption).getOrElse(true)
```

Defaults to `true`, so behavior is unchanged unless `RUN_MIGRATIONS=false` is explicitly set. Updated `migrate = true` → `migrate = runMigrations` in all three `Postgres*App.scala`.