### PR TITLE
fix: actually terminate on failed startup, and retry the initial cache load

### DIFF
--- a/deploy.md
+++ b/deploy.md
@@ -660,38 +660,40 @@ successfully reached `auth` and `auth` answered. Only 502/000 indicates a real p
 
 ### 9.5 `auth`/`edge` never become ready after restarting the whole stack together
 
-**Status: fixed at the application level** (`VersolaApp.run`'s failure handlers now call
-`System.exit(1)` instead of just returning `ExitCode.failure`), but the section below is kept
-because the *cause* is still worth understanding, and because it fully applies if you're ever
-running an older image that predates the fix.
+**Status: fixed at the application level**, in two places — `ReloadingCache.make` retries the
+initial load with exponential backoff, so the affected service waits for `central` instead of
+failing, and if startup does fail anyway `VersolaApp.run`'s failure handlers force-terminate the
+JVM with `Runtime.getRuntime.halt(1)`. The section below is kept because the *cause* is still
+worth understanding, and because it fully applies if you're ever running an older image.
 
 Both `auth` and `edge` read configuration from `central` once, synchronously, during their own
 startup — `auth` syncs OAuth clients, `edge` syncs OAuth clients *and* authorization presets. If
 `central` isn't listening yet at that exact moment (a real risk when all three come up together —
 observed in production: `central` became ready roughly 0.4s **after** `auth` had already given
-up), the failing service's startup effect fails and is logged as `Could not start application`.
+up), the initial cache load fails. It is now retried (7 attempts, 500ms doubling, jittered), which
+covers this window; only if `central` is still unreachable after that does startup fail and log
+`Could not start application`.
 
-Before the fix, the container did not exit and did not restart: each service's diagnostics server
-(`auth`: 8081, `edge`: 8096) starts *before* the failing part and kept running independently,
-holding the JVM alive on its own non-daemon threads, so `restart: unless-stopped` never fired.
-With the fix, a failed startup now force-terminates the process (`System.exit(1)`), which *does*
-trigger `restart: unless-stopped` — Docker's restart policy now provides the retry loop that the
-application previously lacked. This turns a permanent zombie into a bounded number of automatic
-restarts, which is normally enough once `central` is actually up, but is still a blunt retry (no
-backoff, no cap) rather than a graceful wait-and-retry inside the application.
+When startup does fail, the container must exit so `restart: unless-stopped` fires. It did not
+originally: each service's diagnostics server (`auth`: 8081, `edge`: 8096) starts *before* the
+failing part and keeps running independently, holding the JVM alive on its own non-daemon threads.
+Note that `System.exit(1)` does **not** fix this — `exit` runs shutdown hooks and waits for them,
+and `ZIOApp` installs one that waits for the ZIO runtime to drain; called from inside a fiber, that
+hook waits on the runtime while the runtime waits on the fiber blocked in `exit`, and the JVM never
+terminates. `halt(1)` skips shutdown hooks entirely and is what actually terminates the process.
 
-If you do see a container stuck (pre-fix image, or some other stall), confirm with:
+If you do see a container stuck (old image, or some other stall), confirm with:
 ```bash
 docker inspect versola-auth --format='{{json .State}}'    # or versola-edge
 ```
-`FinishedAt` at the zero timestamp with a `StartedAt` well in the past means the process has been
-running since the original failed attempt, with no restart at all — that specifically indicates
-the pre-fix behaviour. Recovery is the same either way: confirm `central` is ready, then
+`FinishedAt` at the zero timestamp with a `StartedAt` well in the past, and `RestartCount` of `0`,
+means the process has been running since the original failed attempt with no restart at all — the
+zombie described above. Recovery is the same either way: confirm `central` is ready, then
 ```bash
 docker compose -f docker-compose.prod.yml restart auth   # and/or edge
 ```
 
-**Practical rule, still true even with the fix:** never bring up all three services in one
+**Practical rule, still worth following:** never bring up all three services in one
 `docker compose -f docker-compose.prod.yml up -d`. Start `central` alone, wait for `curl 127.0.0.1:8091/readiness` to return
 200, *then* bring up `auth` and `edge`. The automated pipeline already does this for you by
 deploying `central` first and gating `auth`/`edge` on it.

