### PR TITLE
fix: gen-env.scala writes invalid central.conf for non-local env names

### DIFF
--- a/scripts/gen-env.scala
+++ b/scripts/gen-env.scala
@@ -117,8 +117,17 @@ def writeFile(dir: File, name: String, content: String): Unit =
 
   // Only pin a known secret in local dev so e2e tests can rely on a stable value.
   // Non-local environments let the bootstrap generate a random secret on first boot.
+  //
+  // Both branches MUST end with "\n": centralConf below interpolates this value into
+  // "|${bootstrapClientSecretLine}|}" — the `}` on that source line is its own
+  // stripMargin-delimited line only because this value supplies the newline that
+  // precedes it. An else-branch of "" (no trailing newline) collapses that into a
+  // single line "||}", and stripMargin only strips the *first* pipe, leaving a
+  // literal "|}" in the generated HOCON — which fails to parse with
+  // "Key '|' may not be followed by token: '}'". Learned this the hard way: it broke
+  // every non-"local" generation (i.e. every generation following deploy.md §3.2).
   val bootstrapClientSecretLine =
-    if isLocal then "  client-secret = \"ZGV2LWNlbnRyYWwtYWRtaW4tc2VjcmV0LTMyYnl0ZXM\"\n" else ""
+    if isLocal then "  client-secret = \"ZGV2LWNlbnRyYWwtYWRtaW4tc2VjcmV0LTMyYnl0ZXM\"\n" else "\n"
 
   // ── Service URLs ──────────────────────────────────────────────────────────────
   // authUrl      – public-facing URL (JWT issuer, server metadata, browser redirects via edge).


### PR DESCRIPTION
## What's broken

`scripts/gen-env.scala` generates an invalid `central.conf` for any
environment name other than `local` — which, per `deploy.md` §3.2, is
exactly how prod configs are documented to be generated.

`central` then fails to start with:
ConfigException$Parse: ... Key '|' may not be followed by token: '}' and crash-loops.

## Root cause

`bootstrapClientSecretLine` (line 120) returned `""` (no trailing
newline) on the non-local branch. The `centralConf` template relies on
that newline to keep the closing `}` of the `bootstrap` block on its
own `stripMargin`-delimited line: `"|${bootstrapClientSecretLine}|}"`.
Without the newline, this collapses into a single line, `"||}"`.
`stripMargin` only strips the *first* pipe, so the generated file ends
up with a literal `|}` instead of `}` — invalid HOCON.

## Fix

One line: `else ""` → `else "\n"`. Added a comment above it explaining
the invariant, so this doesn't regress the same way again.

## How I verified it

Ran `scala-cli run scripts/gen-env.scala` with a non-"local" env name
before and after the fix. Before: `central.conf` contained `|}`.
After: it doesn't, and the file parses.

## Risk

One-line change, only affects the non-local code path of the
generator script. Doesn't touch any compiled service.