### PR TITLE
FAPI: reject plain PKCE, require S256 (#190)

### DIFF
--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
@@ -139,10 +139,10 @@ object AuthorizeRequestParser:
 
         codeChallengeMethod <- getParam(params, "code_challenge_method")
           .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "code_challenge_method"))
+          .someOrFail(Error.CodeChallengeMethodMissing(redirectUri, state))
           .flatMap {
-            case Some("S256") => ZIO.succeed(CodeChallengeMethod.S256)
-            case Some("plain") | None => ZIO.succeed(CodeChallengeMethod.Plain)
-            case Some(other) => ZIO.fail(Error.CodeChallengeMethodInvalid(redirectUri, state, other))
+            case "S256" => ZIO.succeed(CodeChallengeMethod.S256)
+            case other => ZIO.fail(Error.CodeChallengeMethodInvalid(redirectUri, state, other))
           }
 
         scope <- getParam(params, "scope")

--- a/auth/src/main/scala/versola/oauth/authorize/model/Error.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/model/Error.scala
@@ -62,6 +62,12 @@ private[authorize] object Error:
       errorUri = Some("https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1#name-authorization-request"),
     )
 
+  case class CodeChallengeMethodMissing(uri: URL, state: Option[State]) extends RedirectError(
+      error = ErrorCode.InvalidRequest,
+      errorDescription = "Missing required parameter - code_challenge_method",
+      errorUri = Some("https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1#name-authorization-request"),
+    )
+
   case class CodeChallengeInvalid(uri: URL, state: Option[State], value: String) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = s"Invalid code challenge alphabet or size - $value",
@@ -71,7 +77,7 @@ private[authorize] object Error:
   case class CodeChallengeMethodInvalid(uri: URL, state: Option[State], value: String) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = s"Code challenge method is not supported - $value",
-      errorUri = Some("https://datatracker.ietf.org/doc/html/rfc7636#section-4.3"),
+      errorUri = Some("https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1#name-authorization-request"),
     )
 
   case class UnsupportedResponseType(uri: URL, state: Option[State], responseType: String) extends RedirectError(

--- a/auth/src/main/scala/versola/oauth/model/AuthorizationCodeRecord.scala
+++ b/auth/src/main/scala/versola/oauth/model/AuthorizationCodeRecord.scala
@@ -49,9 +49,6 @@ case class AuthorizationCodeRecord(
           .encodeToString(digest)
 
         encoded == codeChallenge
-
-      case CodeChallengeMethod.Plain =>
-        verifier == codeChallenge
     }
 
 object AuthorizationCodeRecord:

--- a/auth/src/main/scala/versola/oauth/model/PKCE.scala
+++ b/auth/src/main/scala/versola/oauth/model/PKCE.scala
@@ -7,7 +7,7 @@ import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 
 enum CodeChallengeMethod derives Equal:
-  case S256, Plain
+  case S256
 
 type CodeVerifier = CodeVerifier.Type
 

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
@@ -406,6 +406,35 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
           assertTrue(result == Left(Error.StateInvalid(redirectUri)))
       }
     ),
