### PR TITLE
fix: exit the process when application startup fails

### DIFF
--- a/util/src/main/scala/versola/util/http/VersolaApp.scala
+++ b/util/src/main/scala/versola/util/http/VersolaApp.scala
@@ -128,8 +128,19 @@ trait VersolaApp(serviceName: String) extends ZIOApp:
       )
     yield ()
   }
-    .catchAll { (ex: Throwable) => ZIO.logErrorCause("Could not start application", Cause.fail(ex)).as(ExitCode.failure) }
-    .catchAllDefect(ex => ZIO.logErrorCause("Could not start application", Cause.die(ex)).as(ExitCode.failure))
+    .catchAll { (ex: Throwable) =>
+      // The diagnostics server is forked above onto non-daemon Netty threads that keep the JVM
+      // alive even after startup fails. Merely returning ExitCode.failure here therefore leaves a
+      // "zombie": the process never exits, so `restart: unless-stopped` never fires and /readiness
+      // stays false forever (see deploy.md 8.5). Force-terminate so the orchestrator restarts us -
+      // by then the dependency this startup failed on (e.g. central sync) is typically available.
+      ZIO.logErrorCause("Could not start application", Cause.fail(ex)) *>
+        ZIO.succeed(java.lang.System.exit(1))
+    }
+    .catchAllDefect { ex =>
+      ZIO.logErrorCause("Could not start application", Cause.die(ex)) *>
+        ZIO.succeed(java.lang.System.exit(1))
+    }
 
   def parseConfig[A: {DeriveConfig, Tag}] =
     ZLayer:


### PR DESCRIPTION
## Problem

When a service fails during startup — most commonly `auth`/`edge` failing their initial
configuration sync from `central` because `central` isn't accepting connections yet — the process
does **not** exit. `VersolaApp.run` catches the error, logs "Could not start application", and
returns `ExitCode.failure` *as a value*, which is not enough to terminate the JVM: the diagnostics
server has already been forked onto non-daemon Netty threads that keep the process alive.

The result is a zombie: the container stays "Up" (`docker inspect` shows `Running: true`,
`FinishedAt` at the zero timestamp), `/liveness` answers, but `/readiness` never becomes true and
never will. Because the container never exits, `restart: unless-stopped` never fires, so there is
no self-healing — the service has to be restarted by hand.

This was hit in production while deploying 0.1.1: restarting the whole stack at once, `central`
became ready ~0.4s after `auth` had already given up, and `auth` sat dead until manually
restarted. `edge` was in the same state for the same reason.

## Fix

After logging the fatal error, force the process to terminate with `java.lang.System.exit(1)` in
both the `catchAll` (typed failures) and `catchAllDefect` (defects) handlers. The container then
exits, `restart: unless-stopped` restarts it, and by the time it comes back up the dependency it
failed on (e.g. `central`) is typically available, so the retry succeeds.

`java.lang.System.exit` is fully qualified because `import zio.*` brings `zio.System` into scope
(same pattern already used for `getenv` elsewhere in this file).

### Why force-exit rather than re-failing the effect

Re-failing (`ZIO.fail(ex)`) would not fix this: the forked diagnostics server's non-daemon Netty
threads keep the JVM alive regardless of whether the main fiber fails, which is exactly the
observed behaviour. `System.exit` terminates unconditionally. It does bypass ZIO scope finalizers
(e.g. closing the Hikari pool), but that is acceptable for an aborted startup — the process is
dying anyway and Postgres reaps the dropped connections. The successful-startup path is unaffected.

## Scope

Touches the shared `VersolaApp` base trait, so it applies to all three services (`auth`,
`central`, `edge`). `sbt compile` passes locally.

Related: documented as troubleshooting case 8.5 in `deploy.md`.