### PR TITLE
feat: manual deploy pipeline with version/service/migrations inputs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,12 @@ jobs:
             set -e
             cd /opt/versola
             sed -i "s|versola-central:[^[:space:]]*|versola-central:${DEPLOY_VERSION}|" docker-compose.prod.yml
+            # Fail loudly if sed matched nothing (e.g. compose format changed) instead of
+            # silently pulling/redeploying the old tag and reporting a green deploy.
+            if ! grep -qF "versola-central:${DEPLOY_VERSION}" docker-compose.prod.yml; then
+              echo "Failed to set central image tag to '${DEPLOY_VERSION}' in docker-compose.prod.yml" >&2
+              exit 1
+            fi
             export RUN_MIGRATIONS="$DEPLOY_RUN_MIGRATIONS"
             docker compose pull central
             docker compose up -d --no-deps central
@@ -109,6 +115,10 @@ jobs:
             fi
 
             sed -i "s|versola-auth:[^[:space:]]*|versola-auth:${DEPLOY_VERSION}|" docker-compose.prod.yml
+            if ! grep -qF "versola-auth:${DEPLOY_VERSION}" docker-compose.prod.yml; then
+              echo "Failed to set auth image tag to '${DEPLOY_VERSION}' in docker-compose.prod.yml" >&2
+              exit 1
+            fi
             export RUN_MIGRATIONS="$DEPLOY_RUN_MIGRATIONS"
             docker compose pull auth
             docker compose up -d --no-deps auth
@@ -163,6 +173,10 @@ jobs:
             fi
 
             sed -i "s|versola-edge:[^[:space:]]*|versola-edge:${DEPLOY_VERSION}|" docker-compose.prod.yml
+            if ! grep -qF "versola-edge:${DEPLOY_VERSION}" docker-compose.prod.yml; then
+              echo "Failed to set edge image tag to '${DEPLOY_VERSION}' in docker-compose.prod.yml" >&2
+              exit 1
+            fi
             export RUN_MIGRATIONS="$DEPLOY_RUN_MIGRATIONS"
             docker compose pull edge
             docker compose up -d --no-deps edge

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,22 +18,42 @@ on:
         type: boolean
         default: true
 
+# Concurrent manual runs would race on the same VPS state (in-place edits of
+# docker-compose.prod.yml, overlapping docker compose calls). Queue instead of
+# running in parallel, and don't cancel a deploy that's already in flight.
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy-central:
     if: inputs.service == 'central' || inputs.service == 'all'
     runs-on: ubuntu-latest
     steps:
+      - name: Validate version input
+        env:
+          DEPLOY_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$DEPLOY_VERSION" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::Invalid version '$DEPLOY_VERSION' — only letters, digits, dots, underscores and hyphens are allowed"
+            exit 1
+          fi
+
       - name: Deploy central
-        uses: appleboy/ssh-action@v1.2.0
+        uses: appleboy/ssh-action@7eaf76671a0d7eec5d98ee897acda4f968735a17 # v1.2.0
+        env:
+          DEPLOY_VERSION: ${{ inputs.version }}
+          DEPLOY_RUN_MIGRATIONS: ${{ inputs.run_migrations }}
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          envs: DEPLOY_VERSION,DEPLOY_RUN_MIGRATIONS
           script: |
             set -e
             cd /opt/versola
-            sed -i "s|versola-central:[^[:space:]]*|versola-central:${{ inputs.version }}|" docker-compose.prod.yml
-            export RUN_MIGRATIONS=${{ inputs.run_migrations }}
+            sed -i "s|versola-central:[^[:space:]]*|versola-central:${DEPLOY_VERSION}|" docker-compose.prod.yml
+            export RUN_MIGRATIONS="$DEPLOY_RUN_MIGRATIONS"
             docker compose pull central
             docker compose up -d --no-deps central
 