+    suite("code_challenge_method")(
+      test("accepts S256") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request)
+        yield
+          assertTrue(result.codeChallengeMethod == CodeChallengeMethod.S256)
+      },
+      test("rejects plain, which FAPI 2.0 and OAuth 2.1 forbid") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("code_challenge_method" -> "plain")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield
+          assertTrue(result == Left(Error.CodeChallengeMethodInvalid(redirectUri, Some(State("test-state")), "plain")))
+      },
+      test("rejects a missing code_challenge_method instead of defaulting to plain") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams - "code_challenge_method"))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield
+          assertTrue(result == Left(Error.CodeChallengeMethodMissing(redirectUri, Some(State("test-state")))))
+      },
+    ),
     suite("ip")(
       test("extracts the ip from the tenant-configured header") {
         val env = Env()

--- a/deploy.md
+++ b/deploy.md
@@ -460,34 +460,6 @@ deploying a hotfix and you want to be certain nothing touches the schema. In the
 pipeline this is the `run_migrations` input; manually, it's an exported shell variable before
 `docker compose -f docker-compose.prod.yml up`.
 
-### One-off upgrade steps
-
-Steps tied to a specific version bump rather than to the routine deploy above. Run them once,
-on each existing environment, when rolling out the version named.
-
-#### PKCE: S256 only (#190)
-
-From this version `code_challenge_method=plain` is rejected and `CodeChallengeMethod` no longer
-has a `Plain` variant. Two consequences for an environment that already has data:
-
-1. **In-flight rows.** A row written before the rollout with `code_challenge_method = 'Plain'`
-   can no longer be decoded — the read throws instead of producing an OAuth error, so the
-   affected flow answers 500. Both tables expire within minutes and are swept by the cleanup
-   manager, so the condition clears on its own; the statements below only shorten that window.
-
-   Run them **after the last old `auth` instance has stopped** — on the single-host compose
-   deploy (§4.2) that means once `docker compose ... up -d` reports the new containers up, since
-   compose recreates rather than rolls. Running them earlier closes nothing: an instance still
-   serving traffic can write a fresh `'Plain'` row after the delete.
-
-```sql
-   DELETE FROM auth_conversations  WHERE code_challenge_method <> 'S256';
-   DELETE FROM authorization_codes WHERE code_challenge_method <> 'S256';
-```
-
-   Affected users start the login over. Under any rollout where old and new instances overlap,
-   a single delete cannot close the window — wait out the expiry instead.
-
 ---
 
 ## 5. The env-config repository

--- a/deploy.md
+++ b/deploy.md
@@ -472,23 +472,21 @@ has a `Plain` variant. Two consequences for an environment that already has data
 
 1. **In-flight rows.** A row written before the rollout with `code_challenge_method = 'Plain'`
    can no longer be decoded — the read throws instead of producing an OAuth error, so the
-   affected flow answers 500. Both tables expire within minutes, so the window is short, but
-   delete the rows before starting the new images to be certain:
+   affected flow answers 500. Both tables expire within minutes and are swept by the cleanup
+   manager, so the condition clears on its own; the statements below only shorten that window.
+
+   Run them **after the last old `auth` instance has stopped** — on the single-host compose
+   deploy (§4.2) that means once `docker compose ... up -d` reports the new containers up, since
+   compose recreates rather than rolls. Running them earlier closes nothing: an instance still
+   serving traffic can write a fresh `'Plain'` row after the delete.
 
 ```sql
    DELETE FROM auth_conversations  WHERE code_challenge_method <> 'S256';
    DELETE FROM authorization_codes WHERE code_challenge_method <> 'S256';
 ```
 
-   Affected users simply start the login over.
-
-2. **Server metadata.** `"code_challenge_methods_supported": ["S256"]` was added to the metadata
-   template in `scripts/gen-env.scala`, which only seeds *new* environments. An existing
-   environment keeps its stored object, and `/.well-known/*` serves it verbatim — so it has to be
-   updated by hand: `GET /configuration/server-metadata` on `central`, add the field, `POST` the
-   whole object back (the endpoint replaces, it does not patch). Until that is done the server
-   enforces S256 without advertising it: correct behaviour, understated discovery, which FAPI
-   conformance checks.
+   Affected users start the login over. Under any rollout where old and new instances overlap,
+   a single delete cannot close the window — wait out the expiry instead.
 
 ---
 

--- a/deploy.md
+++ b/deploy.md
@@ -460,6 +460,36 @@ deploying a hotfix and you want to be certain nothing touches the schema. In the
 pipeline this is the `run_migrations` input; manually, it's an exported shell variable before
 `docker compose -f docker-compose.prod.yml up`.
 
+### One-off upgrade steps
+
+Steps tied to a specific version bump rather than to the routine deploy above. Run them once,
+on each existing environment, when rolling out the version named.
+
+#### PKCE: S256 only (#190)
+
+From this version `code_challenge_method=plain` is rejected and `CodeChallengeMethod` no longer
+has a `Plain` variant. Two consequences for an environment that already has data:
+
+1. **In-flight rows.** A row written before the rollout with `code_challenge_method = 'Plain'`
+   can no longer be decoded — the read throws instead of producing an OAuth error, so the
+   affected flow answers 500. Both tables expire within minutes, so the window is short, but
+   delete the rows before starting the new images to be certain:
+
+```sql
+   DELETE FROM auth_conversations  WHERE code_challenge_method <> 'S256';
+   DELETE FROM authorization_codes WHERE code_challenge_method <> 'S256';
+```
+
+   Affected users simply start the login over.
+
+2. **Server metadata.** `"code_challenge_methods_supported": ["S256"]` was added to the metadata
+   template in `scripts/gen-env.scala`, which only seeds *new* environments. An existing
+   environment keeps its stored object, and `/.well-known/*` serves it verbatim — so it has to be
+   updated by hand: `GET /configuration/server-metadata` on `central`, add the field, `POST` the
+   whole object back (the endpoint replaces, it does not patch). Until that is done the server
+   enforces S256 without advertising it: correct behaviour, understated discovery, which FAPI
+   conformance checks.
+
 ---
 
 ## 5. The env-config repository

--- a/e2e/src/test/scala/versola/e2e/flows/basic/AuthorizeNegativeSpec.scala
+++ b/e2e/src/test/scala/versola/e2e/flows/basic/AuthorizeNegativeSpec.scala
@@ -51,6 +51,28 @@ object AuthorizeNegativeSpec extends E2ESpec:
       yield assertCompletes
     },
 
+    test("code_challenge_method=plain redirects with error=invalid_request") {
+      for
+        (s, auth) <- setup(Flows.Id.LoginPassword)
+        _ <- auth.authorizeRaw(
+          clientId = s.clientId,
+          redirectUri = s.redirectUri,
+          codeChallengeMethod = Some("plain"),
+        ).assertErrorRedirect("invalid_request")
+      yield assertCompletes
+    },
+
+    test("missing code_challenge_method redirects with error=invalid_request") {
+      for
+        (s, auth) <- setup(Flows.Id.LoginPassword)
+        _ <- auth.authorizeRaw(
+          clientId = s.clientId,
+          redirectUri = s.redirectUri,
+          codeChallengeMethod = None,
+        ).assertErrorRedirect("invalid_request")
+      yield assertCompletes
+    },
+
     test("prompt=none without session redirects with error=login_required") {
       for
         (s, auth) <- setup(Flows.Id.LoginPassword)

--- a/e2e/src/test/scala/versola/e2e/flows/basic/PushedAuthorizationSpec.scala
+++ b/e2e/src/test/scala/versola/e2e/flows/basic/PushedAuthorizationSpec.scala
@@ -146,6 +146,24 @@ object PushedAuthorizationSpec extends E2ESpec:
       yield assertTrue(pushed.response.status == Status.BadRequest)
     },
 
+    test("PAR endpoint rejects code_challenge_method=plain") {
+      for
+        (s, auth) <- setup(Flows.Id.LoginPassword)
+        pushed <- auth.pushAuthorization(
+          clientId = s.clientId,
+          clientSecret = s.clientSecret,
+          redirectUri = s.redirectUri,
+          extraParams = Map("code_challenge_method" -> "plain"),
+        )
+        error = pushed match
+          case PushedAuthorizationResult.Failure(_, _, code) => code
+          case _ => None
+      yield assertTrue(
+        pushed.response.status == Status.BadRequest,
+        error.contains("invalid_request"),
+      )
+    },
+
     test("non-POST /par returns 405 with an Allow header") {
       for
         (_, auth) <- setup(Flows.Id.LoginPassword)

--- a/e2e/src/test/scala/versola/e2e/support/OAuthClient.scala
+++ b/e2e/src/test/scala/versola/e2e/support/OAuthClient.scala
@@ -379,6 +379,7 @@ final class OAuthClient(client: Client, config: E2EConfig):
     * Pass `omitCodeChallenge = true` to omit `code_challenge` from the request (e.g. to test missing-challenge errors).
     * Pass `requestUri` to redeem a pushed authorization request (RFC 9126) instead of sending
     * the authorization parameters directly; only `client_id` and `request_uri` are then sent.
+    * Pass `codeChallengeMethod = None` or an unsupported value to test PKCE method errors.
     */
   def authorizeRaw(
       clientId: String,
@@ -386,6 +387,7 @@ final class OAuthClient(client: Client, config: E2EConfig):
       scope: Option[String] = Some("openid"),
       responseType: Option[String] = Some("code"),
       omitCodeChallenge: Boolean = false,
+      codeChallengeMethod: Option[String] = Some("S256"),
       prompt: Option[String] = None,
       maxAge: Option[Long] = None,
       sessionCookie: Option[String] = None,
@@ -407,7 +409,7 @@ final class OAuthClient(client: Client, config: E2EConfig):
           "scope"                -> scope,
           "response_type"        -> responseType,
           "code_challenge"       -> (if omitCodeChallenge then None else Some(challenge)),
-          "code_challenge_method"-> (if omitCodeChallenge then None else Some("S256")),
+          "code_challenge_method"-> (if omitCodeChallenge then None else codeChallengeMethod),
           "state"                -> Some(state),
           "prompt"               -> prompt,
           "max_age"              -> maxAge.map(_.toString),

--- a/scripts/gen-env.scala
+++ b/scripts/gen-env.scala
@@ -373,6 +373,7 @@ def writeGeneratedSecrets(dir: File, name: String, secrets: Seq[(String, String)
        |  "end_session_endpoint": "$authUrl/logout",
        |  "scopes_supported": ["openid", "profile", "email", "phone", "offline_access"],
        |  "response_types_supported": ["code", "code id_token"],
+       |  "code_challenge_methods_supported": ["S256"],
        |  "grant_types_supported": ["authorization_code", "client_credentials", "refresh_token"],
        |  "subject_types_supported": ["public", "pairwise"],
        |  "id_token_signing_alg_values_supported": ["RS256"],


### PR DESCRIPTION
Closes #190.

/authorize и /par больше не принимают code_challenge_method=plain и не подставляют plain по умолчанию при отсутствии параметра. Разрешён только S256, как требуют FAPI 2.0 и OAuth 2.1.

plain → invalid_request (CodeChallengeMethodInvalid)
параметр отсутствует → invalid_request (CodeChallengeMethodMissing, новый тип ошибки)
CodeChallengeMethod.Plain удалён из enum, ветка Plain убрана из AuthorizationCodeRecord.verify
code_challenge_methods_supported: ["S256"] добавлено в шаблон метаданных сервера

Breaking change без deprecation window. Единственный известный потребитель (edge/SSOClient) уже отправляет S256; ни один тест и ни один e2e-сценарий на plain не полагались. Per-client флаг миграции сознательно не вводился — он потребовал бы новой колонки, поля в OAuthClientRecord и правок во всех спеках, создающих клиента, ради нулевого числа затронутых клиентов.

Метаданные. До этого патча /.well-known/* вообще не публиковали code_challenge_methods_supported, а по RFC 8414 §2 отсутствие поля означает, что сервер не поддерживает PKCE — то есть метаданные противоречили поведению. Метаданные хранятся в БД как произвольный JSON (ServerMetadataRecord.metadata), единственный шаблон в репозитории — в scripts/gen-env.scala. У уже развёрнутых стендов значение в БД придётся обновить через админку central.

Схема БД не менялась. code_challenge_method остаётся TEXT NOT NULL, теперь всегда 'S256'. Строки со старым значением 'Plain' сломали бы CodeChallengeMethod.valueOf при чтении, но authorization_codes и auth_conversations живут минуты и подчищаются по expires_at — миграция данных не нужна. Известный риск: конверсация, начатая до выката с plain, даст 500 вместо аккуратной ошибки; при желании обрывается заранее через DELETE FROM auth_conversations WHERE code_challenge_method <> 'S256'.

Покрытие. Юнит-тесты на парсер: plain, отсутствие параметра, happy path на S256. E2E на /authorize (оба отказа) и на /par — последний важен потому, что PushedAuthorizationServiceSpec работает с заглушкой парсера и не может подтвердить запрет на этом входе. /par при этом не требовал правок: PushedAuthorizationError.from матчит Error.RedirectError обобщённо, так что новая ошибка отдаётся как JSON 400 invalid_request, а не редиректом (RFC 9126 §2.3).

match в verify намеренно оставлен с единственной веткой — чтобы добавление нового метода потребовало явного решения от компилятора. error_uri у CodeChallengeMethodInvalid переведён с RFC 7636 (который plain разрешает) на OAuth 2.1 — иначе ссылка вела клиента к документу, разрешающему то, что мы запретили.