--- a/deploy.md
+++ b/deploy.md
@@ -662,9 +662,13 @@ successfully reached `auth` and `auth` answered. Only 502/000 indicates a real p
 
 **Status: fixed at the application level**, in two places — `ReloadingCache.make` retries the
 initial load with exponential backoff, so the affected service waits for `central` instead of
-failing, and if startup does fail anyway `VersolaApp.run`'s failure handlers force-terminate the
-JVM with `Runtime.getRuntime.halt(1)`. The section below is kept because the *cause* is still
-worth understanding, and because it fully applies if you're ever running an older image.
+failing, and if startup does fail anyway `VersolaApp.run`'s failure handlers re-fail instead of
+terminating in place, so `ZIOApp` unwinds the scope and finalizers actually run (Hikari pool
+closed, spans flushed) before the process exits. A daemon watchdog thread bounds that unwind: if
+it hasn't finished within `startupFailureShutdownTimeout` (20s), the watchdog calls
+`Runtime.getRuntime.halt(1)` so a wedged finalizer can't leave the zombie behind again. The
+section below is kept because the *cause* is still worth understanding, and because it fully
+applies if you're ever running an older image.
 
 Both `auth` and `edge` read configuration from `central` once, synchronously, during their own
 startup — `auth` syncs OAuth clients, `edge` syncs OAuth clients *and* authorization presets. If
@@ -680,7 +684,12 @@ failing part and keeps running independently, holding the JVM alive on its own n
 Note that `System.exit(1)` does **not** fix this — `exit` runs shutdown hooks and waits for them,
 and `ZIOApp` installs one that waits for the ZIO runtime to drain; called from inside a fiber, that
 hook waits on the runtime while the runtime waits on the fiber blocked in `exit`, and the JVM never
