### PR TITLE
test(docs-screenshots): add client registration flow form screenshot

### DIFF
--- a/central-ui/tests/docs-screenshots.spec.ts
+++ b/central-ui/tests/docs-screenshots.spec.ts
@@ -50,6 +50,7 @@ const storefrontClient = {
 };
 
 const alphaAdmin = { id: 'alpha_admin', description: { en: 'Alpha admin' }, permissions: ['orders.read', 'orders.write'], active: true };
+const userRole = { id: 'user', description: { en: 'Self-registered user' }, permissions: [], active: true };
 
 const dana = {
   id: '00000000-0000-0000-0000-000000000042',
@@ -65,7 +66,7 @@ const state = {
   permissions: { [tenant]: permissions },
   resources: { [tenant]: [ordersApi] },
   clients: { [tenant]: [storefrontClient] },
-  roles: { [tenant]: [alphaAdmin] },
+  roles: { [tenant]: [alphaAdmin, userRole] },
   users: [dana],
 };
 
@@ -126,6 +127,24 @@ test('client create form', async ({ page }) => {
   await expect(page.locator('.secret-banner .secret-value')).toBeVisible();
   await page.locator('.secret-banner').scrollIntoViewIfNeeded();
   await shot(page, 'client-created-secret');
+});
+
+test('client registration flow form', async ({ page }) => {
+  await loadAdminApp(page, { path: `/?view=clients&tenant=${tenant}`, state });
+
+  await page.getByRole('button', { name: '+ Create Client', exact: true }).click();
+  await page.getByLabel('Client ID').fill('checkout-web');
+  await page.getByLabel('Client Name').fill('Checkout Web');
+  await page.getByPlaceholder('https://app.example.com/callback').fill('https://checkout.example.com/callback');
+  await page.getByPlaceholder('https://app.example.com/callback').press('Enter');
+
+  const registrationRow = page.getByText('Registration', { exact: true }).locator('..');
+  await registrationRow.locator('label.toggle').click();
+  await expect(page.locator('[aria-label="Registration credential (locked)"]')).toContainText('phone');
+
+  await page.getByLabel('Challenge', { exact: true }).selectOption('setPassword');
+  await page.getByRole('group', { name: 'Assigned roles' }).getByRole('checkbox', { name: 'alpha_admin', exact: true }).check();
+  await shot(page, 'client-form-registration', true);
 });
 
 test('resources list', async ({ page }) => {


### PR DESCRIPTION
Adds a Playwright capture for the client **Registration** section (challenge selector + assigned roles) so the How To / Create a Client docs page can show it.

- Adds a `user` role to the shared docs-screenshots fixture state (matches the default self-registration role).
- New test `client registration flow form`: enables Registration, sets Challenge to `set password`, checks an additional role, and captures `client-form-registration.png`.

Generated PNG is copied by hand into `versola-website/public/img/docs/entities/` per the existing convention documented at the top of the spec file. Companion docs PR: versolauth/versola-website#33.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M031AYPH48YEWBGQ8Y6PXYG1&panel=chat)