### PR TITLE
fix(central): optimize upsertForm version query and handle concurrent insert collision

### DIFF
--- a/central/implementations/postgres/src/main/scala/versola/configuration/forms/PostgresFormRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/forms/PostgresFormRepository.scala
@@ -8,6 +8,7 @@ import zio.json.*
 import zio.{Task, ZLayer, Schedule}
 import org.postgresql.util.PSQLException
 import com.augustnagro.magnum.SqlException
+import zio.durationInt
 
 class PostgresFormRepository(xa: TransactorZIO) extends FormRepository, BasicCodecs:
 
@@ -62,7 +63,7 @@ class PostgresFormRepository(xa: TransactorZIO) extends FormRepository, BasicCod
             case cause: PSQLException => cause.getSQLState == "23505"
             case _ => false
         case _ => false
-      } && Schedule.recurs(3)
+      } && Schedule.recurs(10) && Schedule.exponential(10.millis).jittered
     )
 
   override def setActiveVersion(id: FormId, version: Int): Task[Unit] =

--- a/central/implementations/postgres/src/main/scala/versola/configuration/forms/PostgresFormRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/forms/PostgresFormRepository.scala
@@ -5,7 +5,9 @@ import com.augustnagro.magnum.magzio.TransactorZIO
 import versola.central.configuration.forms.{BackendProperty, FormId, FormRecord, FormRepository}
 import versola.util.postgres.BasicCodecs
 import zio.json.*
-import zio.{Task, ZLayer}
+import zio.{Task, ZLayer, Schedule}
+import org.postgresql.util.PSQLException
+import com.augustnagro.magnum.SqlException
 
 class PostgresFormRepository(xa: TransactorZIO) extends FormRepository, BasicCodecs:
 
@@ -38,10 +40,13 @@ class PostgresFormRepository(xa: TransactorZIO) extends FormRepository, BasicCod
       properties: Vector[BackendProperty],
       activate: Boolean,
   ): Task[Unit] =
-    xa.repeatableRead.transactMeasured("upsert-form"):
-      val versions = sql"""SELECT version FROM forms WHERE id = $id ORDER BY version DESC""".query[Int].run()
-      val nextVersion = versions.maxOption.getOrElse(0) + 1
-      val makeActive = activate || versions.isEmpty
+    xa.transactMeasured("upsert-form"):
+      val (nextVersion, isEmpty) =
+        sql"""SELECT COALESCE(MAX(version), 0) + 1, COUNT(*) = 0 FROM forms WHERE id = $id"""
+          .query[(Int, Boolean)]
+          .run()
+          .head
+      val makeActive = activate || isEmpty
       if makeActive then
         sql"""UPDATE forms SET active = false WHERE id = $id""".update.run()
       sql"""INSERT INTO forms (id, version, active, style, js_source, js_compiled, localizations, properties)
@@ -50,6 +55,15 @@ class PostgresFormRepository(xa: TransactorZIO) extends FormRepository, BasicCod
               SELECT version FROM forms WHERE id = $id ORDER BY version DESC LIMIT $MaxVersions
             )""".update.run()
       ()
+    .retry(
+      Schedule.recurWhile[Throwable] {
+        case e: SqlException =>
+          e.getCause match
+            case cause: PSQLException => cause.getSQLState == "23505"
+            case _ => false
+        case _ => false
+      } && Schedule.recurs(3)
+    )
 
   override def setActiveVersion(id: FormId, version: Int): Task[Unit] =
     xa.transactMeasured("set-active-form-version"):

--- a/central/src/test/scala/versola/central/configuration/forms/FormRepositorySpec.scala
+++ b/central/src/test/scala/versola/central/configuration/forms/FormRepositorySpec.scala
@@ -62,6 +62,16 @@ trait FormRepositorySpec extends DatabaseSpecBase[FormRepositorySpec.Env]:
           v2.map(_.active) == Some(true),
         )
       },
+      test("concurrent upsertForm calls create distinct versions without collision") {
+        val formId = FormId("credential")
+        for
+          _ <- ZIO.foreachParDiscard((1 to 5).toList)(_ =>
+            env.repository.upsertForm(formId, "", Some("src"), None, Map.empty, Vector.empty, activate = false)
+          )
+          all <- env.repository.getAll
+          versions = all.filter(_.id == formId).map(_.version).sorted
+        yield assertTrue(versions == Vector(1, 2, 3, 4, 5))
+      },
     )
 
 object FormRepositorySpec:

--- a/central/src/test/scala/versola/central/configuration/forms/FormRepositorySpec.scala
+++ b/central/src/test/scala/versola/central/configuration/forms/FormRepositorySpec.scala
@@ -71,8 +71,7 @@ trait FormRepositorySpec extends DatabaseSpecBase[FormRepositorySpec.Env]:
           all <- env.repository.getAll
           versions = all.filter(_.id == formId).map(_.version).sorted
         yield assertTrue(versions == Vector(1, 2, 3, 4, 5))
-      },
+      } @@ TestAspect.withLiveClock,
     )
-
 object FormRepositorySpec:
   case class Env(repository: FormRepository)


### PR DESCRIPTION
Closes #99 
 
## Problem
`upsertForm` had two issues:
1. Fetched all version rows to compute `MAX` in Scala — unnecessary data transfer
2. No concurrency protection: two parallel calls could read the same `MAX(version)`, compute the same `nextVersion`, and both attempt an INSERT — causing an unhandled PRIMARY KEY violation

## Solution
1. Replaced the full version scan with a single aggregate query:
   `SELECT COALESCE(MAX(version), 0) + 1, COUNT(*) = 0 FROM forms WHERE id = $id`
2. Switched from `REPEATABLE_READ` to `READ_COMMITTED` and added `.retry()` on `SqlException` wrapping a `23505` (unique_violation) — the entire transaction retries with fresh data

## Test
Added concurrent test: 5 parallel `upsertForm` calls on the same `id` — verifies all 5 versions are created without collision