### PR TITLE
fix: refresh token isolation #93

### DIFF
--- a/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
@@ -194,7 +194,7 @@ class PostgresSessionRepository(xa: TransactorZIO)
       refreshToken: MAC.Of[RefreshToken],
       record: RefreshTokenRecord,
   ): IO[Throwable | RefreshAlreadyExchanged, Unit] =
-    xa.repeatableRead.transactMeasured("create-refresh-token") {
+    xa.transactMeasured("create-refresh-token") {
       record.previousRefreshToken
         .foreach { oldToken => sql"""DELETE FROM refresh_tokens WHERE id = $oldToken""".update.run() }
 


### PR DESCRIPTION
## Summary

Removes the unnecessary `TRANSACTION_REPEATABLE_READ` isolation level from `PostgresSessionRepository.createRefreshToken`.

Closes #93

## Why

The transaction body only does a conditional `DELETE` (old token) + `INSERT` (new token) — no `SELECT` that would benefit from repeatable reads. Collision protection during refresh-token rotation is already provided by the `UNIQUE` constraint on `refresh_tokens.previous_id`, combined with the existing `catchSome` that maps unique-violation / serialization-failure SQL states to `RefreshAlreadyExchanged`. The elevated isolation level added overhead and risk of serialization-failure retries without any correctness benefit.

## Change

```diff
- xa.repeatableRead.transactMeasured("create-refresh-token") {
+ xa.transactMeasured("create-refresh-token") {
```

Now runs at the default `READ_COMMITTED` level. `catchSome` handling for both `23505` (unique violation) and `40001` (serialization failure) is left in place — it's a shared helper and harmless defensively, even though `40001` shouldn't occur at `READ_COMMITTED` for this call site.

## Testing

- `PostgresRefreshTokenRepositorySpec` passes, including `"refresh token rotation: fail when old token already used"`, which fires 6 concurrent `createRefreshToken` calls against the same `previousRefreshToken` and asserts exactly one succeeds — this covers the exact race the isolation level was meant to guard against, now proven to hold via the `previous_id` UNIQUE constraint alone.