### PR TITLE
fix: presets repeatable read #95

### DIFF
--- a/central/implementations/postgres/src/main/scala/versola/configuration/clients/PostgresAuthorizationPresetRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/clients/PostgresAuthorizationPresetRepository.scala
@@ -41,7 +41,7 @@ class PostgresAuthorizationPresetRepository(
         .query[AuthorizationPreset].run().headOption
 
   override def replace(clientId: ClientId, presets: Seq[AuthorizationPreset]): Task[Unit] =
-    xa.repeatableRead.transactMeasured("replace-presets"):
+    xa.transactMeasured("replace-presets"):
       sql"""DELETE FROM authorization_presets WHERE client_id = $clientId""".update.run()
       if presets.nonEmpty then
         batchUpdate(presets): preset =>


### PR DESCRIPTION
## What
Switch `PostgresAuthorizationPresetRepository.replace` from `xa.repeatableRead.transactMeasured` to plain `xa.transactMeasured`.

## Why
`replace` only does `DELETE` + batch `INSERT`, with no `SELECT` inside the transaction — so `REPEATABLE_READ` gives no benefit over `READ_COMMITTED` here, just extra overhead.

This also aligns with the existing convention in the codebase: `repeatableRead` is used where a value is read and then relied on for a later write in the same transaction (e.g. `PostgresLocaleRepository`, `PostgresFormRepository.upsertForm`), while pure delete+insert transactions elsewhere (`PostgresOAuthClientRepository.updateClient`, etc.) use plain `transactMeasured`.

Closes #95

## Testing
- `PostgresAuthorizationPresetRepositorySpec` (integration, via `AuthorizationPresetRepositorySpec` contract test)