### PR TITLE
Fix passkey login broken on prod: prevent browser caching of /challenge/passkey/options

### DIFF
--- a/auth/src/main/scala/versola/oauth/conversation/ConversationController.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationController.scala
@@ -96,7 +96,10 @@ object ConversationController extends Controller:
         case Error.ConversationExpired => ZIO.succeed(Response.status(Status.Gone))
         case Error.ServiceUnavailable => ZIO.succeed(Response.status(Status.InternalServerError))
         case _: Error => ZIO.succeed(Response.badRequest)
-        case ex: Throwable => ZIO.fail(ex)
+        // Handled locally (rather than re-failed to the global `Observability.handleErrors`
+        // error mapper) so the resulting 500 still carries `no-store` below — this route's
+        // response is never safe to cache, including on unexpected failure.
+        case ex: Throwable => Observability.cause.set(Some(Cause.fail(ex))).as(Response.internalServerError)
       }.map(_.addHeader(Header.CacheControl.NoStore))
     }
 

--- a/auth/src/main/scala/versola/oauth/conversation/ConversationController.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationController.scala
@@ -97,7 +97,7 @@ object ConversationController extends Controller:
         case Error.ServiceUnavailable => ZIO.succeed(Response.status(Status.InternalServerError))
         case _: Error => ZIO.succeed(Response.badRequest)
         case ex: Throwable => ZIO.fail(ex)
-      }
+      }.map(_.addHeader(Header.CacheControl.NoStore))
     }
 
   val submitPasskeyAssertionRoute =

--- a/auth/src/test/scala/versola/oauth/conversation/ConversationControllerSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/ConversationControllerSpec.scala
@@ -417,7 +417,31 @@ object ConversationControllerSpec extends UnitSpecBase:
         response <- client.batched(Request.get(URL.empty / "challenge" / "passkey" / "options").addHeader(conversationCookie))
       yield assertTrue(
         response.status == Status.Ok,
-        response.headers.get(Header.ContentType).exists(_.mediaType == MediaType.application.json)
+        response.headers.get(Header.ContentType).exists(_.mediaType == MediaType.application.json),
+        response.headers.get(Header.CacheControl).contains(Header.CacheControl.NoStore),
+      )
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
+
+    test("GET /challenge/passkey/options returns 410 with no-store when conversation expired") {
+      for
+        client <- ZIO.service[Client]
+        router = stub[ConversationRouter]
+        configuration = stub[OAuthConfigurationService]
+        renderService = stub[ConversationRenderService]
+        tracing <- NoopTracing.layer.build
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            ConversationController.routes.provideEnvironment(
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing
+            )
+          )
+        )
+        _ <- router.startPasskeyOptions.failsWith(Error.ConversationExpired)
+
+        response <- client.batched(Request.get(URL.empty / "challenge" / "passkey" / "options").addHeader(conversationCookie))
+      yield assertTrue(
+        response.status == Status.Gone,
+        response.headers.get(Header.CacheControl).contains(Header.CacheControl.NoStore),
       )
     }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
     rejectedSubmitTestCase(

--- a/auth/src/test/scala/versola/oauth/conversation/ConversationControllerSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/ConversationControllerSpec.scala
@@ -444,6 +444,29 @@ object ConversationControllerSpec extends UnitSpecBase:
         response.headers.get(Header.CacheControl).contains(Header.CacheControl.NoStore),
       )
     }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
+
+    test("GET /challenge/passkey/options returns 500 with no-store on unexpected failure") {
+      for
+        client <- ZIO.service[Client]
+        router = stub[ConversationRouter]
+        configuration = stub[OAuthConfigurationService]
+        renderService = stub[ConversationRenderService]
+        tracing <- NoopTracing.layer.build
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            ConversationController.routes.provideEnvironment(
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing
+            )
+          )
+        )
+        _ <- router.startPasskeyOptions.failsWith(new RuntimeException("boom"))
+
+        response <- client.batched(Request.get(URL.empty / "challenge" / "passkey" / "options").addHeader(conversationCookie))
+      yield assertTrue(
+        response.status == Status.InternalServerError,
+        response.headers.get(Header.CacheControl).contains(Header.CacheControl.NoStore),
+      )
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
     rejectedSubmitTestCase(
       description = "reject login-password violating configured password regex",
       request = Request.post(


### PR DESCRIPTION
## Bug

On prod, tapping "passkey" did nothing. DevTools showed:

```
GET https://id.versola.kz/challenge/passkey/options?ui_locale=en
410 Gone (from disk cache)
```

## Root cause

`GET /challenge/passkey/options` generates a fresh, session-scoped WebAuthn challenge on every call and returns `410` when the conversation has expired — but it never sent a `Cache-Control` header. Browsers may heuristically cache GET responses (including `410`) that lack explicit caching directives, and cookies aren't part of the HTTP cache key. So a `410` returned for one expired conversation got cached and was later replayed **from disk, without hitting the server**, for a subsequent valid conversation using the same URL.

The client-side handler (`credential.tsx`) treats any `410` from this endpoint as "conversation expired" and silently does `window.location.href = '/challenge'` — so instead of the passkey/WebAuthn prompt appearing, the page just reloaded, making it look like nothing happened.

## Fix

Add `Cache-Control: no-store` to every response this route returns (200/400/410/500), matching the existing convention already used in `PushedAuthorizationController`, `TokenEndpointController`, and `IntrospectionController`.

## Tests

- Updated the existing 200 test to assert `Cache-Control: no-store`.
- Added a new test for the 410 (conversation expired) branch asserting `Cache-Control: no-store`.

Run: `sbt "auth/testOnly versola.oauth.conversation.ConversationControllerSpec"`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M0DJ52SP8REF01VY97QT9GGR&panel=chat)