@@ -57,12 +77,25 @@ jobs:
       (needs.deploy-central.result == 'success' || needs.deploy-central.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
+      - name: Validate version input
+        env:
+          DEPLOY_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$DEPLOY_VERSION" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::Invalid version '$DEPLOY_VERSION' — only letters, digits, dots, underscores and hyphens are allowed"
+            exit 1
+          fi
+
       - name: Deploy auth
-        uses: appleboy/ssh-action@v1.2.0
+        uses: appleboy/ssh-action@7eaf76671a0d7eec5d98ee897acda4f968735a17 # v1.2.0
+        env:
+          DEPLOY_VERSION: ${{ inputs.version }}
+          DEPLOY_RUN_MIGRATIONS: ${{ inputs.run_migrations }}
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          envs: DEPLOY_VERSION,DEPLOY_RUN_MIGRATIONS
           script: |
             set -e
             cd /opt/versola
@@ -73,8 +106,8 @@ jobs:
               exit 1
             fi
 
-            sed -i "s|versola-auth:[^[:space:]]*|versola-auth:${{ inputs.version }}|" docker-compose.prod.yml
-            export RUN_MIGRATIONS=${{ inputs.run_migrations }}
+            sed -i "s|versola-auth:[^[:space:]]*|versola-auth:${DEPLOY_VERSION}|" docker-compose.prod.yml
+            export RUN_MIGRATIONS="$DEPLOY_RUN_MIGRATIONS"
             docker compose pull auth
             docker compose up -d --no-deps auth
 
@@ -97,12 +130,25 @@ jobs:
       (needs.deploy-central.result == 'success' || needs.deploy-central.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
+      - name: Validate version input
+        env:
+          DEPLOY_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$DEPLOY_VERSION" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::Invalid version '$DEPLOY_VERSION' — only letters, digits, dots, underscores and hyphens are allowed"
+            exit 1
+          fi
+
       - name: Deploy edge
-        uses: appleboy/ssh-action@v1.2.0
+        uses: appleboy/ssh-action@7eaf76671a0d7eec5d98ee897acda4f968735a17 # v1.2.0
+        env:
+          DEPLOY_VERSION: ${{ inputs.version }}
+          DEPLOY_RUN_MIGRATIONS: ${{ inputs.run_migrations }}
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          envs: DEPLOY_VERSION,DEPLOY_RUN_MIGRATIONS
           script: |
             set -e
             cd /opt/versola
@@ -113,8 +159,8 @@ jobs:
               exit 1
             fi
 
-            sed -i "s|versola-edge:[^[:space:]]*|versola-edge:${{ inputs.version }}|" docker-compose.prod.yml
-            export RUN_MIGRATIONS=${{ inputs.run_migrations }}
+            sed -i "s|versola-edge:[^[:space:]]*|versola-edge:${DEPLOY_VERSION}|" docker-compose.prod.yml
+            export RUN_MIGRATIONS="$DEPLOY_RUN_MIGRATIONS"
             docker compose pull edge
             docker compose up -d --no-deps edge
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,130 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Image tag to deploy (e.g. 0.1.1, no "v" prefix — see registry tags)'
+        required: true
+        type: string
+      service:
+        description: 'Which service to deploy'
+        required: true
+        type: choice
+        options: [auth, central, edge, all]
+      run_migrations:
+        description: 'Run Flyway migrations on startup'
+        required: true
+        type: boolean
+        default: true
+
+jobs:
+  deploy-central:
+    if: inputs.service == 'central' || inputs.service == 'all'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy central
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            set -e
+            cd /opt/versola
+            sed -i "s|versola-central:[^[:space:]]*|versola-central:${{ inputs.version }}|" docker-compose.prod.yml
+            export RUN_MIGRATIONS=${{ inputs.run_migrations }}
+            docker compose pull central
+            docker compose up -d --no-deps central
+
+            echo "Waiting for central to become ready..."
+            for i in $(seq 1 30); do
+              if curl -sf http://127.0.0.1:8091/readiness > /dev/null; then
+                echo "central is ready"
+                exit 0
+              fi
+              sleep 2
+            done
+            echo "central did not become ready in time" >&2
+            docker compose logs --tail=50 central
+            exit 1
+
+  deploy-auth:
+    needs: deploy-central
+    if: |
+      always() &&
+      (inputs.service == 'auth' || inputs.service == 'all') &&
+      (needs.deploy-central.result == 'success' || needs.deploy-central.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy auth
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            set -e
+            cd /opt/versola
+
+            echo "Checking central is healthy before touching auth..."
+            if ! curl -sf http://127.0.0.1:8091/readiness > /dev/null; then
+              echo "central is not ready — refusing to deploy auth" >&2
+              exit 1
+            fi
+
+            sed -i "s|versola-auth:[^[:space:]]*|versola-auth:${{ inputs.version }}|" docker-compose.prod.yml
+            export RUN_MIGRATIONS=${{ inputs.run_migrations }}
+            docker compose pull auth
+            docker compose up -d --no-deps auth
+
+            for i in $(seq 1 30); do
+              if curl -sf http://127.0.0.1:8081/readiness > /dev/null; then
+                echo "auth is ready"
+                exit 0
+              fi
+              sleep 2
+            done
+            echo "auth did not become ready in time" >&2
+            docker compose logs --tail=50 auth
+            exit 1
+
+  deploy-edge:
+    needs: deploy-central
+    if: |
+      always() &&
+      (inputs.service == 'edge' || inputs.service == 'all') &&
+      (needs.deploy-central.result == 'success' || needs.deploy-central.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy edge
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            set -e
+            cd /opt/versola
+
+            echo "Checking central is healthy before touching edge..."
+            if ! curl -sf http://127.0.0.1:8091/readiness > /dev/null; then
+              echo "central is not ready — refusing to deploy edge" >&2
+              exit 1
+            fi
+
+            sed -i "s|versola-edge:[^[:space:]]*|versola-edge:${{ inputs.version }}|" docker-compose.prod.yml
+            export RUN_MIGRATIONS=${{ inputs.run_migrations }}
+            docker compose pull edge
+            docker compose up -d --no-deps edge
+
+            for i in $(seq 1 30); do
+              if curl -sf http://127.0.0.1:8096/readiness > /dev/null; then
+                echo "edge is ready"
+                exit 0
+              fi
+              sleep 2
+            done
+            echo "edge did not become ready in time" >&2
+            docker compose logs --tail=50 edge
+            exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,7 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          fingerprint: ${{ secrets.VPS_HOST_FINGERPRINT }}
           envs: DEPLOY_VERSION,DEPLOY_RUN_MIGRATIONS
           script: |
             set -e
@@ -59,7 +60,7 @@ jobs:
 
             echo "Waiting for central to become ready..."
             for i in $(seq 1 30); do
-              if curl -sf http://127.0.0.1:8091/readiness > /dev/null; then
+              if curl -sf --max-time 5 http://127.0.0.1:8091/readiness > /dev/null; then
                 echo "central is ready"
                 exit 0
               fi
@@ -95,13 +96,14 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          fingerprint: ${{ secrets.VPS_HOST_FINGERPRINT }}
           envs: DEPLOY_VERSION,DEPLOY_RUN_MIGRATIONS
           script: |
             set -e
             cd /opt/versola
 
             echo "Checking central is healthy before touching auth..."
-            if ! curl -sf http://127.0.0.1:8091/readiness > /dev/null; then
+            if ! curl -sf --max-time 5 http://127.0.0.1:8091/readiness > /dev/null; then
               echo "central is not ready — refusing to deploy auth" >&2
               exit 1
             fi
@@ -112,7 +114,7 @@ jobs:
             docker compose up -d --no-deps auth
 
             for i in $(seq 1 30); do
-              if curl -sf http://127.0.0.1:8081/readiness > /dev/null; then
+              if curl -sf --max-time 5 http://127.0.0.1:8081/readiness > /dev/null; then
                 echo "auth is ready"
                 exit 0
               fi
@@ -148,13 +150,14 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          fingerprint: ${{ secrets.VPS_HOST_FINGERPRINT }}
           envs: DEPLOY_VERSION,DEPLOY_RUN_MIGRATIONS
           script: |
             set -e
             cd /opt/versola
 
             echo "Checking central is healthy before touching edge..."
-            if ! curl -sf http://127.0.0.1:8091/readiness > /dev/null; then
+            if ! curl -sf --max-time 5 http://127.0.0.1:8091/readiness > /dev/null; then
               echo "central is not ready — refusing to deploy edge" >&2
               exit 1
             fi
@@ -165,7 +168,7 @@ jobs:
             docker compose up -d --no-deps edge
 
             for i in $(seq 1 30); do
-              if curl -sf http://127.0.0.1:8096/readiness > /dev/null; then
+              if curl -sf --max-time 5 http://127.0.0.1:8096/readiness > /dev/null; then
                 echo "edge is ready"
                 exit 0
               fi


### PR DESCRIPTION
## What

Adds `.github/workflows/deploy.yml` — a manual (`workflow_dispatch`) deploy pipeline for the
production VPS, closing out the third of the three original deployment tasks.

Inputs:
- `version` — image tag to deploy (matches the tag as published to ghcr.io, no `v` prefix)
- `service` — `auth` / `central` / `edge` / `all`
- `run_migrations` — whether Flyway migrations run on startup (wired to the `RUN_MIGRATIONS`
  flag added in #109)

## Job structure

Three jobs: `deploy-central`, `deploy-auth`, `deploy-edge`. `deploy-auth` and `deploy-edge` both
`needs: deploy-central` and run in parallel with each other once it succeeds.

This isn't just job hygiene — it directly encodes a real startup-ordering bug found while
deploying 0.1.1: if `auth`/`edge` restart before `central` is actually accepting connections, they
fail their initial config sync and get stuck in a state where `/readiness` never becomes true and
the container never exits, so `restart: unless-stopped` never kicks in either (details in
`deploy.md`, section 8.5). Gating `deploy-auth`/`deploy-edge` on `deploy-central`'s job succeeding
— and having `deploy-central` block on `central`'s own `/readiness` before the job is allowed to
succeed — prevents pipeline-driven deploys from hitting this. Each of `deploy-auth`/`deploy-edge`
also does its own live readiness check against `central` before touching anything, in case only
`auth` or only `edge` was selected and `central` wasn't part of this run at all.

Each job polls its own service's `/readiness` after deploying (up to 60s) and fails the job with
the last 50 log lines if it doesn't come up in time, instead of reporting success prematurely.

## Not included

- No version-exists preflight check — a bad tag fails loudly at `docker compose pull`, which is
  visible in the job output.
- No environment protection / required reviewers on this workflow. Worth adding given it deploys
  directly to prod, but that's a repo settings change, not something to bundle into this PR.