### PR TITLE
Bound Argon2id hashing concurrency and lower default password-history size

### DIFF
--- a/auth/implementations/postgres/src/main/scala/versola/PostgresOAuthApp.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/PostgresOAuthApp.scala
@@ -112,11 +112,19 @@ object PostgresOAuthApp extends VersolaApp("auth"):
       PostgresCleanupManager.live
   )
 
+  /** Argon2id hashing runs on the unbounded blocking pool; this applies the configured
+    * concurrency cap (see `Argon2Config`).
+    */
+  private val securityService: URLayer[SecureRandom & CoreConfig, SecurityService] =
+    ZLayer.service[CoreConfig].flatMap { env =>
+      SecurityService.live(env.get[CoreConfig].argon2OrDefault)
+    }
+
   val dependencies: ZLayer[Scope & EnvName & ConfigProvider & Tracing & Client, Throwable, Dependencies] =
     repositories >+>
       parseConfig[CoreConfig] >+>
       SecureRandom.live >+>
-      SecurityService.live >+>
+      securityService >+>
       JsonSchemaValidator.live >+>
       OAuthConfigurationService.live >+>
       CentralSyncTokenService.live >+>

--- a/auth/src/main/scala/versola/oauth/client/model/PasswordHistorySettings.scala
+++ b/auth/src/main/scala/versola/oauth/client/model/PasswordHistorySettings.scala
@@ -3,4 +3,7 @@ package versola.oauth.client.model
 case class PasswordHistorySettings(historySize: Int, numDifferent: Int)
 
 object PasswordHistorySettings:
-  val default: PasswordHistorySettings = PasswordHistorySettings(historySize = 5, numDifferent = 3)
+  // CIAM default: minimal history check, mainly to stop "change it back immediately" resets.
+  // Deployments needing a stricter policy (e.g. internal employee auth) can override via
+  // SystemSettingsController's upsert endpoint.
+  val default: PasswordHistorySettings = PasswordHistorySettings(historySize = 2, numDifferent = 1)

--- a/auth/src/main/scala/versola/oauth/client/model/SystemSettingsRecord.scala
+++ b/auth/src/main/scala/versola/oauth/client/model/SystemSettingsRecord.scala
@@ -12,10 +12,13 @@ case class SystemSettingsRecord(
 object SystemSettingsRecord:
   val DefaultPasswordRegex = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d).{8,}$"
 
+  // CIAM default: minimal history check, mainly to stop "change it back immediately" resets.
+  // Deployments needing a stricter policy (e.g. internal employee auth) can override via
+  // SystemSettingsController's upsert endpoint.
   val default: SystemSettingsRecord =
     SystemSettingsRecord(
       passwordRegex        = DefaultPasswordRegex,
-      passwordHistorySize  = 5,
-      passwordNumDifferent = 3,
+      passwordHistorySize  = 2,
+      passwordNumDifferent = 1,
       identityProviderLogo = None,
     )

--- a/auth/src/main/scala/versola/util/CoreConfig.scala
+++ b/auth/src/main/scala/versola/util/CoreConfig.scala
@@ -15,8 +15,11 @@ case class CoreConfig(
     smtp: Option[CoreConfig.SmtpConfig],
     configurationCacheRefreshInterval: Duration,
     par: Option[CoreConfig.ParConfig],
+    argon2: Option[Argon2Config],
 ):
   def parOrDefault: CoreConfig.ParConfig = par.getOrElse(CoreConfig.ParConfig.default)
+
+  def argon2OrDefault: Argon2Config = argon2.getOrElse(Argon2Config.default)
 
 object CoreConfig:
   case class BootstrapConfig(

--- a/auth/src/test/scala/versola/auth/TestEnvConfig.scala
+++ b/auth/src/test/scala/versola/auth/TestEnvConfig.scala
@@ -105,4 +105,5 @@ object TestEnvConfig:
     ),
     configurationCacheRefreshInterval = 5.minutes,
     par = None,
+    argon2 = None,
   )

--- a/auth/src/test/scala/versola/oauth/authorize/PushedAuthorizationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/PushedAuthorizationServiceSpec.scala
@@ -82,16 +82,18 @@ object PushedAuthorizationServiceSpec extends UnitSpecBase:
     val configuration = stub[OAuthConfigurationService]
 
     def service: UIO[PushedAuthorizationService] =