-terminates. `halt(1)` skips shutdown hooks entirely and is what actually terminates the process.
+terminates. Calling `Runtime.getRuntime.halt(1)` directly avoids that deadlock but skips
+finalizers entirely, so the Hikari pool and OTel exporter never get a chance to close/flush.
+Instead, the failure handlers re-fail the effect so `ZIOApp` unwinds the scope normally, and a
+daemon watchdog thread halts the JVM only if that unwind hasn't completed within
+`startupFailureShutdownTimeout` (20s) — finalizers run on the common path, and the watchdog is
+purely a backstop against a wedged one.
 
 If you do see a container stuck (old image, or some other stall), confirm with:
 ```bash

--- a/util/src/main/scala/versola/util/ReloadingCache.scala
+++ b/util/src/main/scala/versola/util/ReloadingCache.scala
@@ -12,12 +12,29 @@ object ReloadingCache:
   def constant[A](values: Set[A]): ReloadingCache[Set[A]] =
     ReloadingCache(Unsafe.unsafe(Ref.unsafe.make(values)(using _)))
 
+  /** Retries the initial load, which typically fails only because the source isn't up yet.
+    *
+    * A cache whose source is another service (edge and auth both sync their configuration from
+    * central during their own startup) fails its first load whenever it wins the race against that
+    * service. Without a retry the failure propagates out of layer construction and takes the whole
+    * application down - observed in production, with central becoming ready ~0.4s after auth had
+    * already given up (see deploy.md 9.5). Waiting a little is strictly better than dying and
+    * relying on the orchestrator to restart us.
+    *
+    * Bounded, so a genuinely broken source (bad credentials, wrong URL) still fails startup loudly
+    * instead of hanging forever.
+    */
+  private val initialLoadRetry: Schedule[Any, Any, Any] =
+    Schedule.exponential(500.millis, 2.0).jittered && Schedule.recurs(6)
+
   def make[A: Tag](
       schedule: Schedule[Any, Any, Any] = Schedule.spaced(5.minute),
   ): ZIO[Scope & CacheSource[A], Throwable, ReloadingCache[A]] =
     for
       source <- ZIO.service[CacheSource[A]]
       values <- source.getAll
+        .tapErrorCause(err => ZIO.logWarningCause(s"Couldn't initialize cache ${Tag[A].tag}, retrying", err))
+        .retry(initialLoadRetry)
         .tapErrorCause(err => ZIO.logErrorCause(s"Couldn't initialize cache ${Tag[A].tag}", err))
       ref <- Ref.make(values)
       refresh = source.getAll

--- a/util/src/main/scala/versola/util/http/VersolaApp.scala
+++ b/util/src/main/scala/versola/util/http/VersolaApp.scala
@@ -129,18 +129,28 @@ trait VersolaApp(serviceName: String) extends ZIOApp:
     yield ()
   }
     .catchAll { (ex: Throwable) =>
-      // The diagnostics server is forked above onto non-daemon Netty threads that keep the JVM
-      // alive even after startup fails. Merely returning ExitCode.failure here therefore leaves a
-      // "zombie": the process never exits, so `restart: unless-stopped` never fires and /readiness
-      // stays false forever (see deploy.md 8.5). Force-terminate so the orchestrator restarts us -
-      // by then the dependency this startup failed on (e.g. central sync) is typically available.
-      ZIO.logErrorCause("Could not start application", Cause.fail(ex)) *>
-        ZIO.succeed(java.lang.System.exit(1))
+      ZIO.logErrorCause("Could not start application", Cause.fail(ex)) *> terminate
     }
     .catchAllDefect { ex =>
-      ZIO.logErrorCause("Could not start application", Cause.die(ex)) *>
-        ZIO.succeed(java.lang.System.exit(1))
+      ZIO.logErrorCause("Could not start application", Cause.die(ex)) *> terminate
     }
+
+  /** Force-terminates the JVM after a failed startup, so the orchestrator restarts us - by then
+    * the dependency this startup failed on (e.g. central sync) is typically available.
+    *
+    * The diagnostics server is forked above onto non-daemon Netty threads that keep the JVM alive
+    * even after startup fails. Merely returning `ExitCode.failure` therefore leaves a "zombie": the
+    * process never exits, so `restart: unless-stopped` never fires and /readiness stays false
+    * forever (see deploy.md 9.5).
+    *
+    * `halt` rather than `System.exit`: `exit` runs shutdown hooks and waits for them, and `ZIOApp`
+    * installs one that waits for the ZIO runtime to drain. Called from inside a fiber - as it is
+    * here - that hook waits on the runtime while the runtime waits on this fiber, which is blocked
+    * in `exit`. The JVM then never terminates and the zombie above survives anyway. `halt` skips
+    * shutdown hooks entirely, so there is nothing to deadlock against.
+    */
+  private def terminate: UIO[Unit] =
+    ZIO.succeed(java.lang.Runtime.getRuntime.halt(1))
 
   def parseConfig[A: {DeriveConfig, Tag}] =
     ZLayer:

--- a/util/src/main/scala/versola/util/http/VersolaApp.scala
+++ b/util/src/main/scala/versola/util/http/VersolaApp.scala
@@ -129,28 +129,61 @@ trait VersolaApp(serviceName: String) extends ZIOApp:
     yield ()
   }
     .catchAll { (ex: Throwable) =>
-      ZIO.logErrorCause("Could not start application", Cause.fail(ex)) *> terminate
+      ZIO.logErrorCause("Could not start application", Cause.fail(ex)) *>
+        armShutdownWatchdog *> ZIO.fail(ex)
     }
     .catchAllDefect { ex =>
-      ZIO.logErrorCause("Could not start application", Cause.die(ex)) *> terminate
+      ZIO.logErrorCause("Could not start application", Cause.die(ex)) *>
+        armShutdownWatchdog *> ZIO.die(ex)
     }
 
-  /** Force-terminates the JVM after a failed startup, so the orchestrator restarts us - by then
-    * the dependency this startup failed on (e.g. central sync) is typically available.
+  /** How long `ZIOApp`'s shutdown hook waits for the runtime to drain on SIGTERM before giving up.
     *
-    * The diagnostics server is forked above onto non-daemon Netty threads that keep the JVM alive
-    * even after startup fails. Merely returning `ExitCode.failure` therefore leaves a "zombie": the
-    * process never exits, so `restart: unless-stopped` never fires and /readiness stays false
-    * forever (see deploy.md 9.5).
-    *
-    * `halt` rather than `System.exit`: `exit` runs shutdown hooks and waits for them, and `ZIOApp`
-    * installs one that waits for the ZIO runtime to drain. Called from inside a fiber - as it is
-    * here - that hook waits on the runtime while the runtime waits on this fiber, which is blocked
-    * in `exit`. The JVM then never terminates and the zombie above survives anyway. `halt` skips
-    * shutdown hooks entirely, so there is nothing to deadlock against.
+    * ZIO's default is `Duration.Infinity`, which turns any wedged finalizer (a pool draining a dead
+    * socket, an OTel exporter flushing to an unreachable collector) into a container that never
+    * stops. A finite value bounds that: the hook logs a warning and returns, and the JVM finishes
+    * exiting.
     */
-  private def terminate: UIO[Unit] =
-    ZIO.succeed(java.lang.Runtime.getRuntime.halt(1))
+  override def gracefulShutdownTimeout: Duration = 15.seconds
+
+  /** Deadline for the failed-startup path, which `gracefulShutdownTimeout` does not cover. */
+  protected def startupFailureShutdownTimeout: Duration = 20.seconds
+
+  /** Arms a hard deadline on the shutdown that follows a failed startup.
+    *
+    * Startup failures re-fail rather than terminating the JVM directly, so that `ZIOApp` unwinds
+    * the scope and finalizers actually run - the Hikari pool gets closed, spans get flushed - and
+    * so that the exit code is `ZIOApp`'s own. Terminating in place (`System.exit`, `halt`, or
+    * `ZIOApp.exit`) skips all of that.
+    *
+    * The risk of unwinding is that a finalizer hangs. Nothing bounds it on this path:
+    * `gracefulShutdownTimeout` guards only the shutdown *hook*, and the JVM would not exit anyway
+    * because the diagnostics server forked above holds non-daemon Netty threads. The container
+    * would then never exit, `restart: unless-stopped` would never fire, and /readiness would stay
+    * false forever (see deploy.md 9.5).
+    *
+    * So: a plain daemon JVM thread that halts once the deadline passes. Not a forked fiber - the
+    * shutdown being guarded is precisely what interrupts fibers, so a fiber watchdog would be
+    * killed by the thing it is watching. Daemon, so a shutdown that completes in time simply takes
+    * it down with the JVM and the halt never happens.
+    */
+  private def armShutdownWatchdog: UIO[Unit] =
+    ZIO.succeed:
+      val timeout = startupFailureShutdownTimeout
+      val watchdog = new Thread(
+        () =>
+          try Thread.sleep(timeout.toMillis)
+          catch case _: InterruptedException => ()
+
+          java.lang.System.err.println(
+            s"Shutdown after failed startup did not complete within ${timeout.render}; halting.",
+          )
+          java.lang.Runtime.getRuntime.halt(1)
+        ,
+        s"$serviceName-shutdown-watchdog",
+      )
+      watchdog.setDaemon(true)
+      watchdog.start()
 
   def parseConfig[A: {DeriveConfig, Tag}] =
     ZLayer:


### PR DESCRIPTION
## Context

Today in production, `versola-edge` came up before `central` was listening on 8090, failed its synchronous config sync, logged `Could not start application` — and then stayed alive. Eleven minutes later the process was still running with `RestartCount: 0`, holding port 8096 while never binding 8095, so nginx returned 502 on every `/central/*` and `/permissions/me` request. Recovery required a manual `docker restart`.

`deploy.md` §9.5 declares this class of failure "fixed at the application level" by commit 41cee43, and I confirmed the running `0.2.0` image does contain that fix. It does not work.

## Why the existing fix doesn't work

`System.exit` does not exit — it runs shutdown hooks and *waits* for them. `ZIOApp` installs a shutdown hook that blocks until the ZIO runtime drains. Since `System.exit` is called from inside a ZIO fiber, the hook thread waits for the runtime while the runtime waits for the fiber blocked inside `System.exit`. Deadlock. The JVM never terminates, `restart: unless-stopped` never fires, and the end state is identical to the pre-fix zombie the commit was meant to eliminate.

## Changes

**1. `ReloadingCache.make` — retry the initial load**

The root cause, rather than making the crash-restart loop work. A cache whose source is another service fails its first load whenever it wins the race against that service; previously that failure propagated out of layer construction and took the application down. The initial load is now retried with jittered exponential backoff (7 attempts starting at 500ms, ~30s of headroom), so `edge` and `auth` wait for `central` instead of dying. In production `central` became ready ~0.4s after `auth` gave up, so this window is more than sufficient.

Bounded on purpose: a genuinely broken source (bad credentials, wrong URL) still fails startup loudly instead of hanging forever. `central`'s own caches read Postgres, where a retry is equally correct.

**2. `VersolaApp` — guarded graceful shutdown instead of `halt(1)`**

The first version of this PR replaced `System.exit(1)` with `Runtime.getRuntime.halt(1)`, which does avoid the deadlock but skips shutdown hooks and finalizers entirely — the Hikari pool never closes, OTel spans never flush. Measured against several alternatives (see PR discussion), the failure handlers now **re-fail** instead of terminating in place, so `ZIOApp` unwinds the scope and runs finalizers normally, and the exit code is `ZIOApp`'s own.

That unwind isn't bounded by anything on its own — `gracefulShutdownTimeout` only guards the shutdown *hook*, and the diagnostics server's non-daemon Netty threads would keep a wedged JVM alive indefinitely regardless. So a plain daemon watchdog thread is armed alongside the re-fail: if the unwind hasn't finished within `startupFailureShutdownTimeout` (20s), the watchdog calls `halt(1)` itself. A clean shutdown finishes well inside that window and the watchdog thread simply dies with the JVM; only a wedged finalizer ever reaches the halt.

Also overrides `gracefulShutdownTimeout` (15s) on the normal SIGTERM path, which previously defaulted to `Duration.Infinity` — same reasoning, bounding a wedged finalizer instead of leaving the container to hang forever on a stop signal.

**3. `deploy.md` §9.5**

Updated to describe the retry + guarded-shutdown behavior, and to correct the `System.exit` claim from the prior fix.

## Verification

- `util/compile`, `auth/compile`, `edge/compile`, `central/compile` — all pass
- Full `sbt test` (main modules + all postgres-backed specs against a local Postgres) — all green, 0 failures
- Probed the shutdown strategies directly with a standalone harness reproducing `VersolaApp`'s shape (forked diagnostics server, startup failure, optional wedged finalizer):
  - `System.exit` → confirmed deadlock (thread dump: ZIO's shutdown hook blocked in `OneShot.get`, main blocked in `exit`), never exits
  - `halt(1)` / `ZIOApp.exit` → exits in ~1.3s, finalizers skipped
  - re-fail (no watchdog) → finalizers run, but a wedged finalizer leaves a zombie
  - re-fail + watchdog (this PR) → clean shutdown: exits in ~3s, finalizers ran, no halt; wedged finalizer: watchdog halts at the deadline, finalizers still ran before the halt, no zombie
  - Also verified the ordinary SIGTERM path is unaffected: clean shutdown 3s, finalizers ran; a wedged finalizer with `gracefulShutdownTimeout=15s` is halted at 15s instead of hanging forever
- Additionally investigated the reported "too many clients" from Postgres per the reviewer's request: ran the full test suite against a local Postgres while sampling `pg_stat_activity`, peak connections stayed ≤4 and returned to 0 within seconds of completion — no leak from the test suite. Checked production `pg_stat_activity`: 35 idle `PostgreSQL JDBC Driver` connections is the three long-running services' Hikari pools (correctly scoped and held open for the container's lifetime), not a leak.

## Deployment note

Nothing changes on the VPS until new images are built and deployed. The running `0.2.0` stays vulnerable to this race until then.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KZV7BPFKFM3RVJRTAEPHZC56&panel=chat)