### PR TITLE
Scope edge sync of resources and clients via explicit assignment tables

### DIFF
--- a/central/implementations/postgres/migrations/V1020__edge_resource_client_links.sql
+++ b/central/implementations/postgres/migrations/V1020__edge_resource_client_links.sql
@@ -1,0 +1,79 @@
+-- Explicit edge scope for resources and OAuth clients.
+-- These links are intentionally separate from the tenant model: a tenant may
+-- contain data that is not deployed to every edge serving that tenant.
+CREATE TABLE edge_resources (
+    edge_id     TEXT NOT NULL REFERENCES edges(id) ON DELETE CASCADE,
+    resource_id TEXT NOT NULL REFERENCES resources(resource_id) ON DELETE CASCADE,
+    PRIMARY KEY (edge_id, resource_id)
+);
+
+CREATE INDEX edge_resources_resource_id_idx ON edge_resources(resource_id);
+
+CREATE TABLE edge_clients (
+    edge_id   TEXT NOT NULL REFERENCES edges(id) ON DELETE CASCADE,
+    client_id TEXT NOT NULL REFERENCES oauth_clients(id) ON DELETE CASCADE,
+    PRIMARY KEY (edge_id, client_id)
+);
+
+CREATE INDEX edge_clients_client_id_idx ON edge_clients(client_id);
+
+-- Preserve the existing tenant-based assignments during migration. Rows whose
+-- tenant is intentionally unassigned remain unavailable to edge sync.
+INSERT INTO edge_resources (edge_id, resource_id)
+SELECT t.edge_id, r.resource_id
+FROM resources r
+JOIN tenants t ON t.id = r.tenant_id
+WHERE t.edge_id IS NOT NULL;
+
+INSERT INTO edge_clients (edge_id, client_id)
+SELECT t.edge_id, c.id
+FROM oauth_clients c
+JOIN tenants t ON t.id = c.tenant_id
+WHERE t.edge_id IS NOT NULL;
+
+-- Link changes must refresh the corresponding cached record. The resource and
+-- client payloads still use their owning tenant/id, as existing sync events do.
+CREATE OR REPLACE FUNCTION notify_edge_resource_change()
+RETURNS trigger AS $$
+DECLARE
+  resource_row RECORD;
+BEGIN
+  SELECT tenant_id, resource_id INTO resource_row
+  FROM resources
+  WHERE resource_id = CASE WHEN TG_OP = 'DELETE' THEN OLD.resource_id ELSE NEW.resource_id END;
+  IF resource_row IS NOT NULL THEN
+    PERFORM pg_notify('resource_change', json_build_object(
+      'tenantId', resource_row.tenant_id,
+      'id', resource_row.resource_id,
+      'op', 'UPDATE'
+    )::text);
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER edge_resources_notify
+AFTER INSERT OR UPDATE OR DELETE ON edge_resources
+FOR EACH ROW EXECUTE FUNCTION notify_edge_resource_change();
+
+CREATE OR REPLACE FUNCTION notify_edge_client_change()
+RETURNS trigger AS $$
+DECLARE
+  client_row RECORD;
+BEGIN
+  SELECT id INTO client_row
+  FROM oauth_clients
+  WHERE id = CASE WHEN TG_OP = 'DELETE' THEN OLD.client_id ELSE NEW.client_id END;
+  IF client_row IS NOT NULL THEN
+    PERFORM pg_notify('client_change', json_build_object(
+      'id', client_row.id,
+      'op', 'UPDATE'
+    )::text);
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER edge_clients_notify
+AFTER INSERT OR UPDATE OR DELETE ON edge_clients
+FOR EACH ROW EXECUTE FUNCTION notify_edge_client_change();

--- a/central/implementations/postgres/src/main/scala/versola/configuration/clients/PostgresOAuthClientRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/clients/PostgresOAuthClientRepository.scala
@@ -3,6 +3,7 @@ package versola.configuration.clients
 import com.augustnagro.magnum.*
 import com.augustnagro.magnum.magzio.TransactorZIO
 import versola.central.configuration.clients.{AuthFlow, ClientAlreadyExists, ClientId, OAuthClientRecord, OAuthClientRepository, RegistrationFlow}
+import versola.central.configuration.edges.EdgeId
 import versola.central.configuration.permissions.Permission
 import versola.central.configuration.scopes.ScopeToken
 import versola.central.configuration.tenants.TenantId
@@ -19,6 +20,7 @@ class PostgresOAuthClientRepository(
 ) extends OAuthClientRepository, BasicCodecs:
 
   given DbCodec[ClientId] = DbCodec.StringCodec.biMap(ClientId(_), identity[String])
+  given DbCodec[EdgeId] = DbCodec.StringCodec.biMap(EdgeId(_), identity[String])
   given DbCodec[TenantId] = DbCodec.StringCodec.biMap(TenantId(_), identity[String])
   given DbCodec[ScopeToken] = DbCodec.StringCodec.biMap(ScopeToken(_), identity[String])
   given DbCodec[Permission] = DbCodec.StringCodec.biMap(Permission(_), identity[String])
