### PR TITLE
fix: locale repository isolation level #97

### DIFF
--- a/central/implementations/postgres/src/main/scala/versola/configuration/locales/PostgresLocaleRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/locales/PostgresLocaleRepository.scala
@@ -15,7 +15,7 @@ class PostgresLocaleRepository(xa: TransactorZIO) extends LocaleRepository, Basi
       sql"""SELECT code, name, is_default, active FROM locales ORDER BY code""".query[LocaleRecord].run()
 
   override def update(add: Vector[LocaleRecord], delete: Vector[String]): Task[Unit] =
-    xa.repeatableRead.transactMeasured("update-locales"):
+    xa.transactMeasured("update-locales"):
       if delete.nonEmpty then
         sql"""DELETE FROM locales WHERE code = ANY($delete)""".update.run()
         sql"""UPDATE forms
@@ -30,9 +30,8 @@ class PostgresLocaleRepository(xa: TransactorZIO) extends LocaleRepository, Basi
       }
 
   override def setDefault(code: String): Task[Unit] =
-    xa.repeatableRead.transactMeasured("set-default-locale"):
-      sql"""UPDATE locales SET is_default = FALSE WHERE is_default = TRUE""".update.run()
-      sql"""UPDATE locales SET is_default = TRUE WHERE code = $code""".update.run()
+    xa.transactMeasured("set-default-locale"):
+      sql"""UPDATE locales SET is_default = (code = $code)""".update.run()
     .unit
 
 object PostgresLocaleRepository:


### PR DESCRIPTION
Closes #97

Problem

PostgresLocaleRepository.update and .setDefault ran under REPEATABLE_READ via xa.repeatableRead.transactMeasured(...). update has no SELECT at all — the elevated isolation was pure overhead there.

Fix
update: switched to plain xa.transactMeasured(...) (READ COMMITTED). No behavior change — matches the PostgresFormRepository.setActiveVersion convention for write-only transactions.
setDefault: originally had the same two-UPDATE shape (clear old default, set new default) and no explicit SELECT, so it looked like the same case. It isn't — a code review caught that REPEATABLE_READ was implicitly providing conflict detection between the two UPDATEs under concurrent calls (Postgres treats UPDATE ... WHERE as a read for serialization purposes, even without an explicit SELECT). Downgrading it to READ COMMITTED as-is would allow two concurrent setDefault calls to leave two rows with is_default = TRUE. Fixed by collapsing the two UPDATEs into one atomic statement: UPDATE locales SET is_default = (code = $code). This removes the race entirely rather than relying on isolation level to catch it, and needs only READ COMMITTED.
Testing

No behavior change for callers; existing PostgresLocaleRepositorySpec / LocaleRepositorySpec cover both methods. Worth manually testing concurrent setDefault calls if you want extra confidence, though the single-statement fix makes the race structurally impossible.