### PR TITLE
Add e2e coverage for RFC 9126 Pushed Authorization Requests

### DIFF
--- a/e2e/src/test/scala/versola/e2e/flows/basic/PushedAuthorizationSpec.scala
+++ b/e2e/src/test/scala/versola/e2e/flows/basic/PushedAuthorizationSpec.scala
@@ -33,16 +33,16 @@ object PushedAuthorizationSpec extends E2ESpec:
         assertTrue(code.nonEmpty).label("code must not be empty")
     },
 
-    test("redemption succeeds even when client_secret was sent alongside the pushed parameters") {
-      // client_secret_post authentication must not block redemption once it is stripped
-      // from the persisted authorization parameters server-side.
+    test("push + redeem via client_secret_post authentication") {
+      // client_secret must be accepted as an authentication credential (RFC 6749 §2.3.1)
+      // and stripped from the persisted authorization parameters afterward.
       for
         (s, auth) <- setup(Flows.Id.LoginPassword)
         pushed <- auth.pushAuthorization(
           clientId = s.clientId,
           clientSecret = s.clientSecret,
           redirectUri = s.redirectUri,
-          extraParams = Map("client_secret" -> s.clientSecret),
+          useBasicAuth = false,
         ).success
         authorize <- auth.authorizeRaw(
           clientId = s.clientId,

--- a/e2e/src/test/scala/versola/e2e/flows/basic/PushedAuthorizationSpec.scala
+++ b/e2e/src/test/scala/versola/e2e/flows/basic/PushedAuthorizationSpec.scala
@@ -1,0 +1,158 @@
+package versola.e2e.flows.basic
+
+import versola.e2e.support.{*, given}
+import zio.*
+import zio.http.Status
+import zio.test.*
+
+/** RFC 9126 Pushed Authorization Requests: POST /par and its redemption via
+  * `request_uri` at GET /authorize.
+  */
+object PushedAuthorizationSpec extends E2ESpec:
+
+  def spec = suite("Pushed Authorization Requests")(
+
+    test("push + redeem: request_uri carries the pushed parameters through to /authorize") {
+      for
+        (s, auth) <- setup(Flows.Id.LoginPassword)
+        pushed <- auth.pushAuthorization(
+          clientId = s.clientId,
+          clientSecret = s.clientSecret,
+          redirectUri = s.redirectUri,
+        ).success
+        authorize <- auth.authorizeRaw(
+          clientId = s.clientId,
+          redirectUri = s.redirectUri,
+          requestUri = Some(pushed.requestUri),
+        ).assertChallengeRedirect
+        challenge <- auth.getChallenge(authorize.conversationCookie.get).assertStep(ConversationStep.Credential)
+        csrf = challenge.csrf
+        code <- auth.submitLoginPassword(authorize.conversationCookie.get, s.login.get, s.password, csrf)
+          .assertRedirect(auth, authorize.conversationCookie.get)
+      yield assertTrue(pushed.expiresIn > 0).label("expires_in must be positive") &&
+        assertTrue(code.nonEmpty).label("code must not be empty")
+    },
+
+    test("redemption succeeds even when client_secret was sent alongside the pushed parameters") {
+      // client_secret_post authentication must not block redemption once it is stripped
+      // from the persisted authorization parameters server-side.
+      for
+        (s, auth) <- setup(Flows.Id.LoginPassword)
+        pushed <- auth.pushAuthorization(
+          clientId = s.clientId,
+          clientSecret = s.clientSecret,
+          redirectUri = s.redirectUri,
+          extraParams = Map("client_secret" -> s.clientSecret),
+        ).success
+        authorize <- auth.authorizeRaw(
+          clientId = s.clientId,
+          redirectUri = s.redirectUri,
+          requestUri = Some(pushed.requestUri),
+        ).assertChallengeRedirect
+      yield assertTrue(authorize.conversationCookie.isDefined)
+    },
+
+    test("request_uri is single-use: second redemption fails") {
+      for
+        (s, auth) <- setup(Flows.Id.LoginPassword)
+        pushed <- auth.pushAuthorization(
+          clientId = s.clientId,
+          clientSecret = s.clientSecret,
+          redirectUri = s.redirectUri,
+        ).success
+        _ <- auth.authorizeRaw(
+          clientId = s.clientId,
+          redirectUri = s.redirectUri,
+          requestUri = Some(pushed.requestUri),
+        ).assertChallengeRedirect
+        second <- auth.authorizeRaw(
+          clientId = s.clientId,
+          redirectUri = s.redirectUri,
+          requestUri = Some(pushed.requestUri),
+        )
+      yield assertTrue(second.response.status == Status.BadRequest)
+        .label(s"expected 400 on reuse, got ${second.response.status}")
+    },
+
+    test("redemption fails when client_id does not match the client that pushed the request") {
+      for
+        (s, auth) <- setup(Flows.Id.LoginPassword)
+        (other, _) <- setup(Flows.Id.EmailOtp)
+        pushed <- auth.pushAuthorization(
+          clientId = s.clientId,
+          clientSecret = s.clientSecret,
+          redirectUri = s.redirectUri,
+        ).success
+        result <- auth.authorizeRaw(
+          clientId = other.clientId,
+          redirectUri = other.redirectUri,
+          requestUri = Some(pushed.requestUri),
+        )
+      yield assertTrue(result.response.status == Status.BadRequest)
+        .label(s"expected 400 for mismatched client_id, got ${result.response.status}")
+    },
+
+    test("redemption fails when client_id is omitted") {
+      for
+        (s, auth) <- setup(Flows.Id.LoginPassword)
+        pushed <- auth.pushAuthorization(
+          clientId = s.clientId,
+          clientSecret = s.clientSecret,
+          redirectUri = s.redirectUri,
+        ).success
+        result <- auth.authorizeRaw(
+          clientId = s.clientId,
+          redirectUri = s.redirectUri,
+          requestUri = Some(pushed.requestUri),
+          omitClientId = true,
+        )
+      yield assertTrue(result.response.status == Status.BadRequest)
+        .label(s"expected 400 for missing client_id, got ${result.response.status}")
+    },
+
+    test("unknown request_uri returns 400 at /authorize") {
+      for
+        (s, auth) <- setup(Flows.Id.LoginPassword)
+        result <- auth.authorizeRaw(
+          clientId = s.clientId,
+          redirectUri = s.redirectUri,
+          requestUri = Some("urn:ietf:params:oauth:request_uri:does-not-exist"),
+        )
+      yield assertTrue(result.response.status == Status.BadRequest)
+    },
+
+    test("PAR endpoint rejects invalid client credentials with 401 and a WWW-Authenticate challenge") {
+      for
+        (s, auth) <- setup(Flows.Id.LoginPassword)
+        pushed <- auth.pushAuthorization(
+          clientId = s.clientId,
+          clientSecret = "wrong-secret",
+          redirectUri = s.redirectUri,
+        )
+      yield assertTrue(pushed.response.status == Status.Unauthorized) &&
+        assertTrue(pushed.response.header(zio.http.Header.WWWAuthenticate).isDefined)
+          .label("401 from /par must include a WWW-Authenticate challenge")
+    },
+
+    test("PAR endpoint rejects a request_uri parameter in the pushed body") {
+      for
+        (s, auth) <- setup(Flows.Id.LoginPassword)
+        pushed <- auth.pushAuthorization(
+          clientId = s.clientId,
+          clientSecret = s.clientSecret,
+          redirectUri = s.redirectUri,
+          extraParams = Map("request_uri" -> "urn:ietf:params:oauth:request_uri:whatever"),
+        )
+      yield assertTrue(pushed.response.status == Status.BadRequest)
+    },
+
+    test("non-POST /par returns 405 with an Allow header") {
+      for
+        (_, auth) <- setup(Flows.Id.LoginPassword)
+        response <- auth.parRaw(zio.http.Method.GET)
+      yield assertTrue(response.status == Status.MethodNotAllowed) &&
+        assertTrue(response.header(zio.http.Header.Allow).isDefined)
+          .label("405 from /par must include an Allow header")
+    },
+
+  ) @@ TestAspect.sequential @@ TestAspect.timeout(60.seconds)

--- a/e2e/src/test/scala/versola/e2e/support/OAuthClient.scala
+++ b/e2e/src/test/scala/versola/e2e/support/OAuthClient.scala
@@ -389,20 +389,26 @@ final class OAuthClient(client: Client, config: E2EConfig):
       scope: String = "openid",
       responseType: String = "code",
       extraParams: Map[String, String] = Map.empty,
+      useBasicAuth: Boolean = true,
   ): Task[PushedAuthorizationResult] =
     val (_, challenge) = PkceHelper.generate()
     val state = java.util.UUID.randomUUID().toString
-    val body = formBody(Map(
+    // `client_id` is always required in the pushed body per RFC 9126 §2.1, even when the
+    // client authenticates with HTTP Basic. When authenticating with client_secret_post
+    // instead, `client_secret` must travel in the same body — a client must not combine
+    // both authentication methods in a single request.
+    val formParams = Map(
+      "client_id"             -> clientId,
       "response_type"         -> responseType,
       "redirect_uri"          -> redirectUri,
       "scope"                 -> scope,
       "state"                 -> state,
       "code_challenge"        -> challenge,
       "code_challenge_method" -> "S256",
-    ) ++ extraParams)
-    val req = Request.post(s"${config.authUrl}/par", body)
-      .addHeader(Authorization.Basic(clientId, clientSecret))
+    ) ++ (if useBasicAuth then Map.empty else Map("client_secret" -> clientSecret)) ++ extraParams
+    val req0 = Request.post(s"${config.authUrl}/par", formBody(formParams))
       .addHeader(Header.ContentType(MediaType.application.`x-www-form-urlencoded`))
+    val req = if useBasicAuth then req0.addHeader(Authorization.Basic(clientId, clientSecret)) else req0
     Client.batched(req).provide(ZLayer.succeed(client)).flatMap(PushedAuthorizationResult.parse)
 
   /** Issues an arbitrary HTTP method against /par — used to test method-not-allowed handling. */

--- a/e2e/src/test/scala/versola/e2e/support/OAuthClient.scala
+++ b/e2e/src/test/scala/versola/e2e/support/OAuthClient.scala
@@ -67,6 +67,32 @@ case class ChallengeResult(response: Response, html: String):
 extension (task: Task[ChallengeResult])
   def assertStep(expected: ConversationStep): Task[ChallengeResult] = task.flatMap(_.assertStep(expected))
 
+sealed trait PushedAuthorizationResult:
+  def response: Response
+  def success: Task[PushedAuthorizationResult.Success] = this match
+    case s: PushedAuthorizationResult.Success => ZIO.succeed(s)
+    case PushedAuthorizationResult.Failure(resp, body) =>
+      ZIO.fail(RuntimeException(s"Expected PAR success but got: status=${resp.status} body=$body"))
+
+object PushedAuthorizationResult:
+  case class Success(response: Response, requestUri: String, expiresIn: Long) extends PushedAuthorizationResult
+  case class Failure(response: Response, body: String) extends PushedAuthorizationResult
+
+  private case class Raw(request_uri: String, expires_in: Long) derives JsonDecoder
+
+  def parse(response: Response): Task[PushedAuthorizationResult] =
+    response.body.asString.map: body =>
+      if response.status.isSuccess then
+        body.fromJson[Raw].fold(
+          err => Failure(response, s"JSON parse error [$err] body=$body"),
+          raw => Success(response, raw.request_uri, raw.expires_in),
+        )
+      else Failure(response, body)
+
+extension (task: Task[PushedAuthorizationResult])
+  @targetName("pushedAuthorizationSuccess")
+  def success: Task[PushedAuthorizationResult.Success] = task.flatMap(_.success)
+
 sealed trait TokenResult:
   def response: Response
   def success: Task[TokenResult.Success] = this match
@@ -305,6 +331,8 @@ final class OAuthClient(client: Client, config: E2EConfig):
   /** GET /authorize — raw variant with full control over which parameters are sent.
     * Generates PKCE and state internally; use the returned [[AuthorizeResult]] to access the verifier and cookie.
     * Pass `omitCodeChallenge = true` to omit `code_challenge` from the request (e.g. to test missing-challenge errors).
+    * Pass `requestUri` to redeem a pushed authorization request (RFC 9126) instead of sending
+    * the authorization parameters directly; only `client_id` and `request_uri` are then sent.
     */
   def authorizeRaw(
       clientId: String,
@@ -317,23 +345,32 @@ final class OAuthClient(client: Client, config: E2EConfig):
       sessionCookie: Option[String] = None,
       acrValues: Option[String] = None,
       idTokenHint: Option[String] = None,
+      requestUri: Option[String] = None,
+      omitClientId: Boolean = false,
   ): Task[AuthorizeResult] =
     val (verifier, challenge) = PkceHelper.generate()
     val state = java.util.UUID.randomUUID().toString
     for
       base <- ZIO.fromEither(URL.decode(s"${config.authUrl}/authorize")).mapError(new RuntimeException(_))
-      params = List(
-        "client_id"            -> Some(clientId),
-        "redirect_uri"         -> Some(redirectUri),
-        "scope"                -> scope,
-        "response_type"        -> responseType,
-        "code_challenge"       -> (if omitCodeChallenge then None else Some(challenge)),
-        "code_challenge_method"-> (if omitCodeChallenge then None else Some("S256")),
-        "state"                -> Some(state),
-        "prompt"               -> prompt,
-        "max_age"              -> maxAge.map(_.toString),
-        "acr_values"           -> acrValues,
-        "id_token_hint"        -> idTokenHint,
+      params = requestUri.fold(
+        List(
+          "client_id"            -> Some(clientId),
+          "redirect_uri"         -> Some(redirectUri),
+          "scope"                -> scope,
+          "response_type"        -> responseType,
+          "code_challenge"       -> (if omitCodeChallenge then None else Some(challenge)),
+          "code_challenge_method"-> (if omitCodeChallenge then None else Some("S256")),
+          "state"                -> Some(state),
+          "prompt"               -> prompt,
+          "max_age"              -> maxAge.map(_.toString),
+          "acr_values"           -> acrValues,
+          "id_token_hint"        -> idTokenHint,
+        ),
+      )(uri =>
+        List(
+          "client_id"    -> (if omitClientId then None else Some(clientId)),
+          "request_uri"  -> Some(uri),
+        ),
       ).collect { case (k, Some(v)) => k -> v }
       req = Request.get(base.addQueryParams(params))
       reqWithSession = sessionCookie.fold(req)(sc =>
@@ -341,6 +378,37 @@ final class OAuthClient(client: Client, config: E2EConfig):
       )
       response <- Client.batched(reqWithSession).provide(ZLayer.succeed(client))
     yield AuthorizeResult(response, verifier, state, OAuthClient.extractConversationCookie(response))
+
+  /** POST /par — pushes an authorization request per RFC 9126, returning a `request_uri`
+    * reference for redemption at `/authorize`. Authenticates with HTTP Basic.
+    */
+  def pushAuthorization(
+      clientId: String,
+      clientSecret: String,
+      redirectUri: String,
+      scope: String = "openid",
+      responseType: String = "code",
+      extraParams: Map[String, String] = Map.empty,
+  ): Task[PushedAuthorizationResult] =
+    val (_, challenge) = PkceHelper.generate()
+    val state = java.util.UUID.randomUUID().toString
+    val body = formBody(Map(
+      "response_type"         -> responseType,
+      "redirect_uri"          -> redirectUri,
+      "scope"                 -> scope,
+      "state"                 -> state,
+      "code_challenge"        -> challenge,
+      "code_challenge_method" -> "S256",
+    ) ++ extraParams)
+    val req = Request.post(s"${config.authUrl}/par", body)
+      .addHeader(Authorization.Basic(clientId, clientSecret))
+      .addHeader(Header.ContentType(MediaType.application.`x-www-form-urlencoded`))
+    Client.batched(req).provide(ZLayer.succeed(client)).flatMap(PushedAuthorizationResult.parse)
+
+  /** Issues an arbitrary HTTP method against /par — used to test method-not-allowed handling. */
+  def parRaw(method: Method): Task[Response] =
+    val req = Request(method = method, url = URL.decode(s"${config.authUrl}/par").toOption.get)
+    Client.batched(req).provide(ZLayer.succeed(client))
 
   /** GET /challenge — fetches the current challenge form HTML and parses the step meta tag. */
   def getChallenge(cookie: String): Task[ChallengeResult] =


### PR DESCRIPTION
- OAuthClient: add pushAuthorization (POST /par), PushedAuthorizationResult, parRaw for arbitrary methods, and extend authorizeRaw with requestUri / omitClientId to redeem a pushed request at /authorize.
- PushedAuthorizationSpec: push+redeem happy path, client_secret stripped from persisted params, single-use enforcement, client_id binding (mismatch and omission), unknown request_uri, invalid_client 401 with WWW-Authenticate, request_uri rejected in pushed body, and 405 with Allow header for non-POST /par.