### PR TITLE
central-ui: serve admin console under /admin base path

### DIFF
--- a/.github/workflows/deploy-central-ui.yml
+++ b/.github/workflows/deploy-central-ui.yml
@@ -15,9 +15,24 @@ on:
       - 'central-ui/**'
       - '.github/workflows/deploy-central-ui.yml'
 
+# Unlike deploy.yml's production-deploy group (cancel-in-progress: false —
+# each manual run there is a deliberate, explicit request to deploy a specific
+# version, so an older one must never be silently dropped), this workflow
+# fires automatically on every push. If two pushes land close together, only
+# the newest commit's build should end up live; an older run still in flight
+# is superseded work, so it's safe (and correct) to cancel it rather than let
+# it finish last and overwrite the newer deploy.
+concurrency:
+  group: deploy-central-ui
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Least-privilege default: this job only checks out the repo and pushes
+    # files over SSH with our own deploy key — it never touches GITHUB_TOKEN.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -35,12 +50,37 @@ jobs:
         run: npm run build
 
       - name: Copy files to VPS
-        uses: appleboy/scp-action@v0.1.7
+        uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634 # v0.1.7
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          fingerprint: ${{ secrets.VPS_HOST_FINGERPRINT }}
           source: "central-ui/dist/"
           target: "/website/central-ui"
           strip_components: 1
           overwrite: true
+
+      # scp-action's tar + strip_components dance is easy to get subtly wrong
+      # (wrong strip count silently nests or flattens the output). Fail the
+      # deploy loudly here instead of finding out via a 404 on /admin/ later.
+      - name: Verify remote layout
+        uses: appleboy/ssh-action@7eaf76671a0d7eec5d98ee897acda4f968735a17 # v1.2.0
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          fingerprint: ${{ secrets.VPS_HOST_FINGERPRINT }}
+          script: |
+            missing=0
+            for f in index.html versola-admin.js logo-shield.svg; do
+              if [ ! -f "/website/central-ui/dist/$f" ]; then
+                echo "Missing /website/central-ui/dist/$f after deploy." >&2
+                missing=1
+              fi
+            done
+            if [ "$missing" -eq 1 ]; then
+              echo "Check scp-action's source/target/strip_components, and that vite.config.ts's build.lib.fileName / public/ assets haven't changed — the nginx alias for /admin depends on these exact filenames." >&2
+              exit 1
+            fi
+            echo "OK: index.html, versola-admin.js, logo-shield.svg all present"

--- a/.github/workflows/deploy-central-ui.yml
+++ b/.github/workflows/deploy-central-ui.yml
@@ -1,0 +1,46 @@
+name: Deploy Central UI
+
+# central-ui is a static SPA (the admin console served at
+# https://id.versola.kz/admin — see nginx repo's envs/dev/versola.conf).
+# Unlike auth/central/edge it isn't a versioned Docker image behind a manual
+# workflow_dispatch release: it's plain static files, so it auto-deploys on
+# push to main, the same way the versola-website repo deploys the marketing
+# site. Scoped to central-ui/** so unrelated commits elsewhere in this
+# monorepo (auth, central, edge, util) don't trigger a redeploy.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'central-ui/**'
+      - '.github/workflows/deploy-central-ui.yml'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12'
+
+      - name: Install dependencies
+        working-directory: central-ui
+        run: npm install
+
+      - name: Build
+        working-directory: central-ui
+        run: npm run build
+
+      - name: Copy files to VPS
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          source: "central-ui/dist/"
+          target: "/website/central-ui"
+          strip_components: 1
+          overwrite: true

--- a/central-ui/vite.config.ts
+++ b/central-ui/vite.config.ts
@@ -2,6 +2,12 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { defineConfig, type Plugin } from 'vite';
 
