### PR TITLE
auth: fix lack of atomicity in ConversationService.finish (#102)

### DIFF
--- a/auth/implementations/postgres/src/main/scala/versola/PostgresOAuthApp.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/PostgresOAuthApp.scala
@@ -9,7 +9,7 @@ import versola.oauth.challenge.password.{PasswordRepository, PasswordService, Po
 import versola.oauth.client.{ServiceController, OAuthClientSyncClient, OAuthConfigurationService, OAuthScopeSyncClient}
 import versola.oauth.conversation.otp.{EmailOtpProvider, SmsOtpProvider, OtpGenerationService, OtpService}
 import versola.oauth.conversation.limit.{ChallengeThrottleRepository, PostgresChallengeThrottleRepository, SubmissionLimiter}
-import versola.oauth.conversation.{ConversationController, ConversationRenderService, ConversationRepository, ConversationRouter, ConversationService, PostgresConversationRepository}
+import versola.oauth.conversation.{ConversationController, ConversationRenderService, ConversationRepository, ConversationRouter, ConversationService, PostgresConversationFinalizer, PostgresConversationRepository}
 import versola.oauth.introspect.{IntrospectionController, IntrospectionService}
 import versola.oauth.client.CentralSyncTokenService
 import versola.oauth.jwks.{JwksController, JwksService, JwksSyncClient}
@@ -93,6 +93,7 @@ object PostgresOAuthApp extends VersolaApp("auth"):
     PostgresUserRepository.live >+>
       PostgresUserRolesRepository.live >+>
       PostgresConversationRepository.live >+>
+      PostgresConversationFinalizer.live >+>
       PostgresAuthorizationCodeRepository.live >+>
       PostgresSessionRepository.live >+>
       PostgresPasswordRepository.live >+>

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/PostgresAuthorizationCodeRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/PostgresAuthorizationCodeRepository.scala
@@ -71,49 +71,60 @@ class PostgresAuthorizationCodeRepository(
   ): Task[Unit] =
     Clock.instant.flatMap: now =>
       xa.connectMeasured("create-authorization-code"):
-        sql"""
-          INSERT INTO authorization_codes (
-            code,
-            session_id,
-            public_session_id,
-            client_id,
-            user_id,
-            redirect_uri,
-            scope,
-            code_challenge,
-            code_challenge_method,
-            requested_claims,
-            ui_locales,
-            nonce,
-            access_token,
-            amr,
-            auth_time,
-            acr,
-            used,
-            expires_at
-          )
-          VALUES (
-            $code,
-            ${record.sessionId},
-            ${record.publicSessionId},
-            ${record.clientId},
-            ${record.userId},
-            ${record.redirectUri},
-            ${record.scope},
-            ${record.codeChallenge},
-            ${record.codeChallengeMethod.toString},
-            ${record.requestedClaims},
-            ${record.uiLocales}::text[],
-            ${record.nonce},
-            ${record.accessToken},
-            ${record.amr},
-            ${record.authTime},
-            ${record.acr},
-            ${false},
-            ${now.plusSeconds(ttl.toSeconds)}
-          )
-        """.update.run()
+        insertRaw(code, record, now.plusSeconds(ttl.toSeconds))
     .unit
+
+  /** Same insert, without the connect/measure wrapper, so it can be composed into a larger
+    * transaction (see [[versola.oauth.conversation.PostgresConversationFinalizer]]).
+    */
+  private[oauth] def insertRaw(
+      code: MAC.Of[AuthorizationCode],
+      record: AuthorizationCodeRecord,
+      expiresAt: Instant,
+  )(using DbCon): Unit =
+    sql"""
+      INSERT INTO authorization_codes (
+        code,
+        session_id,
+        public_session_id,
+        client_id,
+        user_id,
+        redirect_uri,
+        scope,
+        code_challenge,
+        code_challenge_method,
+        requested_claims,
+        ui_locales,
+        nonce,
+        access_token,
+        amr,
+        auth_time,
+        acr,
+        used,
+        expires_at
+      )
+      VALUES (
+        $code,
+        ${record.sessionId},
+        ${record.publicSessionId},
+        ${record.clientId},
+        ${record.userId},
+        ${record.redirectUri},
+        ${record.scope},
+        ${record.codeChallenge},
+        ${record.codeChallengeMethod.toString},
+        ${record.requestedClaims},
+        ${record.uiLocales}::text[],
+        ${record.nonce},
+        ${record.accessToken},
+        ${record.amr},
+        ${record.authTime},
+        ${record.acr},
+        ${false},
+        $expiresAt
+      )
+    """.update.run()
+    ()
 
   override def delete(code: MAC.Of[AuthorizationCode]): Task[Unit] =
     xa.connectMeasured("delete-authorization-code"):

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/PostgresConversationFinalizer.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/PostgresConversationFinalizer.scala
@@ -1,0 +1,45 @@
+package versola.oauth.conversation
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import versola.oauth.PostgresAuthorizationCodeRepository
+import versola.oauth.session.PostgresSessionRepository
+import versola.util.postgres.BasicCodecs
+import zio.{Clock, Task, ZLayer}
+
+/** Postgres implementation of [[ConversationFinalizer]].
+  *
+  * Deliberately does not have its own SQL: it holds one instance each of
+  * [[PostgresConversationRepository]], [[PostgresAuthorizationCodeRepository]] and
+  * [[PostgresSessionRepository]] and calls their `private[oauth]` "raw" variants — the same code
+  * that backs `delete`/`create`/`create` on those classes, just without their own
+  * connect/transact wrapper — from inside one `xa.transactMeasured` block. This way there is
+  * exactly one place each statement is written; changing one of those methods automatically keeps
+  * this transaction in sync instead of relying on a "mirror this" comment.
+  */
+class PostgresConversationFinalizer(xa: TransactorZIO) extends ConversationFinalizer, BasicCodecs:
+  private val conversations = PostgresConversationRepository(xa)
+  private val codes = PostgresAuthorizationCodeRepository(xa)
+  private val sessions = PostgresSessionRepository(xa)
+
+  override def finish(request: FinishConversationRequest): Task[Boolean] =
+    import request.*
+    Clock.instant.flatMap: now =>
+      xa.transactMeasured("finish-conversation"):
+        val claimed = conversations.deleteRaw(authId, version)
+        if claimed then
+          codes.insertRaw(codeMac, codeRecord, now.plusSeconds(codeTtl.toSeconds))
+          val idleExpiresAt = sessionIdleTtl.map(t => now.plusSeconds(t.toSeconds))
+          sessions.createRaw(
+            sessionIdMac,
+            publicSessionId,
+            session,
+            now,
+            now.plusSeconds(sessionTtl.toSeconds),
+            idleExpiresAt,
+            priorSession,
+          )
+        claimed
+
+object PostgresConversationFinalizer:
+  def live: ZLayer[TransactorZIO, Throwable, ConversationFinalizer] =
+    ZLayer.fromFunction(PostgresConversationFinalizer(_))

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/PostgresConversationRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/PostgresConversationRepository.scala
@@ -159,10 +159,14 @@ class PostgresConversationRepository(xa: TransactorZIO) extends ConversationRepo
     }.map(_ > 0)
 
   override def delete(authId: AuthId, version: Long): Task[Boolean] =
-    xa.connectMeasured("delete-conversation") {
-      sql"""delete from auth_conversations where id = $authId and version = $version"""
-        .update.run()
-    }.map(_ > 0)
+    xa.connectMeasured("delete-conversation")(deleteRaw(authId, version))
+
+  /** Same delete, without the connect/measure wrapper, so it can be composed into a larger
+    * transaction (see [[versola.oauth.conversation.PostgresConversationFinalizer]]).
+    */
+  private[oauth] def deleteRaw(authId: AuthId, version: Long)(using DbCon): Boolean =
+    sql"""delete from auth_conversations where id = $authId and version = $version"""
+      .update.run() > 0
 
 object PostgresConversationRepository:
   def live: ZLayer[TransactorZIO, Throwable, ConversationRepository] =

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
@@ -14,6 +14,7 @@ import zio.json.*
 import zio.{Clock, Duration, IO, Task, ZIO, ZLayer}
 
 import java.sql.{Connection, SQLException}
+import java.time.Instant
 import java.util.UUID
 
 class PostgresSessionRepository(xa: TransactorZIO)
@@ -60,40 +61,58 @@ class PostgresSessionRepository(xa: TransactorZIO)
   ): Task[Unit] =
     Clock.instant.flatMap: now =>
       val idleExpiresAt = idleTtl.map(t => now.plusSeconds(t.toSeconds))
