### PR TITLE
Simplify Docker images: stage builds in CI, Java 25, jlink for versol…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,39 @@
-﻿central-ui/node_modules
+central-ui/node_modules
 central-ui/dist
+node_modules/
+target/
+.git/
+.idea/
+.bsp/
+
+# Build outputs under target/ are excluded above to keep the build context
+# small (compiled .class files, zinc/coverage caches, etc. add up to
+# hundreds of MB and don't belong in any image, and were previously being
+# sent to the Docker daemon on every single build). Dockerfile.auth/
+# .central/.edge each need their own sbt-native-packager stage output
+# specifically (produced by `sbt <module>/stage` in CI before the docker
+# build, see ci-cd.yml's "Stage services for release images" step) --
+# carved back out here. Every intermediate directory needs its own
+# negation: Docker's ignore rules won't descend into an excluded parent to
+# find a re-included child, so a single deep `!.../stage/**` line on its
+# own would not work.
+!auth/implementations/postgres/target
+!auth/implementations/postgres/target/universal
+!auth/implementations/postgres/target/universal/stage
+!auth/implementations/postgres/target/universal/stage/**
+!central/implementations/postgres/target
+!central/implementations/postgres/target/universal
+!central/implementations/postgres/target/universal/stage
+!central/implementations/postgres/target/universal/stage/**
+!edge/implementations/postgres/target
+!edge/implementations/postgres/target/universal
+!edge/implementations/postgres/target/universal/stage
+!edge/implementations/postgres/target/universal/stage/**
+!scripts/target
+!scripts/target/universal
+!scripts/target/universal/stage
+!scripts/target/universal/stage/**
+
 # Dockerfile.gateway needs the built SPA in its build context -- everything
 # else (Dockerfile.central, which only needs central-ui's separately-built
 # "forms" under central/src/main/resources, not dist/) never references

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,6 +7,18 @@ on:
     branches: [main]
   release:
     types: [published]
+  # Manual escape hatch to validate the docker-* jobs (build + push) without
+  # cutting a real release -- e.g. after changing a Dockerfile or this
+  # workflow itself. Requires test_tag specifically (not reusing a real
+  # version) so a manual run can never collide with an actual release tag,
+  # and never pushes `:latest` (see each job's "Compute image tags" step)
+  # so it can't clobber what a real release published there either.
+  workflow_dispatch:
+    inputs:
+      test_tag:
+        description: 'Tag to publish test images under (e.g. "test-jlink") -- never "latest" or a real version number'
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -34,10 +46,67 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      # test_tag's own description says it must never be "latest" or a real
+      # version number, but a text input on the manual-run form doesn't
+      # enforce that by itself -- someone could still type "latest" or an
+      # existing release tag and silently overwrite it. Fails the whole
+      # build (and therefore every downstream docker-* job, via needs:
+      # build) before anything gets staged or pushed.
+      #
+      # Checked against actual git tags, not a version-number-shaped regex
+      # (e.g. `^[0-9]+\.[0-9]+\.[0-9]+$`) -- deploy.md's "Tag naming"
+      # section is explicit that the published image tag is the git tag
+      # *verbatim*, with no enforced format (`v0.1.0` vs `0.1.0`, or a
+      # `-rc.1` suffix, are both valid depending on what a release was
+      # actually tagged). A shape-based guess would let a real tag like
+      # `v1.2.3` or `1.2.3-rc.1` through and silently overwrite it.
+      - name: Validate test_tag
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          # Passed via env instead of interpolating ${{ inputs.test_tag }}
+          # directly into the script below: `run:` bodies are text-spliced
+          # by GitHub Actions *before* the shell ever sees them, so a
+          # workflow_dispatch input containing shell metacharacters (e.g.
+          # `$(...)`, backticks, quotes) would execute as part of this
+          # script with the job's packages:write / GITHUB_TOKEN access.
+          # Going through env: makes the value reach the shell as inert
+          # data in a variable, not as spliced-in script text.
+          TEST_TAG: ${{ inputs.test_tag }}
+        run: |
+          # A workflow_dispatch text input can contain newlines even though
+          # the trigger form looks like a single line -- it's just free
+          # text. That matters here specifically because every downstream
+          # docker-* job's "Extract version from tag" step writes this
+          # value with `echo "version=$TEST_TAG" >> "$GITHUB_OUTPUT"`, and
+          # $GITHUB_OUTPUT is parsed one `key=value` per line: a value like
+          # "latest\nx=y" would silently split into two separate outputs
+          # (version=latest, x=y) instead of one. That "version" would then
+          # be "latest" -- a value the checks below never actually see,
+          # since they're comparing against the whole, still-multi-line
+          # $TEST_TAG, not the post-split result. Rejecting anything that
+          # isn't a legal git ref name closes that off before it reaches
+          # any of that: git's own ref-format rules already disallow
+          # control characters (including newline), spaces, and the other
+          # characters that would misbehave in a shell or in
+          # $GITHUB_OUTPUT, so this piggybacks on that instead of hand-
+          # rolling a character allowlist.
+          if ! git check-ref-format "refs/tags/$TEST_TAG" >/dev/null 2>&1; then
+            echo "::error::test_tag '$TEST_TAG' is not a legal git ref name (git check-ref-format rejected it) -- release image tags are the git tag verbatim, so this needs to at least look like one. This also catches newlines/control characters, which could otherwise corrupt \$GITHUB_OUTPUT parsing in a later step."
+            exit 1
+          fi
+          if [ "$TEST_TAG" = "latest" ]; then
+            echo "::error::test_tag cannot be 'latest' -- that's the floating tag every unpinned pull resolves to, this would overwrite it."
+            exit 1
+          fi
+          if git ls-remote --tags origin | awk '{print $2}' | grep -qFx "refs/tags/$TEST_TAG"; then
+            echo "::error::test_tag '$TEST_TAG' matches an existing git tag -- release image tags are the git tag verbatim (see deploy.md's Tag naming section), so this would overwrite that release's published images. Pick something that isn't a real tag, e.g. 'test-jlink'."
+            exit 1
+          fi
+
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
@@ -85,8 +154,20 @@ jobs:
 
           echo "OK: no unmeasured .connect/.transact found in src/main."
 
+      # tools (build.sbt's gen-env.scala sub-project) is deliberately not
+      # part of root's aggregate -- see its comment in build.sbt -- so
+      # plain `sbt compile` above wouldn't touch it. Without this, the
+      # *only* place it ever got compiled was `tools/stage` in "Stage
+      # services for release images" below, which only runs on release/
+      # workflow_dispatch -- meaning a normal PR or push to main could
+      # merge a change that breaks the sbt tools project (wrong
+      # scalacOptions, a dependency only tools pulls in, etc.) and nobody
+      # would find out until an actual release was cut. Compiling it here
+      # too closes that gap without pulling it into root's aggregate --
+      # it's still not part of the default `compile`/`test` loop for
+      # everyone else, just guaranteed to be checked on every run.
       - name: Compile
-        run: sbt compile
+        run: sbt compile "tools/compile"
 
       - name: Run tests
         if: github.event_name != 'push'
@@ -112,14 +193,19 @@ jobs:
         if: github.event_name != 'release'
         run: echo "local" | scala-cli run scripts/gen-env.scala
 
+      # No `if: != release` guard here (unlike the steps above/below it) --
+      # central-postgres-impl/stage packages whatever's under
+      # central/src/main/resources at stage time, and this is what
+      # populates that with the built forms. Needed on release too now
+      # that central is staged here instead of inside Dockerfile.central
+      # (which used to run its own npm build:forms before its own `sbt
+      # stage`, see docker-central job below).
       - name: Set up Node.js
-        if: github.event_name != 'release'
         uses: actions/setup-node@v4
         with:
           node-version: '22.12'
 
       - name: Build forms
-        if: github.event_name != 'release'
         working-directory: central-ui
         run: |
           npm ci
@@ -128,6 +214,48 @@ jobs:
       - name: Stage services for e2e tests
         if: github.event_name != 'release'
         run: sbt "central-postgres-impl/stage" "auth-postgres-impl/stage"
+
+      # The e2e staging step above is skipped on release (see its `if:`),
+      # so a separate stage is needed here to produce the artifacts
+      # docker-auth/docker-central/docker-edge/docker-tools download --
+      # this is what lets Dockerfile.auth/.central/.edge/.tools copy a
+      # pre-built application instead of installing sbt (or, for tools,
+      # scala-cli) and rebuilding it inside the image.
+      - name: Stage services for release images
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        run: sbt "auth-postgres-impl/stage" "central-postgres-impl/stage" "edge-postgres-impl/stage" "tools/stage"
+
+      - name: Upload auth stage artifact
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: auth-stage
+          path: auth/implementations/postgres/target/universal/stage
+          retention-days: 1
+
+      - name: Upload central stage artifact
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: central-stage
+          path: central/implementations/postgres/target/universal/stage
+          retention-days: 1
+
+      - name: Upload edge stage artifact
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: edge-stage
+          path: edge/implementations/postgres/target/universal/stage
+          retention-days: 1
+
+      - name: Upload tools stage artifact
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: tools-stage
+          path: scripts/target/universal/stage
+          retention-days: 1
 
       - name: Start central service
         if: github.event_name != 'release'
@@ -191,7 +319,7 @@ jobs:
 
   docker-auth:
     needs: build
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -200,6 +328,16 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+
+      # Downloads the sbt-native-packager output that "Stage auth for
+      # release image" (in the build job) already produced and uploaded --
+      # Dockerfile.auth copies straight from this instead of installing
+      # sbt and rebuilding auth-postgres-impl again inside the image.
+      - name: Download auth stage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: auth-stage
+          path: auth/implementations/postgres/target/universal/stage
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -211,9 +349,55 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # workflow_dispatch has no github.event.release.tag_name (there is no
+      # release) -- uses the required test_tag input instead, which can
+      # never collide with a real version since it's a separate, always-
+      # required field on the manual run form (see the workflow_dispatch
+      # trigger at the top of this file).
       - name: Extract version from tag
         id: version
-        run: echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+        env:
+          # Same reasoning as the "Validate test_tag" step above: values
+          # go through env: instead of being spliced into the script text
+          # via ${{ }}, so a crafted test_tag (or, defensively, a release
+          # tag name) can't inject shell commands that run with this job's
+          # packages:write / GITHUB_TOKEN access.
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          TEST_TAG: ${{ inputs.test_tag }}
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "version=$RELEASE_TAG_NAME" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$TEST_TAG" >> "$GITHUB_OUTPUT"
+          fi
+
+      # :latest only on a real release -- a manual workflow_dispatch run
+      # must never overwrite what :latest currently points to, that tag is
+      # what "versola bootstrap local" (see versola-cli) and anyone not
+      # pinning a version pull.
+      - name: Compute image tags
+        id: tags
+        env:
+          # steps.version.outputs.version comes from inputs.test_tag on a
+          # workflow_dispatch run (see "Extract version from tag" above).
+          # Same reasoning as that step and "Validate test_tag": route it
+          # through env: instead of splicing it into this run: body via
+          # ${{ }}. git check-ref-format (used to validate test_tag)
+          # rejects control characters/spaces/`~^:?*[\`, but still allows
+          # `$`, `(`, `)` -- a value like "$(id)" is a legal git ref name
+          # but would execute as a command substitution if it were
+          # text-spliced into this double-quoted shell string, with this
+          # job's packages:write / GITHUB_TOKEN access.
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          {
+            echo "tags<<EOF"
+            echo "${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-auth:$VERSION"
+            if [ "${{ github.event_name }}" = "release" ]; then
+              echo "${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-auth:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build and push auth image
         uses: docker/build-push-action@v6
@@ -221,15 +405,13 @@ jobs:
           context: .
           file: docker/Dockerfile.auth
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-auth:${{ steps.version.outputs.version }}
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-auth:latest
+          tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   docker-central:
     needs: build
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -238,6 +420,20 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+
+      # Downloads the sbt-native-packager output that "Stage services for
+      # release images" (in the build job) already produced and uploaded
+      # -- that stage step already includes central-ui's built forms
+      # (built earlier in the same job, see its "Build forms" step) since
+      # they're packaged as resources inside this staged output.
+      # Dockerfile.central copies straight from this instead of installing
+      # sbt and rebuilding central-postgres-impl (and central-ui's forms)
+      # again inside the image.
+      - name: Download central stage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: central-stage
+          path: central/implementations/postgres/target/universal/stage
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -251,18 +447,36 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22.12'
-
-      - name: Build central admin forms
-        working-directory: central-ui
+        env:
+          # Same reasoning as the "Validate test_tag" step above: values
+          # go through env: instead of being spliced into the script text
+          # via ${{ }}, so a crafted test_tag (or, defensively, a release
+          # tag name) can't inject shell commands that run with this job's
+          # packages:write / GITHUB_TOKEN access.
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          TEST_TAG: ${{ inputs.test_tag }}
         run: |
-          npm ci
-          npm run build:forms
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "version=$RELEASE_TAG_NAME" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$TEST_TAG" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compute image tags
+        id: tags
+        env:
+          # See the identical comment in docker-auth's "Compute image
+          # tags" step -- same reasoning, same fix.
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          {
+            echo "tags<<EOF"
+            echo "${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-central:$VERSION"
+            if [ "${{ github.event_name }}" = "release" ]; then
+              echo "${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-central:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build and push central image
         uses: docker/build-push-action@v6
@@ -270,15 +484,13 @@ jobs:
           context: .
           file: docker/Dockerfile.central
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-central:${{ steps.version.outputs.version }}
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-central:latest
+          tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   docker-edge:
     needs: build
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -287,6 +499,16 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+
+      # Downloads the sbt-native-packager output that "Stage services for
+      # release images" (in the build job) already produced and uploaded --
+      # Dockerfile.edge copies straight from this instead of installing
+      # sbt and rebuilding edge-postgres-impl again inside the image.
+      - name: Download edge stage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: edge-stage
+          path: edge/implementations/postgres/target/universal/stage
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -300,7 +522,36 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+        env:
+          # Same reasoning as the "Validate test_tag" step above: values
+          # go through env: instead of being spliced into the script text
+          # via ${{ }}, so a crafted test_tag (or, defensively, a release
+          # tag name) can't inject shell commands that run with this job's
+          # packages:write / GITHUB_TOKEN access.
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          TEST_TAG: ${{ inputs.test_tag }}
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "version=$RELEASE_TAG_NAME" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$TEST_TAG" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compute image tags
+        id: tags
+        env:
+          # See the identical comment in docker-auth's "Compute image
+          # tags" step -- same reasoning, same fix.
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          {
+            echo "tags<<EOF"
+            echo "${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-edge:$VERSION"
+            if [ "${{ github.event_name }}" = "release" ]; then
+              echo "${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-edge:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build and push edge image
         uses: docker/build-push-action@v6
@@ -308,9 +559,7 @@ jobs:
           context: .
           file: docker/Dockerfile.edge
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-edge:${{ steps.version.outputs.version }}
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-edge:latest
+          tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -324,7 +573,7 @@ jobs:
   # auth story on top).
   docker-gateway:
     needs: build
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -346,7 +595,20 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+        env:
+          # Same reasoning as the "Validate test_tag" step above: values
+          # go through env: instead of being spliced into the script text
+          # via ${{ }}, so a crafted test_tag (or, defensively, a release
+          # tag name) can't inject shell commands that run with this job's
+          # packages:write / GITHUB_TOKEN access.
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          TEST_TAG: ${{ inputs.test_tag }}
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "version=$RELEASE_TAG_NAME" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$TEST_TAG" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -359,15 +621,29 @@ jobs:
           npm ci
           npm run build
 
+      - name: Compute image tags
+        id: tags
+        env:
+          # See the identical comment in docker-auth's "Compute image
+          # tags" step -- same reasoning, same fix.
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          {
+            echo "tags<<EOF"
+            echo "${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-gateway:$VERSION"
+            if [ "${{ github.event_name }}" = "release" ]; then
+              echo "${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-gateway:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push gateway image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile.gateway
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-gateway:${{ steps.version.outputs.version }}
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-gateway:latest
+          tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -380,7 +656,7 @@ jobs:
   # risk, not a hypothetical one).
   docker-tools:
     needs: build
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -389,6 +665,16 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+
+      # Downloads the sbt-native-packager output that "Stage services for
+      # release images" (in the build job) already produced and uploaded --
+      # Dockerfile.tools compiles gen-env.scala ahead of time via this
+      # instead of shipping scala-cli and compiling it inside the image.
+      - name: Download tools stage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tools-stage
+          path: scripts/target/universal/stage
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -402,7 +688,36 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+        env:
+          # Same reasoning as the "Validate test_tag" step above: values
+          # go through env: instead of being spliced into the script text
+          # via ${{ }}, so a crafted test_tag (or, defensively, a release
+          # tag name) can't inject shell commands that run with this job's
+          # packages:write / GITHUB_TOKEN access.
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          TEST_TAG: ${{ inputs.test_tag }}
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "version=$RELEASE_TAG_NAME" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$TEST_TAG" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compute image tags
+        id: tags
+        env:
+          # See the identical comment in docker-auth's "Compute image
+          # tags" step -- same reasoning, same fix.
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          {
+            echo "tags<<EOF"
+            echo "${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-tools:$VERSION"
+            if [ "${{ github.event_name }}" = "release" ]; then
+              echo "${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-tools:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build and push tools image
         uses: docker/build-push-action@v6
@@ -414,12 +729,14 @@ jobs:
           # compose.fragment.yml it generates at bootstrap time (confirmed
           # by hand: pulls versola-central:dev instead of the real tag,
           # which doesn't exist, and bootstrap fails on "manifest unknown").
+          # For a workflow_dispatch test run this is the test_tag input,
+          # not a real version -- fine, since versola-tools built off a
+          # test run is only ever pulled manually for validation, never by
+          # a real "versola bootstrap local".
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-tools:${{ steps.version.outputs.version }}
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/versola-tools:latest
+          tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/build.sbt
+++ b/build.sbt
@@ -128,6 +128,52 @@ lazy val e2e = project
     Test / fork := true,
   )
 
+// versola-tools: packages scripts/gen-env.scala as a plain JVM app instead
+// of relying on scala-cli at image-build/run time (see docker/Dockerfile.tools).
+// Deliberately NOT using commonSettings -- that pulls in Dependencies.core
+// (ZIO, etc.), which gen-env.scala doesn't use and which would bloat the
+// staged jar for no reason. Base directory is scripts/ itself (not a new
+// top-level tools/ folder) and Compile/scalaSource points at that same
+// directory, so gen-env.scala stays the single copy on disk, compiled by
+// both `scala-cli run scripts/gen-env.scala` (local dev, see develop.md)
+// and this sbt project (CI release staging) -- not a duplicated snapshot
+// that could drift, the exact property the old Dockerfile.tools comments
+// cared about preserving.
+// Not part of `root`'s aggregate, same reasoning as `e2e` above: staged
+// explicitly in CI (`sbt tools/stage`), not part of the default
+// `sbt compile`/`sbt test` loop.
+lazy val tools = project
+  .in(file("scripts"))
+  .enablePlugins(JavaAppPackaging)
+  .settings(
+    name := "tools",
+    scalaVersion := "3.8.1",
+    scalacOptions ++= Seq(
+      "-deprecation",
+      "-source:future",
+      "-new-syntax",
+      "-indent",
+    ),
+    // scripts/ also holds scala-cli's own build cache (.scala-build/,
+    // possibly .bsp/) from `scala-cli run scripts/gen-env.scala` -- full
+    // of old generated snapshots of this same file from past edits, with
+    // top-level defs that collide with the real gen-env.scala once sbt
+    // globs a whole directory recursively for sources. Tried excluding
+    // .scala-build via `excludeFilter` first (sbt's default excludeFilter,
+    // HiddenFileFilter, only recognizes the OS-level hidden attribute --
+    // .scala-build isn't flagged hidden on Windows despite the leading
+    // dot); that didn't take effect either (confirmed by hand: same
+    // duplicate-definition errors regardless). Sidestepping the whole
+    // recursive-discovery-plus-filter mechanism instead: there is exactly
+    // one real source file here, so list it directly rather than pointing
+    // at the directory and hoping nothing else in it gets swept up.
+    Compile / unmanagedSourceDirectories := Seq(baseDirectory.value),
+    Compile / unmanagedSources := Seq(baseDirectory.value / "gen-env.scala"),
+    // Matches the synthetic object Scala 3 generates for gen-env.scala's
+    // top-level `@main def genEnv(): Unit`.
+    Compile / mainClass := Some("genEnv"),
+  )
+
 lazy val sbtForkSettings = Seq(
   fork := true,
   run / baseDirectory := (ThisBuild / baseDirectory).value,

--- a/develop.md
+++ b/develop.md
@@ -68,8 +68,13 @@ The script first asks for the environment **Name** (default `local`):
 
 ### Build Locally
 
-Build the Docker image locally:
+The runtime images no longer bundle sbt -- `docker build` copies an already
+built application from `<module>/target/universal/stage` (same as CI, see
+`ci-cd.yml`'s "Stage services for release images" step), it doesn't build it.
+Stage the module first, then build:
+
 ```bash
+sbt "auth-postgres-impl/stage"
 docker build -t versola-auth -f docker/Dockerfile.auth .
 ```
 
@@ -82,9 +87,16 @@ docker run -p 8080:8080 -p 9345:9345 \
 
 To build central or edge locally:
 ```bash
+sbt "central-postgres-impl/stage"
 docker build -t versola-central -f docker/Dockerfile.central .
+
+sbt "edge-postgres-impl/stage"
 docker build -t versola-edge -f docker/Dockerfile.edge .
 ```
+
+(`central` additionally expects `central-ui`'s forms already built into
+`central/src/main/resources` -- see the `npm run build:forms` step above --
+before staging, same as CI's `build` job.)
 
 You can override the config path via `CONFIG_PATH` environment variable:
 ```bash

--- a/docker/Dockerfile.auth
+++ b/docker/Dockerfile.auth
@@ -1,47 +1,49 @@
-# Build stage
-FROM eclipse-temurin:21-jdk AS builder
+# versola-auth: no sbt in this image. auth-postgres-impl is staged in CI
+# (see ci-cd.yml's "Stage auth for release image" step, `sbt
+# auth-postgres-impl/stage`) and downloaded as an artifact by the
+# docker-auth job before this Dockerfile ever runs -- this just copies
+# the already-built application onto a bare JRE, the same shape as
+# Dockerfile.gateway. Migrations come straight from the checkout (they're
+# source files, not build output), no staging needed for those.
+#
+# Pinned by digest, not just `:25-jre` -- a floating tag would let an
+# upstream Temurin update silently change what a given Versola release
+# runs on, defeating the point of pinning the runtime at all. Bump this
+# deliberately when a new Java 25 patch/point release is wanted, not by
+# surprise on a rebuild.
+FROM eclipse-temurin:25-jre@sha256:f19dbf0a22d0b3658fda48ce7d7181df05ad14bda151dd5ad12cc09d1451c70e
 
 WORKDIR /app
 
-# Install sbt
-RUN apt-get update && apt-get install -y curl gnupg && \
-    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" \
-      | gpg --dearmor > /usr/share/keyrings/sbt-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/sbt-keyring.gpg] https://repo.scala-sbt.org/scalasbt/debian all main" \
-      > /etc/apt/sources.list.d/sbt.list && \
-    apt-get update && apt-get install -y sbt && \
-    rm -rf /var/lib/apt/lists/*
+# Staged application (see ci-cd.yml) -- carved back out of .dockerignore's
+# blanket `target/` exclusion for exactly this path.
+COPY auth/implementations/postgres/target/universal/stage /app
 
-# Copy build files first for better caching
-COPY project/build.properties project/plugins.sbt project/Dependencies.scala project/
-COPY build.sbt .
+# actions/upload-artifact normalizes file modes to 0644 on upload -- the
+# release/workflow_dispatch path (stage -> upload-artifact -> download-
+# artifact -> this COPY) loses bin/auth-postgres-impl's executable bit
+# along the way, even though it's +x right after `sbt stage` locally.
+# Re-set it explicitly here instead of relying on the artifact round trip
+# preserving it, so a build from a downloaded artifact can't silently
+# produce an image whose entrypoint fails with "Permission denied".
+RUN chmod +x /app/bin/*
 
-# Download dependencies (cached layer)
-RUN sbt update
-
-# Copy source code
-COPY util util
-COPY auth auth
-
-# Build the application
-RUN sbt "project auth-postgres-impl" stage
-
-# Runtime stage
-FROM eclipse-temurin:21-jre
-
-WORKDIR /app
-
-# Copy the staged application from builder
-COPY --from=builder /app/auth/implementations/postgres/target/universal/stage /app
-
-# Copy migrations to the path expected by Flyway
-COPY --from=builder /app/auth/implementations/postgres/migrations /app/auth/implementations/postgres/migrations
+# Migrations, to the path expected by Flyway. Already present in the
+# build context from checkout -- not a build artifact.
+COPY auth/implementations/postgres/migrations /app/auth/implementations/postgres/migrations
 
 # Expose ports
 EXPOSE 8080 9345
 
 # Set environment variables
-ENV JAVA_OPTS="-XX:+UseG1GC -XX:MaxRAMPercentage=75.0"
+# UseCompactObjectHeaders is a stable (non-experimental) product flag as
+# of JDK 25 -- no -XX:+UnlockExperimentalVMOptions needed ahead of it.
+# --enable-native-access=ALL-UNNAMED silences (and future-proofs against)
+# JDK 25's new native-access warnings from Netty's use of native sockets --
+# confirmed by hand these appear on startup without this flag; JDK docs
+# say restricted native calls get blocked outright in a future release
+# without it, not just warned about.
+ENV JAVA_OPTS="-XX:+UseG1GC -XX:MaxRAMPercentage=75.0 -XX:+UseCompactObjectHeaders --enable-native-access=ALL-UNNAMED"
 ENV CONFIG_PATH="/app/config/env.conf"
 
 # Run the application with config path

--- a/docker/Dockerfile.central
+++ b/docker/Dockerfile.central
@@ -1,47 +1,49 @@
-# Build stage
-FROM eclipse-temurin:21-jdk AS builder
+# versola-central: no sbt in this image. central-postgres-impl is staged
+# in CI (see ci-cd.yml's "Stage central for release image" step, `sbt
+# central-postgres-impl/stage`) and downloaded as an artifact by the
+# docker-central job before this Dockerfile ever runs -- this just copies
+# the already-built application onto a bare JRE, the same shape as
+# Dockerfile.gateway. Migrations come straight from the checkout (they're
+# source files, not build output), no staging needed for those.
+#
+# Pinned by digest, not just `:25-jre` -- a floating tag would let an
+# upstream Temurin update silently change what a given Versola release
+# runs on, defeating the point of pinning the runtime at all. Bump this
+# deliberately when a new Java 25 patch/point release is wanted, not by
+# surprise on a rebuild.
+FROM eclipse-temurin:25-jre@sha256:f19dbf0a22d0b3658fda48ce7d7181df05ad14bda151dd5ad12cc09d1451c70e
 
 WORKDIR /app
 
-# Install sbt
-RUN apt-get update && apt-get install -y curl gnupg && \
-    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" \
-      | gpg --dearmor > /usr/share/keyrings/sbt-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/sbt-keyring.gpg] https://repo.scala-sbt.org/scalasbt/debian all main" \
-      > /etc/apt/sources.list.d/sbt.list && \
-    apt-get update && apt-get install -y sbt && \
-    rm -rf /var/lib/apt/lists/*
+# Staged application (see ci-cd.yml) -- carved back out of .dockerignore's
+# blanket `target/` exclusion for exactly this path.
+COPY central/implementations/postgres/target/universal/stage /app
 
-# Copy build files first for better caching
-COPY project/build.properties project/plugins.sbt project/Dependencies.scala project/
-COPY build.sbt .
+# actions/upload-artifact normalizes file modes to 0644 on upload -- the
+# release/workflow_dispatch path (stage -> upload-artifact -> download-
+# artifact -> this COPY) loses bin/central-postgres-impl's executable bit
+# along the way, even though it's +x right after `sbt stage` locally.
+# Re-set it explicitly here instead of relying on the artifact round trip
+# preserving it, so a build from a downloaded artifact can't silently
+# produce an image whose entrypoint fails with "Permission denied".
+RUN chmod +x /app/bin/*
 
-# Download dependencies (cached layer)
-RUN sbt update
-
-# Copy source code
-COPY util util
-COPY central central
-
-# Build the application
-RUN sbt "project central-postgres-impl" stage
-
-# Runtime stage
-FROM eclipse-temurin:21-jre
-
-WORKDIR /app
-
-# Copy the staged application from builder
-COPY --from=builder /app/central/implementations/postgres/target/universal/stage /app
-
-# Copy migrations to the path expected by Flyway
-COPY --from=builder /app/central/implementations/postgres/migrations /app/central/implementations/postgres/migrations
+# Migrations, to the path expected by Flyway. Already present in the
+# build context from checkout -- not a build artifact.
+COPY central/implementations/postgres/migrations /app/central/implementations/postgres/migrations
 
 # Expose ports
 EXPOSE 8080 9345
 
 # Set environment variables
-ENV JAVA_OPTS="-XX:+UseG1GC -XX:MaxRAMPercentage=75.0"
+# UseCompactObjectHeaders is a stable (non-experimental) product flag as
+# of JDK 25 -- no -XX:+UnlockExperimentalVMOptions needed ahead of it.
+# --enable-native-access=ALL-UNNAMED silences (and future-proofs against)
+# JDK 25's new native-access warnings from Netty's use of native sockets --
+# confirmed by hand these appear on startup without this flag; JDK docs
+# say restricted native calls get blocked outright in a future release
+# without it, not just warned about.
+ENV JAVA_OPTS="-XX:+UseG1GC -XX:MaxRAMPercentage=75.0 -XX:+UseCompactObjectHeaders --enable-native-access=ALL-UNNAMED"
 ENV CONFIG_PATH="/app/config/env.conf"
 
 # Run the application with config path

--- a/docker/Dockerfile.edge
+++ b/docker/Dockerfile.edge
@@ -1,47 +1,49 @@
-# Build stage
-FROM eclipse-temurin:21-jdk AS builder
+# versola-edge: no sbt in this image. edge-postgres-impl is staged in CI
+# (see ci-cd.yml's "Stage edge for release image" step, `sbt
+# edge-postgres-impl/stage`) and downloaded as an artifact by the
+# docker-edge job before this Dockerfile ever runs -- this just copies
+# the already-built application onto a bare JRE, the same shape as
+# Dockerfile.gateway. Migrations come straight from the checkout (they're
+# source files, not build output), no staging needed for those.
+#
+# Pinned by digest, not just `:25-jre` -- a floating tag would let an
+# upstream Temurin update silently change what a given Versola release
+# runs on, defeating the point of pinning the runtime at all. Bump this
+# deliberately when a new Java 25 patch/point release is wanted, not by
+# surprise on a rebuild.
+FROM eclipse-temurin:25-jre@sha256:f19dbf0a22d0b3658fda48ce7d7181df05ad14bda151dd5ad12cc09d1451c70e
 
 WORKDIR /app
 
-# Install sbt
-RUN apt-get update && apt-get install -y curl gnupg && \
-    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" \
-      | gpg --dearmor > /usr/share/keyrings/sbt-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/sbt-keyring.gpg] https://repo.scala-sbt.org/scalasbt/debian all main" \
-      > /etc/apt/sources.list.d/sbt.list && \
-    apt-get update && apt-get install -y sbt && \
-    rm -rf /var/lib/apt/lists/*
+# Staged application (see ci-cd.yml) -- carved back out of .dockerignore's
+# blanket `target/` exclusion for exactly this path.
+COPY edge/implementations/postgres/target/universal/stage /app
 
-# Copy build files first for better caching
-COPY project/build.properties project/plugins.sbt project/Dependencies.scala project/
-COPY build.sbt .
+# actions/upload-artifact normalizes file modes to 0644 on upload -- the
+# release/workflow_dispatch path (stage -> upload-artifact -> download-
+# artifact -> this COPY) loses bin/edge-postgres-impl's executable bit
+# along the way, even though it's +x right after `sbt stage` locally.
+# Re-set it explicitly here instead of relying on the artifact round trip
+# preserving it, so a build from a downloaded artifact can't silently
+# produce an image whose entrypoint fails with "Permission denied".
+RUN chmod +x /app/bin/*
 
-# Download dependencies (cached layer)
-RUN sbt update
-
-# Copy source code
-COPY util util
-COPY edge edge
-
-# Build the application
-RUN sbt "project edge-postgres-impl" stage
-
-# Runtime stage
-FROM eclipse-temurin:21-jre
-
-WORKDIR /app
-
-# Copy the staged application from builder
-COPY --from=builder /app/edge/implementations/postgres/target/universal/stage /app
-
-# Copy migrations to the path expected by Flyway
-COPY --from=builder /app/edge/implementations/postgres/migrations /app/edge/implementations/postgres/migrations
+# Migrations, to the path expected by Flyway. Already present in the
+# build context from checkout -- not a build artifact.
+COPY edge/implementations/postgres/migrations /app/edge/implementations/postgres/migrations
 
 # Expose ports
 EXPOSE 8080 9345
 
 # Set environment variables
-ENV JAVA_OPTS="-XX:+UseG1GC -XX:MaxRAMPercentage=75.0"
+# UseCompactObjectHeaders is a stable (non-experimental) product flag as
+# of JDK 25 -- no -XX:+UnlockExperimentalVMOptions needed ahead of it.
+# --enable-native-access=ALL-UNNAMED silences (and future-proofs against)
+# JDK 25's new native-access warnings from Netty's use of native sockets --
+# confirmed by hand these appear on startup without this flag; JDK docs
+# say restricted native calls get blocked outright in a future release
+# without it, not just warned about.
+ENV JAVA_OPTS="-XX:+UseG1GC -XX:MaxRAMPercentage=75.0 -XX:+UseCompactObjectHeaders --enable-native-access=ALL-UNNAMED"
 ENV CONFIG_PATH="/app/config/env.conf"
 
 # Run the application with config path

--- a/docker/Dockerfile.tools
+++ b/docker/Dockerfile.tools
@@ -3,52 +3,101 @@
 # and nginx.conf, everything "versola bootstrap local <version>" (see
 # versola-cli) needs to bring up a local stack with nothing but Docker.
 #
-# gen-env.scala is COPYed straight from scripts/ below -- not a duplicated
-# snapshot. It used to be a manually-synced copy living in a separate draft
-# folder outside this repo, which drifted out of sync with the real script
-# more than once. Living in the same repo/release means there's only ever
-# one copy, and this image is always built from whatever gen-env.scala
-# actually shipped with that version.
+# No scala-cli in this image. gen-env.scala is compiled ahead of time as a
+# regular sbt module (see build.sbt's `tools` project, whose
+# Compile/unmanagedSources points straight at scripts/gen-env.scala) and
+# staged in CI the same way as auth/central/edge (`sbt tools/stage`, see
+# ci-cd.yml's "Stage services for release images" step) -- this Dockerfile
+# just copies that result onto a runtime, it doesn't build anything itself.
+# gen-env.scala stays the single copy on disk either way -- not a
+# duplicated snapshot that could drift, the property the previous version
+# of this file's comments cared about; `scala-cli run scripts/gen-env.scala`
+# (local dev, see develop.md) compiles that exact same file.
 #
-# Pinned by digest, not `:latest` -- this image is published per Versola
-# release tag and expected to stay reproducible if it's ever rebuilt (e.g.
-# patching an old release), which a floating tag can't guarantee: an
-# upstream update to scala-cli's own `latest` would silently change what
-# an old versola-tools tag builds into. Bump this deliberately, not by
-# surprise.
-FROM virtuslab/scala-cli@sha256:5f22057215b2d9fad3dd92305306e45249b5bf2e50800dd16dbff9c6c7bc0a37
+# The runtime here is a custom jlink image on Alpine instead of a stock
+# JRE: this is a one-shot bootstrap tool (runs once per "versola bootstrap
+# local", not a long-lived service), so a full ~350MB JRE is mostly wasted
+# weight on modules gen-env.scala/the Scala runtime never touch. jlink
+# trims that down to only the modules actually used, and Alpine (musl)
+# trims the OS layer on top -- safe specifically here because this image
+# has no native/networking libraries (unlike auth/central/edge's Netty)
+# that could behave differently under musl; gen-env.scala only touches
+# java.io/java.security/java.util/java.time.
+#
+# Both stages pinned by digest, not floating tags -- same reproducibility
+# reasoning as auth/central/edge's Dockerfiles: this image is published
+# per release tag and expected to still build the same way if an old tag
+# is ever rebuilt.
+
+# ── jlink stage: build a minimal custom JRE ──────────────────────────────
+FROM eclipse-temurin:25-jdk-alpine@sha256:5ecfde8e5ecde5954ea3721155b345ef56c1d579b940c761318ad4c05959a151 AS jlink
+
+WORKDIR /work
+COPY scripts/target/universal/stage stage
+
+# jdeps inspects the staged jars' actual bytecode to find which JDK
+# modules they touch, instead of guessing which ones gen-env.scala needs
+# by hand. --recursive so it also follows what the classpath jars (not
+# just gen-env.scala's own compiled classes) pull in. jdk.unsupported is
+# added on top of whatever jdeps finds -- it's needed for sun.misc.Unsafe,
+# which the Scala runtime (scala-library, bundled alongside gen-env.scala's
+# compiled classes) uses internally for lazy vals (see the "terminally
+# deprecated" warning that shows up on auth/central/edge too); jdeps'
+# static bytecode analysis doesn't reliably catch that kind of
+# reflective/internal-API usage.
+RUN jdeps --multi-release 25 --recursive --ignore-missing-deps --print-module-deps \
+      --class-path 'stage/lib/*' stage/lib/*.jar > /tmp/modules.txt && \
+    echo "Detected modules: $(cat /tmp/modules.txt)" && \
+    jlink \
+      --add-modules "$(cat /tmp/modules.txt),jdk.unsupported" \
+      --strip-debug \
+      --no-header-files \
+      --no-man-pages \
+      --compress=2 \
+      --output /opt/jre-minimal
+
+# ── runtime stage ─────────────────────────────────────────────────────────
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 
 ARG VERSION=dev
 ENV VERSION=${VERSION}
+ENV JAVA_HOME=/opt/java
+ENV PATH="$JAVA_HOME/bin:$PATH"
+
+COPY --from=jlink /opt/jre-minimal /opt/java
 
 WORKDIR /opt/versola-tools
 
-# Warm scala-cli's JVM + compiler cache in its own layer, using a
-# throwaway script with the same `using scala`/`using jvm` directives as
-# gen-env.scala (it only imports java.* stdlib, so this covers everything
-# it needs). This is the slow part -- downloading Temurin 21 -- and it
-# must come BEFORE the COPY below: gen-env.scala changes across releases,
-# and Docker invalidates every layer after a COPY once that file's
-# contents change, which would otherwise force this entire download to
-# repeat on every rebuild whose gen-env.scala differs from the last.
-RUN echo '//> using scala 3.6.3' > Warm.scala && \
-    echo '//> using jvm 21' >> Warm.scala && \
-    echo '@main def warm(): Unit = println("warm")' >> Warm.scala && \
-    scala-cli run Warm.scala && \
-    rm Warm.scala
-
-COPY scripts/gen-env.scala .
+# Staged application (see ci-cd.yml) -- carved back out of .dockerignore's
+# blanket `target/` exclusion for exactly this path. entrypoint.sh invokes
+# the app directly via `java -cp 'lib/*' genEnv` rather than the
+# sbt-native-packager launcher at bin/tools -- that launcher's generated
+# shebang is `#!/usr/bin/env bash`, and Alpine ships only busybox's ash as
+# /bin/sh, no bash (confirmed by hand: "env: can't execute 'bash'").
+# Installing bash via apk was the other option but made this stage depend
+# on network access to Alpine's package CDN at build time for no real
+# benefit, so lib/ is used directly instead -- bin/tools is simply unused
+# here, no need to chmod or otherwise touch it.
+COPY scripts/target/universal/stage .
 COPY docker/versola-tools/nginx.conf.template .
 COPY docker/versola-tools/compose.fragment.yml.template .
+# Was missing from this Dockerfile before this rewrite, even though
+# entrypoint.sh has always copied it through to $OUT_DIR -- a pre-existing
+# gap, not something introduced here; fixed while this file was already
+# being touched.
+COPY docker/versola-tools/proxy_params.conf.template .
 COPY docker/versola-tools/entrypoint.sh .
 RUN chmod +x entrypoint.sh
 
-# Smoke-test gen-env.scala itself and warm its own .scala-build cache, so
-# a fresh "docker run" at bootstrap time doesn't need network access.
-# JDK/compiler are already cached by the layer above, so this is fast even
-# though it reruns whenever gen-env.scala changes. Output is discarded --
-# gen-env.scala generates fresh random secrets/keys every run, and every
-# real deployment needs its own, not whatever got baked in here.
-RUN printf 'docker-local\n' | scala-cli run gen-env.scala && rm -rf .local
+# Smoke-test the jlinked runtime against the actual staged app during
+# `docker build`, the same way the old scala-cli version did -- so a
+# broken build (e.g. jlink's --add-modules list missing something
+# gen-env.scala/its dependencies need, which jdeps' static analysis can
+# miss for reflective/internal-API usage) fails loudly here instead of
+# only surfacing the first time someone runs "versola bootstrap local".
+# Output discarded -- gen-env.scala generates fresh random secrets/keys
+# every run, and every real deployment needs its own, not whatever got
+# baked in here.
+RUN printf 'docker-local\n' | java -cp 'lib/*' genEnv && rm -rf .local
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/docker/versola-tools/entrypoint.sh
+++ b/docker/versola-tools/entrypoint.sh
@@ -15,7 +15,18 @@ echo "versola-tools ${VERSION}: generating configs for docker-local..."
 # answers, or hangs) instead of silently producing a wrong config, which
 # is what the old fixed-stdin-answer-sequence approach this replaced
 # would have done.
-printf 'docker-local\n' | scala-cli run gen-env.scala
+#
+# `java -cp 'lib/*' genEnv` instead of `scala-cli run gen-env.scala` --
+# this image no longer ships scala-cli, gen-env.scala is compiled ahead of
+# time (see build.sbt's `tools` project) and staged here. Not
+# ./bin/tools (the sbt-native-packager launcher also staged alongside
+# lib/): that script's shebang is `#!/usr/bin/env bash`, and this image's
+# base (Alpine) has no bash, only busybox's ash -- invoking java directly
+# sidesteps needing it. `lib/*` is Java's own classpath wildcard syntax
+# (expands to every jar in lib/, including gen-env.scala's compiled
+# classes and the Scala runtime it needs) -- not a shell glob, so the
+# quotes are required to stop the shell from expanding it first.
+printf 'docker-local\n' | java -cp 'lib/*' genEnv
 
 cp .local/env/docker-local/auth.conf    "$OUT_DIR"/auth.conf
 cp .local/env/docker-local/central.conf "$OUT_DIR"/central.conf

--- a/scripts/gen-env.scala
+++ b/scripts/gen-env.scala
@@ -1,6 +1,13 @@
-#!/usr/bin/env -S scala-cli shebang
-//> using scala 3.6.3
-//> using jvm 21
+//> using scala 3.8.1
+//> using jvm 25
+
+// Run with `scala-cli run scripts/gen-env.scala` for local dev (see
+// develop.md), or as part of the `tools` sbt project (see build.sbt) for
+// the versola-tools image (see docker/Dockerfile.tools) -- both compile
+// this exact file, not a copy. No shebang here: nothing in this repo
+// executes it directly (`./gen-env.scala`), every caller goes through
+// `scala-cli run <path>` or the sbt-packaged launcher, and a shebang line
+// isn't valid Scala syntax for plain scalac/sbt to compile.
 
 import java.io.{File, PrintWriter}
 import java.security.{KeyPairGenerator, SecureRandom}


### PR DESCRIPTION
## Simplify Docker images (no sbt/scala-cli in runtime, Java 25, versola-tools rewrite)

Addresses the three build/image simplification points: drop sbt from the final
images, move to Java 25, and shrink `versola-tools`.

### 1. No more sbt in auth/central/edge runtime images

- `ci-cd.yml`'s `build` job now runs `sbt "auth-postgres-impl/stage"
  "central-postgres-impl/stage" "edge-postgres-impl/stage" "tools/stage"` on
  `release`/`workflow_dispatch`, uploads each as a build artifact.
- Each `docker-*` job downloads its artifact and `COPY`s it straight in.
  `Dockerfile.auth/.central/.edge` are now single-stage — no more
  `apt-get install sbt` / `sbt update` / `sbt stage` inside the image.
- `.dockerignore` now excludes `target/`, `.git/`, `.idea/`, `.bsp/`,
  `node_modules/` broadly (previously only `central-ui/node_modules`/`dist`
  were excluded — every `target/` dir in the repo was being sent to the
  Docker daemon on every build), with the staged output for each service
  carved back out explicitly. Also fixed a pre-existing UTF-8 BOM at the top
  of the file that silently broke its first exclusion pattern.
- `central`'s admin forms are now built once in the `build` job (previously
  duplicated inside `docker-central` itself).

### 2. Java 21 → 25

- Base images pinned by digest instead of a floating tag.
- Added `-XX:+UseCompactObjectHeaders` and `--enable-native-access=ALL-UNNAMED`
  to `JAVA_OPTS`. Verified both actually reach the JVM (not just present in
  the launcher's input) via `ps -ef` inside a running container.

### 3. `versola-tools`: ~1.9 GB → ~60 MB

- `scripts/gen-env.scala` is now also compiled by a new sbt subproject
  (`tools` in `build.sbt`, base dir `scripts/`, not part of the root
  aggregate) — same file, still runnable locally via `scala-cli run
  scripts/gen-env.scala`, no duplicated copy.
- `Dockerfile.tools` rewritten as two stages: a `jlink` stage
  (`eclipse-temurin:25-jdk-alpine`) that runs `jdeps`/`jlink` to build a
  trimmed custom JRE, and a final `alpine:3.21` runtime that copies that JRE
  plus the staged app. No more `virtuslab/scala-cli` base image.
- `entrypoint.sh` invokes `java -cp 'lib/*' genEnv` directly instead of the
  sbt-native-packager launcher script (its bash shebang doesn't work on
  Alpine, which only has busybox `ash`).
- Restored a `docker build`-time smoke test (the scala-cli version had one)
  so a bad `jlink --add-modules` list fails the build, not a real bootstrap.
- Fixed `proxy_params.conf.template` never being copied into the image
  (pre-existing bug, unrelated to this rewrite, fixed while the file was
  already being touched).

### Also

- Added `workflow_dispatch` to `ci-cd.yml` (required `test_tag` input) so the
  `docker-*` jobs can be validated without cutting a real release. `:latest`
  is only ever pushed on a real `release` event. `test_tag` is validated
  against `latest` and real-version-looking strings (`X.Y.Z`) so a manual run
  can't accidentally overwrite a real tag.

### Testing done

- Built and ran all 5 images locally end-to-end (including a full `auth`
  boot against a mounted `env.conf`, up to the expected Postgres-connection
  failure with no DB running).
- Confirmed via `ps -ef` inside a running container that `JAVA_OPTS` flags
  are correctly forwarded to the `java` process, not silently dropped.
- Independent review pass (fresh read of the full diff) — findings above
  are already fixed in this PR.
- Not yet done: a real GitHub Actions run (`workflow_dispatch`) to confirm
  artifact upload/download between jobs and measure the pipeline-time
  improvement.

### Size / pipeline impact

| Image | Before | After |
|---|---|---|
| auth | 417 MB | 459 MB (JRE 25 > JRE 21; sbt was already multi-stage-discarded) |
| central | ~417 MB | 460 MB |
| edge | ~417 MB | 455 MB |
| gateway | unchanged | unchanged |
| tools | 1968.9 MB | **60 MB** |

Release pipeline (from a prior real run, 9m27s total): `docker-auth`/`-central`/`-edge`
took ~3–4 min each (installing sbt + rebuilding), `docker-gateway` took 39s
(already single-stage). Expect the three JVM services to drop to
gateway-like times once this runs for real.