+// The admin console is served at https://id.versola.kz/admin/ in production
+// (see deploy.md / nginx routing), so every asset URL baked into the built
+// index.html must be prefixed with this path — otherwise the browser looks
+// for them at the domain root and gets a 404.
+const BASE_PATH = '/admin/';
+
 function distIndexHtmlPlugin(): Plugin {
   return {
     name: 'dist-index-html',
@@ -11,7 +17,9 @@ function distIndexHtmlPlugin(): Plugin {
       const outputDir = path.join(projectRoot, 'dist');
       const outputPath = path.join(outputDir, 'index.html');
       const source = await readFile(sourcePath, 'utf8');
-      const html = source.replace('/src/index.ts', './versola-admin.js');
+      const html = source
+        .replace('/src/index.ts', `${BASE_PATH}versola-admin.js`)
+        .replace('href="/logo-shield.svg"', `href="${BASE_PATH}logo-shield.svg"`);
 
       await mkdir(outputDir, { recursive: true });
       await writeFile(outputPath, html, 'utf8');
@@ -21,7 +29,10 @@ function distIndexHtmlPlugin(): Plugin {
 
 const isPlaywright = process.env.PLAYWRIGHT === 'true';
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
+  // Only prefix in production builds — the local dev server (npm run dev)
+  // still serves from the root so `localhost:3000/` keeps working as before.
+  base: command === 'build' ? BASE_PATH : '/',
   plugins: [distIndexHtmlPlugin()],
   build: {
     lib: {
@@ -51,5 +62,5 @@ export default defineConfig({
   },
   // Public directory for static assets
   publicDir: 'public',
-});
+}));
 

--- a/central-ui/vite.config.ts
+++ b/central-ui/vite.config.ts
@@ -17,9 +17,23 @@ function distIndexHtmlPlugin(): Plugin {
       const outputDir = path.join(projectRoot, 'dist');
       const outputPath = path.join(outputDir, 'index.html');
       const source = await readFile(sourcePath, 'utf8');
+
+      // Guard against index.html being reformatted later without updating
+      // these markers — a silent no-op replace() would otherwise ship a
+      // dist/index.html with a dangling /src/index.ts reference or an
+      // un-prefixed favicon path, and nothing would fail the build to say so.
+      const scriptMarker = '/src/index.ts';
+      const faviconMarker = 'href="/logo-shield.svg"';
+      if (!source.includes(scriptMarker)) {
+        throw new Error(`dist-index-html: expected to find "${scriptMarker}" in index.html — update this plugin if index.html's shape changed.`);
+      }
+      if (!source.includes(faviconMarker)) {
+        throw new Error(`dist-index-html: expected to find '${faviconMarker}' in index.html — update this plugin if index.html's shape changed.`);
+      }
+
       const html = source
-        .replace('/src/index.ts', `${BASE_PATH}versola-admin.js`)
-        .replace('href="/logo-shield.svg"', `href="${BASE_PATH}logo-shield.svg"`);
+        .replace(scriptMarker, `${BASE_PATH}versola-admin.js`)
+        .replace(faviconMarker, `href="${BASE_PATH}logo-shield.svg"`);
 
       await mkdir(outputDir, { recursive: true });
       await writeFile(outputPath, html, 'utf8');
@@ -29,10 +43,13 @@ function distIndexHtmlPlugin(): Plugin {
 
 const isPlaywright = process.env.PLAYWRIGHT === 'true';
 
-export default defineConfig(({ command }) => ({
-  // Only prefix in production builds — the local dev server (npm run dev)
-  // still serves from the root so `localhost:3000/` keeps working as before.
-  base: command === 'build' ? BASE_PATH : '/',
+export default defineConfig(({ command, isPreview }) => ({
+  // Prefix in production builds, and also when previewing that build
+  // (`vite preview` still reports command === 'serve', with isPreview=true
+  // as the only signal) — otherwise `npm run preview` serves dist/ at "/"
+  // while its index.html references /admin/... assets, and everything 404s.
+  // The plain dev server (npm run dev) is the only case that stays at "/".
+  base: command === 'build' || isPreview ? BASE_PATH : '/',
   plugins: [distIndexHtmlPlugin()],
   build: {
     lib: {

--- a/deploy.md
+++ b/deploy.md
@@ -33,7 +33,7 @@ this table looks wrong, `cat /opt/versola/docker-compose.prod.yml` is the source
 |---|---|---|---|
 | `auth` | 8080 | 8081 | yes — `https://id.versola.kz` via nginx |
 | `central` | 8090 | 8091 | no — admin API, reached through `edge` |
-| `edge` | 8095 | 8096 | not yet — needs a domain, see [Known gaps](#10-known-gaps) |
+| `edge` | 8095 | 8096 | yes — path-routed on `https://id.versola.kz` (`/resources`, `/permissions`, `/login`, `/complete`); see [The admin console](#the-admin-console-central-ui) |
 
 Note that the Dockerfiles `EXPOSE 8080 9345`, but `9345` is not what the deployment actually
 uses — with `network_mode: host` the `EXPOSE` directive is inert and `DPORT` decides.
@@ -54,6 +54,33 @@ blocks on its initial config sync. If you restart both, bring `central` up first
 a 502 on `id.versola.kz` until `auth` succeeds. The [`Deploy`](#4-deploying-a-new-version)
 workflow enforces this ordering automatically; see [9.5](#95-authedge-never-become-ready-after-restarting-the-whole-stack-together)
 for what happens if you don't.
+
+### The admin console (central-ui)
+
+`central-ui` is a static SPA (the admin dashboard). It is **not** one of the three Docker services
+— it is plain built assets served by nginx, like the marketing site, and deployed by its own
+[`Deploy Central UI`](https://github.com/versolauth/versola/blob/main/.github/workflows/deploy-central-ui.yml)
+workflow (auto-runs on push to `main` when `central-ui/**` changes; builds `dist/` and `scp`s it to
+`/website/central-ui/dist` on the VPS).
+
+Rather than giving `edge` its own subdomain + certificate, the console and its edge API share the
+`id.versola.kz` origin via nginx path routing (in the [`nginx`](https://github.com/versolauth/nginx)
+repo's `envs/dev/versola.conf`):
+
+| Path on `id.versola.kz` | Routed to | Purpose |
+|---|---|---|
+| `/admin/` | static `central-ui/dist` | the SPA itself |
+| `/resources/`, `/permissions/` | `edge` (8095) | admin API + the caller's permissions, proxied to `central` |
+| `/login/`, `/complete` | `edge` (8095) | OAuth login flow entry point and callback |
+| everything else | `auth` (8080) | the OIDC endpoints, unchanged |
+
+Sharing one origin is deliberate: the `EDGE_SESSION` cookie and the edge's `401`+`Location`
+re-auth redirect are same-origin, so there is no CORS or `SameSite=None` handling to get wrong.
+The browser-facing login preset lives in `env-config`'s `central.conf` (`bootstrap.presets`,
+id `central-admin`) with `redirect-uri = https://id.versola.kz/complete` and
+`post-login-redirect-uri = https://id.versola.kz/admin`; those seed values are applied once, on
+`central`'s first bootstrap against an empty database (see [3.5](#35-compose-file) /
+[6](#6-recreating-the-database-from-scratch)).
 
 ---
 
@@ -257,6 +284,11 @@ Do **not** hand-edit nginx on the server. The config is version-controlled in th
 [`nginx`](https://github.com/versolauth/nginx) repo (`envs/dev/versola.conf`) and its workflow
 copies it over, runs `nginx -t` and reloads on merge to `main`. Editing the file in place means
 the next deploy silently reverts you.
+
+The `id.versola.kz` server block also fronts the admin console: it path-routes `/admin` (static
+`central-ui`), `/resources`, `/permissions`, `/login` and `/complete` to `edge`, with everything
+else falling through to `auth`. See [The admin console](#the-admin-console-central-ui) for the full
+mapping.
 
 ---
 
@@ -714,11 +746,11 @@ each cause has actually happened here:
   `env-config` *is* the security boundary and should be reviewed accordingly, and it's worth
   revisiting if the team or access list grows — encrypting at rest with something like `sops` or
   `git-crypt` would remove this exposure at the cost of a decryption step in the pipeline.
-- **No public domain for `edge`.** Until one exists the admin console cannot be reached from a
-  browser. Needs a DNS record, an nginx server block, a certificate, and `edgeUrl` in
-  `edge.conf` regenerated to match.
-- **`central-ui/package-lock.json` is gitignored**, so the `npm install` in CI is not reproducible
-  between builds.
+- **`central-ui/package-lock.json` is gitignored**, so the `npm install` in both the central image
+  build (`build:forms`) and the `Deploy Central UI` workflow is not reproducible between builds — a
+  transitive dependency can shift under an unchanged commit. Committing the lockfile and switching
+  to `npm ci` would fix this, but it's a repo-wide convention change (the root `.gitignore` ignores
+  all lockfiles), so it's called out here rather than patched piecemeal.
 - **Interactive host access (for people, not the pipeline) is by password.** The `Deploy` workflow
   already authenticates with its own dedicated SSH key (`VPS_SSH_KEY`), which is unaffected by
   this. This gap is specifically about individual engineers' own logins to the host, which should


### PR DESCRIPTION
Adds a deploy pipeline for central-ui (the admin console SPA), mirroring
how versola-website deploys the marketing site: builds on every push to
main and scp's dist/ to the VPS as static files — no Docker image, no
manual workflow_dispatch, since it's just static assets.

Scoped with `paths: central-ui/**` so unrelated commits elsewhere in this
monorepo (auth, central, edge, util) don't trigger a redeploy.

Deploys to /website/central-ui/dist, matching the nginx `alias
/website/central-ui/dist/` added for the /admin location (see the nginx
repo PR "route /admin and edge endpoints on id.versola.kz").

Depends on the central-ui base-path fix (vite base='/admin/') already
merged/pending in a separate PR — without it this would deploy assets
with broken absolute paths.