### PR TITLE
perf: move expiry filtering from Scala to SQL WHERE clause Issue #96

### DIFF
--- a/auth/implementations/postgres/src/main/scala/versola/oauth/PostgresAuthorizationCodeRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/PostgresAuthorizationCodeRepository.scala
@@ -56,12 +56,11 @@ class PostgresAuthorizationCodeRepository(
           SELECT session_id, public_session_id, client_id, user_id, redirect_uri,
                  scope, code_challenge, code_challenge_method,
                  requested_claims, ui_locales, nonce, access_token,
-                 amr, auth_time, acr,
-                 expires_at
+                 amr, auth_time, acr
           FROM authorization_codes
-          WHERE code = $code
-        """.query[(AuthorizationCodeRecord, Instant)].run().headOption
-          .collect { case (record, expiresAt) if expiresAt.isAfter(now) => record }
+          WHERE code = $code AND expires_at > $now"""
+          .query[AuthorizationCodeRecord].run()
+          .headOption
     yield result
 
   override def create(

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/PostgresConversationRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/conversation/PostgresConversationRepository.scala
@@ -65,15 +65,12 @@ class PostgresConversationRepository(xa: TransactorZIO) extends ConversationRepo
   override def find(authId: AuthId): Task[Option[ConversationRecord]] =
     Clock.instant.flatMap: now =>
       xa.connectMeasured("find-conversation") {
-        sql"""select client_id, redirect_uri, scope, code_challenge, code_challenge_method, state, user_id, credential, step, requested_claims, ui_locales, nonce, response_type, user_email, user_phone, user_login, user_claims, auth_flow, user_agent, version, amr, needs_password_change, target_acr, csrf_token, prior_session_id, expires_at
+        sql"""select client_id, redirect_uri, scope, code_challenge, code_challenge_method, state, user_id, credential, step, requested_claims, ui_locales, nonce, response_type, user_email, user_phone, user_login, user_claims, auth_flow, user_agent, version, amr, needs_password_change, target_acr, csrf_token, prior_session_id
               from auth_conversations
-              where id = $authId"""
-          .query[(ConversationRecord, Instant)]
+              where id = $authId AND expires_at > $now"""
+          .query[ConversationRecord]
           .run()
           .headOption
-          .collect { case (conversation, expiresAt) if expiresAt.isAfter(now) =>
-            conversation
-          }
       }
 
   override def create(authId: AuthId, record: ConversationRecord, ttl: Duration): Task[Unit] =

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
@@ -254,11 +254,10 @@ class PostgresSessionRepository(xa: TransactorZIO)
                  expires_at, requested_claims, ui_locales, nonce, previous_id,
                  amr, auth_time, acr
           FROM refresh_tokens
-          WHERE id = $token
-        """.query[RefreshTokenRecord]
+          WHERE id = $token AND expires_at > $now"""
+          .query[RefreshTokenRecord]
           .run()
           .headOption
-          .filter(_.expiresAt.isAfter(now))
     yield result
 
   override def delete(token: MAC.Of[RefreshToken]): Task[Unit] =

--- a/auth/src/test/scala/versola/oauth/conversation/ConversationRepositorySpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/ConversationRepositorySpec.scala
@@ -187,9 +187,11 @@ trait ConversationRepositorySpec extends DatabaseSpecBase[ConversationRepository
         )
       },
       test("find returns None for expired conversation") {
+        val pastAuthId = AuthId(UUID.fromString("00000000-0001-7000-8000-000000000001"))
         for
-          _ <- env.repository.create(authId1, record1, ttl = Duration.Zero)
-          result <- env.repository.find(authId1)
+          _ <- env.repository.create(pastAuthId, record1, ttl = 1.second)
+          _ <- TestClock.adjust(2.seconds)
+          result <- env.repository.find(pastAuthId)
         yield assertTrue(result.isEmpty)
       },
 

--- a/auth/src/test/scala/versola/oauth/conversation/ConversationRepositorySpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/ConversationRepositorySpec.scala
@@ -186,6 +186,12 @@ trait ConversationRepositorySpec extends DatabaseSpecBase[ConversationRepository
           found2.version == found1.version + 1
         )
       },
+      test("find returns None for expired conversation") {
+        for
+          _ <- env.repository.create(authId1, record1, ttl = Duration.Zero)
+          result <- env.repository.find(authId1)
+        yield assertTrue(result.isEmpty)
+      },
 
     )
 


### PR DESCRIPTION
Closes #96 

Changes

- Added `AND expires_at > $now` to the SQL `WHERE` clause in all three queries
- Removed in-Scala `.filter` / `.collect` expiry checks — the database now guarantees only live records are returned
- Removed `expires_at` from `SELECT` in conversation and authorization code queries — it was fetched solely to check expiry in Scala