### PR TITLE
feat: sign SSO_SESSION cookie with Blake3 MAC (#107)

### DIFF
--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
@@ -10,6 +10,7 @@ import versola.oauth.userinfo.model.RequestedClaims
 import versola.util.{Base64, Email, Phone}
 import zio.http.{Header, Method, Request, URL}
 import zio.json.*
+import versola.util.CoreConfig
 import zio.prelude.NonEmptySet
 import zio.{Chunk, IO, Task, ZIO, ZLayer}
 
@@ -19,9 +20,9 @@ trait AuthorizeRequestParser:
   ): IO[Error, AuthorizeRequest]
 
 object AuthorizeRequestParser:
-  def live = ZLayer.fromFunction(Impl(_))
+  def live = ZLayer.fromFunction(Impl(_, _))
 
-  class Impl(oauthClientService: OAuthConfigurationService) extends AuthorizeRequestParser:
+  class Impl(config: CoreConfig, oauthClientService: OAuthConfigurationService) extends AuthorizeRequestParser:
 
     def parse(
         request: Request,
@@ -136,7 +137,7 @@ object AuthorizeRequestParser:
 
         sessionId =
           request.cookie(SessionCookie.name)
-            .flatMap(c => scala.util.Try(SessionId(Base64.urlDecode(c.content))).toOption)
+            .flatMap(c => SessionCookie.parse(c.content, config.security.sessionCookieSecret).toOption)
 
         authorizeRequest = AuthorizeRequest(
           clientId = clientId,

--- a/auth/src/main/scala/versola/oauth/conversation/ConversationRenderService.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationRenderService.scala
@@ -138,6 +138,7 @@ object ConversationRenderService:
               SessionCookie(
                 value = sessionId,
                 ttl = sessionTtl,
+                secret = config.security.sessionCookieSecret,
               ),
             )
 

--- a/auth/src/main/scala/versola/oauth/model/cookies.scala
+++ b/auth/src/main/scala/versola/oauth/model/cookies.scala
@@ -59,13 +59,33 @@ object ConversationCookie:
 object SessionCookie:
   val name = "SSO_SESSION"
 
-  inline def apply(value: SessionId, ttl: Duration): Cookie.Response = Cookie.Response(
-    name = name,
-    content = Base64Url.encode(value),
-    domain = None,
-    path = Some(Path.root),
-    isSecure = true,
-    isHttpOnly = true,
-    maxAge = Some(ttl),
-    sameSite = None,
-  )
+  def apply(value: SessionId, ttl: Duration, secret: Secret.Bytes32): Cookie.Response =
+    val payloadB64 = Base64.urlEncode(value)
+    val sigB64     = Base64.urlEncode(computeMac(value, secret))
+    Cookie.Response(
+      name = name,
+      content = s"$payloadB64.$sigB64",
+      domain = None,
+      path = Some(Path.root),
+      isSecure = true,
+      isHttpOnly = true,
+      maxAge = Some(ttl),
+      sameSite = None,
+    )
+
+  def parse(content: String, secret: Secret.Bytes32): Either[String, SessionId] =
+    val dotIdx = content.lastIndexOf('.')
+    if dotIdx < 0 then Left("missing signature")
+    else
+      val payloadB64 = content.substring(0, dotIdx)
+      val sigB64     = content.substring(dotIdx + 1)
+      for
+        payloadBytes <- scala.util.Try(Base64.urlDecode(payloadB64)).toEither.left.map(_.getMessage)
+        sigBytes     <- scala.util.Try(Base64.urlDecode(sigB64)).toEither.left.map(_.getMessage)
+        _            <- Either.cond(MessageDigest.isEqual(computeMac(payloadBytes, secret), sigBytes), (), "invalid signature")
+      yield SessionId(payloadBytes)
+
+  private def computeMac(data: Array[Byte], key: Secret.Bytes32): Array[Byte] =
+    val mac = Array.ofDim[Byte](32)
+    Blake3.initKeyedHash(key).update(data).doFinalize(mac)
+    mac

--- a/auth/src/main/scala/versola/oauth/model/cookies.scala
+++ b/auth/src/main/scala/versola/oauth/model/cookies.scala
@@ -83,6 +83,7 @@ object SessionCookie:
         payloadBytes <- scala.util.Try(Base64.urlDecode(payloadB64)).toEither.left.map(_.getMessage)
         sigBytes     <- scala.util.Try(Base64.urlDecode(sigB64)).toEither.left.map(_.getMessage)
         _            <- Either.cond(MessageDigest.isEqual(computeMac(payloadBytes, secret), sigBytes), (), "invalid signature")
+        _            <- Either.cond(payloadBytes.length == 32, (), "invalid session id length")
       yield SessionId(payloadBytes)
 
   private def computeMac(data: Array[Byte], key: Secret.Bytes32): Array[Byte] =

--- a/auth/src/main/scala/versola/util/CoreConfig.scala
+++ b/auth/src/main/scala/versola/util/CoreConfig.scala
@@ -49,11 +49,12 @@ object CoreConfig:
   )
 
   case class Security(
-      accessTokensSecret: Secret.Bytes32,
-      clientSecretsSecret: Secret.Bytes16,
-      refreshTokensSecret: Secret.Bytes32,
-      authCodesSecret: Secret.Bytes32,
-      sessionsSecret: Secret.Bytes32,
-      passwordsSecret: Secret.Bytes16,
-      conversationCookieSecret: Secret.Bytes32,
-  )
+    accessTokensSecret: Secret.Bytes32,
+    clientSecretsSecret: Secret.Bytes16,
+    refreshTokensSecret: Secret.Bytes32,
+    authCodesSecret: Secret.Bytes32,
+    sessionsSecret: Secret.Bytes32,
+    passwordsSecret: Secret.Bytes16,
+    conversationCookieSecret: Secret.Bytes32,
+    sessionCookieSecret: Secret.Bytes32,
+)

