### PR TITLE
move public port to 2821

### DIFF
--- a/docker/versola-tools/compose.fragment.yml.template
+++ b/docker/versola-tools/compose.fragment.yml.template
@@ -117,4 +117,4 @@ services:
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
     ports:
-      - "8080:8080"
+      - "2821:2821"

--- a/docker/versola-tools/nginx.conf.template
+++ b/docker/versola-tools/nginx.conf.template
@@ -9,7 +9,9 @@
 #
 #   1. No TLS. Prod terminates HTTPS itself; locally there's no
 #      certificate and no domain, so this just listens on plain HTTP.
-#      Port 8080 matches what "versola doctor" checks is free.
+#      Port 2821 matches what "versola doctor" checks is free -- chosen
+#      deliberately over 8080, which collides with enough other local dev
+#      tooling to be worth avoiding.
 #   2. Upstreams point at container DNS names (auth, edge) instead of
 #      127.0.0.1 -- nginx is its own container here, not sharing the
 #      host's network with auth/edge like it does in prod.
@@ -39,7 +41,7 @@ upstream edge_backend {
 }
 
 server {
-    listen 8080;
+    listen 2821;
     server_name localhost;
 
     client_max_body_size 8m;

--- a/scripts/gen-env.scala
+++ b/scripts/gen-env.scala
@@ -154,7 +154,7 @@ def writeFile(dir: File, name: String, content: String): Unit =
   // authUrl is a public-facing string (JWT issuer, browser redirects) — it
   // never needs to be a Docker service name, even in docker-local, since
   // browsers/JWT verifiers reach it via the host's published port either way.
-  val authUrlDefault      = if isDockerLocal then "http://localhost:8080" else "http://localhost:9003"
+  val authUrlDefault      = if isDockerLocal then "http://localhost:2821" else "http://localhost:9003"
   val authUrl              = prompt(s"  Auth public URL [$authUrlDefault]: ", authUrlDefault)
   // authInternalUrl, unlike authUrl, IS a real network call — central uses it
   // to reach auth's admin API server-to-server. Defaulting this to authUrl
@@ -178,7 +178,7 @@ def writeFile(dir: File, name: String, content: String): Unit =
   // this at 8095 sent the post-login redirect straight to a closed port
   // and the browser got ERR_CONNECTION_REFUSED right after a real login
   // succeeded.
-  val edgeUrlDefault      = if isDockerLocal then "http://localhost:8080" else "http://localhost:9005"
+  val edgeUrlDefault      = if isDockerLocal then "http://localhost:2821" else "http://localhost:9005"
   val edgeUrl              = prompt(s"  Edge URL [$edgeUrlDefault]: ", edgeUrlDefault)
 
   section("\n── Auth service ──────────────────────────────────────────────────────")


### PR DESCRIPTION
Public-facing port for local dev moved from 8080 to 2821.

## Note
Internal container-to-container references (auth's own PORT env var,
nginx's upstream server auth:8080, authInternalDefault) were
deliberately left on 8080 — only the public-facing port changed.