### PR TITLE
Fix mobile layout issues across admin console

### DIFF
--- a/central-ui/src/components/admin-app.ts
+++ b/central-ui/src/components/admin-app.ts
@@ -1,13 +1,16 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { theme, resetStyles } from '../styles/theme';
-import type { NavItem } from './navigation';
+import type { NavItem, VersolaNavigation } from './navigation';
 import { configureCentralApi, fetchMyPermissions } from '../utils/central-api';
 
 import './navigation';
 // Imported directly (not just transitively via navigation) because the splash
 // screen renders the logo without the nav being on the page.
 import './versola-logo';
+// Likewise: the access-denied state renders a content-header without any list
+// component on the page to pull it in.
+import './content-header';
 import './clients-list';
 import './scopes-list';
 import './permissions-list';
@@ -33,7 +36,8 @@ export class VersolaAdmin extends LitElement {
   @state() private currentView: NavItem = 'clients';
   /** Mobile drawer state; ignored by the layout above the 768px breakpoint. */
   @state() private navOpen = false;
-  @query('.nav-toggle') private navToggleButton?: HTMLButtonElement;
+  @query('.main-content') private mainContent?: HTMLElement;
+  @query('versola-navigation') private navigationEl?: VersolaNavigation;
   @state() private currentTenantId: string | null = null;
   @state() private clientToExpandOnLoad: string | null = null;
   @state() private edgeToExpandOnLoad: string | null = null;
@@ -169,13 +173,20 @@ export class VersolaAdmin extends LitElement {
         min-width: 0; /* let flex children shrink instead of overflowing */
       }
 
-      /* Hamburger + backdrop only exist on mobile, where the sidebar is an
-         off-canvas drawer. Hidden entirely on desktop, where the sidebar is
-         always visible. */
-      .nav-toggle {
-        display: none;
+      /* Focus is moved here programmatically when the drawer closes (see
+         closeNav). Kept visible, just inset rather than the browser's default
+         halo around the whole content column — a keyboard/screen-reader user
+         needs to see where focus landed, it's just quieter than the ring on an
+         actual control. */
+      .main-content:focus {
+        outline: 2px solid var(--accent);
+        outline-offset: -2px;
       }
 
+      /* The backdrop only exists on mobile, where the sidebar is an off-canvas
+         drawer. On desktop the sidebar is always visible, so nothing overlays
+         the page. The drawer toggle itself lives in content-header, inline with
+         each screen's title — see the comments on handleOpenNav/handleCloseNav. */
       .nav-backdrop {
         display: none;
       }
@@ -184,28 +195,6 @@ export class VersolaAdmin extends LitElement {
         .main-content {
           margin-left: 0;
           padding: 1rem;
-          /* room for the fixed hamburger so content doesn't start underneath it */
-          padding-top: 4rem;
-        }
-
-        .nav-toggle {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          position: fixed;
-          top: 0.75rem;
-          left: 0.75rem;
-          z-index: 300; /* above the drawer, so it can also close it */
-          width: 2.75rem;
-          height: 2.75rem;
-          padding: 0;
-          border: 1px solid var(--border-dark);
-          border-radius: var(--radius-md);
-          background: var(--bg-card, var(--bg-dark));
-          color: var(--text-primary);
-          font-size: 1.25rem;
-          line-height: 1;
-          cursor: pointer;
         }
 
         .nav-backdrop.visible {
@@ -312,35 +301,67 @@ export class VersolaAdmin extends LitElement {
     this.closeNav();
   }
 
-  private toggleNav() {
-    this.navOpen = !this.navOpen;
-  }
+  /** Handles the `open-nav` event bubbling out of a versola-nav-toggle.
+    *
+    * The drawer toggle used to be a `position: fixed` button owned by this
+    * component. Being pinned to the viewport, it sat on top of whatever the
+    * page happened to be scrolled to — covering card headings mid-page, and
+    * covering the drawer's own logo once opened. It now lives inline with each
+    * screen's title, so it scrolls with the page like any other content.
+    *
+    * Opening and closing are separate events rather than one toggle: the open
+    * button sits in page headers (which are scattered across a dozen
+    * components) while closing happens from inside the drawer, the backdrop,
+    * or Escape. Splitting them means the open button never needs to know
+    * whether the drawer is open, so no drawer state has to be threaded down
+    * through every screen.
+    *
+    * Focus is moved into the drawer once it's rendered open: the toggle that
+    * triggered this lives in <main>, after the drawer in DOM order, and stays
+    * focused by default. A keyboard user tabbing from there would continue
+    * through the rest of main's content — which the backdrop now visually
+    * covers — rather than landing anywhere inside the panel that just opened.
+    */
+  private handleOpenNav = () => {
+    this.navOpen = true;
+    void this.updateComplete.then(async () => {
+      // Waiting on this component's own updateComplete isn't enough: setting
+      // .open on versola-navigation schedules *its* update as a separate,
+      // independently-batched microtask, which may not have run yet. Without
+      // this, .brand-close can still be undefined when focusClose() runs.
+      await this.navigationEl?.updateComplete;
+      this.navigationEl?.focusClose();
+    });
+  };
+
+  private handleCloseNav = () => {
+    this.closeNav();
+  };
 
   /** Closes the mobile drawer, moving focus somewhere still visible.
     *
     * The element that triggered the close (a nav item) is inside the drawer,
     * which becomes `visibility: hidden` — leaving focus on it would strand
-    * keyboard and screen-reader users on an unreachable element. The toggle
-    * button is the natural place to land: it's what reopens the drawer.
+    * keyboard and screen-reader users on an unreachable element.
+    *
+    * Focus lands on <main> rather than the toggle button that opened the
+    * drawer: that button now lives inside versola-nav-toggle's shadow root,
+    * which this component can't reach without reaching through another
+    * component's internals. <main> is a stable, always-present target, and
+    * landing there puts a screen reader at the top of the content the user
+    * just navigated to — arguably a better destination than the button anyway.
+    *
+    * preventScroll matters: focus() scrolls its target into view by default,
+    * which would yank a scrolled page back to the top every time the drawer is
+    * dismissed without navigating anywhere (✕, backdrop, Escape).
+    *
     * Returns early when already closed, so this never runs on desktop.
     */
   private closeNav() {
     if (!this.navOpen) return;
     this.navOpen = false;
     void this.updateComplete.then(() => {
-      const toggle = this.navToggleButton;
-      if (!toggle) return;
-      // Only move focus when the toggle is actually rendered: it's
-      // `display: none` above the breakpoint, and focusing a display:none
-      // element silently does nothing. Above the breakpoint the drawer isn't
-      // hidden either, so focus has nothing to escape from.
-      //
-      // Checked via computed display rather than offsetParent: offsetParent is
-      // null for `position: fixed` elements (which this button is on mobile),
-      // so that test would be false exactly when the focus restore is needed.
-      if (getComputedStyle(toggle).display !== 'none') {
-        toggle.focus();
-      }
+      this.mainContent?.focus({ preventScroll: true });
     });
   }
 
@@ -406,12 +427,19 @@ export class VersolaAdmin extends LitElement {
     this.currentView = 'edges';
   };
 
+  /** Renders the "no permission for this view" state.
+    *
+    * Carries a content-header purely so the drawer toggle is present: this
+    * screen renders instead of a list component, so without it an admin whose
+    * default view is denied would have no way to reach the menu and no way to
+    * navigate anywhere else.
+    */
   private renderAccessDenied() {
     return html`
+      <content-header title="Access Denied"></content-header>
       <div style="display:flex;align-items:center;justify-content:center;min-height:40vh">
         <div style="text-align:center;color:var(--text-secondary)">
           <div style="font-size:3rem;margin-bottom:1rem">🔒</div>
-          <h2 style="color:var(--text-primary);margin-bottom:0.5rem">Access Denied</h2>
           <p style="max-width:32rem;margin:0 auto">
             Please contact your system administrator to gain access.
           </p>
@@ -470,15 +498,7 @@ export class VersolaAdmin extends LitElement {
     }
 
     return html`
-      <div class="app-layout">
-        <button
-          type="button"
-          class="nav-toggle"
-          @click=${this.toggleNav}
-          aria-label=${this.navOpen ? 'Close navigation menu' : 'Open navigation menu'}
-          aria-expanded=${this.navOpen}
-        >${this.navOpen ? '✕' : '☰'}</button>
-
+      <div class="app-layout" @open-nav=${this.handleOpenNav} @close-nav=${this.handleCloseNav}>
         <div
           class="nav-backdrop ${this.navOpen ? 'visible' : ''}"
           @click=${this.closeNav}
@@ -494,7 +514,7 @@ export class VersolaAdmin extends LitElement {
           @tenant-change=${this.handleTenantChange}
         ></versola-navigation>
 
-        <main class="main-content">
+        <main class="main-content" tabindex="-1">
           ${this.renderView()}
         </main>
       </div>

--- a/central-ui/src/components/challenges-list.ts
+++ b/central-ui/src/components/challenges-list.ts
@@ -12,8 +12,10 @@ import {
   upsertChallengeSettings,
 } from '../utils/central-api';
 import { confirmDestructiveAction } from '../utils/confirm-dialog';
+import './content-header';
 import './error-card';
 import './loading-cards';
+import './nav-toggle';
 
 const CODE_PLACEHOLDER = '{{code}}';
 const PASSWORD_PLACEHOLDER = '{{password}}';
@@ -94,19 +96,6 @@ export class VersolaChallengesList extends LitElement {
     iconActionStyles,
     css`
       :host { display: block; }
-      .page-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        margin-bottom: var(--spacing-xl);
-      }
-      .page-title {
-        font-size: 1.625rem;
-        font-weight: 700;
-        letter-spacing: -0.025em;
-        color: var(--text-primary);
-        margin: 0;
-      }
       .form-header {
         display: flex;
         justify-content: space-between;
@@ -245,6 +234,12 @@ export class VersolaChallengesList extends LitElement {
         border: 1px solid var(--border-dark);
         border-radius: var(--radius-md);
         padding: var(--spacing-xs) var(--spacing-md);
+        /* Phone prefixes and ACR names are short, but this class also renders
+           passkey origins, which are full URLs. Without these the tag is an
+           unbreakable box that pushes past the card's right edge on a phone. */
+        max-width: 100%;
+        min-width: 0;
+        overflow-wrap: anywhere;
       }
       .limit-row {
         display: flex;
@@ -339,6 +334,19 @@ export class VersolaChallengesList extends LitElement {
       .prop-value.muted {
         color: var(--text-secondary);
         font-style: italic;
+      }
+      /* The 11rem label column plus a 1.5rem gap leaves almost nothing for the
+         value on a ~390px screen. Below this width the label sits above its
+         value instead of beside it. */
+      @media (max-width: 720px) {
+        .prop-row {
+          grid-template-columns: minmax(0, 1fr);
+          gap: var(--spacing-xs);
+          padding: 0.875rem var(--spacing-md);
+        }
+        .prop-label {
+          white-space: normal;
+        }
       }
       .empty-state {
         text-align: center;
@@ -661,9 +669,12 @@ export class VersolaChallengesList extends LitElement {
 
     return html`
       <div class="form-header">
-        <div class="title-stack">
-          <h1 class="form-title">${isNewOtp ? `Add ${typeLabel}` : `Edit ${typeLabel}`}</h1>
-          ${isNewOtp ? nothing : html`<div class="entity-id-meta">${this.editId}</div>`}
+        <div class="form-header-lead">
+          <versola-nav-toggle></versola-nav-toggle>
+          <div class="title-stack">
+            <h1 class="form-title">${isNewOtp ? `Add ${typeLabel}` : `Edit ${typeLabel}`}</h1>
+            ${isNewOtp ? nothing : html`<div class="entity-id-meta">${this.editId}</div>`}
+          </div>
         </div>
       </div>
 
@@ -980,8 +991,11 @@ export class VersolaChallengesList extends LitElement {
   private renderChallengeEdit() {
     return html`
       <div class="form-header">
-        <div class="title-stack">
-          <h1 class="form-title">Edit Challenge Settings</h1>
+        <div class="form-header-lead">
+          <versola-nav-toggle></versola-nav-toggle>
+          <div class="title-stack">
+            <h1 class="form-title">Edit Challenge Settings</h1>
+          </div>
         </div>
       </div>
 
@@ -1195,9 +1209,7 @@ export class VersolaChallengesList extends LitElement {
     if (this.editingSettings) return this.renderChallengeEdit();
 
     return html`
-      <div class="page-header">
-        <h1 class="page-title">Challenges & Security</h1>
-      </div>
+      <content-header title="Challenges & Security"></content-header>
 
       ${this.isLoading ? html`<versola-loading-cards .count=${3}></versola-loading-cards>`
         : this.errorMessage ? html`

--- a/central-ui/src/components/claim-edit.ts
+++ b/central-ui/src/components/claim-edit.ts
@@ -4,6 +4,7 @@ import { theme } from '../styles/theme';
 import { buttonStyles, cardStyles, formStyles } from '../styles/components';
 import { OAuthScope, User } from '../types';
 import { getScopes } from '../utils/central-api';
+import './nav-toggle';
 
 const EXCLUDED_SCOPES = new Set(['openid', 'offline_access']);
 
@@ -180,9 +181,12 @@ export class VersolaClaimEdit extends LitElement {
   render() {
     return html`
       <div class="form-header">
-        <div class="title-stack">
-          <h1 class="form-title">Edit Claims</h1>
-          <div class="entity-id-meta">${this.user?.id}</div>
+        <div class="form-header-lead">
+          <versola-nav-toggle></versola-nav-toggle>
+          <div class="title-stack">
+            <h1 class="form-title">Edit Claims</h1>
+            <div class="entity-id-meta">${this.user?.id}</div>
+          </div>
         </div>
       </div>
 

--- a/central-ui/src/components/client-form.ts
+++ b/central-ui/src/components/client-form.ts
@@ -4,6 +4,7 @@ import { theme } from '../styles/theme';
 import { buttonStyles, cardStyles, formStyles, iconActionStyles } from '../styles/components';
 import { AuthFactorType, AuthFlow, OAuthClient, OAuthScope, OtpTemplateRecord, Permission, PrimaryCredential, Resource, ThemeRecord } from '../types';
 import { createDefaultAuthFlow, getLocalizedDescription, resolvePermissionEndpointGroups } from '../utils/helpers';
+import './nav-toggle';
 import {
   validateClientId,
   validateRedirectUri,
@@ -1174,11 +1175,14 @@ export class VersolaClientForm extends LitElement {
 
     return html`
       <div class="form-header">
-        <div class="title-stack">
-          <h1 class="form-title">
-            ${this.client ? 'Edit Client' : 'Create New Client'}
-          </h1>
-          ${this.client ? html`<div class="entity-id-meta">${this.formData.id || '—'}</div>` : ''}
+        <div class="form-header-lead">
+          <versola-nav-toggle></versola-nav-toggle>
+          <div class="title-stack">
+            <h1 class="form-title">
+              ${this.client ? 'Edit Client' : 'Create New Client'}
+            </h1>
+            ${this.client ? html`<div class="entity-id-meta">${this.formData.id || '—'}</div>` : ''}
+          </div>
         </div>
       </div>
 

--- a/central-ui/src/components/content-header.ts
+++ b/central-ui/src/components/content-header.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { theme } from '../styles/theme';
+import './nav-toggle';
 
 @customElement('content-header')
 export class ContentHeader extends LitElement {
@@ -25,6 +26,16 @@ export class ContentHeader extends LitElement {
 
       .header-info {
         flex: 1;
+        min-width: 0; /* let a long title wrap instead of stretching the row */
+      }
+
+      /* The toggle is display:none above the breakpoint, so on desktop this row
+         collapses to just the title and the gap contributes nothing. */
+      .title-row {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-md);
+        min-width: 0;
       }
 
       .header-title {
@@ -32,6 +43,8 @@ export class ContentHeader extends LitElement {
         font-weight: 700;
         color: var(--text-primary);
         margin: 0 0 0.5rem 0;
+        min-width: 0;
+        overflow-wrap: anywhere;
       }
 
       .header-description {
@@ -49,6 +62,18 @@ export class ContentHeader extends LitElement {
         .header-container {
           flex-direction: column;
         }
+
+        /* Cancels the h1's bottom margin so the button reads as vertically
+           centred against the title rather than sitting low. */
+        versola-nav-toggle {
+          margin-bottom: 0.5rem;
+        }
+
+        /* 2rem alongside a 2.75rem button leaves too little room for longer
+           titles ("Challenges & Security") on a ~390px screen. */
+        .header-title {
+          font-size: 1.5rem;
+        }
       }
     `,
   ];
@@ -57,7 +82,10 @@ export class ContentHeader extends LitElement {
     return html`
       <div class="header-container">
         <div class="header-info">
-          <h1 class="header-title">${this.title}</h1>
+          <div class="title-row">
+            <versola-nav-toggle></versola-nav-toggle>
+            <h1 class="header-title">${this.title}</h1>
+          </div>
           ${this.description ? html`
             <p class="header-description">${this.description}</p>
           ` : ''}
@@ -70,4 +98,3 @@ export class ContentHeader extends LitElement {
     `;
   }
 }
-

--- a/central-ui/src/components/edge-form.ts
+++ b/central-ui/src/components/edge-form.ts
@@ -4,6 +4,7 @@ import { theme } from '../styles/theme';
 import { buttonStyles, cardStyles, formStyles } from '../styles/components';
 import type { Edge } from '../types/index';
 import { validateEdgeId } from '../utils/validators';
+import './nav-toggle';
 
 @customElement('versola-edge-form')
 export class VersolaEdgeForm extends LitElement {
@@ -50,6 +51,31 @@ export class VersolaEdgeForm extends LitElement {
         margin-top: var(--spacing-xl);
         padding-top: var(--spacing-xl);
         border-top: 1px solid var(--border-dark);
+      }
+
+      /* In edit mode the only child of .form-grid is the action row itself —
+         the Edge ID field is create-only. The separator and the 2rem of space
+         above it exist to divide actions from fields that aren't there, which
+         read as a broken, half-empty card. Dropped when the row stands alone.
+         :only-child is exact here: it matches only when nothing else rendered.
+         Once this form grows real edit-mode content, the divider returns on
+         its own with no CSS change needed. */
+      .form-actions:only-child {
+        margin-top: 0;
+        padding-top: 0;
+        border-top: none;
+      }
+
+      @media (max-width: 720px) {
+        .form-actions {
+          flex-wrap: wrap;
+        }
+
+        /* Rotate Key is pushed left by margin-right:auto; once the row wraps
+           that leaves it stranded on its own line. */
+        .secondary-action-button {
+          margin-right: 0;
+        }
       }
 
       .secondary-action-button {
@@ -160,11 +186,14 @@ export class VersolaEdgeForm extends LitElement {
 
     return html`
       <div class="form-header">
-        <div class="title-stack">
-          <h1 class="form-title">
-            ${isEditMode ? 'Edit Edge' : 'Create New Edge'}
-          </h1>
-          ${isEditMode ? html`<div class="entity-id-meta">${this.edge!.id}</div>` : ''}
+        <div class="form-header-lead">
+          <versola-nav-toggle></versola-nav-toggle>
+          <div class="title-stack">
+            <h1 class="form-title">
+              ${isEditMode ? 'Edit Edge' : 'Create New Edge'}
+            </h1>
+            ${isEditMode ? html`<div class="entity-id-meta">${this.edge!.id}</div>` : ''}
+          </div>
         </div>
       </div>
 

--- a/central-ui/src/components/edges-list.ts
+++ b/central-ui/src/components/edges-list.ts
@@ -83,6 +83,10 @@ export class VersolaEdgesList extends LitElement {
         display: flex;
         align-items: center;
         gap: 0.75rem;
+        /* A long id and the "Key Rotation" badge can't share one line on a
+           phone; let the badge drop below rather than overflow the card. */
+        flex-wrap: wrap;
+        overflow-wrap: anywhere;
       }
 
       .edge-actions {
@@ -229,6 +233,21 @@ export class VersolaEdgesList extends LitElement {
       .empty-state-icon {
         font-size: 3rem;
         margin-bottom: 1rem;
+      }
+
+      /* This screen was the only list without a narrow-screen rule for its card
+         header. A long edge id plus the "Key Rotation" badge plus two icon
+         buttons don't fit one row on a phone, so the row is stacked to match
+         the other lists. */
+      @media (max-width: 720px) {
+        .edge-header {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .edge-actions {
+          margin-left: 0;
+        }
       }
     `,
   ];

--- a/central-ui/src/components/form-edit.ts
+++ b/central-ui/src/components/form-edit.ts
@@ -8,6 +8,7 @@ import { buildPreviewSrcdoc } from '../utils/preview';
 import { humanizeLabel, toggleAnyOf, exclusiveAnyOfValues } from '../utils/helpers';
 import './content-header';
 import './code-editor';
+import './nav-toggle';
 
 @customElement('versola-form-edit')
 export class VersolaFormEdit extends LitElement {
@@ -308,7 +309,10 @@ export class VersolaFormEdit extends LitElement {
 
     return html`
       <div class="title-stack" style="margin-bottom: var(--spacing-lg)">
-        <h1 class="form-title">${this.form?.id === '' ? 'New Form' : 'New Version'}</h1>
+        <div class="form-header-lead">
+          <versola-nav-toggle></versola-nav-toggle>
+          <h1 class="form-title">${this.form?.id === '' ? 'New Form' : 'New Version'}</h1>
+        </div>
         ${this.form?.id === '' ? html`
           <div>
             <label class="field-label">Form ID</label>

--- a/central-ui/src/components/locales-list.ts
+++ b/central-ui/src/components/locales-list.ts
@@ -4,8 +4,10 @@ import { theme } from '../styles/theme';
 import { badgeStyles, buttonStyles, cardStyles, formStyles, iconActionStyles } from '../styles/components';
 import type { FormRecord, Locale, OtpTemplateRecord } from '../types';
 import { fetchForms, fetchLocales, fetchOtpTemplates, updateLocales, setDefaultLocale } from '../utils/central-api';
+import './content-header';
 import './error-card';
 import './loading-cards';
+import './nav-toggle';
 
 // ISO 639-1 language codes; display names are resolved at runtime via Intl.DisplayNames.
 const LANGUAGE_CODES = [
@@ -295,7 +297,10 @@ export class VersolaLocalesList extends LitElement {
     const canAdd = !!this.newCode;
     return html`
       <div class="page-header">
-        <h1 class="page-title">Edit Locales</h1>
+        <div class="form-header-lead">
+          <versola-nav-toggle></versola-nav-toggle>
+          <h1 class="page-title">Edit Locales</h1>
+        </div>
       </div>
       <div class="card">
         ${this.draftLocales.length === 0
@@ -364,10 +369,9 @@ export class VersolaLocalesList extends LitElement {
     if (this.editing) return html`${this.renderEdit()}`;
 
     return html`
-      <div class="page-header">
-        <h1 class="page-title">Locales</h1>
-        ${this.canManage ? html`<button class="btn btn-secondary" @click=${() => this.startEdit()}>Edit</button>` : ''}
-      </div>
+      <content-header title="Locales">
+        ${this.canManage ? html`<button slot="actions" class="btn btn-secondary" @click=${() => this.startEdit()}>Edit</button>` : ''}
+      </content-header>
 
       ${this.isLoading ? html`<versola-loading-cards .count=${3}></versola-loading-cards>`
         : this.errorMessage ? html`

--- a/central-ui/src/components/nav-toggle.ts
+++ b/central-ui/src/components/nav-toggle.ts
@@ -1,0 +1,75 @@
+import { LitElement, html, css } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import { theme } from '../styles/theme';
+
+/** The mobile drawer's "open" button, rendered inline with a screen's title.
+  *
+  * Deliberately stateless: it only ever opens the drawer, so it needs no
+  * knowledge of whether the drawer is currently open. Closing is handled from
+  * inside the drawer (its own ✕), by the backdrop, and by Escape — all owned by
+  * admin-app. That keeps this usable from any header on any screen without
+  * threading drawer state down through a dozen components.
+  *
+  * Hidden above the 768px breakpoint, where the sidebar is always visible and
+  * there is nothing to open.
+  */
+@customElement('versola-nav-toggle')
+export class VersolaNavToggle extends LitElement {
+  static styles = [
+    theme,
+    css`
+      :host {
+        display: none;
+      }
+
+      @media (max-width: 768px) {
+        :host {
+          display: block;
+          flex: none;
+        }
+      }
+
+      button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 2.75rem;
+        height: 2.75rem;
+        padding: 0;
+        border: 1px solid var(--border-dark);
+        border-radius: var(--radius-md);
+        background: var(--bg-dark-card);
+        color: var(--text-primary);
+        font-family: var(--font-family);
+        font-size: 1.25rem;
+        line-height: 1;
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
+
+      button:hover {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+    `,
+  ];
+
+  private open() {
+    this.dispatchEvent(new CustomEvent('open-nav', {
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
+  render() {
+    return html`
+      <button type="button" @click=${this.open} aria-label="Open navigation menu">☰</button>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'versola-nav-toggle': VersolaNavToggle;
+  }
+}

--- a/central-ui/src/components/navigation.ts
+++ b/central-ui/src/components/navigation.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, css } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, query } from 'lit/decorators.js';
 import { theme } from '../styles/theme';
 import './versola-logo';
 import './tenant-selector';
@@ -14,6 +14,21 @@ export class VersolaNavigation extends LitElement {
   @property({ attribute: false }) allowedTenantIds: string[] | null = null;
   /** Mobile drawer state. Reflected so the `:host([open])` rule below can match. */
   @property({ type: Boolean, reflect: true }) open = false;
+  @query('.brand-close') private closeButton?: HTMLButtonElement;
+
+  /** Called by admin-app right after opening the drawer.
+    *
+    * Without this, focus stays on the header toggle the user just activated —
+    * which the backdrop then visually covers, since it renders in normal
+    * document flow inside <main>, after the drawer in DOM order. A keyboard
+    * user pressing Tab from there continues through the rest of main's
+    * (now-obscured) content instead of landing in the panel that just opened.
+    * Landing on the drawer's own close button puts them somewhere real and
+    * gives an immediate, obvious way back out.
+    */
+  focusClose() {
+    this.closeButton?.focus();
+  }
 
   static styles = [
     theme,
@@ -88,6 +103,42 @@ export class VersolaNavigation extends LitElement {
         text-decoration: none;
       }
 
+      /* The drawer's own close button. Lives here, inside the panel, rather
+         than as an overlay pinned to the viewport: laid out as a sibling of the
+         logo it can't cover it, and it slides away with the panel instead of
+         lingering over the page. Only meaningful on mobile, where the panel is
+         a drawer that can be closed at all. */
+      .brand-close {
+        display: none;
+      }
+
+      @media (max-width: 768px) {
+        .brand-close {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          flex: none;
+          margin-left: auto;
+          width: 2.25rem;
+          height: 2.25rem;
+          padding: 0;
+          border: 1px solid var(--border-dark);
+          border-radius: var(--radius-md);
+          background: transparent;
+          color: var(--text-secondary);
+          font-family: var(--font-family);
+          font-size: 1.125rem;
+          line-height: 1;
+          cursor: pointer;
+          transition: all var(--transition-fast);
+        }
+
+        .brand-close:hover {
+          border-color: var(--accent);
+          color: var(--accent);
+        }
+      }
+
       .brand-logo {
         flex-shrink: 0;
         line-height: 0;
@@ -156,6 +207,13 @@ export class VersolaNavigation extends LitElement {
     `,
   ];
 
+  private handleCloseClick() {
+    this.dispatchEvent(new CustomEvent('close-nav', {
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
   private handleNavClick(item: NavItem) {
     this.dispatchEvent(new CustomEvent('nav-change', {
       detail: { item },
@@ -212,6 +270,12 @@ export class VersolaNavigation extends LitElement {
           <versola-logo size="40"></versola-logo>
         </div>
         <div class="brand-name">Versola</div>
+        <button
+          type="button"
+          class="brand-close"
+          @click=${this.handleCloseClick}
+          aria-label="Close navigation menu"
+        >✕</button>
       </div>
 
       <div class="tenant-section">

--- a/central-ui/src/components/permission-form.ts
+++ b/central-ui/src/components/permission-form.ts
@@ -5,6 +5,7 @@ import { theme } from '../styles/theme';
 import type { Permission, Resource, ResourceEndpointId } from '../types';
 import { formatResourceLabel, getLocalizedDescription } from '../utils/helpers';
 import { validatePermission } from '../utils/validators';
+import './nav-toggle';
 
 @customElement('versola-permission-form')
 export class VersolaPermissionForm extends LitElement {
@@ -54,7 +55,6 @@ export class VersolaPermissionForm extends LitElement {
     .endpoint-row { display:flex; align-items:center; justify-content:space-between; gap:.75rem; flex-wrap:wrap; padding:.875rem 1rem; border:1px solid var(--border-dark); border-radius:var(--radius-md); background:rgba(255,255,255,.02); }
     .endpoint-main { display:flex; align-items:center; gap:.75rem; flex-wrap:wrap; min-width:0; }
     .endpoint-meta { color:var(--text-secondary); font-size:.875rem; }
-    .endpoint-path { font-family:var(--font-mono, monospace); color:var(--text-primary); word-break:break-all; }
     .empty-state, .hint-note { color:var(--text-secondary); font-size:.875rem; }
     .actions { display:flex; gap:1rem; justify-content:flex-end; margin-top:var(--spacing-xl); padding-top:var(--spacing-xl); border-top:1px solid var(--border-dark); }
     @media (max-width: 720px) {
@@ -202,9 +202,12 @@ export class VersolaPermissionForm extends LitElement {
   render() {
     return html`
       <div class="form-header">
-        <div class="title-stack">
-          <h1 class="form-title">${this.mode === 'create' ? 'Create Permission' : 'Edit Permission'}</h1>
-          ${this.mode === 'edit' ? html`<div class="entity-id-meta">${this.permissionId || '—'}</div>` : ''}
+        <div class="form-header-lead">
+          <versola-nav-toggle></versola-nav-toggle>
+          <div class="title-stack">
+            <h1 class="form-title">${this.mode === 'create' ? 'Create Permission' : 'Edit Permission'}</h1>
+            ${this.mode === 'edit' ? html`<div class="entity-id-meta">${this.permissionId || '—'}</div>` : ''}
+          </div>
         </div>
       </div>
       <div class="card">

--- a/central-ui/src/components/permissions-list.ts
+++ b/central-ui/src/components/permissions-list.ts
@@ -59,10 +59,14 @@ export class VersolaPermissionsList extends LitElement {
     .endpoint-list { display:grid; gap:.75rem; }
     .endpoint-row { display:flex; align-items:center; justify-content:space-between; gap:.75rem; flex-wrap:wrap; padding:.875rem 1rem; border:1px solid var(--border-dark); border-radius:var(--radius-md); background:rgba(255,255,255,.02); }
     .endpoint-main { display:flex; align-items:center; gap:.75rem; flex-wrap:wrap; min-width:0; }
-    .endpoint-path { font-family:var(--font-mono, monospace); color:var(--text-primary); word-break:break-all; }
     @media (max-width: 720px) {
-      .permission-header { flex-direction:column; }
-      .permission-actions { width:100%; }
+      /* align-items:center is inherited from the base rule, where it vertically
+         centres title against actions in a row. Once the flow turns to a
+         column it centres them *horizontally* instead, which left the title
+         centred while .permission-actions — being full-width — kept its
+         buttons packed to the left. Both now start at the same left edge. */
+      .permission-header { flex-direction:column; align-items:flex-start; }
+      .permission-actions { width:100%; margin-left:0; }
     }
   `];
 

--- a/central-ui/src/components/resources-list.ts
+++ b/central-ui/src/components/resources-list.ts
@@ -14,6 +14,7 @@ import './cel-editor';
 import './content-header';
 import './error-card';
 import './loading-cards';
+import './nav-toggle';
 
 type ResourceEndpointDraft = {
   method: string;
@@ -109,7 +110,6 @@ export class VersolaResourcesList extends LitElement {
     .endpoint-row { display:flex; align-items:center; justify-content:space-between; gap:.75rem; flex-wrap:wrap; padding:.875rem 1rem; border:1px solid var(--border-dark); border-radius:var(--radius-md); background:rgba(255,255,255,.02); }
     .endpoint-main { display:flex; align-items:center; gap:.75rem; flex-wrap:wrap; min-width:0; }
     .endpoint-actions { display:flex; align-items:center; gap:.5rem; margin-left:auto; }
-    .endpoint-path { font-family:var(--font-mono, monospace); color:var(--text-primary); word-break:break-all; }
     .endpoint-card { display:grid; gap:.75rem; padding:.875rem 1rem; border:1px solid var(--border-dark); border-radius:var(--radius-md); background:rgba(255,255,255,.02); cursor:pointer; transition:border-color var(--transition-base), background var(--transition-base); }
     .endpoint-card:hover { border-color:var(--accent); background:rgba(255,255,255,.03); }
     .endpoint-card-header { display:flex; align-items:center; justify-content:space-between; gap:.75rem; flex-wrap:wrap; }
@@ -247,8 +247,15 @@ export class VersolaResourcesList extends LitElement {
       padding: var(--spacing-xs) var(--spacing-md);
     }
     @media (max-width: 720px) {
-      .resource-header { flex-direction:column; }
-      .resource-actions, .form-actions, .section-header, .sub-actions { flex-direction:column; align-items:flex-start; }
+      /* Same inherited-align-items trap as permissions-list: in a column,
+         align-items:center centres the label horizontally instead of
+         vertically. */
+      .resource-header { flex-direction:column; align-items:flex-start; }
+      /* .resource-actions is deliberately NOT in the stacking list below: it
+         holds two icon buttons that belong side by side. Stacking them turned
+         a compact ✎ ✕ pair into a vertical column. */
+      .resource-actions { margin-left:0; }
+      .form-actions, .section-header, .sub-actions { flex-direction:column; align-items:flex-start; }
       .endpoint-editor-grid { grid-template-columns:minmax(0, var(--compact-field-width)); }
       .rule-editor-main, .rule-editor-pattern, .header-editor-item { grid-template-columns:minmax(0, 1fr); }
     }
@@ -1019,9 +1026,12 @@ export class VersolaResourcesList extends LitElement {
 
     return html`
       <div class="form-header">
-        <div class="title-stack">
-          <h1 class="form-title">${title}</h1>
-          ${isEditResource ? html`<div class="entity-id-meta">${this.resourceUri || '—'}</div>` : ''}
+        <div class="form-header-lead">
+          <versola-nav-toggle></versola-nav-toggle>
+          <div class="title-stack">
+            <h1 class="form-title">${title}</h1>
+            ${isEditResource ? html`<div class="entity-id-meta">${this.resourceUri || '—'}</div>` : ''}
+          </div>
         </div>
       </div>
       <div class="card">

--- a/central-ui/src/components/role-form.ts
+++ b/central-ui/src/components/role-form.ts
@@ -4,6 +4,7 @@ import { theme } from '../styles/theme';
 import { buttonStyles, cardStyles, formStyles } from '../styles/components';
 import { Role, Permission, Resource } from '../types';
 import './permission-info';
+import './nav-toggle';
 import { validateRoleId } from '../utils/validators';
 
 @customElement('versola-role-form')
@@ -221,11 +222,14 @@ export class VersolaRoleForm extends LitElement {
 
     return html`
       <div class="form-header">
-        <div class="title-stack">
-          <h1 class="form-title">
-            ${this.roleData ? 'Edit Role' : 'Create New Role'}
-          </h1>
-          ${this.roleData ? html`<div class="entity-id-meta">${this.formData.id || '—'}</div>` : ''}
+        <div class="form-header-lead">
+          <versola-nav-toggle></versola-nav-toggle>
+          <div class="title-stack">
+            <h1 class="form-title">
+              ${this.roleData ? 'Edit Role' : 'Create New Role'}
+            </h1>
+            ${this.roleData ? html`<div class="entity-id-meta">${this.formData.id || '—'}</div>` : ''}
+          </div>
         </div>
       </div>
 

--- a/central-ui/src/components/scope-form.ts
+++ b/central-ui/src/components/scope-form.ts
@@ -4,6 +4,7 @@ import { theme } from '../styles/theme';
 import { buttonStyles, cardStyles, formStyles, iconActionStyles } from '../styles/components';
 import { OAuthScope, OAuthClaim } from '../types';
 import { validateScopeId } from '../utils/validators';
+import './nav-toggle';
 
 @customElement('versola-scope-form')
 export class VersolaScopeForm extends LitElement {
@@ -213,11 +214,14 @@ export class VersolaScopeForm extends LitElement {
   render() {
     return html`
       <div class="form-header">
-        <div class="title-stack">
-          <h1 class="form-title">
-            ${this.scope ? 'Edit Scope' : 'Create New Scope'}
-          </h1>
-          ${this.scope ? html`<div class="entity-id-meta">${this.formData.id || '—'}</div>` : ''}
+        <div class="form-header-lead">
+          <versola-nav-toggle></versola-nav-toggle>
+          <div class="title-stack">
+            <h1 class="form-title">
+              ${this.scope ? 'Edit Scope' : 'Create New Scope'}
+            </h1>
+            ${this.scope ? html`<div class="entity-id-meta">${this.formData.id || '—'}</div>` : ''}
+          </div>
         </div>
       </div>
 

--- a/central-ui/src/components/system-settings.ts
+++ b/central-ui/src/components/system-settings.ts
@@ -4,6 +4,7 @@ import { theme } from '../styles/theme';
 import { buttonStyles, cardStyles, formStyles } from '../styles/components';
 import type { SystemSettingsRecord } from '../types';
 import { fetchSystemSettings, upsertSystemSettings } from '../utils/central-api';
+import './content-header';
 import './error-card';
 import './loading-cards';
 
@@ -33,19 +34,6 @@ export class VersolaSystemSettings extends LitElement {
         --compact-field-max-width: 22.8rem;
         --number-field-max-width: 8rem;
       }
-      .page-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        margin-bottom: var(--spacing-xl);
-      }
-      .page-title {
-        font-size: 1.625rem;
-        font-weight: 700;
-        letter-spacing: -0.025em;
-        color: var(--text-primary);
-        margin: 0;
-      }
       .prop-row {
         display: flex;
         gap: var(--spacing-md);
@@ -58,7 +46,23 @@ export class VersolaSystemSettings extends LitElement {
         color: var(--text-secondary);
         font-size: 0.875rem;
       }
-      .prop-value { color: var(--text-primary); font-size: 0.875rem; }
+      .prop-value {
+        color: var(--text-primary);
+        font-size: 0.875rem;
+        /* The password regex is a long unbroken string; without this it runs
+           past the card edge instead of wrapping. */
+        min-width: 0;
+        overflow-wrap: anywhere;
+      }
+      /* A fixed 220px label column leaves ~100px for the value on a phone.
+         Below this width the label sits above its value instead. */
+      @media (max-width: 720px) {
+        .prop-row {
+          flex-direction: column;
+          gap: var(--spacing-xs);
+        }
+        .prop-label { flex: none; }
+      }
       .form-grid { display: grid; gap: var(--spacing-lg); }
       .number-input {
         display: block;
@@ -130,12 +134,11 @@ export class VersolaSystemSettings extends LitElement {
 
   render() {
     return html`
-      <div class="page-header">
-        <h1 class="page-title">System Settings</h1>
+      <content-header title="System Settings">
         ${this.canManage && !this.editing && this.settings !== null
-          ? html`<button class="btn btn-primary" @click=${() => this.startEdit()}>Edit</button>`
+          ? html`<button slot="actions" class="btn btn-primary" @click=${() => this.startEdit()}>Edit</button>`
           : ''}
-      </div>
+      </content-header>
 
       ${this.errorMessage ? html`<versola-error-card .message=${this.errorMessage}></versola-error-card>` : ''}
       ${this.isLoading ? html`<versola-loading-cards></versola-loading-cards>` : ''}

--- a/central-ui/src/components/theme-edit.ts
+++ b/central-ui/src/components/theme-edit.ts
@@ -5,6 +5,7 @@ import { buttonStyles, cardStyles, formStyles } from '../styles/components';
 import type { ThemeRecord } from '../types';
 import { createTheme, updateTheme, deleteTheme } from '../utils/central-api';
 import './code-editor';
+import './nav-toggle';
 
 @customElement('versola-theme-edit')
 export class VersolaThemeEdit extends LitElement {
@@ -94,7 +95,10 @@ export class VersolaThemeEdit extends LitElement {
     const canSave = this.editId.trim().length > 0;
     return html`
       <div class="title-stack" style="margin-bottom: var(--spacing-lg)">
-        <h1 class="form-title">${isNew ? 'New Theme' : 'Edit Theme'}</h1>
+        <div class="form-header-lead">
+          <versola-nav-toggle></versola-nav-toggle>
+          <h1 class="form-title">${isNew ? 'New Theme' : 'Edit Theme'}</h1>
+        </div>
         ${isNew ? html`
           <div>
             <label class="field-label">Theme ID</label>

--- a/central-ui/src/components/user-form.ts
+++ b/central-ui/src/components/user-form.ts
@@ -5,6 +5,7 @@ import { theme } from '../styles/theme';
 import { buttonStyles, cardStyles, formStyles } from '../styles/components';
 import { Resource, Role, User, UserRoleAssignment } from '../types';
 import { resolvePermissionEndpointGroups } from '../utils/helpers';
+import './nav-toggle';
 
 @customElement('versola-user-form')
 export class VersolaUserForm extends LitElement {
@@ -170,8 +171,12 @@ export class VersolaUserForm extends LitElement {
         min-width: 3.5rem;
       }
 
+      /* Local to this screen (it truncates rather than wraps), but the missing
+         font-size was the same oversight as the shared .endpoint-path: without
+         it the path rendered at the browser default and got clipped sooner. */
       .endpoint-path {
         font-family: var(--font-mono);
+        font-size: 0.8125rem;
         color: var(--text-secondary);
         overflow: hidden;
         text-overflow: ellipsis;
@@ -469,9 +474,12 @@ export class VersolaUserForm extends LitElement {
 
     return html`
       <div class="form-header">
-        <div class="title-stack">
-          <h1 class="form-title">${title}</h1>
-          ${this.userData ? html`<div class="entity-id-meta">${this.formData.id}</div>` : ''}
+        <div class="form-header-lead">
+          <versola-nav-toggle></versola-nav-toggle>
+          <div class="title-stack">
+            <h1 class="form-title">${title}</h1>
+            ${this.userData ? html`<div class="entity-id-meta">${this.formData.id}</div>` : ''}
+          </div>
         </div>
       </div>
 

--- a/central-ui/src/styles/components.ts
+++ b/central-ui/src/styles/components.ts
@@ -228,6 +228,18 @@ export const formStyles = css`
     min-width: 0;
   }
 
+  /* Keeps the mobile drawer toggle grouped with a form's title.
+     .form-header rows are justify-content: space-between, so without this
+     wrapper the toggle and the title would be pushed to opposite ends.
+     The toggle is display:none above the breakpoint, which collapses this
+     back to a plain title on desktop. */
+  .form-header-lead {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
+    min-width: 0;
+  }
+
   .compact-input {
     display: block;
     width: 100%;
@@ -377,7 +389,20 @@ export const formStyles = css`
   }
 `;
 
+/** Endpoint method badge + path, as shown in permission and resource cards. */
 export const methodBadgeStyles = css`
+  /* Previously declared inline in permissions-list, permission-form and
+     resources-list, none of which set a size — so paths rendered at the
+     browser's default 16px while the rest of the UI sits at 0.875rem. The
+     oversized text pushed long paths (/configuration/edges/rotate-key) onto a
+     second line and shoved the row's remove button down with it. */
+  .endpoint-path {
+    font-family: var(--font-mono, monospace);
+    font-size: 0.8125rem;
+    color: var(--text-primary);
+    word-break: break-all;
+  }
+
   .method-badge {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
Move the drawer toggle out of a fixed-position overlay and into page
headers, so it no longer covers content the page is scrolled to. The
drawer's close button moves inside the panel, next to the logo, where it
can no longer overlap the brand.

Add the toggle to full-page form states and the access-denied state,
which render their own headers instead of content-header and would
otherwise leave the drawer unreachable. Retrofit content-header onto
locales, challenges and system settings, per UI_STYLE_GUIDE.

Also fix, on narrow screens:
- card headers centring their title while action buttons stayed left,
  from align-items inherited into a column layout (permissions,
  resources)
- resource action icons stacking vertically instead of staying a row
- edge card headers having no narrow-screen rule at all
- endpoint paths rendering at the browser default size, wrapping rows
  and pushing remove buttons onto a second line
- passkey origins and the password regex overflowing their cards
- the edit-edge card showing a divider above an otherwise empty body"