### PR TITLE
fix gen-env-docker-local-edge-url

### DIFF
--- a/develop.md
+++ b/develop.md
@@ -33,11 +33,13 @@ The script first asks for the environment **Name** (default `local`):
       hostnames, and edge's own port isn't published to the host at all.
 
     `edge` needs both at once for one thing: `EdgeConfig.versolaUrl` (public — the
-    browser redirect, and the token `iss` check) vs `EdgeConfig.versolaInternalUrl`
-    (real network call — edge's own token/userinfo exchange with `auth`). Getting this
-    backwards doesn't fail loudly; it 404s or connection-refuses partway through a login
-    that otherwise looks like it's working — confirmed by hand while testing
-    `versola bootstrap local`.
+    browser redirect, and the token `iss` check) vs `EdgeConfig.internalUrl` (real
+    network call — edge's own token/userinfo exchange with `auth`), which resolves
+    from the optional `EdgeConfig.versolaInternalUrl` field and falls back to
+    `versolaUrl` when it's absent, so configs generated before this field existed
+    keep working. Getting this backwards doesn't fail loudly; it 404s or
+    connection-refuses partway through a login that otherwise looks like it's
+    working — confirmed by hand while testing `versola bootstrap local`.
 - **any other name** — runs interactively, prompting for service URLs and Postgres
   credentials. Files are written to `.local/env/<name>/` (`auth.conf`, `central.conf`,
   `edge.conf`).

--- a/develop.md
+++ b/develop.md
@@ -11,10 +11,33 @@ scala-cli run scripts/gen-env.scala
 The script first asks for the environment **Name** (default `local`):
 
 - **`local`** — runs non-interactively. All remaining prompts are skipped and defaults are
-  used. Files are written to the service dev directories consumed by `sbt` (see below):
+  used (`localhost`-based — auth/central/edge are assumed to share one network, e.g. run
+  directly via `sbt` or with `network_mode: host`). Files are written to the service dev
+  directories consumed by `sbt` (see below):
     - `auth/dev/env.conf`
     - `central/dev/env.conf`
     - `edge/dev/env.conf`
+- **`docker-local`** — also runs non-interactively, for the case where auth/central/edge
+  each run in their own container on one Docker Compose bridge network, sitting behind
+  nginx as the single published port (used by `versola bootstrap local`). Files are
+  written to `.local/env/docker-local/` (see below).
+
+  Defaults split into two kinds, and it matters which is which:
+    - **Real network calls between containers** (Postgres, `central`'s and `edge`'s calls
+      to `auth`'s admin API) point at the other container's Compose service name, e.g.
+      `http://auth:8080`, `jdbc:postgresql://postgres:5432/...` — containers on a bridge
+      network can't reach each other via `localhost`.
+    - **Anything a browser has to load** (auth/edge's own public URLs, the post-login
+      redirect) points at nginx's published port instead, `http://localhost:8080` — a
+      browser outside the Compose network has no way to resolve `auth` or `edge` as
+      hostnames, and edge's own port isn't published to the host at all.
+
+    `edge` needs both at once for one thing: `EdgeConfig.versolaUrl` (public — the
+    browser redirect, and the token `iss` check) vs `EdgeConfig.versolaInternalUrl`
+    (real network call — edge's own token/userinfo exchange with `auth`). Getting this
+    backwards doesn't fail loudly; it 404s or connection-refuses partway through a login
+    that otherwise looks like it's working — confirmed by hand while testing
+    `versola bootstrap local`.
 - **any other name** — runs interactively, prompting for service URLs and Postgres
   credentials. Files are written to `.local/env/<name>/` (`auth.conf`, `central.conf`,
   `edge.conf`).

--- a/edge/src/main/scala/versola/edge/EdgeConfig.scala
+++ b/edge/src/main/scala/versola/edge/EdgeConfig.scala
@@ -22,12 +22,16 @@ case class EdgeConfig(
     // calls edge makes on its own, not through the user's browser. When
     // edge and auth aren't on the same network as the browser (e.g. each
     // in its own Docker container, "versola bootstrap local"), this is a
-    // *different* address than versolaUrl -- defaults to versolaUrl so
-    // existing configs that predate this field keep working unchanged
+    // *different* address than versolaUrl. Optional (rather than a plain
+    // URL defaulting to versolaUrl) because a case class default can't
+    // reference a sibling parameter -- use the `internalUrl` accessor
+    // below, which resolves the fallback. Absent for existing configs
+    // that predate this field, which keeps them working unchanged
     // (correct wherever edge/auth/the browser all share one network, as
     // in prod and plain local dev).
-    versolaInternalUrl: URL = versolaUrl,
-)
+    versolaInternalUrl: Option[URL] = None,
+):
+  def internalUrl: URL = versolaInternalUrl.getOrElse(versolaUrl)
 
 object EdgeConfig:
 

--- a/edge/src/main/scala/versola/edge/EdgeConfig.scala
+++ b/edge/src/main/scala/versola/edge/EdgeConfig.scala
@@ -13,7 +13,20 @@ case class EdgeConfig(
     privateKey: PrivateKey,
     security: EdgeConfig.Security,
     central: EdgeConfig.CentralConfig,
+    // Public-facing: the browser is redirected here (SSOClient.authorizeUrl)
+    // and it's what a token's `iss` claim is checked against
+    // (EdgeService.sameOrigin) -- it must be an address a browser can
+    // reach, not necessarily one this edge instance can reach itself.
     versolaUrl: URL,
+    // Server-to-server: SSOClient's tokenUrl/userInfoUrl are real network
+    // calls edge makes on its own, not through the user's browser. When
+    // edge and auth aren't on the same network as the browser (e.g. each
+    // in its own Docker container, "versola bootstrap local"), this is a
+    // *different* address than versolaUrl -- defaults to versolaUrl so
+    // existing configs that predate this field keep working unchanged
+    // (correct wherever edge/auth/the browser all share one network, as
+    // in prod and plain local dev).
+    versolaInternalUrl: URL = versolaUrl,
 )
 
 object EdgeConfig:

--- a/edge/src/main/scala/versola/edge/SSOClient.scala
+++ b/edge/src/main/scala/versola/edge/SSOClient.scala
@@ -51,13 +51,13 @@ object SSOClient:
       config: EdgeConfig,
   ) extends SSOClient:
     // authorizeUrl is where the browser gets redirected -- it must stay on
-    // versolaUrl (public-facing), never versolaInternalUrl. tokenUrl and
+    // versolaUrl (public-facing), never internalUrl. tokenUrl and
     // userInfoUrl are real calls this process makes itself below, so they
-    // use versolaInternalUrl -- see the comments on EdgeConfig for why
-    // these two aren't the same address everywhere.
+    // use internalUrl -- see the comments on EdgeConfig for why these two
+    // aren't the same address everywhere.
     private val authorizeUrl: URL = config.versolaUrl / "authorize"
-    private val tokenUrl: URL = config.versolaInternalUrl / "token"
-    private val userInfoUrl = config.versolaInternalUrl / "userinfo"
+    private val tokenUrl: URL = config.internalUrl / "token"
+    private val userInfoUrl = config.internalUrl / "userinfo"
 
     override def authorizeUri(
         preset: AuthorizationPreset,

--- a/edge/src/main/scala/versola/edge/SSOClient.scala
+++ b/edge/src/main/scala/versola/edge/SSOClient.scala
@@ -50,9 +50,14 @@ object SSOClient:
       httpClient: Client,
       config: EdgeConfig,
   ) extends SSOClient:
+    // authorizeUrl is where the browser gets redirected -- it must stay on
+    // versolaUrl (public-facing), never versolaInternalUrl. tokenUrl and
+    // userInfoUrl are real calls this process makes itself below, so they
+    // use versolaInternalUrl -- see the comments on EdgeConfig for why
+    // these two aren't the same address everywhere.
     private val authorizeUrl: URL = config.versolaUrl / "authorize"
-    private val tokenUrl: URL = config.versolaUrl / "token"
-    private val userInfoUrl = config.versolaUrl / "userinfo"
+    private val tokenUrl: URL = config.versolaInternalUrl / "token"
+    private val userInfoUrl = config.versolaInternalUrl / "userinfo"
 
     override def authorizeUri(
         preset: AuthorizationPreset,

--- a/edge/src/test/scala/versola/edge/EdgeConfigSpec.scala
+++ b/edge/src/test/scala/versola/edge/EdgeConfigSpec.scala
@@ -1,0 +1,117 @@
+package versola.edge
+
+import versola.edge.model.EdgeId
+import versola.util.{PrivateKeyUtil, Secret}
+import zio.*
+import zio.config.magnolia.{DeriveConfig, deriveConfig}
+import zio.config.typesafe.TypesafeConfigProvider
+import zio.http.URL
+import zio.test.*
+
+import java.security.KeyPairGenerator
+import java.util.Base64
+
+/** Pure config-parsing tests for EdgeConfig, mirroring PostgresConfigSpec's
+  * pattern: a kebab-case [[zio.ConfigProvider]] over a raw HOCON string,
+  * loaded via `deriveConfig[EdgeConfig]` — the same mechanism
+  * `VersolaApp.parseConfig` uses in production.
+  *
+  * The `DeriveConfig` givens below duplicate what `PostgresEdgeApp` defines
+  * for the running app. They can't be reused directly: `PostgresEdgeApp`
+  * lives in a downstream subproject (`edge/implementations/postgres`) that
+  * depends on this one, not the other way around.
+  */
+object EdgeConfigSpec extends ZIOSpecDefault:
+
+  private given DeriveConfig[EdgeId] = DeriveConfig[String].map(EdgeId(_))
+
+  private given DeriveConfig[Secret.Bytes32] = DeriveConfig[String]
+    .mapOrFail: str =>
+      Secret.Bytes32.fromBase64Url(str)
+        .left.map(message => zio.Config.Error.InvalidData(message = message))
+        .filterOrElse(
+          _.length == 32,
+          zio.Config.Error.InvalidData(message = s"Base64-encoded string must be 32 bytes. '$str' is not."),
+        )
+
+  private given DeriveConfig[URL] = DeriveConfig[String]
+    .mapOrFail(URL.decode(_).left.map(ex => zio.Config.Error.InvalidData(message = ex.getMessage)))
+
+  private given DeriveConfig[java.security.PrivateKey] = DeriveConfig[String]
+    .mapOrFail: str =>
+      PrivateKeyUtil.parse(str, "RSA")
+        .left.map(ex => zio.Config.Error.InvalidData(message = ex.getMessage))
+
+  private val edgeConfigDescriptor = deriveConfig[EdgeConfig]
+
+  // A throwaway RSA-2048 key, generated fresh per test run — its value
+  // doesn't matter, EdgeConfig just needs something PrivateKeyUtil.parse
+  // accepts.
+  private val privateKeyB64: String =
+    val kpg = KeyPairGenerator.getInstance("RSA")
+    kpg.initialize(2048)
+    Base64.getEncoder.encodeToString(kpg.generateKeyPair().getPrivate.getEncoded)
+
+  // Also throwaway — Secret.Bytes32 just needs 32 raw bytes, base64url-encoded.
+  private val secret32 = Base64.getUrlEncoder.withoutPadding.encodeToString(Array.fill(32)(7.toByte))
+
+  private def hocon(includeInternalUrl: Boolean): String =
+    val internalLine = if includeInternalUrl then """versola-internal-url = "http://auth:8080"""" else ""
+    s"""id = "edge-default"
+       |key-id = "test-key"
+       |private-key = \"\"\"$privateKeyB64\"\"\"
+       |security {
+       |  token-encryption {
+       |    key = "$secret32"
+       |  }
+       |  edge-sessions {
+       |    secret = "$secret32"
+       |    ttl = 30 days
+       |  }
+       |}
+       |central {
+       |  url = "http://central:8090"
+       |}
+       |versola-url = "http://localhost:8080"
+       |$internalLine
+       |""".stripMargin
+
+  def spec = suite("EdgeConfig")(
+    suite("parsing")(
+      // Regression for the docker-local login bug: SSOClient's tokenUrl/
+      // userInfoUrl need to point at a different address than the
+      // browser-facing authorizeUrl once edge, auth, and the browser
+      // aren't all on the same network. See gen-env.scala's docker-local
+      // defaults and SSOClient.scala for the two call sites this field
+      // split covers.
+      test("parses versola-internal-url distinct from versola-url when both are set") {
+        for config <- TypesafeConfigProvider
+            .fromHoconString(hocon(includeInternalUrl = true))
+            .kebabCase
+            .load(edgeConfigDescriptor)
+        yield assertTrue(
+          config.versolaUrl == URL.decode("http://localhost:8080").toOption.get,
+          config.versolaInternalUrl == Some(URL.decode("http://auth:8080").toOption.get),
+          config.internalUrl == URL.decode("http://auth:8080").toOption.get,
+          config.internalUrl != config.versolaUrl,
+        )
+      },
+      // The actual bug this PR fixes: an env.conf generated before this
+      // field existed (every environment except a freshly regenerated
+      // docker-local one) has no versola-internal-url key at all. This
+      // must still parse — and versolaInternalUrl must fall back to
+      // versolaUrl — or every existing deployment fails to start on
+      // upgrade.
+      test("internalUrl falls back to versolaUrl when versola-internal-url is absent") {
+        for config <- TypesafeConfigProvider
+            .fromHoconString(hocon(includeInternalUrl = false))
+            .kebabCase
+            .load(edgeConfigDescriptor)
+        yield assertTrue(
+          config.versolaInternalUrl == None,
+          config.internalUrl == config.versolaUrl,
+          config.versolaUrl == URL.decode("http://localhost:8080").toOption.get,
+        )
+      },
+    ),
+  )

--- a/scripts/gen-env.scala
+++ b/scripts/gen-env.scala
@@ -168,8 +168,16 @@ def writeFile(dir: File, name: String, content: String): Unit =
   // the same treatment.
   val centralUrlDefault   = if isDockerLocal then "http://central:8090" else "http://localhost:9001"
   val centralUrl           = prompt(s"  Central URL [$centralUrlDefault]: ", centralUrlDefault)
-  // edgeUrl is public-facing only (same reasoning as authUrl above).
-  val edgeUrlDefault      = if isDockerLocal then "http://localhost:8095" else "http://localhost:9005"
+  // edgeUrl is public-facing only, same reasoning as authUrl above — BUT
+  // in docker-local, nginx (not edge's own port) is the actual public
+  // entry point a browser can reach. edge's own port (8095) isn't
+  // published to the host at all; nginx already proxies /complete,
+  // /login, /resources, /permissions through to it internally (see
+  // versola-tools/nginx.conf.template). Confirmed by hand: pointing this
+  // at 8095 sent the post-login redirect straight to a closed port and
+  // the browser got ERR_CONNECTION_REFUSED right after a real login
+  // succeeded.
+  val edgeUrlDefault      = if isDockerLocal then "http://localhost:8080" else "http://localhost:9005"
   val edgeUrl              = prompt(s"  Edge URL [$edgeUrlDefault]: ", edgeUrlDefault)
 
   section("\n── Auth service ──────────────────────────────────────────────────────")

--- a/scripts/gen-env.scala
+++ b/scripts/gen-env.scala
@@ -516,6 +516,7 @@ def writeFile(dir: File, name: String, content: String): Unit =
        |}
        |
        |versola-url = "$authUrl"
+       |versola-internal-url = "$authInternalUrl"
        |""".stripMargin
 
   // ── Write files ───────────────────────────────────────────────────────────────

--- a/scripts/gen-env.scala
+++ b/scripts/gen-env.scala
@@ -171,11 +171,12 @@ def writeFile(dir: File, name: String, content: String): Unit =
   // edgeUrl is public-facing only, same reasoning as authUrl above — BUT
   // in docker-local, nginx (not edge's own port) is the actual public
   // entry point a browser can reach. edge's own port (8095) isn't
-  // published to the host at all; nginx already proxies /complete,
-  // /login, /resources, /permissions through to it internally (see
-  // versola-tools/nginx.conf.template). Confirmed by hand: pointing this
-  // at 8095 sent the post-login redirect straight to a closed port and
-  // the browser got ERR_CONNECTION_REFUSED right after a real login
+  // published to the host at all; the nginx config used by "versola
+  // bootstrap local" (currently in the separate versola-cli repo, not
+  // this one) already proxies /complete, /login, /resources,
+  // /permissions through to edge internally. Confirmed by hand: pointing
+  // this at 8095 sent the post-login redirect straight to a closed port
+  // and the browser got ERR_CONNECTION_REFUSED right after a real login
   // succeeded.
   val edgeUrlDefault      = if isDockerLocal then "http://localhost:8080" else "http://localhost:9005"
   val edgeUrl              = prompt(s"  Edge URL [$edgeUrlDefault]: ", edgeUrlDefault)


### PR DESCRIPTION
What
Two related fixes found while testing real browser login against `versola bootstrap local`'s docker-local stack (see versola-cli, section on manual testing):

1. `gen-env.scala`: `docker-local`'s `edgeUrl` default was `http://localhost:8095` (edge's own port). It should be `http://localhost:8080` (nginx) -- nginx is the only port actually published to the host in this setup; edge's own port isn't reachable from a browser at all.
2. `EdgeConfig`/`SSOClient`: `versolaUrl` was doing double duty -- it's both the browser-redirect target (`authorizeUrl`, and the `iss` same-origin check in `EdgeService`) and the address edge itself calls directly (`tokenUrl`/`userInfoUrl`). Those need different addresses once edge isn't on the same network as the browser -- added `versolaInternalUrl: Option[URL] = None` plus an `internalUrl` accessor that falls back to `versolaUrl` when unset, and pointed the two S2S calls at `internalUrl`. (Option, not a plain default, because a case class default can't reference a sibling parameter -- `versolaInternalUrl: URL = versolaUrl` doesn't compile.) Existing configs (no `versola-internal-url` key) are unaffected.

Why both together
Fixing only #1 gets the post-login redirect back to nginx correctly, but the token exchange right after it fails the same way (`tokenUrl` pointing at a browser-facing address edge can't reach from inside its own container) -- so neither fix is useful without the other for this flow to actually complete.

Testing
Reproduced by hand against `versola bootstrap local 0.1.1`: logged in as admin through `http://localhost:8080/login/central-admin` (real form, real password), confirmed the browser reached `/complete` on the correct port. `versola-tools`/`gen-env.scala`'s `docker-local` mode already covered by prior testing.

Added `EdgeConfigSpec` to prove the fallback in isolation: parses a config with `versola-internal-url` set (internal resolves to the distinct value) and one without it (internal falls back to `versolaUrl`) -- so non-docker-local environments (prod, plain `local`) are confirmed unaffected, not just assumed. No existing config needs regenerating for this to be safe to merge.