### PR TITLE
Support path parameters in registered resource endpoints

### DIFF
--- a/central-ui/src/components/resources-list.ts
+++ b/central-ui/src/components/resources-list.ts
@@ -469,7 +469,12 @@ export class VersolaResourcesList extends LitElement {
     if (!validation.valid) { this.error = validation.error ?? 'Resource URI is invalid'; return; }
     const invalidEndpoint = this.endpointDrafts.find(endpoint => this.isEndpointPathInvalid(endpoint.path));
     if (invalidEndpoint) {
-      this.error = `Endpoint path must start with "/" and contain only latin letters, digits, and "-" per segment (no consecutive "/"): ${endpointLabel(invalidEndpoint)}`;
+      this.error = `Endpoint path must start with "/" and contain only latin letters, digits, "-", or a "{name}" parameter per segment (no consecutive "/", no repeated parameter names): ${endpointLabel(invalidEndpoint)}`;
+      return;
+    }
+    const ambiguousEndpoint = this.findAmbiguousEndpoint();
+    if (ambiguousEndpoint) {
+      this.error = `Endpoint path differs from another endpoint of the same method only in its parameter names: ${endpointLabel(ambiguousEndpoint)}`;
       return;
     }
     const celIssue = this.findCelIssue();
@@ -525,7 +530,20 @@ export class VersolaResourcesList extends LitElement {
   private isEndpointPathInvalid(path: string) {
     const trimmed = path.trim();
     if (trimmed.length === 0) return false;
-    return !/^\/([a-zA-Z0-9-]+(\/[a-zA-Z0-9-]+)*)?$/.test(trimmed);
+    const segment = '([a-zA-Z0-9-]+|\\{[a-zA-Z_][a-zA-Z0-9_]*\\})';
+    if (!new RegExp(`^\\/(${segment}(\\/${segment})*)?$`).test(trimmed)) return true;
+    const params = trimmed.split('/').filter(part => part.startsWith('{'));
+    return new Set(params).size !== params.length;
+  }
+
+  /** Two endpoints of the same method whose paths differ only in parameter names match
+   * exactly the same requests, so edge could never tell them apart. */
+  private findAmbiguousEndpoint() {
+    const shape = (path: string) => path.trim().split('/').map(part => (part.startsWith('{') ? '{}' : part)).join('/');
+    return this.endpointDrafts.find((endpoint, index) => this.endpointDrafts.slice(0, index).some(earlier =>
+      earlier.method === endpoint.method &&
+      shape(earlier.path) === shape(endpoint.path) &&
+      earlier.path.trim() !== endpoint.path.trim()));
   }
 
   private findCelIssue(): string | null {
@@ -858,6 +876,7 @@ export class VersolaResourcesList extends LitElement {
         <li><span class="option-tooltip-code">user</span> — userinfo claims (only when "Fetch userinfo" is enabled).</li>
         <li><span class="option-tooltip-code">request</span> — incoming request data:
           <ul class="option-tooltip-list">
+            <li><span class="option-tooltip-code">request.path.params</span> — map of path parameters matched by the endpoint's <span class="option-tooltip-code">{name}</span> segments.</li>
             <li><span class="option-tooltip-code">request.query</span> — map of query parameters (first value per key).</li>
             <li><span class="option-tooltip-code">request.queryAll</span> — map of query parameters (all values per key as a list).</li>
             <li><span class="option-tooltip-code">request.headers</span> — map of request headers (first value per key).</li>

--- a/central-ui/tests/resources.spec.ts
+++ b/central-ui/tests/resources.spec.ts
@@ -244,11 +244,17 @@ test('shows resource validation errors before saving', async ({ page }) => {
   await expect(relativePathField).toHaveClass(/input-error/);
   await expect(relativePathField).toHaveCSS('border-top-color', 'rgb(248, 81, 73)');
   await page.getByRole('button', { name: 'Create Resource', exact: true }).click();
-  await expect(page.getByText('Endpoint path must start with "/" and contain only latin letters, digits, and "-" per segment (no consecutive "/"): GET users', { exact: true })).toBeVisible();
+  await expect(page.getByText('Endpoint path must start with "/" and contain only latin letters, digits, "-", or a "{name}" parameter per segment (no consecutive "/", no repeated parameter names): GET users', { exact: true })).toBeVisible();
+
+  await relativePathField.fill('/users/{id}/orders/{id}');
+  await page.getByRole('button', { name: 'Create Resource', exact: true }).click();
+  await expect(page.getByText('Endpoint path must start with "/" and contain only latin letters, digits, "-", or a "{name}" parameter per segment (no consecutive "/", no repeated parameter names): GET /users/{id}/orders/{id}', { exact: true })).toBeVisible();
 
   await relativePathField.fill('/users/{id}');
+  await page.getByRole('button', { name: 'Add endpoint', exact: true }).click();
+  await page.locator('.endpoint-editor').last().getByPlaceholder('/users').fill('/users/{userId}');
   await page.getByRole('button', { name: 'Create Resource', exact: true }).click();
-  await expect(page.getByText('Endpoint path must start with "/" and contain only latin letters, digits, and "-" per segment (no consecutive "/"): GET /users/{id}', { exact: true })).toBeVisible();
+  await expect(page.getByText('Endpoint path differs from another endpoint of the same method only in its parameter names: GET /users/{userId}', { exact: true })).toBeVisible();
 
   expect(api.requests.some(request => request.method === 'POST' && request.pathname === '/configuration/resources')).toBeFalsy();
 });

--- a/central/src/main/scala/versola/central/configuration/resources/ResourceService.scala
+++ b/central/src/main/scala/versola/central/configuration/resources/ResourceService.scala
@@ -181,14 +181,54 @@ object ResourceService:
       ZIO.foldLeft(endpoints)(Option.empty[ResourceValidationError]):
         case (Some(err), _) => ZIO.succeed(Some(err))
         case (None, endpoint) => validateEndpoint(endpoint)
+      .map(_.orElse(findAmbiguousEndpoint(endpoints)))
 
-    private val validPathRegex = "^/([a-zA-Z0-9-]+(/[a-zA-Z0-9-]+)*)?$".r
+    private val staticSegmentRegex = "[a-zA-Z0-9-]+".r
+    private val pathParamRegex = "\\{([a-zA-Z_][a-zA-Z0-9_]*)\\}".r
+
+    /** Two templates with the same method that differ only in their parameter names
+      * (e.g. `/users/{id}` and `/users/{userId}`) match exactly the same requests, so
+      * edge could never tell which one the caller meant. Identical templates are left
+      * to edge, which picks between them deterministically.
+      */
+    private def findAmbiguousEndpoint(
+        endpoints: Vector[CreateResourceEndpointRequest],
+    ): Option[ResourceValidationError] =
+      val shapes = endpoints.map: endpoint =>
+        (endpoint.method.toUpperCase, pathShape(endpoint.path.trim), endpoint.path.trim, endpoint.id)
+      shapes.zipWithIndex.collectFirst:
+        case ((method, shape, path, id), index)
+            if shapes.take(index).exists((m, s, p, _) => m == method && s == shape && p != path) =>
+          ResourceValidationError.AmbiguousEndpointPath(id, path)
+
+    /** Path with every parameter placeholder collapsed to a positional marker, so two
+      * templates that match the same requests share a shape. */
+    private def pathShape(path: String): Vector[String] =
+      pathSegments(path).map:
+        case pathParamRegex(_) => "{}"
+        case segment => segment
+
+    private def pathSegments(path: String): Vector[String] =
+      path.stripPrefix("/") match
+        case "" => Vector.empty
+        case rest => rest.split("/", -1).toVector
+
+    /** A registered path is a `/`-prefixed sequence of static segments and `{name}`
+      * placeholders, each matching exactly one request segment. Placeholder names must be
+      * identifiers, and unique within the path so no `request.path.params` entry is lost.
+      */
+    private def isValidEndpointPath(path: String): Boolean =
+      val segments = pathSegments(path)
+      val params = segments.collect { case pathParamRegex(name) => name }
+      path.startsWith("/") &&
+        segments.forall(segment => staticSegmentRegex.matches(segment) || pathParamRegex.matches(segment)) &&
+        params.distinct.size == params.size
 
     private def validateEndpoint(
         endpoint: CreateResourceEndpointRequest,
     ): Task[Option[ResourceValidationError]] =
       val trimmedPath = endpoint.path.trim
-      if !validPathRegex.matches(trimmedPath) then
+      if !isValidEndpointPath(trimmedPath) then
         return ZIO.some(ResourceValidationError.InvalidEndpointPath(endpoint.id))
       val allowCheck = endpoint.allow.filter(_.trim.nonEmpty) match
         case None => ZIO.none

--- a/central/src/main/scala/versola/central/configuration/resources/ResourceService.scala
+++ b/central/src/main/scala/versola/central/configuration/resources/ResourceService.scala
@@ -125,30 +125,49 @@ object ResourceService:
         validateEndpoints(request.endpoints).flatMap:
           case Some(error) => ZIO.left(error)
           case None =>
-            for
-              secret <- if request.internal then generateSecret.map(Some(_)) else ZIO.none
-              encryptedSecret <- ZIO.foreach(secret)(encryptRawSecret)
-              _ <- resourceRepository.createResource(
-                tenantId = request.tenantId,
-                resourceId = request.resourceId,
-                resource = request.resource,
-                audience = request.audience,
-                endpoints = request.endpoints.map(asRecord),
-                secret = encryptedSecret,
-              )
-            yield Right((request.resourceId, secret))
+            findAmbiguousEndpoint(request.endpoints.map(EndpointRef.from)) match
+              case Some(error) => ZIO.left(error)
+              case None =>
+                for
+                  secret <- if request.internal then generateSecret.map(Some(_)) else ZIO.none
+                  encryptedSecret <- ZIO.foreach(secret)(encryptRawSecret)
+                  _ <- resourceRepository.createResource(
+                    tenantId = request.tenantId,
+                    resourceId = request.resourceId,
+                    resource = request.resource,
+                    audience = request.audience,
+                    endpoints = request.endpoints.map(asRecord),
+                    secret = encryptedSecret,
+                  )
+                yield Right((request.resourceId, secret))
 
     override def updateResource(request: UpdateResourceRequest): Task[Either[ResourceValidationError, Unit]] =
       validateEndpoints(request.createEndpoints).flatMap:
         case Some(error) => ZIO.left(error)
         case None =>
-          resourceRepository.updateResource(
-            resourceId = request.resourceId,
-            resourcePatch = request.resource,
-            audiencePatch = request.audience,
-            deleteEndpoints = request.deleteEndpoints,
-            addEndpoints = request.createEndpoints.map(asRecord),
-          ).map(Right(_))
+          resourceRepository.findResource(request.resourceId).flatMap: existing =>
+            findAmbiguousEndpoint(finalEndpointRefs(existing, request)) match
+              case Some(error) => ZIO.left(error)
+              case None =>
+                resourceRepository.updateResource(
+                  resourceId = request.resourceId,
+                  resourcePatch = request.resource,
+                  audiencePatch = request.audience,
+                  deleteEndpoints = request.deleteEndpoints,
+                  addEndpoints = request.createEndpoints.map(asRecord),
+                ).map(Right(_))
+
+    /** The endpoint set the resource will have once `request` is applied: retained
+      * existing endpoints (neither deleted nor replaced) plus the submitted ones,
+      * mirroring the repository's own upsert-by-id semantics (see [[ResourceRepository.updateResource]]).
+      * Ambiguity must be checked against this final set, not just the submitted endpoints,
+      * since a PUT can add an ambiguous endpoint while silently retaining a conflicting
+      * one already stored (by omitting it from `deleteEndpoints`).
+      */
+    private def finalEndpointRefs(existing: Option[ResourceRecord], request: UpdateResourceRequest): Vector[EndpointRef] =
+      val overwrittenOrDeleted = request.deleteEndpoints ++ request.createEndpoints.map(_.id)
+      val retained = existing.fold(Vector.empty[ResourceEndpointRecord])(_.endpoints).filterNot(e => overwrittenOrDeleted.contains(e.id))
+      retained.map(EndpointRef.from) ++ request.createEndpoints.map(EndpointRef.from)
 
     override def rotateSecret(resourceId: ResourceId): Task[Secret] =
       for
@@ -181,10 +200,19 @@ object ResourceService:
       ZIO.foldLeft(endpoints)(Option.empty[ResourceValidationError]):
         case (Some(err), _) => ZIO.succeed(Some(err))
         case (None, endpoint) => validateEndpoint(endpoint)
-      .map(_.orElse(findAmbiguousEndpoint(endpoints)))
 
     private val staticSegmentRegex = "[a-zA-Z0-9-]+".r
     private val pathParamRegex = "\\{([a-zA-Z_][a-zA-Z0-9_]*)\\}".r
+
+    /** The (method, path, id) shape of an endpoint, regardless of whether it comes from
+      * a submitted request or an already-stored record; ambiguity depends on nothing else. */
+    private case class EndpointRef(id: ResourceEndpointId, method: String, path: String)
+
+    private object EndpointRef:
+      def from(request: CreateResourceEndpointRequest): EndpointRef =
+        EndpointRef(request.id, request.method, request.path)
+      def from(record: ResourceEndpointRecord): EndpointRef =
+        EndpointRef(record.id, record.method, record.path)
 
     /** Two templates with the same method that differ only in their parameter names
       * (e.g. `/users/{id}` and `/users/{userId}`) match exactly the same requests, so
@@ -192,7 +220,7 @@ object ResourceService:
       * to edge, which picks between them deterministically.
       */
     private def findAmbiguousEndpoint(
-        endpoints: Vector[CreateResourceEndpointRequest],
+        endpoints: Vector[EndpointRef],
     ): Option[ResourceValidationError] =
       val shapes = endpoints.map: endpoint =>
         (endpoint.method.toUpperCase, pathShape(endpoint.path.trim), endpoint.path.trim, endpoint.id)

--- a/central/src/main/scala/versola/central/configuration/resources/ResourceValidationError.scala
+++ b/central/src/main/scala/versola/central/configuration/resources/ResourceValidationError.scala
@@ -10,3 +10,6 @@ enum ResourceValidationError derives JsonCodec, Schema:
   case InvalidInjectExpression(endpointId: ResourceEndpointId, ruleName: String, expression: String, message: String)
   case InvalidStepUpConditionExpression(endpointId: ResourceEndpointId, expression: String, message: String)
   case InvalidEndpointPath(endpointId: ResourceEndpointId)
+  /** Another endpoint with the same method matches exactly the same requests, differing
+    * only in its path parameter names. */
+  case AmbiguousEndpointPath(endpointId: ResourceEndpointId, path: String)

--- a/central/src/test/scala/versola/central/configuration/resources/ResourceServiceSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/resources/ResourceServiceSpec.scala
@@ -363,6 +363,7 @@ object ResourceServiceSpec extends ZIOSpecDefault, ZIOStubs:
       val env = new Env
 
       for
+        _ <- env.repository.findResource.succeedsWith(Some(resource))
         _ <- env.repository.updateResource.succeedsWith(())
         result <- env.service.updateResource(updateRequest)
       yield assertTrue(
@@ -374,6 +375,52 @@ object ResourceServiceSpec extends ZIOSpecDefault, ZIOStubs:
           Vector(updatedEndpoint, createdEndpoint),
           Set(removedEndpointId),
         )),
+      )
+    },
+    test("updateResource returns error when a submitted endpoint is ambiguous with one retained from the existing resource") {
+      val env = new Env
+      val storedParameterized = ResourceEndpointRecord(existingEndpointId, "/users/{id}", "GET", false, None, Vector.empty, None, None, None)
+      val storedResource = ResourceRecord(tenantId, resourceId, originalUri, audience, Vector(storedParameterized), None, None)
+      val request = UpdateResourceRequest(
+        resourceId = resourceId,
+        resource = None,
+        audience = None,
+        deleteEndpoints = Set.empty,
+        createEndpoints = Vector(
+          CreateResourceEndpointRequest(createdEndpointId, "/users/{userId}", "GET", false, None, Vector.empty, stepUpCondition = None, stepUpAcr = None, maxAge = None),
+        ),
+      )
+
+      for
+        _ <- env.repository.findResource.succeedsWith(Some(storedResource))
+        _ <- env.repository.updateResource.succeedsWith(())
+        result <- env.service.updateResource(request)
+      yield assertTrue(
+        result == Left(ResourceValidationError.AmbiguousEndpointPath(createdEndpointId, "/users/{userId}")),
+        env.repository.updateResource.calls.isEmpty,
+      )
+    },
+    test("updateResource accepts a submitted endpoint ambiguous with one it also deletes") {
+      val env = new Env
+      val storedParameterized = ResourceEndpointRecord(existingEndpointId, "/users/{id}", "GET", false, None, Vector.empty, None, None, None)
+      val storedResource = ResourceRecord(tenantId, resourceId, originalUri, audience, Vector(storedParameterized), None, None)
+      val request = UpdateResourceRequest(
+        resourceId = resourceId,
+        resource = None,
+        audience = None,
+        deleteEndpoints = Set(existingEndpointId),
+        createEndpoints = Vector(
+          CreateResourceEndpointRequest(createdEndpointId, "/users/{userId}", "GET", false, None, Vector.empty, stepUpCondition = None, stepUpAcr = None, maxAge = None),
+        ),
+      )
+
+      for
+        _ <- env.repository.findResource.succeedsWith(Some(storedResource))
+        _ <- env.repository.updateResource.succeedsWith(())
+        result <- env.service.updateResource(request)
+      yield assertTrue(
+        result == Right(()),
+        env.repository.updateResource.calls.nonEmpty,
       )
     },
     test("deleteResource delegates id to repository") {

--- a/central/src/test/scala/versola/central/configuration/resources/ResourceServiceSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/resources/ResourceServiceSpec.scala
@@ -178,17 +178,90 @@ object ResourceServiceSpec extends ZIOSpecDefault, ZIOStubs:
         env.repository.createResource.calls.isEmpty,
       )
     },
