### PR TITLE
feat: add support for RFC 8414 server metadata and well-known endpoints

### DIFF
--- a/auth/implementations/postgres/src/main/scala/versola/PostgresOAuthApp.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/PostgresOAuthApp.scala
@@ -17,6 +17,7 @@ import versola.oauth.revoke.{AccessTokenRevocationService, RevocationController,
 import versola.oauth.session.{PostgresSessionRepository, SessionRepository, SessionService}
 import versola.oauth.token.{AuthorizationCodeRepository, OAuthTokenService, TokenEndpointController}
 import versola.oauth.userinfo.{UserInfoController, UserInfoService}
+import versola.oauth.metadata.{MetadataController, MetadataSyncClient}
 import versola.user.{PostgresUserRepository, PostgresUserRolesRepository, UserController, UserRepository, UserRolesRepository}
 import versola.util.*
 import versola.util.http.VersolaApp
@@ -79,6 +80,7 @@ object PostgresOAuthApp extends VersolaApp("auth"):
       ConversationController.routes,
       UserInfoController.routes,
       JwksController.routes,
+      MetadataController.routes,
       UserController.routes,
       ServiceController.routes,
     ).reduce(_ ++ _)
@@ -103,6 +105,7 @@ object PostgresOAuthApp extends VersolaApp("auth"):
       OAuthConfigurationService.live(Schedule.spaced(1.minute)) >+>
       CentralSyncTokenService.live >+>
       JwksSyncClient.live >+>
+      MetadataSyncClient.live >+>
       JwksService.live(Schedule.spaced(1.minute)) >+>
       AuthPropertyGenerator.live >+>
       SessionService.live >+>

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/PostgresConversationRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/PostgresConversationRepository.scala
@@ -14,6 +14,7 @@ import versola.util.postgres.BasicCodecs
 import versola.util.{Email, Phone}
 import zio.http.URL
 import zio.json.*
+import zio.json.ast.Json
 import zio.prelude.NonEmptySet
 import zio.{Clock, Duration, Task, ZLayer}
 
@@ -50,7 +51,7 @@ class PostgresConversationRepository(xa: TransactorZIO) extends ConversationRepo
   given DbCodec[Instant] = DbCodec.InstantCodec
   given DbCodec[ConversationStep] = jsonCodec[ConversationStep]
   given DbCodec[RequestedClaims] = jsonCodec[RequestedClaims]
-  given DbCodec[zio.json.ast.Json.Obj] = jsonCodec[zio.json.ast.Json.Obj]
+  given DbCodec[Json.Obj] = jsonCodec[Json.Obj]
   given DbCodec[AuthFlow] = jsonBCodec[AuthFlow]
   given DbCodec[ResponseTypeEntry] = DbCodec.StringCodec.biMap(ResponseTypeEntry.valueOf, _.toString)
   given DbCodec[NonEmptySet[ResponseTypeEntry]] = DbCodec.StringCodec.biMap(

--- a/auth/src/main/scala/versola/oauth/client/CentralSyncTokenService.scala
+++ b/auth/src/main/scala/versola/oauth/client/CentralSyncTokenService.scala
@@ -2,6 +2,7 @@ package versola.oauth.client
 
 import versola.util.{CacheSource, CoreConfig, JWT, ReloadingCache}
 import zio.http.{Client, Header, Request, Response, Status}
+import zio.json.ast.Json
 import zio.{Schedule, Scope, Task, UIO, ZIO, ZLayer, durationInt}
 
 trait CentralSyncTokenService:
@@ -23,7 +24,7 @@ object CentralSyncTokenService:
         issuer = "auth",
         subject = "auth",
         audience = List("central"),
-        custom = zio.json.ast.Json.Obj(),
+        custom = Json.Obj(),
       ),
       ttl = TokenTtl,
       signature = JWT.Signature.Symmetric(config.central.secretKey),

--- a/auth/src/main/scala/versola/oauth/client/OAuthConfigurationService.scala
+++ b/auth/src/main/scala/versola/oauth/client/OAuthConfigurationService.scala
@@ -2,8 +2,10 @@ package versola.oauth.client
 
 import versola.oauth.client.model.{Acr, ChallengeSettingsRecord, ClientId, ClientSecret, FormRecord, Locales, OAuthClientRecord, OtpSettings, OtpTemplateRecord, PassedAuthFactor, PasskeySettings, PasswordHistorySettings, ScopeRecord, ScopeToken, SubmissionLimits, SystemSettingsRecord, TenantId, ThemeRecord}
 import versola.oauth.conversation.otp.model.OtpTemplate
+import versola.oauth.metadata.{MetadataSyncClient, ServerMetadataRecord}
 import versola.util.{CoreConfig, ReloadingCache, Secret, SecureRandom, SecurityService}
 import zio.*
+import zio.json.ast.Json
 import zio.http.Client
 import zio.prelude.{EqualOps, NonEmptyList, NonEmptySet}
 
@@ -49,6 +51,8 @@ trait OAuthConfigurationService:
 
   def getSessionIdleTtl(id: ClientId): UIO[Option[Duration]]
 
+  def getMetadata: UIO[Option[Json.Obj]]
+
   def syncConfiguration: Task[Unit]
 
 object OAuthConfigurationService:
@@ -66,8 +70,9 @@ object OAuthConfigurationService:
           (LocaleSyncClient.live >+> ZLayer(ReloadingCache.make[Locales](schedule))) >+>
           (OtpTemplateSyncClient.live >+> ZLayer(ReloadingCache.make[Vector[OtpTemplateRecord]](schedule))) >+>
           (ChallengeSettingsSyncClient.live >+> ZLayer(ReloadingCache.make[Vector[ChallengeSettingsRecord]](schedule))) >+>
-          (SystemSettingsSyncClient.live >+> ZLayer(ReloadingCache.make[SystemSettingsRecord](schedule)))))
-    syncClients >>> ZLayer.fromFunction(Impl(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _))
+          (SystemSettingsSyncClient.live >+> ZLayer(ReloadingCache.make[SystemSettingsRecord](schedule))) >+>
+          (MetadataSyncClient.live >+> ZLayer(ReloadingCache.make[Option[Json.Obj]](schedule)))))
+    syncClients >>> ZLayer.fromFunction(Impl(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _))
   }
 
   case class Impl(
@@ -87,6 +92,8 @@ object OAuthConfigurationService:
       challengeSettingsRepository: ChallengeSettingsSyncClient,
       systemSettingsCache: ReloadingCache[SystemSettingsRecord],
       systemSettingsRepository: SystemSettingsSyncClient,
+      metadataCache: ReloadingCache[Option[Json.Obj]],
+      metadataRepository: MetadataSyncClient,
   ) extends OAuthConfigurationService:
 
     def find(id: ClientId): UIO[Option[OAuthClientRecord]] =