--- a/auth/src/test/scala/versola/auth/TestEnvConfig.scala
+++ b/auth/src/test/scala/versola/auth/TestEnvConfig.scala
@@ -73,6 +73,7 @@ object TestEnvConfig:
       sessionsSecret = Secret.Bytes32(Array.fill(32)(0.toByte)),
       passwordsSecret = Secret.Bytes16(Array.fill(16)(0.toByte)),
       conversationCookieSecret = Secret.Bytes32(Array.fill(32)(0.toByte)),
+      sessionCookieSecret      = Secret.Bytes32(Array.fill(32)(0.toByte)),
     ),
     jwt = jwtConfig,
     central = CoreConfig.CentralSyncConfig(

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
@@ -35,7 +35,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
 
   class Env:
     val configuration = stub[OAuthConfigurationService]
-    val parser = AuthorizeRequestParser.Impl(configuration)
+    val parser = AuthorizeRequestParser.Impl(TestEnvConfig.coreConfig, configuration)
 
   def validParams = Map(
     "client_id" -> clientId.toString,

--- a/auth/src/test/scala/versola/oauth/model/CookiesSpec.scala
+++ b/auth/src/test/scala/versola/oauth/model/CookiesSpec.scala
@@ -8,6 +8,7 @@ import versola.util.Secret
 import zio.*
 import zio.json.*
 import zio.test.*
+import versola.util.Base64
 
 import java.util.UUID
 
@@ -50,15 +51,32 @@ object CookiesSpec extends ZIOSpecDefault:
     ),
 
     suite("SessionCookie")(
-      test("creates a session cookie with correct name and properties") {
+      test("creates a session cookie with valid signature") {
         val sessionId = SessionId(Array.fill(32)(1.toByte))
-        val cookie    = SessionCookie(sessionId, 1.hour)
+        val cookie    = SessionCookie(sessionId, 1.hour, secret)
         assertTrue(
           cookie.name == SessionCookie.name,
           cookie.isHttpOnly,
           cookie.isSecure,
           cookie.maxAge.contains(1.hour)
-        )
+        ) &&
+        assertTrue(SessionCookie.parse(cookie.content, secret).map(_.toSeq) == Right(sessionId.toSeq))
+      },
+
+      test("parse fails with wrong secret") {
+        val sessionId   = SessionId(Array.fill(32)(1.toByte))
+        val content     = SessionCookie(sessionId, 1.hour, secret).content
+        val wrongSecret = Secret.Bytes32(Array.fill(32)(9.toByte))
+        assertTrue(SessionCookie.parse(content, wrongSecret).isLeft)
+      },
+
+      test("parse fails with tampered content") {
+        val sessionId      = SessionId(Array.fill(32)(1.toByte))
+        val content        = SessionCookie(sessionId, 1.hour, secret).content
+        val parts          = content.split('.')
+        val tamperedPayload = Base64.urlEncode(Array.fill(32)(2.toByte))
+        val tamperedContent = s"$tamperedPayload.${parts(1)}"
+        assertTrue(SessionCookie.parse(tamperedContent, secret).isLeft)
       }
     )
   )