-      val priorId = priorSession.map(_.id)
       xa.transactMeasured("create-session"):
-        // The new session continues the same browser session as the prior one (step-up,
-        // idle-slide re-issue): carry over the RPs already registered on it so none of them
-        // miss a later logout notification because of the rotation.
-        val priorClients = priorId.toList.flatMap: prior =>
-          sql"""SELECT clients FROM sso_sessions WHERE id = $prior""".query[List[ClientEntry]].run().headOption.getOrElse(Nil)
-        val clients = (session.clients ++ priorClients).distinctBy(_.clientId)
+        createRaw(id, publicId, session, now, now.plusSeconds(ttl.toSeconds), idleExpiresAt, priorSession)
+
+  /** Same insert (including prior-session handling), without the transact/measure wrapper, so it
+    * can be composed into a larger transaction (see
+    * [[versola.oauth.conversation.PostgresConversationFinalizer]]).
+    *
+    * @param now used both for `created_at`-relative expiry math already baked into `expiresAt`/
+    *            `idleExpiresAt` by the caller, and to timestamp the prior-session invalidation.
+    */
+  private[oauth] def createRaw(
+      id: MAC.Of[SessionId],
+      publicId: PublicSessionId,
+      session: SessionRecord,
+      now: Instant,
+      expiresAt: Instant,
+      idleExpiresAt: Option[Instant],
+      priorSession: Option[PriorSession],
+  )(using DbCon): Unit =
+    // The new session continues the same browser session as the prior one (step-up,
+    // idle-slide re-issue): carry over the RPs already registered on it so none of them
+    // miss a later logout notification because of the rotation.
+    val priorId = priorSession.map(_.id)
+    val priorClients = priorId.toList.flatMap: prior =>
+      sql"""SELECT clients FROM sso_sessions WHERE id = $prior""".query[List[ClientEntry]].run().headOption.getOrElse(Nil)
+    val clients = (session.clients ++ priorClients).distinctBy(_.clientId)
+    sql"""
+      INSERT INTO sso_sessions (id, public_id, clients, user_id, user_agent, created_at, amr, expires_at, idle_expires_at)
+      VALUES (
+        $id,
+        $publicId,
+        $clients,
+        ${session.userId},
+        ${session.userAgent},
+        ${session.createdAt},
+        ${session.amr},
+        $expiresAt,
+        $idleExpiresAt
+      )
+    """.update.run()
+    priorSession.foreach:
+      case PriorSession.Invalidate(prior) =>
+        sql"""UPDATE sso_sessions SET expires_at = $now WHERE id = $prior""".update.run()
+        sql"""UPDATE refresh_tokens SET expires_at = $now WHERE session_id = $prior""".update.run()
+      case PriorSession.MigrateTokens(prior, amr, authTime, acr) =>
+        sql"""UPDATE sso_sessions SET expires_at = $now WHERE id = $prior""".update.run()
         sql"""
-          INSERT INTO sso_sessions (id, public_id, clients, user_id, user_agent, created_at, amr, expires_at, idle_expires_at)
-          VALUES (
-            $id,
-            $publicId,
-            $clients,
-            ${session.userId},
-            ${session.userAgent},
-            ${session.createdAt},
-            ${session.amr},
-            ${now.plusSeconds(ttl.toSeconds)},
-            $idleExpiresAt
-          )
+          UPDATE refresh_tokens
+          SET session_id = $id, amr = $amr, auth_time = $authTime, acr = $acr
+          WHERE session_id = $prior AND expires_at > $now
         """.update.run()
-        priorSession.foreach:
-          case PriorSession.Invalidate(prior) =>
-            sql"""UPDATE sso_sessions SET expires_at = $now WHERE id = $prior""".update.run()
-            sql"""UPDATE refresh_tokens SET expires_at = $now WHERE session_id = $prior""".update.run()
-          case PriorSession.MigrateTokens(prior, amr, authTime, acr) =>
-            sql"""UPDATE sso_sessions SET expires_at = $now WHERE id = $prior""".update.run()
-            sql"""
-              UPDATE refresh_tokens
-              SET session_id = $id, amr = $amr, auth_time = $authTime, acr = $acr
-              WHERE session_id = $prior AND expires_at > $now
-            """.update.run()
-        ()
+    ()
 
   override def findSession(id: MAC.Of[SessionId]): Task[Option[SessionRecord]] =
     Clock.instant.flatMap: now =>