@@ -262,6 +269,9 @@ object OAuthConfigurationService:
               .flatMap { case (k, vs) => NonEmptyList.fromIterableOption(vs).map(Acr(k) -> _) },
           )
 
+    override def getMetadata: UIO[Option[Json.Obj]] =
+      metadataCache.get
+
     override def syncConfiguration: Task[Unit] =
       for
         clients           <- clientRepository.getAll
@@ -280,6 +290,8 @@ object OAuthConfigurationService:
         _                 <- challengeSettingsCache.set(challengeSettings)
         systemSettings    <- systemSettingsRepository.getAll
         _                 <- systemSettingsCache.set(systemSettings)
+        metadata          <- metadataRepository.getAll
+        _                 <- metadataCache.set(metadata)
       yield ()
 
     private val IllegalStateTemplate = OtpTemplate("{{code}}")

--- a/auth/src/main/scala/versola/oauth/conversation/ConversationRenderService.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationRenderService.scala
@@ -128,7 +128,7 @@ object ConversationRenderService:
                 for
                   signingKey <- jwksService.getPublicKeys.map(_.active)
                   cHash = JWT.leftHalfHash(encodedCode, signingKey.algorithm)
-                  dataWithCHash = data.copy(claims = data.claims + ("c_hash" -> zio.json.ast.Json.Str(cHash)))
+                  dataWithCHash = data.copy(claims = data.claims + ("c_hash" -> Json.Str(cHash)))
                   token <- serializeIdToken(dataWithCHash, signingKey)
                 yield Some(token)
               case None => ZIO.none

--- a/auth/src/main/scala/versola/oauth/conversation/ConversationService.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationService.scala
@@ -690,7 +690,7 @@ object ConversationService:
                 else
                   val displayName: String =
                     conversation.userClaims.flatMap(_.fields.toMap.get("name"))
-                      .collect { case zio.json.ast.Json.Str(v) => v }
+                      .collect { case Json.Str(v) => v }
                       .orElse(conversation.userEmail.map(_.toString))
                       .orElse(conversation.userPhone.map(_.toString))
                       .orElse(conversation.userLogin.map(_.toString))

--- a/auth/src/main/scala/versola/oauth/metadata/MetadataController.scala
+++ b/auth/src/main/scala/versola/oauth/metadata/MetadataController.scala
@@ -1,0 +1,33 @@
+package versola.oauth.metadata
+
+import versola.oauth.client.OAuthConfigurationService
+import versola.util.http.Controller
+import zio.*
+import zio.http.*
+import zio.json.*
+
+object MetadataController extends Controller:
+  val routes: Routes[OAuthConfigurationService, Throwable] = Routes(
+    oauthMetadataEndpoint,
+    oidcMetadataEndpoint,
+  )
+
+  private val oauthMetadataEndpoint =
+    Method.GET / ".well-known" / "oauth-authorization-server" -> handler { (request: Request) =>
+      for
+        service <- ZIO.service[OAuthConfigurationService]
+        metadata <- service.getMetadata
+      yield metadata match
+        case Some(json) => Response.json(json.toJson)
+        case None       => Response.status(Status.NotFound)
+    }
+
+  private val oidcMetadataEndpoint =
+    Method.GET / ".well-known" / "openid-configuration" -> handler { (request: Request) =>
+      for
+        service <- ZIO.service[OAuthConfigurationService]
+        metadata <- service.getMetadata
+      yield metadata match
+        case Some(json) => Response.json(json.toJson)
+        case None       => Response.status(Status.NotFound)
+    }

--- a/auth/src/main/scala/versola/oauth/metadata/MetadataController.scala
+++ b/auth/src/main/scala/versola/oauth/metadata/MetadataController.scala
@@ -7,7 +7,9 @@ import zio.http.*
 import zio.json.*
 
 object MetadataController extends Controller:
