### PR TITLE
fix: create forms output directory before writing generated forms

### DIFF
--- a/central-ui/scripts/build-forms.mjs
+++ b/central-ui/scripts/build-forms.mjs
@@ -1,12 +1,17 @@
 import { build } from 'esbuild';
 import { solidPlugin } from 'esbuild-plugin-solid';
-import { writeFile, copyFile } from 'node:fs/promises';
+import { writeFile, copyFile, mkdir } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const formsSrcDir = resolve(here, '../forms');
 const outDir = resolve(here, '../../central/src/main/resources/forms');
+
+// outDir is gitignored (generated output), so on a fresh checkout it doesn't exist yet.
+// writeFile/copyFile below don't create parent directories, so without this the first
+// write fails with ENOENT — this is exactly what would happen in CI right now.
+await mkdir(outDir, { recursive: true });
 
 const forms = ['credential', 'otp', 'password', 'access-denied', 'passkey-enroll', 'set-password'];
 const sharedAssets = ['common.css'];


### PR DESCRIPTION
## Problem

`central-ui/scripts/build-forms.mjs` writes generated form assets into
`central/src/main/resources/forms/`, which is gitignored (it's build
output, not source). `writeFile`/`copyFile` don't create missing parent
directories, so on a clean checkout — exactly what CI does — the script
fails on the very first form with `ENOENT`.

This means the fix in #108 (running `npm run build:forms` in the
`docker-central` CI job) does not actually work: the job would fail
before the Docker image is even built, so `docker-central` never
produces a fixed image.

Locally this went unnoticed because the output directory already
existed from previous runs. It would reproduce on any fresh clone or
after `git clean`.

## Fix

Create the output directory before writing to it:

```js
await mkdir(outDir, { recursive: true });
```

## Verification

Reproduced both states on a simulated clean checkout (script + its
`forms/` input copied into an isolated temp directory with no
pre-existing output directory):

- **Without the fix:** `ENOENT: no such file or directory, open
  '.../central/src/main/resources/forms/credential.js'`, exit code 1
  — matches what CI would hit.
- **With the fix:** all 6 forms build successfully (`credential`,
  `otp`, `password`, `access-denied`, `passkey-enroll`,
  `set-password`) plus `common.css`, exit code 0.