### PR TITLE
fix(central-ui): remove misleading request.path / {name} placeholder tooltip

### DIFF
--- a/central-ui/src/components/resources-list.ts
+++ b/central-ui/src/components/resources-list.ts
@@ -824,7 +824,6 @@ export class VersolaResourcesList extends LitElement {
         <li><span class="option-tooltip-code">user</span> — userinfo claims (only when "Fetch userinfo" is enabled).</li>
         <li><span class="option-tooltip-code">request</span> — incoming request data:
           <ul class="option-tooltip-list">
-            <li><span class="option-tooltip-code">request.path</span> — map of path parameters from <span class="option-tooltip-code">{name}</span> placeholders.</li>
             <li><span class="option-tooltip-code">request.query</span> — map of query parameters (first value per key).</li>
             <li><span class="option-tooltip-code">request.queryAll</span> — map of query parameters (all values per key as a list).</li>
             <li><span class="option-tooltip-code">request.headers</span> — map of request headers (first value per key).</li>


### PR DESCRIPTION
## Bug
The Allow (CEL) info tooltip on the endpoint editor advertised:

> `request.path` — map of path parameters from `{name}` placeholders.

But `central` rejects any endpoint path containing a `{name}` segment at registration time — both server-side (`ResourceService.validPathRegex = "^/([a-zA-Z0-9-]+(/[a-zA-Z0-9-]+)*)?$".r`, covered by the existing test `"createResource returns error when endpoint path contains path parameters"`) and in the UI's own `isEndpointPathInvalid` check, which uses the identical regex. So `request.path` can never actually contain anything in practice — the tooltip was describing a capability that doesn't exist through the registration flow (even though `edge`'s runtime `extractPathParams` technically supports it, it's unreachable since no such path can ever be saved).

## Fix
Removed the `request.path` bullet from the tooltip.

## Related
Companion docs fix in versola-website: [PR #29](https://github.com/versolauth/versola-website/pull/29) removed the same claim from the public docs.

## Verification
- `npx playwright test resources.spec.ts`: 17/17 passed
- Full `central-ui` suite: 113 passed, same 2 pre-existing unrelated `app-shell.spec.ts` failures on main

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KZX9EDMKWTN8S2X9HAPMYDMX&panel=chat)