@@ -47,6 +49,19 @@ class PostgresOAuthClientRepository(
   override def find(clientId: ClientId): Task[Option[OAuthClientRecord]] =
     xa.connectMeasured("find-client"):
       findClient(clientId).query[OAuthClientRecord].run().headOption
+
+  override def getForEdge(edgeId: EdgeId): Task[Vector[OAuthClientRecord]] =
+    xa.connectMeasured("get-edge-clients"):
+      sql"""
+        SELECT c.id, c.tenant_id, c.client_name, c.redirect_uris, c.scope, c.secret, c.previous_secret,
+               c.access_token_ttl, c.refresh_token_ttl, c.permissions, c.theme, c.auth_flow, c.registration_flow,
+               c.otp_template_id, c.front_channel_logout_uri, c.front_channel_logout_session_required,
+               c.back_channel_logout_uri
+        FROM oauth_clients c
+        INNER JOIN edge_clients ec ON ec.client_id = c.id
+        WHERE ec.edge_id = $edgeId
+        ORDER BY c.id
+      """.query[OAuthClientRecord].run()
 
   override def createClient(client: OAuthClientRecord): IO[ClientAlreadyExists | Throwable, Unit] =
     xa.connectMeasured("create-client"):

--- a/central/implementations/postgres/src/main/scala/versola/configuration/resources/PostgresResourceRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/resources/PostgresResourceRepository.scala
@@ -6,6 +6,7 @@ import com.augustnagro.magnum.pg.PgCodec
 import com.augustnagro.magnum.pg.json.JsonBDbCodec
 import versola.central.configuration.ResourceUri
 import versola.central.configuration.clients.ClientId
+import versola.central.configuration.edges.EdgeId
 import versola.central.configuration.resources.{
   ResourceEndpointId,
   ResourceEndpointRecord,
@@ -23,6 +24,7 @@ class PostgresResourceRepository(xa: TransactorZIO) extends ResourceRepository, 
   given DbCodec[ResourceId] = DbCodec.StringCodec.biMap(ResourceId(_), identity[String])
   given DbCodec[ResourceUri] = DbCodec.StringCodec.biMap(ResourceUri(_), identity[String])
   given DbCodec[TenantId] = DbCodec.StringCodec.biMap(TenantId(_), identity[String])
+  given DbCodec[EdgeId] = DbCodec.StringCodec.biMap(EdgeId(_), identity[String])
   given DbCodec[ClientId] = DbCodec.StringCodec.biMap(ClientId(_), identity[String])
   given DbCodec[List[ClientId]] =
     PgCodec.SeqCodec[String].biMap(_.map(ClientId(_)).toList, _.map(identity[String]))
@@ -39,10 +41,23 @@ class PostgresResourceRepository(xa: TransactorZIO) extends ResourceRepository, 
       WHERE resource_id = $resourceId
     """.query[ResourceRecord]
 
+  private val resourceColumns =
+    "tenant_id, resource_id, resource, audience, endpoints, secret, previous_secret"
+
   override def getAll: Task[Vector[ResourceRecord]] =
     xa.connectMeasured("get-all-resources"):
       sql"""
         SELECT tenant_id, resource_id, resource, audience, endpoints, secret, previous_secret FROM resources
+      """.query[ResourceRecord].run()
+
+  override def getForEdge(edgeId: EdgeId): Task[Vector[ResourceRecord]] =
+    xa.connectMeasured("get-edge-resources"):
+      sql"""
+        SELECT r.tenant_id, r.resource_id, r.resource, r.audience, r.endpoints, r.secret, r.previous_secret
+        FROM resources r
+        INNER JOIN edge_resources er ON er.resource_id = r.resource_id
+        WHERE er.edge_id = $edgeId
+        ORDER BY r.resource_id
       """.query[ResourceRecord].run()
 
   override def findResource(

--- a/central/src/main/scala/versola/central/configuration/clients/OAuthClientRepository.scala
+++ b/central/src/main/scala/versola/central/configuration/clients/OAuthClientRepository.scala
@@ -3,6 +3,7 @@ package versola.central.configuration.clients
 import versola.central.configuration.permissions.Permission
 import versola.central.configuration.scopes.ScopeToken
 import versola.central.configuration.tenants.TenantId
+import versola.central.configuration.edges.EdgeId
 import versola.central.configuration.{PatchClientRedirectUris, PatchClientScope, PatchPermissions}
 import versola.util.{CacheSource, Patch}
 import zio.*
@@ -11,6 +12,9 @@ import zio.http.URL
 trait OAuthClientRepository extends CacheSource[Vector[OAuthClientRecord]]:
 
   def getAll: Task[Vector[OAuthClientRecord]]
+
+  /** Returns clients explicitly assigned to the edge. */
+  def getForEdge(edgeId: EdgeId): Task[Vector[OAuthClientRecord]]
 
   def find(clientId: ClientId): Task[Option[OAuthClientRecord]]
 

--- a/central/src/main/scala/versola/central/configuration/clients/OAuthClientService.scala
+++ b/central/src/main/scala/versola/central/configuration/clients/OAuthClientService.scala
@@ -102,12 +102,7 @@ object OAuthClientService:
     override def getClientsForSync(edgeId: Option[EdgeId]): Task[Vector[OAuthClientRecord]] =
       edgeId match
         case None => cache.get
-        case Some(id) =>
-          for
-            clients <- cache.get
-            tenants <- tenantRepository.getAll
-            allowedTenantIds = tenants.filter(_.edgeId.contains(id)).map(_.id).toSet
-          yield clients.filter(c => allowedTenantIds.contains(c.tenantId))
+        case Some(id) => clientRepository.getForEdge(id).flatMap(ZIO.foreach(_)(decryptSecrets(_, securityService, clientSecretsKey)))
 
     override def getTenantClients(
         tenantId: TenantId,

--- a/central/src/main/scala/versola/central/configuration/resources/ResourceRepository.scala
+++ b/central/src/main/scala/versola/central/configuration/resources/ResourceRepository.scala
@@ -3,12 +3,16 @@ package versola.central.configuration.resources
 import versola.central.configuration.ResourceUri
 import versola.central.configuration.clients.ClientId
 import versola.central.configuration.tenants.TenantId
+import versola.central.configuration.edges.EdgeId
 import versola.util.CacheSource
 import zio.Task
 
 trait ResourceRepository extends CacheSource[Vector[ResourceRecord]]:
 
   def getAll: Task[Vector[ResourceRecord]]
+
+  /** Returns resources explicitly assigned to the edge. */
+  def getForEdge(edgeId: EdgeId): Task[Vector[ResourceRecord]]
 
   def findResource(
       resourceId: ResourceId,

--- a/central/src/main/scala/versola/central/configuration/resources/ResourceService.scala
+++ b/central/src/main/scala/versola/central/configuration/resources/ResourceService.scala
@@ -105,12 +105,7 @@ object ResourceService:
     override def getResourcesForSync(edgeId: Option[EdgeId]): Task[Vector[ResourceRecord]] =
       edgeId match
         case None => cache.get
-        case Some(id) =>
-          for
-            resources <- cache.get
-            tenants <- tenantRepository.getAll
-            allowedTenantIds = tenants.filter(_.edgeId.contains(id)).map(_.id).toSet
-          yield resources.filter(r => allowedTenantIds.contains(r.tenantId))
+        case Some(id) => resourceRepository.getForEdge(id).flatMap(ZIO.foreach(_)(decryptSecrets(_, securityService, secretsKey)))
 
     override def verifySecret(provided: Secret): Task[Boolean] =
       cache.get.map: resources =>


### PR DESCRIPTION
## Problem

Edge sync of resources and OAuth clients was scoped indirectly: `ResourceService.getResourcesForSync` and `OAuthClientService.getClientsForSync` looked up which tenants were assigned to an edge (`tenants.edge_id`) and returned every resource/client owned by those tenants. This meant an edge implicitly received all data for any tenant assigned to it, with no way to grant an edge only a subset of a tenant's resources/clients.

## Change

Adds two explicit assignment tables, independent of tenant-to-edge assignment:

- `edge_resources(edge_id, resource_id)`
- `edge_clients(edge_id, client_id)`

`ResourceRepository.getForEdge` / `OAuthClientRepository.getForEdge` query these tables directly (via INNER JOIN), and the sync-path methods on `ResourceService` / `OAuthClientService` use them instead of deriving scope through `TenantRepository`. An edge now receives only resources/clients (with all of their endpoints) explicitly linked to it.

The migration backfills both tables from the current `tenants.edge_id` assignments so existing sync behavior is preserved until assignments are managed explicitly, and adds `NOTIFY` triggers on the new tables so an assignment change invalidates the affected cached resource/client via the existing `resource_change`/`client_change` channels.

`ResourceRecord` and `OAuthClientRecord` are unchanged, as is `EdgeRecord` — edge scope is not carried on the domain records, only resolved at the repository query level for sync.

Roles and permissions are intentionally left on the existing tenant-based edge filtering for now (out of scope for this change).

## Not done in this PR

- No endpoint-level assignment (resource-level only, per discussion).
- No admin API for managing `edge_resources`/`edge_clients` yet.
- Roles/permissions scoping unchanged.

## Testing

I was unable to compile or run tests in my environment (no JVM/sbt/Docker available). Please run the `central` and PostgreSQL repository/service test suites locally before merging, in particular:

- `PostgresResourceRepositorySpec` / `PostgresOAuthClientRepositorySpec`
- `ResourceServiceSpec` / `OAuthClientServiceSpec`
- Migration `V1020__edge_resource_client_links.sql` applies cleanly and backfill matches expectations against existing data.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M00HFMRC83XY2CA4C9JHNV1D&panel=chat)