### PR TITLE
fix: add pessimistic locks (FOR UPDATE) to config update methods

### DIFF
--- a/central/implementations/postgres/src/main/scala/versola/configuration/clients/PostgresOAuthClientRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/clients/PostgresOAuthClientRepository.scala
@@ -70,8 +70,14 @@ class PostgresOAuthClientRepository(
       authFlow: Option[AuthFlow],
       otpTemplateId: Option[String],
   ): Task[Unit] =
-    xa.repeatableRead.transactMeasured("update-client"):
-      val client = findClient(clientId).query[OAuthClientRecord].run().head
+    xa.transactMeasured("update-client"):
+      // Lock the row (READ_COMMITTED + FOR UPDATE) to prevent lost updates from concurrent writers.
+      val client = sql"""
+        SELECT id, tenant_id, client_name, redirect_uris, scope, external_audience, secret, previous_secret, access_token_ttl, refresh_token_ttl, permissions, theme, auth_flow, otp_template_id
+        FROM oauth_clients
+        WHERE id = $clientId
+        FOR UPDATE
+      """.query[OAuthClientRecord].run().head
       val newClientName = clientName.getOrElse(client.clientName)
       val newRedirectUris = client.redirectUris -- patchRedirectUris.remove ++ patchRedirectUris.add
       val newScope = client.scope -- patchScope.remove ++ patchScope.add

--- a/central/implementations/postgres/src/main/scala/versola/configuration/permissions/PostgresPermissionRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/permissions/PostgresPermissionRepository.scala
@@ -66,10 +66,12 @@ class PostgresPermissionRepository(xa: TransactorZIO) extends PermissionReposito
       descriptionPatch: PatchDescription,
       endpointIdsPatch: Option[Set[ResourceEndpointId]],
   ): Task[Unit] =
-    xa.repeatableRead.transactMeasured("update-permission"):
+    xa.transactMeasured("update-permission"):
+      // Lock the row (READ_COMMITTED + FOR UPDATE) to prevent lost updates from concurrent writers.
       val existing = sql"""
         SELECT tenant_id, id, description, endpoint_ids FROM permissions
         WHERE tenant_id = $tenantId AND id = $permission
+        FOR UPDATE
       """.query[PermissionRecord].run().headOption
 
       existing match

--- a/central/implementations/postgres/src/main/scala/versola/configuration/resources/PostgresResourceRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/resources/PostgresResourceRepository.scala
@@ -64,8 +64,13 @@ class PostgresResourceRepository(xa: TransactorZIO) extends ResourceRepository, 
       addEndpoints: Vector[ResourceEndpointRecord],
       deleteEndpoints: Set[ResourceEndpointId],
   ): Task[Unit] =
-    xa.repeatableRead.transactMeasured("update-resource"):
-      findResourceQuery(resourceId).run().headOption match
+    xa.transactMeasured("update-resource"):
+      // Lock the row (READ_COMMITTED + FOR UPDATE) to prevent lost updates from concurrent writers.
+      sql"""
+        SELECT tenant_id, resource_id, resource, endpoints FROM resources
+        WHERE resource_id = $resourceId
+        FOR UPDATE
+      """.query[ResourceRecord].run().headOption match
         case None => ()
         case Some(resource) =>
           val endpointsToRemove = deleteEndpoints ++ addEndpoints.map(_.id)

--- a/central/implementations/postgres/src/main/scala/versola/configuration/roles/PostgresRoleRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/roles/PostgresRoleRepository.scala
@@ -70,8 +70,11 @@ class PostgresRoleRepository(
       descriptionPatch: PatchDescription,
       permissionsPatch: PatchPermissions,
   ): Task[Unit] =
-    xa.repeatableRead.transactMeasured("update-role"):
-      getRole(id, tenantId).run().headOption match
+    xa.transactMeasured("update-role"):
+      // Lock the row (READ_COMMITTED + FOR UPDATE) to prevent lost updates from concurrent writers.
+      sql"""SELECT id, tenant_id, description, permissions, active FROM roles
+            WHERE tenant_id = $tenantId AND id = $id
+            FOR UPDATE""".query[RoleRecord].run().headOption match
         case None => ()
         case Some(role) =>
           val newDescr = (role.description -- descriptionPatch.delete) ++ descriptionPatch.add

--- a/central/implementations/postgres/src/main/scala/versola/configuration/scopes/PostgresOAuthScopeRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/scopes/PostgresOAuthScopeRepository.scala
@@ -54,9 +54,10 @@ class PostgresOAuthScopeRepository(
       id: ScopeToken,
       patch: PatchScope,
   ): Task[Unit] =
-    xa.repeatableRead.transactMeasured("update-scope"):
+    xa.transactMeasured("update-scope"):
+      // Lock the row (READ_COMMITTED + FOR UPDATE) to prevent lost updates from concurrent writers.
       val scope =
-        sql"""SELECT tenant_id, id, description, claims::jsonb[] FROM oauth_scopes WHERE tenant_id = $tenantId AND id = $id"""
+        sql"""SELECT tenant_id, id, description, claims::jsonb[] FROM oauth_scopes WHERE tenant_id = $tenantId AND id = $id FOR UPDATE"""
           .query[ScopeRecord].run().head
 
       val newClaims = scope.claims


### PR DESCRIPTION
Closes #94

### Problem
Several `update*` methods in central repositories follow a read-modify-write
pattern (SELECT → compute in Scala → UPDATE) inside a `REPEATABLE_READ`
transaction. `REPEATABLE_READ` prevents lost updates by raising a
serialization error (SQLState `40001`) when a concurrent writer has already
committed, but there is no retry logic for these errors, so under concurrency
the operation simply fails from the caller's perspective.

### Fix
Switched all affected methods to the **FOR UPDATE + READ_COMMITTED** approach
(the first option recommended in the issue): dropped `.repeatableRead` and
added `FOR UPDATE` to the SELECT inside each transaction. This takes a
row-level lock, blocking concurrent writers until the transaction commits, so
serialization failures are eliminated entirely rather than surfaced as errors.

This matches the pattern already established in the codebase
(`PostgresUserRepository.patch` uses `SELECT ... FOR UPDATE` under the default
READ_COMMITTED isolation). READ_COMMITTED is the driver default — Hikari does
not override `transactionIsolation`, and dropping `.repeatableRead` returns the
connection to that default.

The shared `find*` query helpers are left untouched: the locking SELECT is
inlined only in the update methods, so read-only lookups do not take locks.

### Affected methods
- `PostgresOAuthClientRepository.updateClient`
- `PostgresPermissionRepository.updatePermission`
- `PostgresRoleRepository.updateRole`
- `PostgresOAuthScopeRepository.updateScope`
- `PostgresResourceRepository.updateResource`

### Testing
No automated tests added: central repositories currently have no test harness
(there is no `src/test` for the central postgres module; DB test infrastructure
exists only in the `util` module). The change is mechanical and mirrors an
existing, reviewed pattern. Verified locally with `compile`.