### PR TITLE
auth: fail authorization code exchange on reuse (double-spend)

### DIFF
--- a/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
+++ b/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
@@ -69,13 +69,14 @@ object OAuthTokenService:
         _ <- authorizationCodeRepository.markAsUsed(codeMac).flatMap:
           case Left(at) =>
             accessTokenRevocationService.revoke(at) *>
-              sessionRepository.deleteByAccessToken(at)
+              sessionRepository.deleteByAccessToken(at) *>
+              ZIO.fail(TokenEndpointError.InvalidGrant)
 
           case Right(_) =>
             ZIO.unit
 
         now <- zio.Clock.instant
-        accessToken <- authPropertyGenerator.nextAccessToken
+        accessToken = codeRecord.accessToken
 
         issuedTokens <- issueTokens(
           accessToken = accessToken,

--- a/auth/src/test/scala/versola/oauth/token/OAuthTokenServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/token/OAuthTokenServiceSpec.scala
@@ -257,6 +257,79 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           result == Left(TokenEndpointError.InvalidGrant),
         )
       },
+      test("fail with InvalidGrant and revoke the previously issued token when code is reused (double-spend)") {
+        val env = new Env
+        for
+          codeRecord = AuthorizationCodeRecord(
+            sessionId = sessionId1,
+            clientId = clientId1,
+            userId = userId1,
+            redirectUri = redirectUri1,
+            scope = scope1,
+            codeChallenge = codeChallenge1,
+            codeChallengeMethod = CodeChallengeMethod.S256,
+            requestedClaims = None,
+            uiLocales = None,
+            nonce = None,
+            accessToken = accessToken1,
+            amr = amr1,
+            authTime = authTime1,
+          )
+
+          _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
+          _ <- env.securityService.mac.succeedsWith(codeMac1)
+          _ <- env.authCodeRepo.find.succeedsWith(Some(codeRecord))
+          _ <- env.authCodeRepo.markAsUsed.succeedsWith(Left(accessToken1))
+          _ <- env.accessTokenRevocationService.revoke.succeedsWith(())
+          _ <- env.tokenRepo.deleteByAccessToken.succeedsWith(())
+
+          request = CodeExchangeRequest(authCode1, redirectUri1, codeVerifier1)
+          credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
+
+          result <- env.service.exchangeAuthorizationCode(request, credentials).either
+        yield assertTrue(
+          result == Left(TokenEndpointError.InvalidGrant),
+          env.accessTokenRevocationService.revoke.calls == List(accessToken1),
+          env.tokenRepo.deleteByAccessToken.calls == List(accessToken1),
+          env.tokenRepo.createRefreshToken.calls.isEmpty,
+        )
+      },
+      test("issues the access token embedded in the authorization code, not a freshly generated one") {
+        val env = new Env
+        val freshAccessToken = AccessToken(Array.fill(32)(11.toByte))
+        for
+          codeRecord = AuthorizationCodeRecord(
+            sessionId = sessionId1,
+            clientId = clientId1,
+            userId = userId1,
+            redirectUri = redirectUri1,
+            scope = scope2,
+            codeChallenge = codeChallenge1,
+            codeChallengeMethod = CodeChallengeMethod.S256,
+            requestedClaims = None,
+            uiLocales = None,
+            nonce = None,
+            accessToken = accessToken1,
+            amr = amr1,
+            authTime = authTime1,
+          )
+
+          _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
+          _ <- env.securityService.mac.succeedsWith(codeMac1)
+          _ <- env.authCodeRepo.find.succeedsWith(Some(codeRecord))
+          _ <- env.authCodeRepo.markAsUsed.succeedsWith(Right(()))
+          _ <- env.propertyGenerator.nextAccessToken.succeedsWith(freshAccessToken)
+          _ <- env.userRolesRepo.findRolesByUserAndTenant.succeedsWith(List.empty)
+
+          request = CodeExchangeRequest(authCode1, redirectUri1, codeVerifier1)
+          credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
+
+          result <- env.service.exchangeAuthorizationCode(request, credentials)
+        yield assertTrue(
+          result.accessToken == accessToken1,
+          result.accessToken != freshAccessToken,
+        )
+      },
       test("does not fetch admin roles for non-admin clients") {
         val env = new Env
         for


### PR DESCRIPTION
Closes #101 

## Problem
`OAuthTokenService.exchangeAuthorizationCode` detected code reuse via
`markAsUsed` (`Left(accessToken)`), revoked the previously issued
access token, but then proceeded to issue a new set of tokens anyway.
RFC 6749 §4.1.2 requires the server to deny the request, not just
revoke the old one.

## Root cause (two parts)
1. The `Left` branch had no `ZIO.fail` — execution fell through to
   token issuance.
2. `exchangeAuthorizationCode` issued a freshly generated access
   token (`authPropertyGenerator.nextAccessToken`) instead of the one
   stored on `AuthorizationCodeRecord.accessToken`. That stored field
   exists specifically so `revoke`/`deleteByAccessToken` can find the
   token on reuse — but since it was never the token actually handed
   to the client, revocation on reuse was silently a no-op.

## Fix
- `markAsUsed` returning `Left` now fails the request with
  `TokenEndpointError.InvalidGrant` after revoking.
- The access token issued on successful exchange is now
  `codeRecord.accessToken` (the one already persisted on the code),
  so a later reuse attempt can actually find and revoke it.

## Tests
Added to `OAuthTokenServiceSpec`:
- reuse → `InvalidGrant`, `revoke`/`deleteByAccessToken` called with
  the original token, no new refresh token created.
- successful exchange → returned access token matches
  `codeRecord.accessToken`, not a freshly generated one.

Repository-level reuse detection (incl. concurrent attempts) was
already covered by `AuthorizationCodeRepositorySpec` — untouched.