-      SecureRandom.live.build.map { env =>
+      SecureRandom.live.build.flatMap { env =>
         val secureRandom = env.get[SecureRandom]
-        PushedAuthorizationService.Impl(
-          config,
-          parser,
-          repository,
-          configuration,
-          secureRandom,
-          SecurityService.Impl(secureRandom),
-        )
+        Semaphore.make(1).map { hashingSemaphore =>
+          PushedAuthorizationService.Impl(
+            config,
+            parser,
+            repository,
+            configuration,
+            secureRandom,
+            SecurityService.Impl(secureRandom, hashingSemaphore),
+          )
+        }
       }.provideLayer(zio.Scope.default)
 
     def happyPath: UIO[Unit] =
@@ -154,7 +156,8 @@ object PushedAuthorizationServiceSpec extends UnitSpecBase:
         service <- env.service
         response <- service.push(validParams(), credentials, request)
         reference <- ZIO.fromEither(RequestUri.parse(response.requestUri)).mapError(RuntimeException(_))
-        expected <- SecurityService.Impl(secureRandom).mac(Secret(reference), config.security.parRequestsSecret)
+        hashingSemaphore <- Semaphore.make(1)
+        expected <- SecurityService.Impl(secureRandom, hashingSemaphore).mac(Secret(reference), config.security.parRequestsSecret)
         stored = env.repository.create.calls.head._1
       yield assertTrue(
         stored.toSeq == expected.toSeq,

--- a/auth/src/test/scala/versola/util/CryptoServiceSpec.scala
+++ b/auth/src/test/scala/versola/util/CryptoServiceSpec.scala
@@ -12,7 +12,7 @@ object CryptoServiceSpec extends ZIOSpecDefault:
     suite("CryptoServiceSpec")(
       encryptDecryptTests,
       errorHandlingTests,
-    ).provide(SecureRandom.live >>> ZLayer.fromFunction(SecurityService.Impl(_)))
+    ).provide(SecureRandom.live >>> SecurityService.live)
 
   private def encryptDecryptTests =
     suite("encrypt/decrypt")(

--- a/central/src/main/scala/versola/central/configuration/system/SystemSettingsRecord.scala
+++ b/central/src/main/scala/versola/central/configuration/system/SystemSettingsRecord.scala
@@ -16,10 +16,13 @@ case class SystemSettingsRecord(
 object SystemSettingsRecord:
   val DefaultPasswordRegex = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d).{8,}$"
 
+  // CIAM default: minimal history check, mainly to stop "change it back immediately" resets.
+  // Deployments needing a stricter policy (e.g. internal employee auth) can override via
+  // SystemSettingsController's upsert endpoint.
   val default: SystemSettingsRecord =
     SystemSettingsRecord(
       passwordRegex        = DefaultPasswordRegex,
-      passwordHistorySize  = 5,
-      passwordNumDifferent = 3,
+      passwordHistorySize  = 2,
+      passwordNumDifferent = 1,
       identityProviderLogo = None,
     )

--- a/scripts/gen-env.scala
+++ b/scripts/gen-env.scala
@@ -511,6 +511,17 @@ def writeGeneratedSecrets(dir: File, name: String, secrets: Seq[(String, String)
        |  max-request-size = 8192
        |}
        |
+       |# Admission control for Argon2id password hashing, which runs on ZIO's unbounded
+       |# blocking pool (see Argon2Config). max-concurrent bounds concurrent password hashes:
+       |# each holds ~19 MiB of heap for its duration, so worst-case hashing heap is roughly
+       |# max-concurrent * 19 MiB -- the default of 12 (~228 MiB) is sized for auth's 512m
+       |# mem_limit. Raise it only together with the container's memory limit, or logins
+       |# will OOM the pod. Overridable via ARGON2_MAX_CONCURRENCY without editing this file.
+       |argon2 {
+       |  max-concurrent = 12
+       |  max-concurrent = $${?ARGON2_MAX_CONCURRENCY}
+       |}
+       |
        |jwt {
        |  issuer = "$authUrl"
        |  private-key = ${secretKeyField(useOpenBao, jwtKey.privateB64, "JWT_PRIVATE_KEY")}

--- a/util/src/main/scala/versola/util/Argon2Config.scala
+++ b/util/src/main/scala/versola/util/Argon2Config.scala
@@ -1,0 +1,18 @@
+package versola.util
+
+/** Admission control for Argon2id password hashing, which runs on ZIO's unbounded blocking
+  * pool. Without a cap, the number of concurrent hashes is bounded only by inbound request
+  * volume.
+  *
+  * @param maxConcurrent
+  *   concurrent Argon2id hashes. Each holds ~19 MiB of heap for its duration, so this is the
+  *   knob that bounds worst-case hashing heap usage (roughly `maxConcurrent * 19 MiB`). Size it
+  *   against the container's heap budget.
+  */
+case class Argon2Config(maxConcurrent: Int)
+
+object Argon2Config:
+  /** ~228 MiB of Argon2 headroom, which fits the 384 MiB heap the auth container gets from its
+    * 512 MiB `mem_limit` at `-XX:MaxRAMPercentage=75` (see deploy.md).
+    */
+  val default: Argon2Config = Argon2Config(maxConcurrent = 12)

--- a/util/src/main/scala/versola/util/JWT.scala
+++ b/util/src/main/scala/versola/util/JWT.scala
@@ -6,7 +6,7 @@ import com.nimbusds.jose.{JOSEObjectType, JWSAlgorithm, JWSHeader, JWSSigner}
 import com.nimbusds.jwt.{JWTClaimsSet, SignedJWT}
 import zio.json.*
 import zio.json.ast.Json
-import zio.{Chunk, Clock, Duration, IO, Task, UIO, ZIO}
+import zio.{Chunk, Clock, Duration, IO, Task, ZIO}
 
 import java.nio.charset.StandardCharsets
 import java.security.PrivateKey

--- a/util/src/main/scala/versola/util/SecurityService.scala
+++ b/util/src/main/scala/versola/util/SecurityService.scala
@@ -3,7 +3,7 @@ package versola.util
 import org.apache.commons.codec.digest.Blake3
 import org.bouncycastle.crypto.generators.Argon2BytesGenerator
 import org.bouncycastle.crypto.params.Argon2Parameters
-import zio.{Clock, Task, UIO, URLayer, ZIO, ZLayer}
+import zio.{Clock, Semaphore, Task, UIO, URLayer, ZIO, ZLayer}
 
 import java.security.{KeyPairGenerator, PrivateKey, PublicKey}
 import java.security.interfaces.{RSAPrivateKey, RSAPublicKey}
@@ -26,10 +26,21 @@ trait SecurityService:
   def generateRsaKeyPair: UIO[RsaKeyPair]
 
 object SecurityService:
+  /** Used by services that never hash passwords (central, edge); auth passes its configured
+    * `Argon2Config`.
+    */
   def live: URLayer[SecureRandom, SecurityService] =
-    ZLayer.fromFunction(Impl(_))
+    live(Argon2Config.default)
 
-  class Impl(secureRandom: SecureRandom) extends SecurityService:
+  def live(argon2Config: Argon2Config): URLayer[SecureRandom, SecurityService] =
+    ZLayer.fromZIO {
+      for
+        secureRandom <- ZIO.service[SecureRandom]
+        hashingSemaphore <- Semaphore.make(argon2Config.maxConcurrent.toLong)
+      yield Impl(secureRandom, hashingSemaphore)
+    }
+
+  class Impl(secureRandom: SecureRandom, hashingSemaphore: Semaphore) extends SecurityService:
 
     private val Algorithm = "AES"
     private val Transformation = "AES/GCM/NoPadding"
@@ -93,7 +104,7 @@ object SecurityService:
         MAC(mac)
 
     override def hashPassword(password: Secret, salt: Salt, pepper: Secret.Bytes16): Task[MAC] =
-      ZIO.attemptBlocking:
+      val hashEffect = ZIO.attemptBlocking {
         // Combine salt and pepper as additional data
         val params = new Argon2Parameters.Builder(Argon2Parameters.ARGON2_id)
           .withVersion(Argon2Parameters.ARGON2_VERSION_13)
@@ -110,6 +121,12 @@ object SecurityService:
         val hash = Array.ofDim[Byte](Argon2HashLength)
         generator.generateBytes(password, hash)
         MAC(hash)
+      }
+      // Admission control: Argon2id holds ~19 MiB of heap per in-flight hash, so unbounded
+      // concurrency (this runs on ZIO's unbounded blocking pool) is an OOM vector under login
+      // load. The semaphore caps concurrent hashes; excess requests queue as cheap fibers
+      // instead of each claiming 19 MiB up front.
+      hashingSemaphore.withPermit(hashEffect)
 
     override def generateRsaKeyPair: UIO[RsaKeyPair] =
       for


### PR DESCRIPTION
## Why

Argon2id hashing runs on ZIO's unbounded blocking pool and holds ~19 MiB of heap per in-flight hash. With no concurrency cap, the number of concurrent hashes scales with inbound login traffic with no ceiling — a real OOM vector. At just 200 logins/s and ~75ms/hash that's already ~15 concurrent hashes (~285 MiB resident), before counting that every wrong-password submission walked up to 5 historical hashes sequentially, multiplying the cost per request.

(RSA-2048 token signing was evaluated for the same treatment and rejected — signing is ~100x faster than hashing and already indirectly bounded by the Postgres/Hikari pool size on every issuance path, so a semaphore there would only risk becoming a bottleneck on the hottest endpoint.)

## What changed

- **New `Argon2Config` (util module)**: `case class Argon2Config(maxConcurrent: Int)`, default `12` (sized for auth's 512Mi `mem_limit` at `-XX:MaxRAMPercentage=75`).
- **`SecurityService.live(Argon2Config)`**: gates `hashPassword` behind a `zio.Semaphore` sized from it. Excess requests queue as suspended fibers instead of each claiming 19 MiB of heap up front.
- **`CoreConfig` (auth)**: new optional `argon2: Option[Argon2Config]` field with `argon2OrDefault`, following the existing `par`/`parOrDefault` pattern. `PostgresOAuthApp` wires the configured value through. `central`/`edge` are unaffected (they don't hash passwords) and keep `SecurityService.live`'s no-arg default.
- **`gen-env.scala`**: emits an `argon2 { max-concurrent = ... }` block with a default plus a `${?ARGON2_MAX_CONCURRENCY}` HOCON override line — same env-var-override idiom already used by `secretField` — so ops can tune this per deployment without editing the generated config file.
- **Lower default password-history policy** (`historySize` 5→2, `numDifferent` 3→1) in `PasswordHistorySettings` and both auth's and central's `SystemSettingsRecord`. Deployments needing a stricter policy can still override it via `SystemSettingsController`'s upsert endpoint.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M0MPRRD8TZX0JNVDTP4VA5FC&panel=chat)