--- a/auth/src/test/scala/versola/oauth/model/CookiesSpec.scala
+++ b/auth/src/test/scala/versola/oauth/model/CookiesSpec.scala
@@ -17,6 +17,7 @@ object CookiesSpec extends ZIOSpecDefault:
   private val authId = AuthId(UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
   private val clientId = ClientId("test-client")
   private val secret = TestEnvConfig.coreConfig.security.conversationCookieSecret
+  private val sessionSecret = TestEnvConfig.coreConfig.security.sessionCookieSecret
 
   def spec = suite("CookiesSpec")(
     suite("ConversationCookie")(
@@ -53,30 +54,30 @@ object CookiesSpec extends ZIOSpecDefault:
     suite("SessionCookie")(
       test("creates a session cookie with valid signature") {
         val sessionId = SessionId(Array.fill(32)(1.toByte))
-        val cookie    = SessionCookie(sessionId, 1.hour, secret)
+        val cookie    = SessionCookie(sessionId, 1.hour, sessionSecret)
         assertTrue(
           cookie.name == SessionCookie.name,
           cookie.isHttpOnly,
           cookie.isSecure,
           cookie.maxAge.contains(1.hour)
         ) &&
-        assertTrue(SessionCookie.parse(cookie.content, secret).map(_.toSeq) == Right(sessionId.toSeq))
+        assertTrue(SessionCookie.parse(cookie.content, sessionSecret).map(_.toSeq) == Right(sessionId.toSeq))
       },
 
       test("parse fails with wrong secret") {
         val sessionId   = SessionId(Array.fill(32)(1.toByte))
-        val content     = SessionCookie(sessionId, 1.hour, secret).content
+        val content     = SessionCookie(sessionId, 1.hour, sessionSecret).content
         val wrongSecret = Secret.Bytes32(Array.fill(32)(9.toByte))
         assertTrue(SessionCookie.parse(content, wrongSecret).isLeft)
       },
 
       test("parse fails with tampered content") {
         val sessionId      = SessionId(Array.fill(32)(1.toByte))
-        val content        = SessionCookie(sessionId, 1.hour, secret).content
+        val content        = SessionCookie(sessionId, 1.hour, sessionSecret).content
         val parts          = content.split('.')
         val tamperedPayload = Base64.urlEncode(Array.fill(32)(2.toByte))
         val tamperedContent = s"$tamperedPayload.${parts(1)}"
-        assertTrue(SessionCookie.parse(tamperedContent, secret).isLeft)
+        assertTrue(SessionCookie.parse(tamperedContent, sessionSecret).isLeft)
       }
     )
   )

--- a/scripts/gen-env.scala
+++ b/scripts/gen-env.scala
@@ -103,6 +103,7 @@ def writeFile(dir: File, name: String, content: String): Unit =
   val sessionsSecret            = rand(rng, 32)
   val passwordsSecret           = rand(rng, 16)
   val conversationCookieSecret  = rand(rng, 32) // auth only: signs the SSO_CONVERSATION cookie
+  val sessionCookieSecret       = rand(rng, 32)
   val edgeTokenEncKey           = rand(rng, 32)
   val edgeSessionsSecret        = rand(rng, 32)
 
@@ -246,6 +247,7 @@ def writeFile(dir: File, name: String, content: String): Unit =
        |  sessions-secret              = "$sessionsSecret"
        |  passwords-secret             = "$passwordsSecret"
        |  conversation-cookie-secret   = "$conversationCookieSecret"
+       |  session-cookie-secret        = "$sessionCookieSecret"  
        |}
        |
        |jwt {


### PR DESCRIPTION
Closes #107 

SSO_SESSION cookie was only Base64Url-encoded, not signed. This PR signs it with a Blake3 keyed-hash MAC using a dedicated `sessionCookieSecret`, following the same pattern as `ConversationCookie`.

closes #107