### PR TITLE
fix: dead now param user repository #100

### DIFF
--- a/auth/implementations/postgres/src/main/scala/versola/user/PostgresUserRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/user/PostgresUserRepository.scala
@@ -7,11 +7,11 @@ import com.augustnagro.magnum.pg.PgCodec.given
 import versola.util.postgres.BasicCodecs
 import versola.user.model.*
 import versola.util.{Email, Phone}
-import zio.{Clock, Task, ZIO, ZLayer}
+import zio.{Task, ZIO, ZLayer}
 import zio.json.*
 import zio.json.ast.Json
 
-import java.time.{Instant, LocalDate}
+import java.time.LocalDate
 import java.util.UUID
 
 class PostgresUserRepository(
@@ -19,22 +19,17 @@ class PostgresUserRepository(
 ) extends UserRepository, BasicCodecs:
 
   override def findOrCreate(userId: UserId, credential: Either[Email, Phone]): Task[(UserRecord, WasCreated)] =
-    for
-      now <- Clock.instant
-      (user, wasCreated) <- xa.connectMeasured("find-or-create-user"):
-        credential match
-          case Left(email) => createByEmailQuery(userId, email, now).run().head
-          case Right(phone) => createByPhoneQuery(userId, phone, now).run().head
-    yield (user, WasCreated(wasCreated))
+    xa.connectMeasured("find-or-create-user"):
+      credential match
+        case Left(email) => createByEmailQuery(userId, email).run().head
+        case Right(phone) => createByPhoneQuery(userId, phone).run().head
+    .map((user, wasCreated) => (user, WasCreated(wasCreated)))
 
   override def create(id: UserId): Task[UserRecord] =
-    for
-      now <- Clock.instant
-      user <- xa.connectMeasured("create-user"):
-        createQuery(id, now).run().head
-    yield user
+    xa.connectMeasured("create-user"):
+      createQuery(id).run().head
 
-  private def createByEmailQuery(id: UserId, email: Email, now: Instant) =
+  private def createByEmailQuery(id: UserId, email: Email) =
     sql"""insert into users (id, email, phone, login, claims, ui_locales)
           values ($id, $email, null, null, '{}'::jsonb, null)
           on conflict (email) where email is not null
@@ -42,7 +37,7 @@ class PostgresUserRepository(
           returning id, email, phone, login, claims, ui_locales, (xmax = 0) as created
        """.returning[(UserRecord, Boolean)]
 
-  private def createByPhoneQuery(id: UserId, phone: Phone, now: Instant) =
+  private def createByPhoneQuery(id: UserId, phone: Phone) =
     sql"""insert into users (id, email, phone, login, claims, ui_locales)
           values ($id, null, $phone, null, '{}'::jsonb, null)
           on conflict (phone) where phone is not null
@@ -50,7 +45,7 @@ class PostgresUserRepository(
           returning id, email, phone, login, claims, ui_locales, (xmax = 0) as created
        """.returning[(UserRecord, Boolean)]
 
-  private def createQuery(id: UserId, now: Instant) =
+  private def createQuery(id: UserId) =
     sql"""insert into users (id, email, phone, login, claims, ui_locales)
           values ($id, null, null, null, '{}'::jsonb, null)
           returning id, email, phone, login, claims, ui_locales


### PR DESCRIPTION
Closes #100 

`PostgresUserRepository.findOrCreate` and `.create` called `Clock.instant`
and passed `now` into `createByEmailQuery`, `createByPhoneQuery`, and
`createQuery`, but none of these methods referenced `now` in their SQL —
the users table has no timestamp column (`UserRecord.createdAt` is derived
from `id.createdAt`). The `Clock.instant` effect was running on every call
for nothing.

Changes:
- Removed `now: Instant` parameter from `createByEmailQuery`,
  `createByPhoneQuery`, `createQuery`.
- Removed the corresponding `Clock.instant` calls in `findOrCreate` and
  `create`.
- Removed now-unused `Clock`/`Instant` imports.

These methods are private and the public `UserRepository` interface is
unchanged, so no callers or tests are affected. No behavior change —
pure dead code removal.