### PR TITLE
fix: locale repository batch update #98

### DIFF
--- a/central/implementations/postgres/src/main/scala/versola/configuration/locales/PostgresLocaleRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/locales/PostgresLocaleRepository.scala
@@ -24,10 +24,10 @@ class PostgresLocaleRepository(xa: TransactorZIO) extends LocaleRepository, Basi
         sql"""UPDATE otp_templates
               SET localizations = localizations - $delete
               WHERE jsonb_exists_any(localizations, $delete)""".update.run()
-      add.foreach { locale =>
-        sql"""INSERT INTO locales (code, name, is_default, active) VALUES (${locale.code}, ${locale.name}, ${locale.isDefault}, ${locale.active})
-              ON CONFLICT (code) DO UPDATE SET name = EXCLUDED.name, active = EXCLUDED.active""".update.run()
-      }
+      if add.nonEmpty then
+        batchUpdate(add): locale =>
+          sql"""INSERT INTO locales (code, name, is_default, active) VALUES (${locale.code}, ${locale.name}, ${locale.isDefault}, ${locale.active})
+                ON CONFLICT (code) DO UPDATE SET name = EXCLUDED.name, active = EXCLUDED.active""".update
 
   override def setDefault(code: String): Task[Unit] =
     xa.repeatableRead.transactMeasured("set-default-locale"):


### PR DESCRIPTION
PostgresLocaleRepository.update inserted locales one-by-one via a foreach loop, firing a separate SQL round-trip per locale. Replaced with batchUpdate, following the same pattern already used in PostgresAuthorizationPresetRepository.replace.

No behavior change — same INSERT ... ON CONFLICT DO UPDATE per row, just batched into a single statement.

Changes:

central/implementations/postgres/src/main/scala/versola/configuration/locales/PostgresLocaleRepository.scala: add.foreach { ... } → if add.nonEmpty then batchUpdate(add): ...

Testing:
Covered by existing LocaleRepositorySpec / PostgresLocaleRepositorySpec (multi-locale add, upsert preserving is_default, active persistence) — no new tests needed since this is a performance-only refactor with no behavioral change.

Closes #98