-    test("createResource returns error when endpoint path contains path parameters") {
+    test("createResource accepts endpoint paths with named path parameters") {
+      val env = new Env
+      val request = createRequest.copy(
+        endpoints = Vector(
+          CreateResourceEndpointRequest(existingEndpointId, "/tenants/{tenantId}/orders/{orderId}", "GET", false, None, Vector.empty, stepUpCondition = None, stepUpAcr = None, maxAge = None),
+        ),
+      )
+      for
+        _ <- env.repository.createResource.succeedsWith(())
+        result <- env.service.createResource(request)
+      yield assertTrue(
+        result == Right((resourceId, None)),
+        env.repository.createResource.calls.head._5 == Vector(
+          ResourceEndpointRecord(existingEndpointId, "/tenants/{tenantId}/orders/{orderId}", "GET", false, None, Vector.empty, None, None, None),
+        ),
+      )
+    },
+    test("createResource returns error when a path parameter is malformed") {
       val env = new Env
       val badRequest = createRequest.copy(
         endpoints = Vector(
-          CreateResourceEndpointRequest(existingEndpointId, "/users/{id}", "GET", false, None, Vector.empty, stepUpCondition = None, stepUpAcr = None, maxAge = None),
+          CreateResourceEndpointRequest(existingEndpointId, "/users/{}", "GET", false, None, Vector.empty, stepUpCondition = None, stepUpAcr = None, maxAge = None),
         ),
       )
       for result <- env.service.createResource(badRequest)
       yield assertTrue(
         result == Left(ResourceValidationError.InvalidEndpointPath(existingEndpointId)),
         env.repository.createResource.calls.isEmpty,
+      )
+    },
+    test("createResource returns error when a path parameter is not a complete segment") {
+      val env = new Env
+      val badRequest = createRequest.copy(
+        endpoints = Vector(
+          CreateResourceEndpointRequest(existingEndpointId, "/users/u-{id}", "GET", false, None, Vector.empty, stepUpCondition = None, stepUpAcr = None, maxAge = None),
+        ),
+      )
+      for result <- env.service.createResource(badRequest)
+      yield assertTrue(
+        result == Left(ResourceValidationError.InvalidEndpointPath(existingEndpointId)),
+        env.repository.createResource.calls.isEmpty,
+      )
+    },
+    test("createResource returns error when path parameter names repeat") {
+      val env = new Env
+      val badRequest = createRequest.copy(
+        endpoints = Vector(
+          CreateResourceEndpointRequest(existingEndpointId, "/users/{id}/orders/{id}", "GET", false, None, Vector.empty, stepUpCondition = None, stepUpAcr = None, maxAge = None),
+        ),
+      )
+      for result <- env.service.createResource(badRequest)
+      yield assertTrue(
+        result == Left(ResourceValidationError.InvalidEndpointPath(existingEndpointId)),
+        env.repository.createResource.calls.isEmpty,
+      )
+    },
+    test("createResource returns error when two endpoints of the same method have the same path shape") {
+      val env = new Env
+      val badRequest = createRequest.copy(
+        endpoints = Vector(
+          CreateResourceEndpointRequest(existingEndpointId, "/users/{id}", "GET", false, None, Vector.empty, stepUpCondition = None, stepUpAcr = None, maxAge = None),
+          CreateResourceEndpointRequest(createdEndpointId, "/users/{userId}", "GET", false, None, Vector.empty, stepUpCondition = None, stepUpAcr = None, maxAge = None),
+        ),
+      )
+      for result <- env.service.createResource(badRequest)
+      yield assertTrue(
+        result == Left(ResourceValidationError.AmbiguousEndpointPath(createdEndpointId, "/users/{userId}")),
+        env.repository.createResource.calls.isEmpty,
+      )
+    },
+    test("createResource accepts a static endpoint alongside a parameterized one of the same method") {
+      val env = new Env
+      val request = createRequest.copy(
+        endpoints = Vector(
+          CreateResourceEndpointRequest(existingEndpointId, "/users/me", "GET", false, None, Vector.empty, stepUpCondition = None, stepUpAcr = None, maxAge = None),
+          CreateResourceEndpointRequest(createdEndpointId, "/users/{userId}", "GET", false, None, Vector.empty, stepUpCondition = None, stepUpAcr = None, maxAge = None),
+        ),
+      )
+      for
+        _ <- env.repository.createResource.succeedsWith(())
+        result <- env.service.createResource(request)
+      yield assertTrue(
+        result == Right((resourceId, None)),
+        env.repository.createResource.calls.nonEmpty,
       )
     },
     test("createResource returns error when endpoint path contains consecutive slashes") {

--- a/edge/src/main/scala/versola/edge/EdgeService.scala
+++ b/edge/src/main/scala/versola/edge/EdgeService.scala
@@ -370,6 +370,9 @@ object EdgeService:
 
         resource <- resourceService.findByResourceId(resourceId).someOrFail(Outcome.NotFound)
         endpoint <- findEndpoint(resource.endpoints, request.method.name, restPath)
+        // the registered template, not the concrete path: a parameterized endpoint would
+        // otherwise produce one metric time series per parameter value
+        _ <- Observability.setRoutePath(s"/resources/$resourceId${endpoint.path}")
         parsedBody <- readJsonBody(request)
         typedClaims <- checkPermissions(session.claims, endpoint, request, parsedBody)
         _ <- checkAudience(resource, typedClaims)
@@ -597,8 +600,9 @@ object EdgeService:
         case (k, values) => k -> values.map(_.renderedValue).asJava
 
       val pathParams = extractPathParams(endpoint.path, restPath)
+      val pathData = Map[String, AnyRef]("params" -> pathParams.asJava)
       val requestData = scala.collection.mutable.LinkedHashMap[String, AnyRef](
-        "path" -> pathParams.asJava,
+        "path" -> pathData.asJava,
         "query" -> queryMap.asJava,
         "queryAll" -> queriesMap.asJava,
         "headers" -> headerMap.asJava,
@@ -711,6 +715,12 @@ object EdgeService:
     private def isJsonRequest(request: Request): Boolean =
       request.header(Header.ContentType).exists(_.mediaType == MediaType.application.json)
 
+    /** Picks the most specific endpoint whose template matches the request: a static
+      * segment always wins over a `{name}` placeholder at the same position, so
+      * `/users/me` takes precedence over `/users/{userId}` whatever the registration
+      * order is. Templates that stay tied (they differ only in placeholder names, which
+      * central rejects on registration) are ordered by path so the choice is stable.
+      */
     private def findEndpoint(
         endpoints: Vector[ResourceEndpoint],
         method: String,
@@ -718,9 +728,20 @@ object EdgeService:
     ): IO[Outcome, ResourceEndpoint] =
       ZIO.fromOption {
         val pathSegments = normalizePath(restPath.encode)
-        endpoints.find: endpoint =>
-          endpoint.method.equalsIgnoreCase(method) && matchesSegments(normalizePath(endpoint.path), pathSegments)
+        endpoints
+          .filter: endpoint =>
+            endpoint.method.equalsIgnoreCase(method) && matchesSegments(normalizePath(endpoint.path), pathSegments)
+          .minByOption(endpoint => (specificity(normalizePath(endpoint.path)), endpoint.path))
       }.orElseFail(Outcome.NotFound)
+
+    /** Placeholder mask of a template, one character per segment: candidates all have the
+      * same segment count, so comparing masks lexicographically prefers the template whose
+      * leftmost differing segment is static. */
+    private def specificity(pattern: Vector[String]): String =
+      pattern.map:
+        case s"{$_}" => '1'
+        case _ => '0'
+      .mkString
 
     private def matchesSegments(pattern: Vector[String], path: Vector[String]): Boolean =
       pattern.size == path.size && pattern.zip(path).forall:

--- a/edge/src/test/scala/versola/edge/EdgeServiceProxySpec.scala
+++ b/edge/src/test/scala/versola/edge/EdgeServiceProxySpec.scala
@@ -8,6 +8,7 @@ import org.scalamock.stubs.ZIOStubs
 import versola.edge.login.LoginRepository
 import versola.edge.model.*
 import versola.util.cel.CelEvaluator
+import versola.util.http.Observability
 import versola.util.{EnvName, JWT, ReloadingCache, Secret, SecureRandom, SecurityService}
 import zio.*
 import zio.http.*
@@ -156,10 +157,12 @@ object EdgeServiceProxySpec extends ZIOSpecDefault, ZIOStubs:
   private val usersEndpointId = ResourceEndpointId(java.util.UUID.fromString("018f0f2a-1c7b-7000-8000-000000000401"))
   private val userByIdEndpointId = ResourceEndpointId(java.util.UUID.fromString("018f0f2a-1c7b-7000-8000-000000000402"))
   private val createUserEndpointId = ResourceEndpointId(java.util.UUID.fromString("018f0f2a-1c7b-7000-8000-000000000403"))
+  private val currentUserEndpointId = ResourceEndpointId(java.util.UUID.fromString("018f0f2a-1c7b-7000-8000-000000000404"))
+  private val tenantOrderEndpointId = ResourceEndpointId(java.util.UUID.fromString("018f0f2a-1c7b-7000-8000-000000000405"))
 
   /** Endpoints granted by `setupDefaults` so proxy-behaviour scenarios are not gated by deny-by-default authorization. */
   private val scenarioEndpointIds: Set[ResourceEndpointId] =
-    Set(usersEndpointId, userByIdEndpointId, createUserEndpointId)
+    Set(usersEndpointId, userByIdEndpointId, createUserEndpointId, currentUserEndpointId, tenantOrderEndpointId)
 
   private def usersEndpoint(allow: Option[String] = None,
                              inject: Vector[InjectRule] = Vector.empty,
@@ -176,6 +179,18 @@ object EdgeServiceProxySpec extends ZIOSpecDefault, ZIOStubs:
     ResourceEndpoint(
       id = userByIdEndpointId,
       method = "GET", path = "/users/{id}", fetchUserInfo = false, allow = allow, inject = inject, stepUpCondition = None, stepUpAcr = None, maxAge = None,
+    )
+
+  private def currentUserEndpoint(inject: Vector[InjectRule] = Vector.empty) =
+    ResourceEndpoint(
+      id = currentUserEndpointId,
+      method = "GET", path = "/users/me", fetchUserInfo = false, allow = None, inject = inject, stepUpCondition = None, stepUpAcr = None, maxAge = None,
+    )
+
+  private def tenantOrderEndpoint(allow: Option[String] = None, inject: Vector[InjectRule] = Vector.empty) =
+    ResourceEndpoint(
+      id = tenantOrderEndpointId,
+      method = "GET", path = "/tenants/{tenantId}/orders/{orderId}", fetchUserInfo = false, allow = allow, inject = inject, stepUpCondition = None, stepUpAcr = None, maxAge = None,
     )
 
   private def createUserEndpoint(allow: Option[String] = None,
@@ -671,8 +686,8 @@ object EdgeServiceProxySpec extends ZIOSpecDefault, ZIOStubs:
     test("matches parameterized path and exposes path parameters in CEL context") {
       val env = new Env
       val endpoint = userByIdEndpoint(
-        allow = Some("request.path.id == token.sub"),
-        inject = Vector(InjectRule(InjectTarget.header, "x-resource-id", "request.path.id")),
+        allow = Some("request.path.params.id == token.sub"),
+        inject = Vector(InjectRule(InjectTarget.header, "x-resource-id", "request.path.params.id")),
       )
       for
         _ <- env.setupDefaults()
@@ -690,9 +705,95 @@ object EdgeServiceProxySpec extends ZIOSpecDefault, ZIOStubs:
         upstream.exists(_.headers.get("x-resource-id").contains("user-1")),
       )
     },
+    test("exposes every parameter of a multi-segment template under request.path.params") {
+      val env = new Env
+      val endpoint = tenantOrderEndpoint(
+        allow = Some("request.path.params.tenantId == 'acme' && request.path.params.orderId == '123'"),
+        inject = Vector(
+          InjectRule(InjectTarget.header, "x-tenant", "request.path.params.tenantId"),
+          InjectRule(InjectTarget.header, "x-order", "request.path.params.orderId"),
+        ),
+      )
+      for
+        _ <- env.setupDefaults()
+        capture <- captureUpstream()
+        client <- ZIO.service[Client]
+        security <- ZIO.service[SecurityService]
+        _ <- env.withResources(usersResource(endpoint))
+        token <- env.signToken()
+        request = Request.get(URL.empty / "tenants" / "acme" / "orders" / "123").addCookie(sessionCookie(token))
+        service = env.buildService(client, security)
+        response <- service.proxy(ResourceId("users-api"), Path.decode("/tenants/acme/orders/123"), request)
+        upstream <- capture.get
+      yield assertTrue(
+        response.status == Status.Ok,
+        upstream.exists(_.headers.get("x-tenant").contains("acme")),
+        upstream.exists(_.headers.get("x-order").contains("123")),
+      )
+    },
+    test("reports the registered template, not the concrete path, as the metric route") {
+      val env = new Env
+      for
+        _ <- env.setupDefaults()
+        _ <- captureUpstream()
+        client <- ZIO.service[Client]
+        security <- ZIO.service[SecurityService]
+        _ <- env.withResources(usersResource(tenantOrderEndpoint()))
+        token <- env.signToken()
+        request = Request.get(URL.empty / "tenants" / "acme" / "orders" / "123").addCookie(sessionCookie(token))
+        service = env.buildService(client, security)
+        response <- service.proxy(ResourceId("users-api"), Path.decode("/tenants/acme/orders/123"), request)
+        routePath <- Observability.routePath.get
+      yield assertTrue(
+        response.status == Status.Ok,
+        routePath.contains("/resources/users-api/tenants/{tenantId}/orders/{orderId}"),
+      )
+    },
+    test("leaves the metric route at its default when no endpoint matches") {
+      val env = new Env
+      for
+        _ <- env.setupDefaults()
+        client <- ZIO.service[Client]
+        security <- ZIO.service[SecurityService]
+        _ <- env.withResources(usersResource(usersEndpoint()))
+        token <- env.signToken()
+        request = Request.get(URL.empty / "ghosts" / "42").addCookie(sessionCookie(token))
+        service = env.buildService(client, security)
+        (response, routePath) <- Observability.routePath.locally(None):
+          service.proxy(ResourceId("users-api"), Path.decode("/ghosts/42"), request) <*> Observability.routePath.get
+      yield assertTrue(
+        response.status == Status.NotFound,
+        routePath.isEmpty,
+      )
+    },
+    test("prefers a static endpoint over a parameterized one whatever the registration order") {
+      val env = new Env
+      val parameterized = userByIdEndpoint(inject = Vector(InjectRule(InjectTarget.header, "x-matched", "'by-id'")))
+      val static = currentUserEndpoint(inject = Vector(InjectRule(InjectTarget.header, "x-matched", "'me'")))
+      def matchedHeader(endpoints: ResourceEndpoint*) =
+        for
+          capture <- captureUpstream()
+          client <- ZIO.service[Client]
+          security <- ZIO.service[SecurityService]
+          _ <- env.withResources(usersResource(endpoints*))
+          token <- env.signToken()
+          request = Request.get(URL.empty / "users" / "me").addCookie(sessionCookie(token))
+          service = env.buildService(client, security)
+          _ <- service.proxy(ResourceId("users-api"), Path.decode("/users/me"), request)
+          upstream <- capture.get
+        yield upstream.flatMap(_.headers.get("x-matched"))
+      for
+        _ <- env.setupDefaults()
+        staticFirst <- matchedHeader(static, parameterized)
+        parameterizedFirst <- matchedHeader(parameterized, static)
+      yield assertTrue(
+        staticFirst.contains("me"),
+        parameterizedFirst.contains("me"),
+      )
+    },
     test("returns 403 when path parameter does not satisfy allow expression") {
       val env = new Env
-      val endpoint = userByIdEndpoint(allow = Some("request.path.id == token.sub"))
+      val endpoint = userByIdEndpoint(allow = Some("request.path.params.id == token.sub"))
       for
         _ <- env.setupDefaults()
         client <- ZIO.service[Client]

--- a/util/src/main/scala/versola/util/http/Observability.scala
+++ b/util/src/main/scala/versola/util/http/Observability.scala
@@ -112,6 +112,22 @@ object Observability:
   def setRouteLabel(key: String, value: String): UIO[Unit] =
     routeLabel.set(Some(s"$key=$value"))
 
+  /** Replaces the route path of the current request's
+    * `http_server_requests_total`/`http_server_request_duration_seconds` metrics, which
+    * defaults to the matched route's pattern. Used where a single pattern fans out into
+    * several routes known only at request time, e.g. edge's `/resources/{resourceId}/...`
+    * proxy resolving to a registered endpoint template. The value must come from
+    * configuration rather than the request itself, otherwise metric cardinality becomes
+    * unbounded. [[middleware]] resets it per request so it never leaks into a subsequent
+    * one.
+    */
+  val routePath: FiberRef[Option[String]] = zio.Unsafe.unsafe { case given zio.Unsafe =>
+    FiberRef.unsafe.make(Option.empty[String])
+  }
+
+  def setRoutePath(path: String): UIO[Unit] =
+    routePath.set(Some(path))
+
   val serverLogging: FiberRef[HttpObservabilityConfig.Server] = zio.Unsafe.unsafe { case given zio.Unsafe =>
     FiberRef.unsafe.make(HttpObservabilityConfig.Server.default)
   }
@@ -213,71 +229,81 @@ object Observability:
     )
   }
 
+  /** Instruments every route with its own pattern (e.g. `/resources/{resourceId}/...`)
+    * rather than the concrete request path, so path parameters cannot blow up metric
+    * cardinality or span names. Handlers may narrow the route path to another bounded
+    * value with [[setRoutePath]].
+    */
   val middleware: Middleware[Tracing] = new Middleware[Tracing]:
     def apply[Env1 <: Tracing, Err](routes: Routes[Env1, Err]): Routes[Env1, Err] =
-      routes
-        .transform: handler =>
-          Handler.scoped[Env1]:
-            Handler.fromFunctionZIO[Request]: request =>
-              ZIO.serviceWithZIO[Tracing]: tracing =>
-                // the log context is restored once the request completes, so auth details set
-                // mid-flow annotate every log line of this request and no other
-                logContext.locallyWith(identity)(
-                  routeLabel.locally(None)(
-                  for
-                    startTime <- Clock.instant
-                    now <- Clock.nanoTime
-                    basePath = request.path.encode
-                    baseTags = Set(
-                      MetricLabel("method", request.method.name),
-                      MetricLabel("route", basePath),
-                    )
-                    response <- activeRequests.tagged(baseTags).increment
-                      .zipRight(handler(request))
-                      .ensuring(activeRequests.tagged(baseTags).decrement)
-                    masking <- serverLogging.get
-                    (requestLog, responseLog) <- toLog(request, masking) <&> toLog(request, response, masking)
-                    after <- Clock.nanoTime
-                    status = response.status.code
-                    statusClass = s"${status / 100}xx"
-                    label <- routeLabel.get
-                    route = label.fold(basePath)(l => s"$basePath?$l")
-                    tags = Set(
-                      MetricLabel("method", request.method.name),
-                      MetricLabel("route", route),
-                    )
-                    _ <- requestsCount
-                      .tagged(tags + MetricLabel("status", status.toString) + MetricLabel("status_class", statusClass))
-                      .increment
-                    _ <- requestDuration
-                      .tagged(tags + MetricLabel("status_class", statusClass))
-                      .update((after - now) / 1e9)
-                    log = receiveHttp(
-                      ReceiveHttpLog(
-                        request = requestLog,
-                        response = responseLog,
-                        startTime = startTime,
-                        elapsedMillis = (after - now) / 1000000,
-                      ),
-                    )
-                    loggerName = logging.loggerName("versola.http.HttpServer")
-                    cause <- cause.get
-                    _ <- cause match
-                      case Some(cause) =>
-                        ZIO.logErrorCause("receive-http", cause) @@ log @@ loggerName
-                      case None =>
-                        ZIO.logInfo("receive-http") @@ log @@ loggerName
-                    _ <- Observability.cause.set(None)
-                  yield response,
-                  ),
-                ) @@ tracing.aspects.extractSpan(
-                  TraceContextPropagator.default,
-                  IncomingContextCarrier.default(
-                    mutable.Map.from(request.headers.map(h => h.headerName -> h.renderedValue)),
-                  ),
-                  s"${request.method.name} ${request.path.encode}",
-                  SpanKind.SERVER,
+      Routes.fromIterable(routes.routes.map(route => route.transform(instrument(route.routePattern.pathCodec.render))))
+
+    private def instrument[Env1 <: Tracing](
+        pattern: String,
+    )(handler: Handler[Env1, Response, Request, Response]): Handler[Env1, Response, Request, Response] =
+      Handler.scoped[Env1]:
+        Handler.fromFunctionZIO[Request]: request =>
+          ZIO.serviceWithZIO[Tracing]: tracing =>
+            // the log context is restored once the request completes, so auth details set
+            // mid-flow annotate every log line of this request and no other
+            logContext.locallyWith(identity)(
+              routeLabel.locally(None)(
+              routePath.locally(None)(
+              for
+                startTime <- Clock.instant
+                now <- Clock.nanoTime
+                baseTags = Set(
+                  MetricLabel("method", request.method.name),
+                  MetricLabel("route", pattern),
                 )
+                response <- activeRequests.tagged(baseTags).increment
+                  .zipRight(handler(request))
+                  .ensuring(activeRequests.tagged(baseTags).decrement)
+                masking <- serverLogging.get
+                (requestLog, responseLog) <- toLog(request, masking) <&> toLog(request, response, masking)
+                after <- Clock.nanoTime
+                status = response.status.code
+                statusClass = s"${status / 100}xx"
+                label <- routeLabel.get
+                path <- routePath.get.map(_.getOrElse(pattern))
+                route = label.fold(path)(l => s"$path?$l")
+                tags = Set(
+                  MetricLabel("method", request.method.name),
+                  MetricLabel("route", route),
+                )
+                _ <- requestsCount
+                  .tagged(tags + MetricLabel("status", status.toString) + MetricLabel("status_class", statusClass))
+                  .increment
+                _ <- requestDuration
+                  .tagged(tags + MetricLabel("status_class", statusClass))
+                  .update((after - now) / 1e9)
+                log = receiveHttp(
+                  ReceiveHttpLog(
+                    request = requestLog,
+                    response = responseLog,
+                    startTime = startTime,
+                    elapsedMillis = (after - now) / 1000000,
+                  ),
+                )
+                loggerName = logging.loggerName("versola.http.HttpServer")
+                cause <- cause.get
+                _ <- cause match
+                  case Some(cause) =>
+                    ZIO.logErrorCause("receive-http", cause) @@ log @@ loggerName
+                  case None =>
+                    ZIO.logInfo("receive-http") @@ log @@ loggerName
+                _ <- Observability.cause.set(None)
+              yield response,
+              ),
+              ),
+            ) @@ tracing.aspects.extractSpan(
+              TraceContextPropagator.default,
+              IncomingContextCarrier.default(
+                mutable.Map.from(request.headers.map(h => h.headerName -> h.renderedValue)),
+              ),
+              s"${request.method.name} $pattern",
+              SpanKind.SERVER,
+            )
 
   val client: ZLayer[Tracing, Throwable, Client] =
     (Client.default ++ ZLayer.service[Tracing]).map: env =>

--- a/util/src/test/scala/versola/util/http/ObservabilitySpec.scala
+++ b/util/src/test/scala/versola/util/http/ObservabilitySpec.scala
@@ -100,7 +100,11 @@ object ObservabilitySpec extends ZIOSpecDefault:
       Observability.handleErrors(
         Routes(
           Method.GET / "resources" / string("alias") / trailing ->
-            handler((_: String, _: Path, _: Request) => Response.text("proxied")),
+            handler((alias: String, rest: Path, _: Request) =>
+              Observability.setRoutePath(s"/resources/$alias/items/{itemId}")
+                .when(rest.segments.headOption.contains("items"))
+                .as(Response.text("proxied")),
+            ),
         ),
       ),
     )
@@ -219,13 +223,13 @@ object ObservabilitySpec extends ZIOSpecDefault:
       test("records counter and histogram for successful requests") {
         val counterTags = Set(
           MetricLabel("method", "GET"),
-          MetricLabel("route", "ok"),
+          MetricLabel("route", "/ok"),
           MetricLabel("status", "200"),
           MetricLabel("status_class", "2xx"),
         )
         val durationTags = Set(
           MetricLabel("method", "GET"),
-          MetricLabel("route", "ok"),
+          MetricLabel("route", "/ok"),
           MetricLabel("status_class", "2xx"),
         )
         for
@@ -244,7 +248,7 @@ object ObservabilitySpec extends ZIOSpecDefault:
       test("counts 5xx errors via status_class") {
         val counterTags = Set(
           MetricLabel("method", "GET"),
-          MetricLabel("route", "boom"),
+          MetricLabel("route", "/boom"),
           MetricLabel("status", "500"),
           MetricLabel("status_class", "5xx"),
         )
@@ -259,10 +263,10 @@ object ObservabilitySpec extends ZIOSpecDefault:
           requests >= 1.0,
         )
       }.provideSomeLayer[Scope](testLayer) @@ TestAspect.silentLogging,
-      test("uses the raw path as the route label for the resources proxy") {
+      test("falls back to the route pattern for an unresolved resources proxy path") {
         val tags = Set(
           MetricLabel("method", "GET"),
-          MetricLabel("route", "resources/myalias/extra"),
+          MetricLabel("route", "/resources/{alias}/..."),
           MetricLabel("status", "200"),
           MetricLabel("status_class", "2xx"),
         )
@@ -277,10 +281,36 @@ object ObservabilitySpec extends ZIOSpecDefault:
           requests >= 1.0,
         )
       }.provideSomeLayer[Scope](testLayer) @@ TestAspect.silentLogging,
+      test("keeps the route label bounded across distinct path parameter values") {
+        val tags = Set(
+          MetricLabel("method", "GET"),
+          MetricLabel("route", "/resources/myalias/items/{itemId}"),
+          MetricLabel("status", "200"),
+          MetricLabel("status_class", "2xx"),
+        )
+        val activeTags = Set(
+          MetricLabel("method", "GET"),
+          MetricLabel("route", "/resources/{alias}/..."),
+        )
+        for
+          env <- tracingLayer.build
+          _ <- TestClient.addRoutes(proxyRoutes.provideEnvironment(env))
+          client <- ZIO.service[Client]
+          _ <- ZIO.foreachDiscard(Chunk("1", "2", "3")): itemId =>
+            client.batched(Request.get(URL.empty / "resources" / "myalias" / "items" / itemId))
+          requests <- counterCount(tags)
+          concrete <- counterCount(tags - MetricLabel("route", "/resources/myalias/items/{itemId}") + MetricLabel("route", "/resources/myalias/items/1"))
+          active <- Metric.gauge("http_server_active_requests").tagged(activeTags).value.map(_.value)
+        yield assertTrue(
+          requests >= 3.0,
+          concrete == 0.0,
+          active == 0.0,
+        )
+      }.provideSomeLayer[Scope](testLayer) @@ TestAspect.silentLogging,
       test("appends the route label set mid-handler to the route metric label") {
         val tags = Set(
           MetricLabel("method", "GET"),
-          MetricLabel("route", "labeled?grant_type=client_credentials"),
+          MetricLabel("route", "/labeled?grant_type=client_credentials"),
           MetricLabel("status", "200"),
           MetricLabel("status_class", "2xx"),
         )


### PR DESCRIPTION
Closes #196.

## Registration (central)

- `ResourceService` accepts endpoint paths whose segments are either static (`[a-zA-Z0-9-]+`) or a `{name}` parameter, where `name` is an identifier. Malformed (`/users/{}`), partial (`/users/u-{id}`) and repeated (`/users/{id}/orders/{id}`) placeholders are still `InvalidEndpointPath`.
- New `ResourceValidationError.AmbiguousEndpointPath`: two endpoints of the same method whose paths differ only in their parameter names (`/users/{id}` vs `/users/{userId}`) can never be told apart, so they are rejected at registration.
- Central UI mirrors both checks client-side and documents `request.path.params` in the Allow (CEL) tooltip.

## Routing and CEL (edge)

- `findEndpoint` picks the most specific matching template: a static segment wins over a placeholder at the same position, so `/users/me` beats `/users/{userId}` whatever the registration order is. Remaining ties are broken by path, so the choice is stable.
- Matched values reach CEL as `request.path.params.<name>` (previously they were exposed directly as `request.path`).

## Observability (util, edge)

- `Observability.middleware` instruments each route with its own route pattern (e.g. `/resources/{resourceId}/...`) instead of the concrete request path, for request-count, duration and active-request metrics as well as server span names.
- New `Observability.setRoutePath` lets a handler narrow the route label to another bounded value; edge sets it to the matched template, e.g. `/resources/orders/tenants/{tenantId}/orders/{orderId}`. Unmatched proxy paths fall back to the route pattern.

## Tests

- Central: parameterized paths accepted, malformed/partial/duplicate placeholders and ambiguous shapes rejected, static plus parameterized endpoints of the same method accepted.
- Edge: multi-parameter extraction and CEL evaluation, static-over-parameterized precedence in both registration orders, template used as the metric route, fallback left untouched when nothing matches.
- Util: bounded route labels across several distinct parameter values (including active requests) and pattern fallback for unresolved proxy paths.

Full `sbt test` and the central-ui Playwright suite pass locally (`tests/roles.spec.ts` ‘creates a role with selected permissions’ fails on `main` as well, unrelated).

Docs are updated separately in versolauth/versola-website.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M0NBG5ZQDQ67H7N2SVD6AM8P&panel=chat)