### PR TITLE
fix(auth): serialize concurrent password changes (#92)

### DIFF
--- a/auth/implementations/postgres/src/main/scala/versola/oauth/challenge/password/PostgresPasswordRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/challenge/password/PostgresPasswordRepository.scala
@@ -20,6 +20,10 @@ class PostgresPasswordRepository(xa: TransactorZIO) extends PasswordRepository, 
   given DbCodec[Instant] = DbCodec.InstantCodec
   given DbCodec[PasswordRecord] = DbCodec.derived[PasswordRecord]
 
+  // Note: this read-only listing orders by created_at (the logical "password set" time) for
+  // display. The reuse/prune read in `create` deliberately orders by id (physical commit order)
+  // instead, because it must stay correct under concurrent changes where created_at can be
+  // non-monotonic relative to insert order. The two only diverge under clock skew.
   override def list(userId: UserId): Task[Vector[PasswordRecord]] =
     xa.connectMeasured("list-passwords"):
       sql"""
@@ -40,12 +44,34 @@ class PostgresPasswordRepository(xa: TransactorZIO) extends PasswordRepository, 
     for
       now <- Clock.instant
       result <- xa.transactMeasured("create-password") {
-        // Only permanent passwords count toward history and reuse checks
+        // Serialise concurrent password changes for the same user. The transaction runs at
+        // READ COMMITTED, so FOR UPDATE alone cannot stop a second, concurrent change from
+        // missing the not-yet-visible insert of the first (phantom read); it also would not
+        // lock anything when the user has no history yet. Taking a per-user advisory lock as a
+        // separate statement before the history SELECT forces the second transaction to wait,
+        // then read a snapshot that already includes the first transaction's committed insert.
+        // The lock is released automatically on commit/rollback.
+        //
+        // Why an advisory lock and not the unique-index + ON CONFLICT + FOR UPDATE pattern used
+        // in challenge throttling: that pattern needs a single natural-key row to anchor on.
+        // Password history has no such anchor (two different passwords are both valid rows) and
+        // the empty-history case has nothing to lock, so we serialise on the user id instead.
+        //
+        // The SELECT result (a single dummy row) is intentionally ignored; we call it only to
+        // acquire the lock.
+        sql"SELECT 1 FROM pg_advisory_xact_lock(${PostgresPasswordRepository.PasswordHistoryLockNamespace}, hashtext(${userId.toString}))"
+          .query[Int].run()
+
+        // Only permanent passwords count toward history and reuse checks.
+        // Order by id (SERIAL), not created_at: id is assigned at INSERT inside the serialized
+        // section, so it reflects the true commit order. `now` is captured before the advisory
+        // lock, so created_at values of two contending changes can be inverted relative to commit
+        // order — ordering by id keeps reuse/prune correct under contention.
         val permanents = sql"""
           SELECT id, user_id, password, salt, created_at, expires_at
           FROM user_passwords
           WHERE user_id = $userId AND expires_at IS NULL
-          ORDER BY created_at DESC, id DESC
+          ORDER BY id DESC
         """.query[PasswordRecord].run()
 
         if permanents.take(numDifferent).exists(_.password === password) then
@@ -92,5 +118,18 @@ class PostgresPasswordRepository(xa: TransactorZIO) extends PasswordRepository, 
     .unit
 
 object PostgresPasswordRepository:
+  /** Namespace (first key) for the transaction-level advisory lock guarding password history
+    * changes. Advisory-lock keys are global to the entire database — shared across every table,
+    * feature, and service on it — so this value must be unique DB-wide, not just within this
+    * module. It is `92` (the issue number) by convention; if more advisory locks are introduced,
+    * move these into a single shared registry to guarantee uniqueness. The second key is derived
+    * from the user id via `hashtext`.
+    *
+    * `hashtext` is 32-bit, so two distinct user ids can collide and briefly serialize each other's
+    * password changes. This is an accepted trade-off: collisions are rare and only cost a short
+    * wait, never a correctness issue.
+    */
+  private[password] val PasswordHistoryLockNamespace: Int = 92
+
   def live: ZLayer[TransactorZIO, Throwable, PasswordRepository] =
     ZLayer.fromFunction(PostgresPasswordRepository(_))

--- a/auth/src/test/scala/versola/oauth/challenge/password/PasswordRepositorySpec.scala
+++ b/auth/src/test/scala/versola/oauth/challenge/password/PasswordRepositorySpec.scala
@@ -115,6 +115,41 @@ trait PasswordRepositorySpec extends DatabaseSpecBase[PasswordRepositorySpec.Env
           rows2 <- env.repository.list(userId2)
         yield assertTrue(rows1.size == 1, rows2.size == 1)
       },
+
+      // Concurrency: two simultaneous changes to the SAME new password must not both pass the
+      // reuse check. With per-user serialization the second transaction observes the first's
+      // committed insert, so exactly one succeeds and the other is rejected as reuse.
+      test("concurrent create of the same password: exactly one succeeds, the other is reuse") {
+        for
+          _ <- env.repository.create(userId1, pass(1), salt(1), historySize = 5, numDifferent = 3)
+          results <- ZIO.collectAllPar(List(
+            env.repository.create(userId1, pass(2), salt(2), historySize = 5, numDifferent = 3).either,
+            env.repository.create(userId1, pass(2), salt(2), historySize = 5, numDifferent = 3).either,
+          ))
+          rows <- env.repository.list(userId1)
+        yield assertTrue(
+          results.count(_.isRight) == 1,
+          results.count(_ == Left(PasswordReuseError(3))) == 1,
+          // seed pass(1) + exactly one pass(2) → 2 rows (would be 3 without the lock)
+          rows.size == 2,
+        )
+      },
+
+      // Concurrency: two simultaneous changes with an empty starting history must still respect
+      // historySize. Without serialization both read the empty history, both insert, and prune
+      // removes nothing, leaving historySize + 1 rows.
+      test("concurrent create with empty history respects historySize (prune)") {
+        for
+          results <- ZIO.collectAllPar(List(
+            env.repository.create(userId1, pass(1), salt(1), historySize = 1, numDifferent = 1).either,
+            env.repository.create(userId1, pass(2), salt(2), historySize = 1, numDifferent = 1).either,
+          ))
+          rows <- env.repository.list(userId1)
+        yield assertTrue(
+          results.forall(_.isRight),
+          rows.size == 1,
+        )
+      },
     )
 
 object PasswordRepositorySpec:


### PR DESCRIPTION
fix(auth): serialize concurrent password changes (#92)

Closes #92

Problem

PostgresPasswordRepository.create reads password history, checks reuse, then inserts — all in one READ COMMITTED transaction. Two concurrent changes for the same user can both read the old history, both pass the reuse check, and both insert, bypassing the reuse/history-size constraints.

Why FOR UPDATE (as suggested in the issue) isn't enough

Under READ COMMITTED it doesn't close the race:

Phantom: FOR UPDATE locks only returned rows; after unblocking, the second txn re-reads the same rows and still misses the first txn's new insert.
Empty history: the SELECT returns 0 rows, so nothing is locked — also breaks prune.
Fix

Take a per-user transaction advisory lock before reading history:

scala
sql"SELECT 1 FROM pg_advisory_xact_lock($PasswordHistoryLockNamespace, hashtext(${userId.toString}))"
  .query[Int].run()

The second txn waits for the first to commit, then reads a snapshot that includes its insert. Fixes reuse, empty-history, and prune. Lock auto-releases on commit/rollback. Namespace constant = 92 scopes the lock per feature.

Tests

Two parallel-change tests in PasswordRepositorySpec (real Postgres): same password → exactly one succeeds + one PasswordReuseError; empty history → historySize respected. Both fail on main and with FOR UPDATE-only.

Notes
hashtext is internal but stable; can swap if preferred.