-  val routes: Routes[OAuthConfigurationService, Throwable] = Routes(
+  type Env = OAuthConfigurationService
+
+  def routes: Routes[Env, Throwable] = Routes(
     oauthMetadataEndpoint,
     oidcMetadataEndpoint,
   )

--- a/auth/src/main/scala/versola/oauth/metadata/MetadataSyncClient.scala
+++ b/auth/src/main/scala/versola/oauth/metadata/MetadataSyncClient.scala
@@ -1,0 +1,26 @@
+package versola.oauth.metadata
+
+import versola.oauth.client.CentralSyncTokenService
+import versola.util.{CacheSource, CoreConfig}
+import zio.http.Request
+import zio.json.DecoderOps
+import zio.json.ast.Json
+import zio.{Task, URLayer, ZIO, ZLayer}
+
+trait MetadataSyncClient extends CacheSource[Option[Json.Obj]]
+
+object MetadataSyncClient:
+  val live: URLayer[CoreConfig & CentralSyncTokenService, MetadataSyncClient] =
+    ZLayer.fromFunction(Impl(_, _))
+
+  class Impl(
+      config: CoreConfig,
+      centralSyncTokenService: CentralSyncTokenService,
+  ) extends MetadataSyncClient:
+    private val MetadataSyncURL = config.central.url / "configuration" / "server-metadata" / "sync"
+
+    override def getAll: Task[Option[Json.Obj]] =
+      ZIO.scoped:
+        centralSyncTokenService.syncRequest(Request.get(MetadataSyncURL))
+          .flatMap(_.body.asJsonFromCodec[Json.Obj])
+          .map(Some(_))

--- a/auth/src/main/scala/versola/oauth/metadata/ServerMetadataRecord.scala
+++ b/auth/src/main/scala/versola/oauth/metadata/ServerMetadataRecord.scala
@@ -1,0 +1,10 @@
+package versola.oauth.metadata
+
+import zio.json.ast.Json
+import zio.json.{JsonCodec, JsonDecoder, JsonEncoder}
+import zio.schema.{Schema, derived}
+
+case class ServerMetadataRecord(
+    id: String,
+    metadata: Json.Obj,
+) derives Schema, JsonCodec

--- a/central-ui/src/components/admin-app.ts
+++ b/central-ui/src/components/admin-app.ts
@@ -22,7 +22,7 @@ import './users-list';
 import './forms-list';
 import './locales-list';
 import './challenges-list';
-import './jwks-list';
+import './well-known';
 import './system-settings';
 
 
@@ -252,7 +252,7 @@ export class VersolaAdmin extends LitElement {
         return p.has('tenants:read');
       case 'edges':
         return p.has('edges:read');
-      case 'jwks':
+      case 'well-known':
         return p.has('jwks:read');
       case 'clients':
       case 'scopes':
@@ -284,7 +284,7 @@ export class VersolaAdmin extends LitElement {
         return p.has('tenants:manage');
       case 'edges':
         return p.has('edges:manage');
-      case 'jwks':
+      case 'well-known':
         return p.has('jwks:manage');
       case 'clients':
       case 'scopes':
@@ -405,7 +405,7 @@ export class VersolaAdmin extends LitElement {
     const expandClient = params.get('expandClient');
     const expandEdge = params.get('expandEdge');
 
-    if (urlView === 'clients' || urlView === 'scopes' || urlView === 'permissions' || urlView === 'resources' || urlView === 'roles' || urlView === 'tenants' || urlView === 'edges' || urlView === 'users' || urlView === 'forms' || urlView === 'locales' || urlView === 'challenges' || urlView === 'jwks' || urlView === 'system-settings') {
+    if (urlView === 'clients' || urlView === 'scopes' || urlView === 'permissions' || urlView === 'resources' || urlView === 'roles' || urlView === 'tenants' || urlView === 'edges' || urlView === 'users' || urlView === 'forms' || urlView === 'locales' || urlView === 'challenges' || urlView === 'well-known' || urlView === 'system-settings') {
       this.currentView = urlView;
     }
 
@@ -495,8 +495,8 @@ export class VersolaAdmin extends LitElement {
         return html`<versola-locales-list .tenantId=${this.currentTenantId} .canManage=${this.canManage('locales')}></versola-locales-list>`;
       case 'challenges':
         return html`<versola-challenges-list .tenantId=${this.currentTenantId} .canManage=${this.canManage('challenges')}></versola-challenges-list>`;
-      case 'jwks':
-        return html`<versola-jwks-list .canManage=${this.canManage('jwks')}></versola-jwks-list>`;
+      case 'well-known':
+        return html`<versola-well-known .canManage=${this.canManage('well-known')}></versola-well-known>`;
       case 'system-settings':
         return html`<versola-system-settings .canManage=${this.canManage('system-settings')}></versola-system-settings>`;
       default:

--- a/central-ui/src/components/navigation.ts
+++ b/central-ui/src/components/navigation.ts
@@ -4,7 +4,7 @@ import { theme } from '../styles/theme';
 import './versola-logo';
 import './tenant-selector';
 
-export type NavItem = 'clients' | 'scopes' | 'permissions' | 'resources' | 'roles' | 'tenants' | 'edges' | 'users' | 'forms' | 'locales' | 'challenges' | 'jwks' | 'system-settings';
+export type NavItem = 'clients' | 'scopes' | 'permissions' | 'resources' | 'roles' | 'tenants' | 'edges' | 'users' | 'forms' | 'locales' | 'challenges' | 'well-known' | 'system-settings';
 
 @customElement('versola-navigation')
 export class VersolaNavigation extends LitElement {
@@ -229,7 +229,7 @@ export class VersolaNavigation extends LitElement {
         return p.has('tenants:read');
       case 'edges':
         return p.has('edges:read');
-      case 'jwks':
+      case 'well-known':
         return p.has('jwks:read');
       case 'clients':
       case 'scopes':
@@ -300,7 +300,7 @@ export class VersolaNavigation extends LitElement {
           <div class="nav-section-title">Global</div>
           ${this.navItem('edges', 'Edges')}
           ${this.navItem('forms', 'Forms')}
-          ${this.navItem('jwks', 'JWKS')}
+          ${this.navItem('well-known', 'Well Known')}
           ${this.navItem('locales', 'Locales')}
           ${this.navItem('system-settings', 'System Settings')}
           ${this.navItem('tenants', 'Tenants')}

--- a/central-ui/src/components/well-known.ts
+++ b/central-ui/src/components/well-known.ts
@@ -2,19 +2,26 @@ import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { theme } from '../styles/theme';
 import { buttonStyles, cardStyles, formStyles } from '../styles/components';
-import { createJwk, deleteJwk, fetchJwks, updateJwk } from '../utils/central-api';
+import { fetchJwks, deleteJwk, createJwk, updateJwk, fetchServerMetadata, upsertServerMetadata } from '../utils/central-api';
 import { confirmDestructiveAction } from '../utils/confirm-dialog';
 import './content-header';
 import './error-card';
 import './loading-cards';
 
-@customElement('versola-jwks-list')
-export class VersolaJwksList extends LitElement {
+@customElement('versola-well-known')
+export class VersolaWellKnown extends LitElement {
   @property({ type: Boolean }) canManage = false;
 
   @state() private keys: Record<string, unknown>[] = [];
+  @state() private metadata: Record<string, unknown> | null = null;
   @state() private isLoading = false;
+  @state() private isLoadingMetadata = false;
   @state() private errorMessage = '';
+  @state() private metadataError = '';
+  @state() private metadataInput = '';
+  @state() private isSavingMetadata = false;
+  @state() private isEditingMetadata = false;
+
   @state() private formMode: 'add' | 'edit' | null = null;
   @state() private editingKid = '';
   @state() private jwkInput = '';
@@ -24,6 +31,7 @@ export class VersolaJwksList extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     void this.loadData();
+    void this.loadMetadata();
   }
 
   static styles = [
@@ -34,6 +42,38 @@ export class VersolaJwksList extends LitElement {
     css`
       :host {
         display: block;
+      }
+
+      .section-title {
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: var(--text-primary);
+        margin: var(--spacing-xl) 0 var(--spacing-lg) 0;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .metadata-card {
+        background: var(--bg-dark-card);
+        border: 1px solid var(--border-dark);
+        border-radius: var(--radius-lg);
+        padding: var(--spacing-lg);
+        margin-bottom: var(--spacing-xl);
+      }
+
+      .metadata-json {
+        background: var(--bg-dark);
+        border: 1px solid var(--border-dark);
+        border-radius: var(--radius-md);
+        padding: var(--spacing-md);
+        font-family: var(--font-mono);
+        font-size: 0.8125rem;
+        color: var(--text-secondary);
+        overflow-x: auto;
+        white-space: pre-wrap;
+        word-break: break-all;
+        margin: 0;
       }
 
       .key-card {
@@ -174,6 +214,50 @@ export class VersolaJwksList extends LitElement {
     }
   }
 
+  private async loadMetadata() {
+    this.isLoadingMetadata = true;
+    this.metadataError = '';
+    try {
+      this.metadata = await fetchServerMetadata();
+      this.metadataInput = JSON.stringify(this.metadata, null, 2);
+    } catch (err) {
+      this.metadataError = err instanceof Error ? err.message : 'Failed to load server metadata';
+    } finally {
+      this.isLoadingMetadata = false;
+    }
+  }
+
+  private handleEditMetadata() {
+    this.isEditingMetadata = true;
+    this.metadataInput = JSON.stringify(this.metadata, null, 2);
+  }
+
+  private handleCancelMetadata() {
+    this.isEditingMetadata = false;
+    this.metadataInput = JSON.stringify(this.metadata, null, 2);
+  }
+
+  private async handleSaveMetadata() {
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(this.metadataInput);
+    } catch {
+      alert('Invalid JSON in metadata');
+      return;
+    }
+
+    this.isSavingMetadata = true;
+    try {
+      await upsertServerMetadata(parsed);
+      this.metadata = parsed;
+      this.isEditingMetadata = false;
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to save metadata');
+    } finally {
+      this.isSavingMetadata = false;
+    }
+  }
+
   private handleAddClick() {
     this.formMode = 'add';
     this.editingKid = '';
@@ -251,7 +335,7 @@ export class VersolaJwksList extends LitElement {
     const isEdit = this.formMode === 'edit';
     return html`
       <div class="add-form-card">
-        <h3 class="add-form-title">${isEdit ? `Edit JWK · ${this.editingKid}` : 'Add JWK'}</h3>
+        <h3 class="add-form-title">\${isEdit ? \`Edit JWK · \${this.editingKid}\` : 'Add JWK'}</h3>
         <div class="form-group">
           <label class="form-label" for="jwk-input">JWK JSON</label>
           <textarea
@@ -259,19 +343,19 @@ export class VersolaJwksList extends LitElement {
             class="form-control"
             rows="10"
             placeholder='{"kid": "my-key-id", "kty": "RSA", "use": "sig", ...}'
-            .value=${this.jwkInput}
-            @input=${(e: Event) => { this.jwkInput = (e.target as HTMLTextAreaElement).value; }}
+            .value=\${this.jwkInput}
+            @input=\${(e: Event) => { this.jwkInput = (e.target as HTMLTextAreaElement).value; }}
           ></textarea>
-          ${isEdit ? html`<div class="form-hint">The 'kid' cannot be changed when editing.</div>` : ''}
-          ${this.formError ? html`<div class="add-error">${this.formError}</div>` : ''}
+          \${isEdit ? html\`<div class="form-hint">The 'kid' cannot be changed when editing.</div>\` : ''}
+          \${this.formError ? html\`<div class="add-error">\${this.formError}</div>\` : ''}
         </div>
         <div class="add-form-actions">
           <button
             class="btn btn-primary"
-            @click=${this.handleSubmitForm}
-            ?disabled=${this.isSubmitting}
-          >${this.isSubmitting ? 'Saving…' : isEdit ? 'Save Changes' : 'Add Key'}</button>
-          <button class="btn btn-secondary" @click=${this.handleCancelForm}>Cancel</button>
+            @click=\${this.handleSubmitForm}
+            ?disabled=\${this.isSubmitting}
+          >\${this.isSubmitting ? 'Saving…' : isEdit ? 'Save Changes' : 'Add Key'}</button>
+          <button class="btn btn-secondary" @click=\${this.handleCancelForm}>Cancel</button>
         </div>
       </div>
     `;
@@ -285,26 +369,26 @@ export class VersolaJwksList extends LitElement {
       <div class="key-card">
         <div class="key-header">
           <div class="key-header-info">
-            <span class="key-id">${kid}</span>
-            <span class="key-meta">${kty}${alg ? ` · ${alg}` : ''}</span>
+            <span class="key-id">\${kid}</span>
+            <span class="key-meta">\${kty}\${alg ? \` · \${alg}\` : ''}</span>
           </div>
-          ${this.canManage ? html`
+          \${this.canManage ? html\`
           <div class="key-actions">
             <button
               class="icon-action"
               title="Edit key"
-              aria-label="Edit key ${kid}"
-              @click=${() => this.handleEditClick(key)}
+              aria-label="Edit key \${kid}"
+              @click=\${() => this.handleEditClick(key)}
             >✎</button>
             <button
               class="icon-action danger"
               title="Delete key"
-              aria-label="Delete key ${kid}"
-              @click=${() => this.handleDeleteKey(kid)}
+              aria-label="Delete key \${kid}"
+              @click=\${() => this.handleDeleteKey(kid)}
             >✕</button>
-          </div>` : ''}
+          </div>\` : ''}
         </div>
-        <pre class="key-json">${JSON.stringify(key, null, 2)}</pre>
+        <pre class="key-json">\${JSON.stringify(key, null, 2)}</pre>
       </div>
     `;
   }
@@ -312,48 +396,89 @@ export class VersolaJwksList extends LitElement {
   render() {
     return html`
       <content-header
-        title="JWKS"
-        description="JSON Web Key Set served by this central instance"
-      >
-        ${this.canManage ? html`
-        <button slot="actions" class="btn btn-primary" @click=${this.handleAddClick}>
+        title="Well Known"
+        description="Public configuration and keys served by this central instance"
+      ></content-header>
+
+      <div class="section-title">
+        <span>Server Metadata</span>
+        \${this.canManage && !this.isEditingMetadata ? html\`
+          <button class="btn btn-primary" @click=\${this.handleEditMetadata}>Edit Metadata</button>
+        \` : ''}
+      </div>
+
+      \${this.isLoadingMetadata ? html\`<versola-loading-cards .count=\${1}></versola-loading-cards>\` : this.renderMetadata()}
+
+      <div class="section-title">
+        <span>JWKS</span>
+        \${this.canManage ? html\`
+        <button slot="actions" class="btn btn-primary" @click=\${this.handleAddClick}>
           + Add Key
-        </button>` : ''}
-      </content-header>
+        </button>\` : ''}
+      </div>
 
-      ${this.formMode !== null ? this.renderForm() : ''}
+      \${this.formMode !== null ? this.renderForm() : ''}
 
-      ${this.isLoading
-        ? html`<versola-loading-cards .count=${3}></versola-loading-cards>`
+      \${this.isLoading
+        ? html\`<versola-loading-cards .count=\${3}></versola-loading-cards>\`
         : this.errorMessage
-          ? html`
+          ? html\`
             <versola-error-card
               heading="Could not load JWKS"
-              .message=${this.errorMessage}
-              @retry=${() => this.loadData()}
+              .message=\${this.errorMessage}
+              @retry=\${() => this.loadData()}
             ></versola-error-card>
-          `
+          \`
           : this.keys.length === 0 && this.formMode === null
-            ? html`
+            ? html\`
               <div class="card">
                 <div class="empty-state">
                   <div class="empty-state-icon">🔑</div>
                   <p>No keys found.</p>
-                  ${this.canManage ? html`
-                  <button class="btn btn-primary" @click=${this.handleAddClick} style="margin-top: 1rem;">
+                  \${this.canManage ? html\`
+                  <button class="btn btn-primary" @click=\${this.handleAddClick} style="margin-top: 1rem;">
                     + Add Key
-                  </button>` : ''}
+                  </button>\` : ''}
                 </div>
               </div>
-            `
+            \`
             : this.keys.map(k => this.renderKey(k))
       }
+    `;
+  }
+
+  private renderMetadata() {
+    if (this.isEditingMetadata) {
+      return html`
+        <div class="metadata-card">
+          <div class="form-group">
+            <textarea
+              class="form-control"
+              rows="15"
+              .value=\${this.metadataInput}
+              @input=\${(e: Event) => this.metadataInput = (e.target as HTMLTextAreaElement).value}
+            ></textarea>
+          </div>
+          <div style="display: flex; gap: 1rem; margin-top: 1rem;">
+            <button class="btn btn-primary" @click=\${this.handleSaveMetadata} ?disabled=\${this.isSavingMetadata}>
+              \${this.isSavingMetadata ? 'Saving...' : 'Save Metadata'}
+            </button>
+            <button class="btn btn-secondary" @click=\${this.handleCancelMetadata}>Cancel</button>
+          </div>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="metadata-card">
+        <pre class="metadata-json">\${JSON.stringify(this.metadata, null, 2)}</pre>
+      </div>
     `;
   }
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    'versola-jwks-list': VersolaJwksList;
+    'versola-well-known': VersolaWellKnown;
   }
 }

--- a/central-ui/src/utils/central-api.ts
+++ b/central-ui/src/utils/central-api.ts
@@ -956,6 +956,15 @@ export async function deleteJwk(kid: string): Promise<void> {
   await requestVoid('/configuration/jwks', { method: 'DELETE', query: { kid } });
 }
 
+export async function fetchServerMetadata(): Promise<Record<string, unknown>> {
+  return request<Record<string, unknown>>('/configuration/server-metadata');
+}
+
+export async function upsertServerMetadata(metadata: Record<string, unknown>): Promise<void> {
+  await requestVoid('/configuration/server-metadata', { method: 'POST', body: metadata });
+}
+
+
 export async function fetchEdges(): Promise<Edge[]> {
   const response = await request<EdgesResponse>('/configuration/edges');
   return sortById(response.edges.map(edge => ({

--- a/central/implementations/postgres/migrations/V1018__server_metadata_table.sql
+++ b/central/implementations/postgres/migrations/V1018__server_metadata_table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE server_metadata (
+    id TEXT PRIMARY KEY,
+    metadata JSONB NOT NULL
+);
+
+CREATE OR REPLACE FUNCTION notify_metadata_change()
+RETURNS trigger AS $$
+BEGIN
+  PERFORM pg_notify('metadata_change', '');
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER metadata_notify
+AFTER INSERT OR UPDATE OR DELETE ON server_metadata
+FOR EACH STATEMENT EXECUTE FUNCTION notify_metadata_change();

--- a/central/implementations/postgres/src/main/scala/versola/BootstrapService.scala
+++ b/central/implementations/postgres/src/main/scala/versola/BootstrapService.scala
@@ -6,7 +6,7 @@ import versola.central.configuration.system.{SystemSettingsRecord, SystemSetting
 import versola.central.configuration.clients.{AuthFlow, AuthorizationPreset, AuthorizationPresetRepository, ClientAlreadyExists, OAuthClientService, PresetId, PrimaryAuthFlow, PrimaryCredential, ResponseType}
 import versola.central.configuration.edges.{EdgeId, EdgeRepository}
 import versola.central.configuration.forms.{BackendProperty, BooleanProperty, FormId, FormRepository, NumberProperty, StringArrayProperty}
-import versola.central.configuration.jwks.{JwksRepository, JwksService}
+import versola.central.configuration.jwks.JwksRepository
 import versola.central.configuration.locales.{LocaleRecord, LocaleRepository}
 import versola.central.configuration.permissions.{Permission, PermissionRepository}
 import versola.central.configuration.resources.{ResourceEndpointId, ResourceEndpointRecord, ResourceId, ResourceRepository}
@@ -15,6 +15,7 @@ import versola.central.configuration.scopes.{Claim, OAuthScopeRepository, ScopeT
 import versola.central.configuration.tenants.{TenantId, TenantRepository}
 import versola.central.configuration.themes.{ThemeRecord, ThemeRepository}
 import versola.central.configuration.{CreateClaim, CreateClientRequest, ResourceUri}
+import versola.central.configuration.metadata.ServerMetadataRepository
 import versola.central.users.{Login, UserConflict, UserId, UserRepository}
 import versola.util.{RedirectUri, Secret}
 import zio.json.DecoderOps
@@ -366,6 +367,8 @@ object BootstrapService:
     "POST"   -> "/configuration/jwks",
     "PUT"    -> "/configuration/jwks",
     "DELETE" -> "/configuration/jwks",
+    "GET"    -> "/configuration/server-metadata",
+    "POST"   -> "/configuration/server-metadata",
     "GET"    -> "/configuration/locales",
     "PUT"    -> "/configuration/locales",
     "PUT"    -> "/configuration/locales/default",
@@ -415,7 +418,7 @@ object BootstrapService:
         try source.mkString finally source.close()
 
   val live: ZLayer[
-    TenantRepository & PermissionRepository & OAuthScopeRepository & RoleRepository & OtpChallengeRepository & ChallengeSettingsRepository & SystemSettingsRepository & ThemeRepository & LocaleRepository & FormRepository & OAuthClientService & AuthorizationPresetRepository & EdgeRepository & ResourceRepository & JwksRepository & JwksService & UserRepository & CentralConfig,
+    TenantRepository & PermissionRepository & OAuthScopeRepository & RoleRepository & OtpChallengeRepository & ChallengeSettingsRepository & SystemSettingsRepository & ThemeRepository & LocaleRepository & FormRepository & OAuthClientService & AuthorizationPresetRepository & EdgeRepository & ResourceRepository & JwksRepository & ServerMetadataRepository & UserRepository & CentralConfig,
     Throwable,
     BootstrapService,
   ] =
@@ -438,7 +441,7 @@ object BootstrapService:
       edgeRepo: EdgeRepository,
       resourceRepo: ResourceRepository,
       jwksRepo: JwksRepository,
-      jwksService: JwksService,
+      metadataRepo: ServerMetadataRepository,
       userRepo: UserRepository,
       config: CentralConfig,
   ) extends BootstrapService:
@@ -467,7 +470,7 @@ object BootstrapService:
           _ <- linkTenantEdge(tenantId, config)
           _ <- seedCentralResource(config)
           _ <- seedJwks(config)
-          _ <- jwksService.sync()
+          _ <- seedMetadata(config)
         yield ()
       }.unit
 
@@ -681,3 +684,9 @@ object BootstrapService:
               case None    => jwksRepo.create(kid, jwk)
           case None =>
             ZIO.logWarning("Skipping bootstrap JWK without a 'kid' field")
+
+    private def seedMetadata(config: CentralConfig.BootstrapConfig): Task[Unit] =
+      ZIO.foreachDiscard(config.metadata): metadata =>
+        metadataRepo.get.flatMap:
+          case Some(_) => ZIO.unit
+          case None    => metadataRepo.upsert(metadata)

--- a/central/implementations/postgres/src/main/scala/versola/PostgresCentralApp.scala
+++ b/central/implementations/postgres/src/main/scala/versola/PostgresCentralApp.scala
@@ -8,7 +8,8 @@ import versola.central.configuration.system.{SystemSettingsController, SystemSet
 import versola.central.configuration.clients.{AuthorizationPresetController, AuthorizationPresetRepository, AuthorizationPresetService, ClientController, OAuthClientRepository, OAuthClientService}
 import versola.central.configuration.edges.{EdgeController, EdgeRepository, EdgeService}
 import versola.central.configuration.forms.{FormController, FormRepository, FormService}
-import versola.central.configuration.jwks.{JwksController, JwksRepository, JwksService}
+import versola.central.configuration.metadata.{ServerMetadataController, ServerMetadataRepository, ServerMetadataService}
+import versola.configuration.metadata.PostgresServerMetadataRepository
 import versola.central.configuration.locales.{LocaleController, LocaleRepository, LocaleService}
 import versola.central.configuration.themes.{ThemeController, ThemeRepository, ThemeService}
 import versola.central.configuration.permissions.{PermissionController, PermissionRepository, PermissionService}
@@ -87,10 +88,8 @@ object PostgresCentralApp extends VersolaApp("central"):
       UserService &
       AuthClient &
       UserOutboxProcessor &
-      JwksRepository &
-      JwksService &
-      SecureRandom &
-      SecurityService
+      ServerMetadataRepository &
+      ServerMetadataService &
 
   override def routes: Routes[Dependencies & Tracing & EnvName, Throwable] =
     List(
@@ -109,6 +108,7 @@ object PostgresCentralApp extends VersolaApp("central"):
       SystemSettingsController.routes,
       UserController.routes,
       JwksController.routes,
+      ServerMetadataController.routes,
       ServiceController.routes,
     ).reduce(_ ++ _)
 
@@ -131,6 +131,7 @@ object PostgresCentralApp extends VersolaApp("central"):
           PostgresSystemSettingsRepository.live >+>
           PostgresCacheSyncRepository.live >+>
           PostgresJwksRepository.live >+>
+          PostgresServerMetadataRepository.live >+>
           PostgresUserRepository.live
       )
 
@@ -150,6 +151,7 @@ object PostgresCentralApp extends VersolaApp("central"):
       EdgeService.live(schedule) >+>
       LocaleService.live >+>
       JwksService.live(schedule) >+>
+      ServerMetadataService.live(schedule) >+>
       BootstrapService.live >+>
       FormService.live(schedule) >+>
       ThemeService.live(schedule) >+>

--- a/central/implementations/postgres/src/main/scala/versola/PostgresCentralApp.scala
+++ b/central/implementations/postgres/src/main/scala/versola/PostgresCentralApp.scala
@@ -8,6 +8,7 @@ import versola.central.configuration.system.{SystemSettingsController, SystemSet
 import versola.central.configuration.clients.{AuthorizationPresetController, AuthorizationPresetRepository, AuthorizationPresetService, ClientController, OAuthClientRepository, OAuthClientService}
 import versola.central.configuration.edges.{EdgeController, EdgeRepository, EdgeService}
 import versola.central.configuration.forms.{FormController, FormRepository, FormService}
+import versola.central.configuration.jwks.{JwksController, JwksService}
 import versola.central.configuration.metadata.{ServerMetadataController, ServerMetadataRepository, ServerMetadataService}
 import versola.configuration.metadata.PostgresServerMetadataRepository
 import versola.central.configuration.locales.{LocaleController, LocaleRepository, LocaleService}
@@ -90,6 +91,7 @@ object PostgresCentralApp extends VersolaApp("central"):
       UserOutboxProcessor &
       ServerMetadataRepository &
       ServerMetadataService &
+      JwksService
 
   override def routes: Routes[Dependencies & Tracing & EnvName, Throwable] =
     List(

--- a/central/implementations/postgres/src/main/scala/versola/configuration/metadata/PostgresServerMetadataRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/metadata/PostgresServerMetadataRepository.scala
@@ -1,0 +1,35 @@
+package versola.configuration.metadata
+
+import com.augustnagro.magnum.*
+import com.augustnagro.magnum.magzio.TransactorZIO
+import versola.central.configuration.metadata.{ServerMetadataRecord, ServerMetadataRepository}
+import versola.util.postgres.BasicCodecs
+import zio.json.ast.Json
+import zio.{Task, ZLayer}
+
+class PostgresServerMetadataRepository(xa: TransactorZIO) extends ServerMetadataRepository, BasicCodecs:
+
+  given DbCodec[Json.Obj] = jsonCodec[Json.Obj]
+  given DbCodec[ServerMetadataRecord] = DbCodec.derived
+
+  override def get: Task[Option[ServerMetadataRecord]] =
+    xa.connectMeasured("get-server-metadata"):
+      sql"""
+        SELECT id, metadata
+        FROM server_metadata
+        WHERE id = 'default'
+      """.query[ServerMetadataRecord].run().headOption
+
+  override def upsert(metadata: Json.Obj): Task[Unit] =
+    xa.connectMeasured("upsert-server-metadata"):
+      sql"""
+        INSERT INTO server_metadata (id, metadata)
+        VALUES ('default', $metadata)
+        ON CONFLICT (id) DO UPDATE SET
+          metadata = EXCLUDED.metadata
+      """.update.run()
+    .unit
+
+object PostgresServerMetadataRepository:
+  def live: ZLayer[TransactorZIO, Nothing, ServerMetadataRepository] =
+    ZLayer.fromFunction(PostgresServerMetadataRepository(_))

--- a/central/src/main/scala/versola/central/CentralConfig.scala
+++ b/central/src/main/scala/versola/central/CentralConfig.scala
@@ -30,6 +30,7 @@ object CentralConfig:
       redirectUris: List[String],
       edges: Option[List[CentralConfig.BootstrapConfig.EdgeSeed]],
       jwks: Option[Json.Obj],
+      metadata: Option[Json.Obj],
       presets: Option[List[CentralConfig.BootstrapConfig.PresetSeed]],
       centralUrl: Option[String],
       /** Base64Url-encoded fixed secret for the central-admin OAuth client.

--- a/central/src/main/scala/versola/central/configuration/metadata/ServerMetadataController.scala
+++ b/central/src/main/scala/versola/central/configuration/metadata/ServerMetadataController.scala
@@ -1,5 +1,8 @@
 package versola.central.configuration.metadata
 
+import versola.central.{CentralConfig, authorizeBasic, authorizeInternal}
+import versola.central.configuration.edges.EdgeService
+import versola.central.configuration.clients.OAuthClientService
 import versola.util.http.Controller
 import zio.*
 import zio.http.*
@@ -7,6 +10,8 @@ import zio.json.*
 import zio.json.ast.Json
 
 object ServerMetadataController extends Controller:
+  type Env = OAuthClientService & CentralConfig & EdgeService & ServerMetadataService
+
   def routes: Routes[Env, Throwable] = Routes(
     getMetadataEndpoint,
     upsertMetadataEndpoint,

--- a/central/src/main/scala/versola/central/configuration/metadata/ServerMetadataController.scala
+++ b/central/src/main/scala/versola/central/configuration/metadata/ServerMetadataController.scala
@@ -1,0 +1,42 @@
+package versola.central.configuration.metadata
+
+import versola.util.http.Controller
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.json.ast.Json
+
+object ServerMetadataController extends Controller:
+  def routes: Routes[Env, Throwable] = Routes(
+    getMetadataEndpoint,
+    upsertMetadataEndpoint,
+    getMetadataSyncEndpoint,
+  )
+
+  val getMetadataEndpoint =
+    Method.GET / "configuration" / "server-metadata" -> handler { (request: Request) =>
+      for
+        _ <- authorizeBasic(request)
+        service <- ZIO.service[ServerMetadataService]
+        metadata <- service.getMetadata
+      yield Response.json(metadata.getOrElse(Json.Obj()).toJson)
+    }
+
+  val upsertMetadataEndpoint =
+    Method.POST / "configuration" / "server-metadata" -> handler { (request: Request) =>
+      for
+        _ <- authorizeBasic(request)
+        service <- ZIO.service[ServerMetadataService]
+        metadata <- request.body.asJsonFromCodec[Json.Obj]
+        _ <- service.upsertMetadata(metadata)
+      yield Response.status(Status.NoContent)
+    }
+
+  val getMetadataSyncEndpoint =
+    Method.GET / "configuration" / "server-metadata" / "sync" -> handler { (request: Request) =>
+      for
+        _ <- authorizeInternal(request)
+        service <- ZIO.service[ServerMetadataService]
+        metadata <- service.getMetadata
+      yield Response.json(metadata.getOrElse(Json.Obj()).toJson)
+    }

--- a/central/src/main/scala/versola/central/configuration/metadata/ServerMetadataRecord.scala
+++ b/central/src/main/scala/versola/central/configuration/metadata/ServerMetadataRecord.scala
@@ -1,0 +1,10 @@
+package versola.central.configuration.metadata
+
+import zio.json.ast.Json
+import zio.json.{JsonCodec, JsonDecoder, JsonEncoder}
+import zio.schema.{Schema, derived}
+
+case class ServerMetadataRecord(
+    id: String,
+    metadata: Json.Obj,
+) derives Schema, JsonCodec

--- a/central/src/main/scala/versola/central/configuration/metadata/ServerMetadataRepository.scala
+++ b/central/src/main/scala/versola/central/configuration/metadata/ServerMetadataRepository.scala
@@ -1,0 +1,12 @@
+package versola.central.configuration.metadata
+
+import versola.util.CacheSource
+import zio.Task
+import zio.json.ast.Json
+
+trait ServerMetadataRepository extends CacheSource[Option[ServerMetadataRecord]]:
+  def get: Task[Option[ServerMetadataRecord]]
+  
+  override def getAll: Task[Option[ServerMetadataRecord]] = get
+
+  def upsert(metadata: Json.Obj): Task[Unit]

--- a/central/src/main/scala/versola/central/configuration/metadata/ServerMetadataService.scala
+++ b/central/src/main/scala/versola/central/configuration/metadata/ServerMetadataService.scala
@@ -1,0 +1,30 @@
+package versola.central.configuration.metadata
+
+import versola.util.ReloadingCache
+import zio.json.ast.Json
+import zio.{Schedule, Scope, Task, UIO, ZLayer}
+
+trait ServerMetadataService:
+  def getMetadata: UIO[Option[Json.Obj]]
+  def upsertMetadata(metadata: Json.Obj): Task[Unit]
+  def sync(): Task[Unit]
+
+object ServerMetadataService:
+  def live(
+      schedule: Schedule[Any, Any, Any],
+  ): ZLayer[ServerMetadataRepository & Scope, Throwable, ServerMetadataService] =
+    ZLayer(ReloadingCache.make[Option[ServerMetadataRecord]](schedule))
+      >>> ZLayer.fromFunction(Impl(_, _))
+
+  case class Impl(
+      cache: ReloadingCache[Option[ServerMetadataRecord]],
+      repository: ServerMetadataRepository,
+  ) extends ServerMetadataService:
+    override def getMetadata: UIO[Option[Json.Obj]] =
+      cache.get.map(_.map(_.metadata))
+
+    override def upsertMetadata(metadata: Json.Obj): Task[Unit] =
+      repository.upsert(metadata)
+
+    override def sync(): Task[Unit] =
+      repository.get.flatMap(cache.set)

--- a/scripts/gen-env.scala
+++ b/scripts/gen-env.scala
@@ -121,12 +121,14 @@ def writeFile(dir: File, name: String, content: String): Unit =
     if isLocal then "  client-secret = \"ZGV2LWNlbnRyYWwtYWRtaW4tc2VjcmV0LTMyYnl0ZXM\"\n" else ""
 
   // ── Service URLs ──────────────────────────────────────────────────────────────
-  // Each service's public base URL, prompted once and reused wherever another
-  // service needs to reach it (auth is also the JWT issuer and edge's upstream).
+  // authUrl      – public-facing URL (JWT issuer, server metadata, browser redirects via edge).
+  // authInternalUrl – internal S2S URL used by central to call auth's admin APIs.
+  //                   Defaults to authUrl; override in k8s / service-mesh deployments.
   section("\n── Service URLs ──────────────────────────────────────────────────────")
-  val authUrl    = prompt("  Auth URL [http://localhost:9003]: ",    "http://localhost:9003")
-  val centralUrl = prompt("  Central URL [http://localhost:9001]: ", "http://localhost:9001")
-  val edgeUrl    = prompt("  Edge URL [http://localhost:9005]: ",    "http://localhost:9005")
+  val authUrl         = prompt("  Auth public URL [http://localhost:9003]: ",           "http://localhost:9003")
+  val authInternalUrl = prompt(s"  Auth internal URL [$authUrl]: ",                    authUrl)
+  val centralUrl      = prompt("  Central URL [http://localhost:9001]: ",               "http://localhost:9001")
+  val edgeUrl         = prompt("  Edge URL [http://localhost:9005]: ",                  "http://localhost:9005")
 
   section("\n── Auth service ──────────────────────────────────────────────────────")
   val authPgUrl       = prompt("  Postgres URL [jdbc:postgresql://localhost:5432/auth]: ", "jdbc:postgresql://localhost:5432/auth")
@@ -142,6 +144,25 @@ def writeFile(dir: File, name: String, content: String): Unit =
   val centralPgUrl        = prompt("  Postgres URL [jdbc:postgresql://localhost:5432/auth]: ", "jdbc:postgresql://localhost:5432/auth")
   val centralPgUser       = prompt("  Postgres user [dev]: ",                         "dev")
   val centralPgPass       = prompt("  Postgres password [1234]: ",                    "1234")
+
+
+  val metadata =
+    s"""{
+       |  "issuer": "$authUrl",
+       |  "authorization_endpoint": "$authUrl/authorize",
+       |  "token_endpoint": "$authUrl/token",
+       |  "userinfo_endpoint": "$authUrl/userinfo",
+       |  "jwks_uri": "$authUrl/.well-known/jwks.json",
+       |  "introspection_endpoint": "$authUrl/introspect",
+       |  "revocation_endpoint": "$authUrl/revoke",
+       |  "scopes_supported": ["openid", "profile", "email", "phone", "offline_access"],
+       |  "response_types_supported": ["code", "code id_token"],
+       |  "grant_types_supported": ["authorization_code", "client_credentials", "refresh_token"],
+       |  "subject_types_supported": ["public", "pairwise"],
+       |  "id_token_signing_alg_values_supported": ["RS256"],
+       |  "token_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"],
+       |  "claims_supported": ["sub", "iss", "aud", "exp", "iat", "jti", "nonce", "auth_time", "acr", "amr"]
+       |}""".stripMargin
 
   section("\n── Edge service ──────────────────────────────────────────────────────")
   val edgePgUrl       = prompt("  Postgres URL [jdbc:postgresql://localhost:5432/auth]: ", "jdbc:postgresql://localhost:5432/auth")
@@ -252,7 +273,7 @@ def writeFile(dir: File, name: String, content: String): Unit =
        |  sessions-secret              = "$sessionsSecret"
        |  passwords-secret             = "$passwordsSecret"
        |  conversation-cookie-secret   = "$conversationCookieSecret"
-       |  session-cookie-secret        = "$sessionCookieSecret"  
+       |  session-cookie-secret        = "$sessionCookieSecret"
        |}
        |
        |jwt {
@@ -332,6 +353,7 @@ def writeFile(dir: File, name: String, content: String): Unit =
        |  ]
        |  # Matches the JWT signing key in auth (jwt.private-key).
        |  jwks = \"\"\"$jwks\"\"\"
+       |  metadata = \"\"\"$metadata\"\"\"
        |  presets = [
        |    {
        |      id = "central-admin"
@@ -347,7 +369,7 @@ def writeFile(dir: File, name: String, content: String): Unit =
        |client-secrets-secret = "$clientSecretsSecret"
        |
        |auth {
-       |  url = "$authUrl"
+       |  url = "$authInternalUrl"
        |}
        |
        |user-outbox {


### PR DESCRIPTION
This PR implements RFC 8414 Authorization Server Metadata support in Versola.

### Changes
- **Auth**: Added `.well-known/oauth-authorization-server` and `.well-known/openid-configuration` endpoints.
- **Central**: Added server metadata storage (Postgres), service, and management APIs.
- **Central UI**: Renamed "JWKS" to "Well Known" and added a JSON editor for server metadata.
- **Bootstrap**: Added metadata seeding.
- **Config**: Split `authUrl` into public `authUrl` and internal `authInternalUrl` in `gen-env.scala` to support split-brain DNS / internal routing.
- **Refactoring**: Cleaned up `zio.json` imports and redundant sync calls.

Closes #136

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KYMK94J9EF76ZGH2PG66X7YP&panel=chat)