--- a/auth/implementations/postgres/src/test/scala/versola/oauth/conversation/PostgresConversationFinalizerSpec.scala
+++ b/auth/implementations/postgres/src/test/scala/versola/oauth/conversation/PostgresConversationFinalizerSpec.scala
@@ -1,0 +1,342 @@
+package versola.oauth.conversation
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import com.augustnagro.magnum.sql
+import versola.oauth.PostgresAuthorizationCodeRepository
+import versola.oauth.authorize.model.ResponseTypeEntry
+import versola.oauth.client.model.{Acr, AuthFlow, AuthMethodRef, ClientId, ScopeToken}
+import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep}
+import versola.oauth.model.{AccessToken, AuthorizationCode, AuthorizationCodeRecord, CodeChallenge, CodeChallengeMethod}
+import versola.oauth.session.PostgresSessionRepository
+import versola.oauth.session.model.{ClientEntry, PriorSession, PublicSessionId, RefreshTokenRecord, SessionId, SessionRecord, UserAgentInfo}
+import versola.user.model.UserId
+import versola.util.MAC
+import versola.util.postgres.PostgresSpec
+import zio.*
+import zio.http.URL
+import zio.test.*
+
+import java.sql.SQLException
+import java.time.Instant
+import java.util.UUID
+
+/** Regression coverage for issue #102: `ConversationFinalizer.finish` must delete the conversation
+  * and create the authorization code + session as a single atomic unit — never a state where the
+  * conversation is gone but the code/session were never created.
+  */
+object PostgresConversationFinalizerSpec extends PostgresSpec:
+
+  // Fixed (non-random) UUIDs, same convention as ConversationRepositorySpec: AuthId/UserId derive
+  // their embedded "createdAt" from the UUID bits (UUIDv7), so arbitrary UUIDs must be reused
+  // consistently rather than generated with UUID.randomUUID().
+  private val authId1 = AuthId(UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+  private val authId2 = AuthId(UUID.fromString("bbbbbbbb-cccc-dddd-eeee-ffffffffffff"))
+  private val authId3 = AuthId(UUID.fromString("cccccccc-cccc-dddd-eeee-ffffffffffff"))
+  private val authId4 = AuthId(UUID.fromString("dddddddd-cccc-dddd-eeee-ffffffffffff"))
+  private val authId5 = AuthId(UUID.fromString("eeeeeeee-cccc-dddd-eeee-ffffffffffff"))
+  private val userId1 = UserId(UUID.fromString("f077fb08-9935-4a6d-8643-bf97c073bf0f"))
+  private val userId2 = UserId(UUID.fromString("a077fb08-9935-4a6d-8643-bf97c073bf0f"))
+  private val userId3 = UserId(UUID.fromString("b077fb08-9935-4a6d-8643-bf97c073bf0f"))
+  private val userId4 = UserId(UUID.fromString("c077fb08-9935-4a6d-8643-bf97c073bf0f"))
+  private val userId5 = UserId(UUID.fromString("d077fb08-9935-4a6d-8643-bf97c073bf0f"))
+
+  private val clientId = ClientId("test-client")
+  private val redirectUri = URL.decode("https://example.com/callback").toOption.get
+  private val codeChallenge = CodeChallenge("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+
+  /** True if `t`, or any of its causes, is a Postgres unique-violation (SQLSTATE 23505). Used to
+    * make sure the "rollback" tests actually fail for the reason we're forcing, not for some
+    * unrelated bug that would make them pass vacuously.
+    */
+  private def isUniqueViolation(t: Throwable, depth: Int = 0): Boolean =
+    depth < 10 && (t match
+      case sql: SQLException => sql.getSQLState == "23505"
+      case _ => Option(t.getCause).exists(isUniqueViolation(_, depth + 1))
+    )
+
+  private def newConversation(userId: UserId) = ConversationRecord(
+    clientId = clientId,
+    redirectUri = redirectUri,
+    scope = Set(ScopeToken("openid")),
+    codeChallenge = codeChallenge,
+    codeChallengeMethod = CodeChallengeMethod.S256,
+    state = None,
+    userId = Some(userId),
+    credential = None,
+    step = ConversationStep.AccessDenied,
+    requestedClaims = None,
+    uiLocales = None,
+    nonce = None,
+    responseType = zio.prelude.NonEmptySet(ResponseTypeEntry.Code),
+    userEmail = None,
+    userPhone = None,
+    userLogin = None,
+    userClaims = None,
+    authFlow = AuthFlow.default,
+    userAgent = None,
+    version = 0,
+    amr = Map.empty,
+    needsPasswordChange = false,
+    targetAcr = None,
+    csrfToken = "csrf",
+    priorSessionId = None,
+  )
+
+  private def newCodeRecord(
+      userId: UserId,
+      sessionIdMac: MAC.Of[SessionId],
+      publicSessionId: PublicSessionId,
+      now: Instant,
+  ) = AuthorizationCodeRecord(
+    sessionId = sessionIdMac,
+    publicSessionId = publicSessionId,
+    clientId = clientId,
+    userId = userId,
+    redirectUri = redirectUri,
+    scope = Set(ScopeToken("openid")),
+    codeChallenge = codeChallenge,
+    codeChallengeMethod = CodeChallengeMethod.S256,
+    requestedClaims = None,
+    uiLocales = None,
+    nonce = None,
+    accessToken = AccessToken.fromString("access-token"),
+    amr = Set.empty,
+    authTime = now,
+    acr = None,
+  )
+
+  private def newSession(userId: UserId, publicSessionId: PublicSessionId, now: Instant) =
+    SessionRecord(
+      userId = userId,
+      clients = List(ClientEntry(clientId, now)),
+      userAgent = UserAgentInfo.parse(None),
+      createdAt = now,
+      amr = Map.empty,
+      publicId = publicSessionId,
+    )
+
+  private def newRefreshToken(
+      userId: UserId,
+      sessionIdMac: MAC.Of[SessionId],
+      publicSessionId: PublicSessionId,
+      now: Instant,
+  ) = RefreshTokenRecord(
+    sessionId = sessionIdMac,
+    publicSessionId = publicSessionId,
+    accessToken = AccessToken.fromString("prior-access-token"),
+    userId = userId,
+    clientId = clientId,
+    externalAudience = Nil,
+    scope = Set(ScopeToken("openid")),
+    issuedAt = now,
+    expiresAt = now.plusSeconds(3600),
+    requestedClaims = None,
+    uiLocales = None,
+    nonce = None,
+    previousRefreshToken = None,
+    amr = Set(AuthMethodRef.pwd),
+    authTime = now,
+    acr = None,
+  )
+
+  /** Builds a request for `finish`, defaulting the ttl/idle-ttl fields so each test only has to
+    * spell out what it's actually varying.
+    */
+  private def newRequest(
+      authId: AuthId,
+      userId: UserId,
+      codeMac: MAC.Of[AuthorizationCode],
+      sessionIdMac: MAC.Of[SessionId],
+      publicSessionId: PublicSessionId,
+      now: Instant,
+      priorSession: Option[PriorSession] = None,
+  ) = FinishConversationRequest(
+    authId = authId,
+    version = 0L,
+    codeMac = codeMac,
+    codeRecord = newCodeRecord(userId, sessionIdMac, publicSessionId, now),
+    codeTtl = 1.minute,
+    sessionIdMac = sessionIdMac,
+    publicSessionId = publicSessionId,
+    session = newSession(userId, publicSessionId, now),
+    sessionTtl = 1.hour,
+    sessionIdleTtl = Some(30.minutes),
+    priorSession = priorSession,
+  )
+
+  // Every test truncates the same shared tables (auth_conversations, authorization_codes,
+  // sso_sessions, refresh_tokens) as its setup step. Without forcing sequential execution, ZIO
+  // Test runs these in parallel by default, so one test's TRUNCATE can wipe out a row another
+  // concurrently-running test just inserted (flaky, order-dependent failures).
+  override val spec: Spec[TransactorZIO & TestEnvironment & Scope, Any] =
+    suite("PostgresConversationFinalizerSpec")(
+      test("commits delete + create code + create session together") {
+        for
+          xa <- ZIO.service[TransactorZIO]
+          _ <- xa.connect(sql"TRUNCATE TABLE auth_conversations, authorization_codes, sso_sessions, refresh_tokens".update.run())
+          now <- Clock.instant
+          finalizer = PostgresConversationFinalizer(xa)
+          conversations = PostgresConversationRepository(xa)
+          codes = PostgresAuthorizationCodeRepository(xa)
+          sessions = PostgresSessionRepository(xa)
+          _ <- conversations.create(authId1, newConversation(userId1), 15.minutes)
+          codeMac = MAC(Array.fill(32)(1.toByte))
+          sessionIdMac = MAC(Array.fill(32)(2.toByte))
+          publicSessionId = PublicSessionId("public-1")
+          claimed <- finalizer.finish(newRequest(authId1, userId1, codeMac, sessionIdMac, publicSessionId, now))
+          conversationAfter <- conversations.find(authId1)
+          codeAfter <- codes.find(codeMac)
+          sessionAfter <- sessions.findSession(sessionIdMac)
+        yield assertTrue(
+          claimed,
+          conversationAfter.isEmpty,
+          codeAfter.isDefined,
+          sessionAfter.isDefined,
+        )
+      },
+      test("rolls back the conversation delete when session creation fails on a unique violation (issue #102)") {
+        for
+          xa <- ZIO.service[TransactorZIO]
+          _ <- xa.connect(sql"TRUNCATE TABLE auth_conversations, authorization_codes, sso_sessions, refresh_tokens".update.run())
+          now <- Clock.instant
+          finalizer = PostgresConversationFinalizer(xa)
+          conversations = PostgresConversationRepository(xa)
+          codes = PostgresAuthorizationCodeRepository(xa)
+          _ <- conversations.create(authId2, newConversation(userId2), 15.minutes)
+          conflictingPublicSessionId = PublicSessionId("duplicate-public-id")
+          existingSessionIdMac = MAC(Array.fill(32)(8.toByte))
+          // A pre-existing session with the same public_id (UNIQUE) makes the INSERT inside
+          // finish() fail with a constraint violation. Before the fix this couldn't happen inside
+          // one transaction with the delete, so the conversation delete would have already
+          // committed on its own — this test asserts that no longer happens.
+          _ <- PostgresSessionRepository(xa).create(
+            existingSessionIdMac,
+            conflictingPublicSessionId,
+            newSession(userId2, conflictingPublicSessionId, now),
+            1.hour,
+            None,
+            None,
+          )
+          codeMac = MAC(Array.fill(32)(3.toByte))
+          sessionIdMac = MAC(Array.fill(32)(4.toByte))
+          outcome <- finalizer.finish(newRequest(authId2, userId2, codeMac, sessionIdMac, conflictingPublicSessionId, now)).either
+          conversationAfter <- conversations.find(authId2)
+          codeAfter <- codes.find(codeMac)
+        yield assertTrue(
+          outcome.fold(isUniqueViolation(_), _ => false),
+          conversationAfter.isDefined,
+          codeAfter.isEmpty,
+        )
+      },
+      test("rolls back the conversation delete when the authorization code insert fails on a unique violation (issue #102)") {
+        for
+          xa <- ZIO.service[TransactorZIO]
+          _ <- xa.connect(sql"TRUNCATE TABLE auth_conversations, authorization_codes, sso_sessions, refresh_tokens".update.run())
+          now <- Clock.instant
+          finalizer = PostgresConversationFinalizer(xa)
+          conversations = PostgresConversationRepository(xa)
+          codes = PostgresAuthorizationCodeRepository(xa)
+          sessions = PostgresSessionRepository(xa)
+          _ <- conversations.create(authId3, newConversation(userId3), 15.minutes)
+          conflictingCodeMac = MAC(Array.fill(32)(9.toByte))
+          otherSessionIdMac = MAC(Array.fill(32)(10.toByte))
+          otherPublicSessionId = PublicSessionId("other-public-session")
+          // A pre-existing authorization_codes row with the same `code` PK makes the INSERT
+          // inside finish() fail before it ever reaches the session INSERT — this is the other
+          // failure point named in issue #102 (the finalizer's own regression test previously
+          // only exercised the session-insert failure, not this one).
+          _ <- codes.create(conflictingCodeMac, newCodeRecord(userId3, otherSessionIdMac, otherPublicSessionId, now), 1.minute)
+          sessionIdMac = MAC(Array.fill(32)(11.toByte))
+          publicSessionId = PublicSessionId("public-3")
+          outcome <- finalizer.finish(newRequest(authId3, userId3, conflictingCodeMac, sessionIdMac, publicSessionId, now)).either
+          conversationAfter <- conversations.find(authId3)
+          sessionAfter <- sessions.findSession(sessionIdMac)
+        yield assertTrue(
+          outcome.fold(isUniqueViolation(_), _ => false),
+          conversationAfter.isDefined,
+          sessionAfter.isEmpty,
+        )
+      },
+      test("invalidates the prior session and its refresh token on PriorSession.Invalidate") {
+        for
+          xa <- ZIO.service[TransactorZIO]
+          _ <- xa.connect(sql"TRUNCATE TABLE auth_conversations, authorization_codes, sso_sessions, refresh_tokens".update.run())
+          now <- Clock.instant
+          finalizer = PostgresConversationFinalizer(xa)
+          conversations = PostgresConversationRepository(xa)
+          sessions = PostgresSessionRepository(xa)
+          _ <- conversations.create(authId4, newConversation(userId4), 15.minutes)
+          priorSessionIdMac = MAC(Array.fill(32)(20.toByte))
+          priorPublicSessionId = PublicSessionId("prior-public-session-invalidate")
+          _ <- sessions.create(priorSessionIdMac, priorPublicSessionId, newSession(userId4, priorPublicSessionId, now), 1.hour, None, None)
+          priorRefreshTokenMac = MAC(Array.fill(32)(21.toByte))
+          _ <- sessions.createRefreshToken(priorRefreshTokenMac, newRefreshToken(userId4, priorSessionIdMac, priorPublicSessionId, now))
+            .mapError(e => new RuntimeException(e.toString))
+          codeMac = MAC(Array.fill(32)(22.toByte))
+          newSessionIdMac = MAC(Array.fill(32)(23.toByte))
+          newPublicSessionId = PublicSessionId("public-4")
+          claimed <- finalizer.finish(
+            newRequest(
+              authId4,
+              userId4,
+              codeMac,
+              newSessionIdMac,
+              newPublicSessionId,
+              now,
+              priorSession = Some(PriorSession.Invalidate(priorSessionIdMac)),
+            ),
+          )
+          priorSessionAfter <- sessions.findSession(priorSessionIdMac)
+          priorTokenAfter <- sessions.findToken(priorRefreshTokenMac)
+          newSessionAfter <- sessions.findSession(newSessionIdMac)
+        yield assertTrue(
+          claimed,
+          priorSessionAfter.isEmpty,
+          priorTokenAfter.isEmpty,
+          newSessionAfter.isDefined,
+        )
+      },
+      test("migrates the prior session's refresh token to the new session on PriorSession.MigrateTokens") {
+        for
+          xa <- ZIO.service[TransactorZIO]
+          _ <- xa.connect(sql"TRUNCATE TABLE auth_conversations, authorization_codes, sso_sessions, refresh_tokens".update.run())
+          now <- Clock.instant
+          finalizer = PostgresConversationFinalizer(xa)
+          conversations = PostgresConversationRepository(xa)
+          sessions = PostgresSessionRepository(xa)
+          _ <- conversations.create(authId5, newConversation(userId5), 15.minutes)
+          priorSessionIdMac = MAC(Array.fill(32)(30.toByte))
+          priorPublicSessionId = PublicSessionId("prior-public-session-migrate")
+          _ <- sessions.create(priorSessionIdMac, priorPublicSessionId, newSession(userId5, priorPublicSessionId, now), 1.hour, None, None)
+          priorRefreshTokenMac = MAC(Array.fill(32)(31.toByte))
+          _ <- sessions.createRefreshToken(priorRefreshTokenMac, newRefreshToken(userId5, priorSessionIdMac, priorPublicSessionId, now))
+            .mapError(e => new RuntimeException(e.toString))
+          codeMac = MAC(Array.fill(32)(32.toByte))
+          newSessionIdMac = MAC(Array.fill(32)(33.toByte))
+          newPublicSessionId = PublicSessionId("public-5")
+          migratedAmr = Set(AuthMethodRef.otp)
+          migratedAcr = Some(Acr("urn:test:step-up"))
+          claimed <- finalizer.finish(
+            newRequest(
+              authId5,
+              userId5,
+              codeMac,
+              newSessionIdMac,
+              newPublicSessionId,
+              now,
+              priorSession = Some(PriorSession.MigrateTokens(priorSessionIdMac, migratedAmr, now, migratedAcr)),
+            ),
+          )
+          priorSessionAfter <- sessions.findSession(priorSessionIdMac)
+          migratedTokenAfter <- sessions.findToken(priorRefreshTokenMac)
+        yield assertTrue(
+          claimed,
+          priorSessionAfter.isEmpty,
+          migratedTokenAfter.exists { t =>
+            java.util.Arrays.equals(t.sessionId: Array[Byte], newSessionIdMac: Array[Byte]) &&
+            t.amr == migratedAmr &&
+            t.acr == migratedAcr
+          },
+        )
+      },
+    ).@@(TestAspect.sequential)

--- a/auth/src/main/scala/versola/oauth/conversation/ConversationFinalizer.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationFinalizer.scala
@@ -1,0 +1,43 @@
+package versola.oauth.conversation
+
+import versola.oauth.conversation.model.AuthId
+import versola.oauth.model.{AuthorizationCode, AuthorizationCodeRecord}
+import versola.oauth.session.model.{PriorSession, PublicSessionId, SessionId, SessionRecord}
+import versola.util.MAC
+import zio.{Duration, Task}
+
+/** Everything `ConversationFinalizer.finish` needs, bundled by name instead of position.
+  *
+  * Kept as a named record rather than 11 positional parameters: `codeTtl` and `sessionTtl` are
+  * both plain `Duration`, and `codeMac`/`sessionIdMac` are both `MAC.Of[_]` — a positional
+  * argument list that long makes it easy to transpose two same-typed arguments without the
+  * compiler ever noticing.
+  */
+case class FinishConversationRequest(
+    authId: AuthId,
+    version: Long,
+    codeMac: MAC.Of[AuthorizationCode],
+    codeRecord: AuthorizationCodeRecord,
+    codeTtl: Duration,
+    sessionIdMac: MAC.Of[SessionId],
+    publicSessionId: PublicSessionId,
+    session: SessionRecord,
+    sessionTtl: Duration,
+    sessionIdleTtl: Option[Duration],
+    priorSession: Option[PriorSession],
+)
+
+/** Atomically completes a conversation: deletes the conversation row and, only if that delete
+  * actually claimed it (optimistic version match), creates the authorization code and the SSO
+  * session in the same database transaction.
+  *
+  * This exists so `ConversationService.finish` cannot end up in the state where the conversation
+  * is gone but the authorization code / session were never created (see issue #102) — the delete
+  * and the two creates either all commit together or all roll back together.
+  */
+trait ConversationFinalizer:
+  /** @return true if the conversation was claimed (deleted) and the authorization code/session
+    *         were created; false if the conversation delete didn't match (already finished,
+    *         deleted, or concurrently modified) — in which case nothing is written.
+    */
+  def finish(request: FinishConversationRequest): Task[Boolean]

--- a/auth/src/main/scala/versola/oauth/conversation/ConversationService.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationService.scala
@@ -14,9 +14,7 @@ import versola.oauth.conversation.model.{AuthId, ConversationRecord, Conversatio
 import versola.oauth.conversation.otp.OtpService
 import versola.oauth.conversation.otp.model.SubmitOtpResult
 import versola.oauth.model.{AuthorizationCode, AuthorizationCodeRecord}
-import versola.oauth.session.SessionRepository
 import versola.oauth.session.model.{ClientEntry, PublicSessionId, SessionId, SessionRecord, UserAgentInfo, PriorSession}
-import versola.oauth.token.AuthorizationCodeRepository
 import versola.oauth.userinfo.UserInfoService
 import versola.user.UserRepository
 import versola.user.model.{Login, UserId, UserRecord}
@@ -143,15 +141,14 @@ trait ConversationService:
 
 object ConversationService:
   def live =
-    ZLayer.fromFunction(Impl(_, _, _, _, _, _, _, _, _, _, _, _, _, _, _))
+    ZLayer.fromFunction(Impl(_, _, _, _, _, _, _, _, _, _, _, _, _, _))
 
   class Impl(
       otpService: OtpService,
       passwordService: PasswordService,
       conversationRepository: ConversationRepository,
       userRepository: UserRepository,
-      authorizationCodeRepository: AuthorizationCodeRepository,
-      sessionRepository: SessionRepository,
+      conversationFinalizer: ConversationFinalizer,
       authPropertyGenerator: AuthPropertyGenerator,
       securityService: SecurityService,
       userInfoService: UserInfoService,
@@ -554,21 +551,36 @@ object ConversationService:
               publicId = publicSessionId,
             )
             codeMac <- securityService.mac(Secret(code), config.security.authCodesSecret)
-            claimed <- conversationRepository.delete(authId, conversation.version)
+            // Always create a new session (rotates the ID, issues a fresh cookie with full TTL).
+            // For step-up the accumulated AMR is already in conversation.amr.
+            // When offline_access is in scope the client holds a refresh token on-device:
+            // migrate prior session's tokens to the new session so the device RT stays valid.
+            // Otherwise (web/BFF) expire the prior session's tokens outright.
+            priorSession = conversation.priorSessionId.map: prior =>
+              if conversation.hasOfflineAccess then
+                PriorSession.MigrateTokens(prior, amr, now, conversation.targetAcr)
+              else
+                PriorSession.Invalidate(prior)
+            // Deletes the conversation and creates the authorization code + session in one DB
+            // transaction, so a failure partway through rolls everything back instead of leaving
+            // the conversation deleted with no code/session to show for it (issue #102).
+            claimed <- conversationFinalizer.finish(
+              FinishConversationRequest(
+                authId = authId,
+                version = conversation.version,
+                codeMac = codeMac,
+                codeRecord = record,
+                codeTtl = 1.minute,
+                sessionIdMac = sessionIdMac,
+                publicSessionId = publicSessionId,
+                session = session,
+                sessionTtl = sessionTtl,
+                sessionIdleTtl = sessionIdleTtl,
+                priorSession = priorSession,
+              ),
+            )
             result <- if claimed then
               for
-                _ <- authorizationCodeRepository.create(codeMac, record, 1.minute)
-                // Always create a new session (rotates the ID, issues a fresh cookie with full TTL).
-                // For step-up the accumulated AMR is already in conversation.amr.
-                // When offline_access is in scope the client holds a refresh token on-device:
-                // migrate prior session's tokens to the new session so the device RT stays valid.
-                // Otherwise (web/BFF) expire the prior session's tokens outright.
-                priorSession = conversation.priorSessionId.map: prior =>
-                  if conversation.hasOfflineAccess then
-                    PriorSession.MigrateTokens(prior, amr, now, conversation.targetAcr)
-                  else
-                    PriorSession.Invalidate(prior)
-                _ <- sessionRepository.create(sessionIdMac, publicSessionId, session, sessionTtl, sessionIdleTtl, priorSession)
                 idTokenData <- if conversation.responseType.contains(ResponseTypeEntry.IdToken) && conversation.scope.contains(ScopeToken.OpenId) then
                   generateIdTokenData(userId, conversation, amr, now, conversation.targetAcr, publicSessionId)
                 else

--- a/auth/src/test/scala/versola/oauth/conversation/ConversationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/ConversationServiceSpec.scala
@@ -15,10 +15,8 @@ import versola.oauth.conversation.model.{AuthId, ConversationRecord, Conversatio
 import versola.oauth.conversation.otp.OtpService
 import versola.oauth.conversation.otp.model.SubmitOtpResult
 import versola.oauth.model.*
-import versola.oauth.session.SessionRepository
 import versola.oauth.session.model.PriorSession
 import versola.oauth.session.model.*
-import versola.oauth.token.AuthorizationCodeRepository
 import versola.oauth.userinfo.UserInfoService
 import versola.user.UserRepository
 import versola.user.model.*
@@ -81,8 +79,7 @@ object ConversationServiceSpec extends UnitSpecBase:
     val passwordService = stub[PasswordService]
     val conversationRepository = stub[ConversationRepository]
     val userRepository = stub[UserRepository]
-    val authorizationCodeRepository = stub[AuthorizationCodeRepository]
-    val sessionRepository = stub[SessionRepository]
+    val conversationFinalizer = stub[ConversationFinalizer]
     val authPropertyGenerator = stub[AuthPropertyGenerator]
     val securityService = stub[SecurityService]
     val userInfoService = stub[UserInfoService]
@@ -97,8 +94,7 @@ object ConversationServiceSpec extends UnitSpecBase:
       passwordService,
       conversationRepository,
       userRepository,
-      authorizationCodeRepository,
-      sessionRepository,
+      conversationFinalizer,
       authPropertyGenerator,
       securityService,
       userInfoService,
@@ -216,9 +212,7 @@ object ConversationServiceSpec extends UnitSpecBase:
           _ <- env.authPropertyGenerator.nextAccessToken.succeedsWith(accessToken)
           _ <- env.configService.getSessionTtl.succeedsWith(1.hour)
           _ <- env.configService.getSessionIdleTtl.succeedsWith(Some(30.minutes))
-          _ <- env.conversationRepository.delete.succeedsWith(true)
-          _ <- env.authorizationCodeRepository.create.succeedsWith(())
-          _ <- env.sessionRepository.create.succeedsWith(())
+          _ <- env.conversationFinalizer.finish.succeedsWith(true)
           result <- env.service.finish(authId, record)
         yield
           result match
@@ -254,18 +248,16 @@ object ConversationServiceSpec extends UnitSpecBase:
           _ <- env.authPropertyGenerator.nextAccessToken.succeedsWith(accessToken)
           _ <- env.configService.getSessionTtl.succeedsWith(1.hour)
           _ <- env.configService.getSessionIdleTtl.succeedsWith(Some(30.minutes))
-          _ <- env.conversationRepository.delete.succeedsWith(true)
-          _ <- env.authorizationCodeRepository.create.succeedsWith(())
-          _ <- env.sessionRepository.create.succeedsWith(())
+          _ <- env.conversationFinalizer.finish.succeedsWith(true)
           result <- env.service.finish(authId, record)
-          createCalls = env.sessionRepository.create.calls
+          finishCalls = env.conversationFinalizer.finish.calls
         yield
           result match
             case ConversationResult.Complete(_, _, _, s, _) =>
               assertTrue(s == sessionId) &&
-              assertTrue(createCalls.nonEmpty) &&
-              assertTrue(createCalls.head._1 == sessionIdMac) &&
-              assertTrue(createCalls.head._6 == Some(PriorSession.Invalidate(priorSessionIdMac)))
+              assertTrue(finishCalls.nonEmpty) &&
+              assertTrue(finishCalls.head.sessionIdMac == sessionIdMac) &&
+              assertTrue(finishCalls.head.priorSession == Some(PriorSession.Invalidate(priorSessionIdMac)))
             case _ => assertTrue(false)
       },
       test("invalidates prior session and creates new one during re-auth") {
@@ -294,19 +286,43 @@ object ConversationServiceSpec extends UnitSpecBase:
           _ <- env.authPropertyGenerator.nextAccessToken.succeedsWith(accessToken)
           _ <- env.configService.getSessionTtl.succeedsWith(1.hour)
           _ <- env.configService.getSessionIdleTtl.succeedsWith(Some(30.minutes))
-          _ <- env.conversationRepository.delete.succeedsWith(true)
-          _ <- env.authorizationCodeRepository.create.succeedsWith(())
-          _ <- env.sessionRepository.create.succeedsWith(())
+          _ <- env.conversationFinalizer.finish.succeedsWith(true)
           result <- env.service.finish(authId, record)
-          createCalls = env.sessionRepository.create.calls
+          finishCalls = env.conversationFinalizer.finish.calls
         yield
           result match
             case ConversationResult.Complete(_, _, _, s, _) =>
               assertTrue(s == sessionId) &&
-              assertTrue(createCalls.nonEmpty) &&
-              assertTrue(createCalls.head._1 == sessionIdMac) &&
-              assertTrue(createCalls.head._6 == Some(PriorSession.Invalidate(priorSessionIdMac)))
+              assertTrue(finishCalls.nonEmpty) &&
+              assertTrue(finishCalls.head.sessionIdMac == sessionIdMac) &&
+              assertTrue(finishCalls.head.priorSession == Some(PriorSession.Invalidate(priorSessionIdMac)))
             case _ => assertTrue(false)
+      },
+      test("returns IllegalState when the finalizer doesn't claim the conversation") {
+        // Covers issue #102: delete+create+create now happen inside ConversationFinalizer.finish
+        // as one DB transaction. If it reports `false` (stale version / already finished /
+        // create failed and rolled back), finish() must not report success.
+        val env = Env()
+        val now = Instant.parse("2026-07-13T10:00:00Z")
+        val record = conversationRecord.copy(userId = Some(userId))
+        val code = AuthorizationCode.fromString("code")
+        val sessionId = SessionId.fromString("session")
+        val testPublicSessionId = versola.oauth.session.model.PublicSessionId("public-session")
+        val accessToken = AccessToken.fromString("token")
+        val mac = MAC(Array.fill(32)(1.toByte))
+
+        for
+          _ <- TestClock.setTime(now)
+          _ <- env.authPropertyGenerator.nextAuthorizationCode.succeedsWith(code)
+          _ <- env.authPropertyGenerator.nextSessionId.succeedsWith(sessionId)
+          _ <- env.authPropertyGenerator.nextPublicSessionId.succeedsWith(testPublicSessionId)
+          _ <- env.securityService.mac.succeedsWith(mac)
+          _ <- env.authPropertyGenerator.nextAccessToken.succeedsWith(accessToken)
+          _ <- env.configService.getSessionTtl.succeedsWith(1.hour)
+          _ <- env.configService.getSessionIdleTtl.succeedsWith(Some(30.minutes))
+          _ <- env.conversationFinalizer.finish.succeedsWith(false)
+          result <- env.service.finish(authId, record)
+        yield assertTrue(result == ConversationResult.IllegalState)
       },
 
     ),
@@ -387,9 +403,7 @@ object ConversationServiceSpec extends UnitSpecBase:
           _ <- env.authPropertyGenerator.nextAccessToken.succeedsWith(accessToken)
           _ <- env.configService.getSessionTtl.succeedsWith(1.hour)
           _ <- env.configService.getSessionIdleTtl.succeedsWith(None)
-          _ <- env.conversationRepository.delete.succeedsWith(true)
-          _ <- env.authorizationCodeRepository.create.succeedsWith(())
-          _ <- env.sessionRepository.create.succeedsWith(())
+          _ <- env.conversationFinalizer.finish.succeedsWith(true)
           result <- env.service.offerPasskeyEnroll(authId, record)
         yield
           assertTrue(result.isInstanceOf[ConversationResult.Complete])

--- a/auth/src/test/scala/versola/oauth/conversation/OtpConversationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/OtpConversationServiceSpec.scala
@@ -13,8 +13,6 @@ import versola.oauth.conversation.model.{AuthId, ConversationRecord, Conversatio
 import versola.oauth.conversation.otp.OtpService
 import versola.oauth.conversation.otp.model.SubmitOtpResult
 import versola.oauth.model.{CodeChallenge, CodeChallengeMethod}
-import versola.oauth.session.SessionRepository
-import versola.oauth.token.AuthorizationCodeRepository
 import versola.oauth.userinfo.UserInfoService
 import versola.oauth.userinfo.model.UserInfoResponse
 import versola.user.UserRepository
@@ -56,8 +54,7 @@ object OtpConversationServiceSpec extends UnitSpecBase:
     val passwordService = stub[PasswordService]
     val conversationRepository = stub[ConversationRepository]
     val userRepository = stub[UserRepository]
-    val authorizationCodeRepository = stub[AuthorizationCodeRepository]
-    val sessionRepository = stub[SessionRepository]
+    val conversationFinalizer = stub[ConversationFinalizer]
     val authPropertyGenerator = stub[AuthPropertyGenerator]
     val securityService = stub[SecurityService]
     val userInfoService = stub[versola.oauth.userinfo.UserInfoService]
@@ -72,8 +69,7 @@ object OtpConversationServiceSpec extends UnitSpecBase:
       passwordService,
       conversationRepository,
       userRepository,
-      authorizationCodeRepository,
-      sessionRepository,
+      conversationFinalizer,
       authPropertyGenerator,
       securityService,
       userInfoService,
@@ -387,9 +383,7 @@ object OtpConversationServiceSpec extends UnitSpecBase:
           _ <- env.securityService.mac.returnsZIOOnCall:
             case 1 => ZIO.succeed(testSessionIdMac)
             case 2 => ZIO.succeed(testCodeMac)
-          _ <- env.authorizationCodeRepository.create.succeedsWith(())
-          _ <- env.sessionRepository.create.succeedsWith(())
-          _ <- env.conversationRepository.delete.succeedsWith(true)
+          _ <- env.conversationFinalizer.finish.succeedsWith(true)
           _ <- env.configService.getSessionTtl.succeedsWith(zio.Duration.fromSeconds(86400))
           _ <- env.configService.getSessionIdleTtl.succeedsWith(Option.empty[zio.Duration])
           _ <- env.userInfoService.getUserInfoForIdToken.succeedsWith(
@@ -437,9 +431,7 @@ object OtpConversationServiceSpec extends UnitSpecBase:
           _ <- env.securityService.mac.returnsZIOOnCall:
             case 1 => ZIO.succeed(testSessionIdMac)
             case 2 => ZIO.succeed(testCodeMac)
-          _ <- env.authorizationCodeRepository.create.succeedsWith(())
-          _ <- env.sessionRepository.create.succeedsWith(())
-          _ <- env.conversationRepository.delete.succeedsWith(true)
+          _ <- env.conversationFinalizer.finish.succeedsWith(true)
           _ <- env.configService.getSessionTtl.succeedsWith(zio.Duration.fromSeconds(86400))
           _ <- env.configService.getSessionIdleTtl.succeedsWith(Option.empty[zio.Duration])
           result <- env.service.finish(authId, conversation)
@@ -469,9 +461,7 @@ object OtpConversationServiceSpec extends UnitSpecBase:
           _ <- env.securityService.mac.returnsZIOOnCall:
             case 1 => ZIO.succeed(testSessionIdMac)
             case 2 => ZIO.succeed(testCodeMac)
-          _ <- env.authorizationCodeRepository.create.succeedsWith(())
-          _ <- env.sessionRepository.create.succeedsWith(())
-          _ <- env.conversationRepository.delete.succeedsWith(true)
+          _ <- env.conversationFinalizer.finish.succeedsWith(true)
           _ <- env.configService.getSessionTtl.succeedsWith(zio.Duration.fromSeconds(86400))
           _ <- env.configService.getSessionIdleTtl.succeedsWith(Option.empty[zio.Duration])
           result <- env.service.finish(authId, conversation)

--- a/auth/src/test/scala/versola/oauth/conversation/PasskeyConversationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/PasskeyConversationServiceSpec.scala
@@ -11,8 +11,6 @@ import versola.oauth.conversation.limit.{ChallengeType, LimitStatus, SubmissionL
 import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep}
 import versola.oauth.conversation.otp.OtpService
 import versola.oauth.model.{CodeChallenge, CodeChallengeMethod}
-import versola.oauth.session.SessionRepository
-import versola.oauth.token.AuthorizationCodeRepository
 import versola.oauth.userinfo.UserInfoService
 import versola.user.UserRepository
 import versola.user.model.{UserId, UserRecord}
@@ -48,8 +46,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
     val passwordService = stub[PasswordService]
     val conversationRepository = stub[ConversationRepository]
     val userRepository = stub[UserRepository]
-    val authorizationCodeRepository = stub[AuthorizationCodeRepository]
-    val sessionRepository = stub[SessionRepository]
+    val conversationFinalizer = stub[ConversationFinalizer]
     val authPropertyGenerator = stub[AuthPropertyGenerator]
     val securityService = stub[SecurityService]
     val userInfoService = stub[UserInfoService]
@@ -65,8 +62,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
       passwordService,
       conversationRepository,
       userRepository,
-      authorizationCodeRepository,
-      sessionRepository,
+      conversationFinalizer,
       authPropertyGenerator,
       securityService,
       userInfoService,
@@ -351,9 +347,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.authPropertyGenerator.nextPublicSessionId.succeedsWith(testPublicSessionId)
           _ <- env.securityService.mac.succeedsWith(testMac)
           _ <- env.authPropertyGenerator.nextAccessToken.succeedsWith(testAccessToken)
-          _ <- env.authorizationCodeRepository.create.succeedsWith(())
-          _ <- env.sessionRepository.create.succeedsWith(())
-          _ <- env.conversationRepository.delete.succeedsWith(true)
+          _ <- env.conversationFinalizer.finish.succeedsWith(true)
           _ <- env.configService.getSessionTtl.succeedsWith(zio.Duration.fromSeconds(86400))
           _ <- env.configService.getSessionIdleTtl.succeedsWith(Option.empty[zio.Duration])
           result <- env.service.offerPasskeyEnroll(authId, recordWithUser)
@@ -395,9 +389,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.authPropertyGenerator.nextPublicSessionId.succeedsWith(testPublicSessionId)
           _ <- env.securityService.mac.succeedsWith(testMac)
           _ <- env.authPropertyGenerator.nextAccessToken.succeedsWith(testAccessToken)
-          _ <- env.authorizationCodeRepository.create.succeedsWith(())
-          _ <- env.sessionRepository.create.succeedsWith(())
-          _ <- env.conversationRepository.delete.succeedsWith(true)
+          _ <- env.conversationFinalizer.finish.succeedsWith(true)
           _ <- env.configService.getSessionTtl.succeedsWith(zio.Duration.fromSeconds(86400))
           _ <- env.configService.getSessionIdleTtl.succeedsWith(Option.empty[zio.Duration])
           result <- env.service.finishPasskeyEnroll(authId, recordWithUser, enrollStep, "resp", "my-passkey")
@@ -430,9 +422,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.authPropertyGenerator.nextPublicSessionId.succeedsWith(testPublicSessionId)
           _ <- env.securityService.mac.succeedsWith(testMac)
           _ <- env.authPropertyGenerator.nextAccessToken.succeedsWith(testAccessToken)
-          _ <- env.authorizationCodeRepository.create.succeedsWith(())
-          _ <- env.sessionRepository.create.succeedsWith(())
-          _ <- env.conversationRepository.delete.succeedsWith(true)
+          _ <- env.conversationFinalizer.finish.succeedsWith(true)
           _ <- env.configService.getSessionTtl.succeedsWith(zio.Duration.fromSeconds(86400))
           _ <- env.configService.getSessionIdleTtl.succeedsWith(Option.empty[zio.Duration])
           result <- env.service.skipPasskey(authId, recordWithUser)

--- a/auth/src/test/scala/versola/oauth/conversation/PasswordConversationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/PasswordConversationServiceSpec.scala
@@ -12,8 +12,6 @@ import versola.oauth.conversation.limit.{LimitStatus, SubmissionLimiter}
 import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep}
 import versola.oauth.conversation.otp.OtpService
 import versola.oauth.model.{CodeChallenge, CodeChallengeMethod}
-import versola.oauth.session.SessionRepository
-import versola.oauth.token.AuthorizationCodeRepository
 import versola.oauth.userinfo.UserInfoService
 import versola.user.UserRepository
 import versola.user.model.{Login, UserId, UserRecord}
@@ -50,8 +48,7 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
     val passwordService = stub[PasswordService]
     val conversationRepository = stub[ConversationRepository]
     val userRepository = stub[UserRepository]
-    val authorizationCodeRepository = stub[AuthorizationCodeRepository]
-    val sessionRepository = stub[SessionRepository]
+    val conversationFinalizer = stub[ConversationFinalizer]
     val authPropertyGenerator = stub[AuthPropertyGenerator]
     val securityService = stub[SecurityService]
     val userInfoService = stub[UserInfoService]
@@ -66,8 +63,7 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
       passwordService,
       conversationRepository,
       userRepository,
-      authorizationCodeRepository,
-      sessionRepository,
+      conversationFinalizer,
       authPropertyGenerator,
       securityService,
       userInfoService,


### PR DESCRIPTION
closes #102 

### Problem
In `ConversationService.finish`, the conversation was deleted from the DB, then the
authorization code and the session were created via two separate repository calls with no
shared transaction. If `delete` succeeded but either `create` failed (transient DB error, rare
collision), the conversation was gone but no code/session existed — an unrecoverable
`IllegalState` for the user, with no way to retry.

### Fix
Introduced `ConversationFinalizer`, a narrow interface with a single `finish(...)` method that
performs delete-conversation + create-authorization-code + create-session as one unit.
`PostgresConversationFinalizer` implements it with all three writes inside a single
`xa.transactMeasured` block, so they commit or roll back together — mirroring the
multi-statement transaction pattern already used in `PostgresSessionRepository`
(`invalidateByUserId`, `invalidate`, `create`).

`ConversationRepository`, `AuthorizationCodeRepository`, and `SessionRepository` are unchanged;
`ConversationService` no longer depends on the latter two directly (they were only used inside
`finish`).

### Changes
- **New:** `ConversationFinalizer` (trait) and `PostgresConversationFinalizer` (impl).
- **New:** `PostgresConversationFinalizerSpec` — DB-backed test covering:
  - happy path: delete + code + session all commit together.
  - regression for #102: forces a unique-constraint conflict during session creation and asserts
    the conversation delete is rolled back (not silently lost).
- `ConversationService.finish` now calls `conversationFinalizer.finish(...)` once instead of
  `delete` → `create` → `create`. Public signature unchanged, no caller impact.
- `PostgresOAuthApp` wires `PostgresConversationFinalizer.live` into the layer graph.
- `ConversationServiceSpec` updated for the new dependency; added a test for
  `finish` reporting `false` → `IllegalState`.
- No migrations changed — no schema changes required.
