### PR TITLE
k8s: Helm chart skeleton (Deployments, Services, values.yaml)

### DIFF
--- a/k8s/versola/.helmignore
+++ b/k8s/versola/.helmignore
@@ -1,0 +1,8 @@
+# Patterns to ignore when building packages.
+.git/
+.gitignore
+*.swp
+*.bak
+*.tmp
+*.orig
+.DS_Store

--- a/k8s/versola/Chart.yaml
+++ b/k8s/versola/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: versola
+description: >-
+  Helm chart for running Versola's auth, central, edge and gateway services
+  in Kubernetes. Does not bundle Postgres or a secret backend -- see
+  https://github.com/versolauth/versola/issues/206 for the ground rules and
+  deploy.md for the equivalent docker-compose deployment.
+type: application
+version: 0.1.0
+appVersion: "0.4.0"
+home: https://github.com/versolauth/versola
+sources:
+  - https://github.com/versolauth/versola

--- a/k8s/versola/templates/NOTES.txt
+++ b/k8s/versola/templates/NOTES.txt
@@ -1,0 +1,13 @@
+Versola has been deployed. Services created:
+{{- range $name, $svc := .Values.services }}
+{{- if $svc.enabled }}
+  - {{ include "versola.fullname" $ }}-{{ $name }} (port {{ $svc.port }}, diagnostics {{ $svc.diagnosticsPort }})
+{{- end }}
+{{- end }}
+{{- if .Values.gateway.enabled }}
+  - {{ include "versola.fullname" . }}-gateway (port {{ .Values.gateway.port }})
+{{- end }}
+
+No Ingress is created by this chart (see https://github.com/versolauth/versola/issues/210).
+Each service's config must be supplied via its own `services.<name>.config.existingSecret`
+(and, where used, `extraEnvFrom`) -- this chart does not generate or bundle secrets.

--- a/k8s/versola/templates/_helpers.tpl
+++ b/k8s/versola/templates/_helpers.tpl
@@ -1,0 +1,236 @@
+{{/*
+Base name of the chart.
+*/}}
+{{- define "versola.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully-qualified release name, e.g. "myrelease-versola".
+*/}}
+{{- define "versola.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Labels common to every resource in this chart.
+*/}}
+{{- define "versola.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{ include "versola.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels common to every resource in this chart.
+*/}}
+{{- define "versola.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "versola.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Per-component labels. Expects a dict: {component: <name>, context: $}.
+*/}}
+{{- define "versola.componentLabels" -}}
+{{ include "versola.labels" .context }}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+
+{{/*
+Per-component selector labels. Expects a dict: {component: <name>, context: $}.
+*/}}
+{{- define "versola.componentSelectorLabels" -}}
+{{ include "versola.selectorLabels" .context }}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+
+{{/*
+Image reference for a service. Expects a dict: {global: .Values.global, svc: <service values>, chart: .Chart}.
+*/}}
+{{- define "versola.image" -}}
+{{- printf "%s/%s/%s:%s" .global.imageRegistry .global.imageRepository .svc.image.repository (default .chart.AppVersion .svc.image.tag) -}}
+{{- end -}}
+
+{{/*
+Default gateway nginx.conf, adapted from docker/versola-tools/nginx.conf.template
+for in-cluster Service DNS names (this chart's own auth/edge Services) instead
+of Compose service names, and a values-driven listen port instead of the fixed
+2821 used for local dev. Routing itself (which paths go to auth vs edge, the
+/central/admin/ static split) is otherwise unchanged -- see that file for the
+full reasoning behind each location block.
+*/}}
+{{- define "versola.defaultNginxConf" -}}
+upstream auth_backend {
+    server {{ include "versola.fullname" . }}-auth:{{ .Values.services.auth.port }};
+    keepalive 32;
+}
+
+upstream edge_backend {
+    server {{ include "versola.fullname" . }}-edge:{{ .Values.services.edge.port }};
+    keepalive 32;
+}
+
+server {
+    listen {{ .Values.gateway.port }};
+    server_name _;
+
+    client_max_body_size 8m;
+
+    location = /admin {
+        return 301 /central/admin/$is_args$args;
+    }
+
+    location /admin/ {
+        rewrite ^/admin/(.*)$ /central/admin/$1 permanent;
+    }
+
+    location = /central {
+        return 301 /central/admin/$is_args$args;
+    }
+
+    location = /central/ {
+        return 301 /central/admin/$is_args$args;
+    }
+
+    location = /central/admin {
+        return 301 /central/admin/$is_args$args;
+    }
+
+    location /central/admin/ {
+        root /usr/share/nginx/html;
+        index index.html;
+        try_files $uri $uri/ =404;
+        add_header Cache-Control "no-cache" always;
+    }
+
+    location = /central/permissions/me {
+        proxy_pass http://edge_backend/permissions/me;
+        include proxy_params.conf;
+    }
+
+    location /central/ {
+        rewrite ^/central/(.*)$ /resources/central/$1 break;
+
+        proxy_pass http://edge_backend;
+        include proxy_params.conf;
+    }
+
+    location = /resources {
+        proxy_pass http://edge_backend;
+        include proxy_params.conf;
+    }
+
+    location /resources/ {
+        proxy_pass http://edge_backend;
+        include proxy_params.conf;
+    }
+
+    location = /permissions {
+        proxy_pass http://edge_backend;
+        include proxy_params.conf;
+    }
+
+    location /permissions/ {
+        proxy_pass http://edge_backend;
+        include proxy_params.conf;
+    }
+
+    location = /authorize {
+        proxy_pass http://auth_backend;
+        include proxy_params.conf;
+    }
+
+    location = /token {
+        proxy_pass http://auth_backend;
+        include proxy_params.conf;
+    }
+
+    location = /introspect {
+        proxy_pass http://auth_backend;
+        include proxy_params.conf;
+    }
+
+    location = /revoke {
+        proxy_pass http://auth_backend;
+        include proxy_params.conf;
+    }
+
+    location = /userinfo {
+        proxy_pass http://auth_backend;
+        include proxy_params.conf;
+    }
+
+    location /.well-known/ {
+        proxy_pass http://auth_backend;
+        include proxy_params.conf;
+    }
+
+    location = /challenge {
+        proxy_pass http://auth_backend;
+        include proxy_params.conf;
+    }
+
+    location /challenge/ {
+        proxy_pass http://auth_backend;
+        include proxy_params.conf;
+    }
+
+    location = /login {
+        proxy_pass http://edge_backend;
+        include proxy_params.conf;
+    }
+
+    location /login/ {
+        proxy_pass http://edge_backend;
+        include proxy_params.conf;
+    }
+
+    location = /complete {
+        proxy_pass http://edge_backend;
+        include proxy_params.conf;
+    }
+
+    location = /complete/ {
+        proxy_pass http://edge_backend;
+        include proxy_params.conf;
+    }
+
+    location = /logout {
+        proxy_pass http://auth_backend;
+        include proxy_params.conf;
+    }
+
+    location /logout/ {
+        proxy_pass http://edge_backend;
+        include proxy_params.conf;
+    }
+
+    location / {
+        proxy_pass http://auth_backend;
+        include proxy_params.conf;
+    }
+}
+{{- end -}}
+
+{{/*
+Default gateway proxy_params.conf, copied as-is from
+docker/versola-tools/proxy_params.conf.template.
+*/}}
+{{- define "versola.defaultProxyParamsConf" -}}
+proxy_http_version 1.1;
+proxy_set_header Host $host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header Connection "";
+{{- end -}}

--- a/k8s/versola/templates/deployment.yaml
+++ b/k8s/versola/templates/deployment.yaml
@@ -1,0 +1,98 @@
+{{- range $name, $svc := .Values.services }}
+{{- if $svc.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "versola.fullname" $ }}-{{ $name }}
+  labels:
+    {{- include "versola.componentLabels" (dict "component" $name "context" $) | nindent 4 }}
+spec:
+  replicas: {{ $svc.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "versola.componentSelectorLabels" (dict "component" $name "context" $) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "versola.componentSelectorLabels" (dict "component" $name "context" $) | nindent 8 }}
+    spec:
+      {{- with $.Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      # See values.yaml's top-level comment on preStopSleepSeconds /
+      # terminationGracePeriodSeconds for why this has to cover both the
+      # preStop sleep below and VersolaApp's own gracefulShutdownTimeout.
+      terminationGracePeriodSeconds: {{ $.Values.terminationGracePeriodSeconds }}
+      containers:
+        - name: {{ $name }}
+          image: {{ include "versola.image" (dict "global" $.Values.global "svc" $svc "chart" $.Chart) }}
+          imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ $svc.port }}
+            - name: diagnostics
+              containerPort: {{ $svc.diagnosticsPort }}
+          env:
+            - name: PORT
+              value: {{ $svc.port | quote }}
+            - name: DPORT
+              value: {{ $svc.diagnosticsPort | quote }}
+            # See VersolaApp.scala's bindHost comment and #207: prod's VPS
+            # sets this to 127.0.0.1 because of network_mode: host, which
+            # would make every pod unreachable here. Deliberately not a
+            # values.yaml knob -- this chart must never inherit that value.
+            - name: BIND_HOST
+              value: "0.0.0.0"
+            - name: CONFIG_PATH
+              value: /app/config/env.conf
+            # The migration Job + RUN_MIGRATIONS wiring is #209 -- every
+            # replica stays a plain server until that lands.
+            - name: RUN_MIGRATIONS
+              value: "false"
+            {{- with $svc.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with $svc.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if $svc.config.existingSecret }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+              readOnly: true
+          {{- end }}
+          # /liveness and /readiness are served by the diagnostics server,
+          # separate from application traffic on `http` -- see
+          # VersolaApp.scala's serviceRoutes.
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: diagnostics
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: diagnostics
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep {{ $.Values.preStopSleepSeconds }}"]
+          resources:
+            {{- toYaml $svc.resources | nindent 12 }}
+      {{- if $svc.config.existingSecret }}
+      volumes:
+        - name: config
+          secret:
+            secretName: {{ $svc.config.existingSecret }}
+            items:
+              - key: {{ $svc.config.secretKey }}
+                path: env.conf
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/k8s/versola/templates/gateway-configmap.yaml
+++ b/k8s/versola/templates/gateway-configmap.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.gateway.enabled (not .Values.gateway.nginxConfig.existingConfigMap) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "versola.fullname" . }}-gateway-nginx
+  labels:
+    {{- include "versola.componentLabels" (dict "component" "gateway" "context" .) | nindent 4 }}
+data:
+  nginx.conf: |
+    {{- if .Values.gateway.nginxConfig.content }}
+    {{- .Values.gateway.nginxConfig.content | nindent 4 }}
+    {{- else }}
+    {{- include "versola.defaultNginxConf" . | nindent 4 }}
+    {{- end }}
+  proxy_params.conf: |
+    {{- include "versola.defaultProxyParamsConf" . | nindent 4 }}
+{{- end }}

--- a/k8s/versola/templates/gateway-deployment.yaml
+++ b/k8s/versola/templates/gateway-deployment.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "versola.fullname" . }}-gateway
+  labels:
+    {{- include "versola.componentLabels" (dict "component" "gateway" "context" .) | nindent 4 }}
+spec:
+  replicas: {{ .Values.gateway.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "versola.componentSelectorLabels" (dict "component" "gateway" "context" .) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "versola.componentSelectorLabels" (dict "component" "gateway" "context" .) | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.gateway.terminationGracePeriodSeconds }}
+      containers:
+        - name: gateway
+          image: {{ include "versola.image" (dict "global" .Values.global "svc" .Values.gateway "chart" .Chart) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.gateway.port }}
+          volumeMounts:
+            # See docker/versola-tools/nginx.conf.template's own comment on
+            # why "include proxy_params.conf;" resolves against
+            # /etc/nginx/proxy_params.conf and not conf.d/ -- nginx
+            # resolves relative include paths against the master config's
+            # directory (/etc/nginx), not the file doing the including.
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: nginx.conf
+              readOnly: true
+            - name: nginx-conf
+              mountPath: /etc/nginx/proxy_params.conf
+              subPath: proxy_params.conf
+              readOnly: true
+          # gateway is nginx (see docker/Dockerfile.gateway), not a
+          # VersolaApp service -- it has no DPORT, no /liveness or
+          # /readiness. A plain TCP check against its own listener catches
+          # a crashed/wedged process without coupling gateway's readiness
+          # to auth/edge being up: nginx answers on this port regardless of
+          # upstream health, a downed backend just means proxied routes
+          # 502, which is a backend problem rather than a reason to pull
+          # gateway itself out of rotation.
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep {{ .Values.gateway.preStopSleepSeconds }}"]
+          resources:
+            {{- toYaml .Values.gateway.resources | nindent 12 }}
+      volumes:
+        - name: nginx-conf
+          configMap:
+            name: {{ .Values.gateway.nginxConfig.existingConfigMap | default (printf "%s-gateway-nginx" (include "versola.fullname" .)) }}
+{{- end }}

--- a/k8s/versola/templates/gateway-service.yaml
+++ b/k8s/versola/templates/gateway-service.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "versola.fullname" . }}-gateway
+  labels:
+    {{- include "versola.componentLabels" (dict "component" "gateway" "context" .) | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "versola.componentSelectorLabels" (dict "component" "gateway" "context" .) | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.gateway.port }}
+      targetPort: http
+{{- end }}

--- a/k8s/versola/templates/service.yaml
+++ b/k8s/versola/templates/service.yaml
@@ -1,0 +1,22 @@
+{{- range $name, $svc := .Values.services }}
+{{- if $svc.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "versola.fullname" $ }}-{{ $name }}
+  labels:
+    {{- include "versola.componentLabels" (dict "component" $name "context" $) | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "versola.componentSelectorLabels" (dict "component" $name "context" $) | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ $svc.port }}
+      targetPort: http
+    - name: diagnostics
+      port: {{ $svc.diagnosticsPort }}
+      targetPort: diagnostics
+{{- end }}
+{{- end }}

--- a/k8s/versola/values.yaml
+++ b/k8s/versola/values.yaml
@@ -1,0 +1,150 @@
+# Default values for the versola chart.
+#
+# Ground rules this chart follows (see #206 and deploy.md):
+#   - No bundled Postgres. Point `config.existingSecret` (per service, below)
+#     at an env.conf that already has an external connection URL.
+#   - No bundled secret backend. This chart consumes secret values/refs
+#     (native Secret, External Secrets Operator, Vault, ...), it never
+#     generates or mandates one.
+#   - Ingress/HPA/PDB/topology spread are separate issues (#210, #211) --
+#     out of scope here.
+
+nameOverride: ""
+fullnameOverride: ""
+
+global:
+  # Images are pulled as <imageRegistry>/<imageRepository>/<repository>:<tag>,
+  # e.g. ghcr.io/versolauth/versola-auth:0.4.0.
+  imageRegistry: ghcr.io
+  imageRepository: versolauth
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+
+# terminationGracePeriodSeconds / preStopSleepSeconds for the JVM services
+# (auth, central, edge) below.
+#
+# VersolaApp.gracefulShutdownTimeout (see util/src/main/scala/versola/util/http/VersolaApp.scala)
+# is 15s: on SIGTERM the app itself waits up to that long for the HTTP
+# server to drain and finalizers (Hikari pool close, span flush) to run
+# before the JVM exits on its own.
+#
+# preStopSleepSeconds delays *sending* that SIGTERM by a few seconds --
+# kubelet only sends it once the preStop hook returns -- giving
+# kube-proxy/endpoint controllers time to stop routing new traffic to a
+# pod that's already Terminating. Without it, a pod can receive a new
+# request in the same instant it starts shutting down.
+#
+# terminationGracePeriodSeconds must cover both phases plus a margin for
+# the JVM to actually exit, or kubelet SIGKILLs before graceful shutdown
+# finishes: preStopSleepSeconds (5s) + gracefulShutdownTimeout (15s) + 10s
+# margin = 30s.
+preStopSleepSeconds: 5
+terminationGracePeriodSeconds: 30
+
+# auth, central, edge: the three JVM services described by VersolaApp.scala.
+# Keyed by name so templates/deployment.yaml and templates/service.yaml can
+# render one Deployment + Service per entry instead of repeating themselves.
+services:
+  auth:
+    enabled: true
+    image:
+      repository: versola-auth
+      tag: "" # defaults to .Chart.AppVersion
+    replicaCount: 1
+    port: 8080 # PORT -- application traffic
+    diagnosticsPort: 8081 # DPORT -- /metrics, /liveness, /readiness
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        memory: 512Mi
+    config:
+      # Name of a Secret that already contains an env.conf key (HOCON --
+      # see deploy.md 3.2/3.3), mounted at CONFIG_PATH. Left empty by
+      # default -- this chart doesn't generate one.
+      existingSecret: ""
+      secretKey: env.conf
+    # Extra plain env vars: [{name: FOO, value: bar}, ...].
+    extraEnv: []
+    # Extra envFrom entries, e.g. for the ${?VAR} secret placeholders
+    # gen-env.scala writes into env.conf (JWT_PRIVATE_KEY,
+    # ACCESS_TOKENS_SECRET, POSTGRES_PASSWORD, ...): point this at
+    # whichever Secret your backend resolves them into.
+    #   extraEnvFrom:
+    #     - secretRef:
+    #         name: auth-secrets
+    extraEnvFrom: []
+  central:
+    enabled: true
+    image:
+      repository: versola-central
+      tag: ""
+    replicaCount: 1
+    port: 8090
+    diagnosticsPort: 8091
+    resources:
+      requests:
+        cpu: 250m
+        memory: 768Mi
+      limits:
+        memory: 768Mi
+    config:
+      existingSecret: ""
+      secretKey: env.conf
+    extraEnv: []
+    extraEnvFrom: []
+  edge:
+    enabled: true
+    image:
+      repository: versola-edge
+      tag: ""
+    replicaCount: 1
+    port: 8095
+    diagnosticsPort: 8096
+    resources:
+      requests:
+        cpu: 250m
+        memory: 384Mi
+      limits:
+        memory: 384Mi
+    config:
+      existingSecret: ""
+      secretKey: env.conf
+    extraEnv: []
+    extraEnvFrom: []
+
+# gateway: nginx with central-ui's static build baked in (see
+# docker/Dockerfile.gateway) -- not a VersolaApp service, so it has no
+# PORT/DPORT and no /liveness or /readiness to probe (see
+# templates/gateway-deployment.yaml for how it's probed instead).
+gateway:
+  enabled: true
+  image:
+    repository: versola-gateway
+    tag: ""
+  replicaCount: 1
+  port: 2821
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 128Mi
+  # nginx has no equivalent of gracefulShutdownTimeout -- these just need
+  # to give it enough room to stop receiving new connections and drain
+  # existing ones.
+  preStopSleepSeconds: 5
+  terminationGracePeriodSeconds: 20
+  nginxConfig:
+    # Name of a ConfigMap that already has an `nginx.conf` key (and,  if
+    # your routing still uses it, a `proxy_params.conf` key), if you'd
+    # rather manage gateway's routing outside this chart. Takes precedence
+    # over `content` below.
+    existingConfigMap: ""
+    # Inline override for the rendered nginx.conf. Leave empty to use the
+    # chart's own default (adapted from
+    # docker/versola-tools/nginx.conf.template for in-cluster Service DNS
+    # instead of Compose service names -- see templates/_helpers.tpl's
+    # "versola.defaultNginxConf").
+    content: ""


### PR DESCRIPTION
Closes #207. Part of #206.

Baseline Helm chart (`k8s/versola/`) to run `auth`, `central`, `edge`, `gateway` in Kubernetes. No bundled Postgres, no bundled secret backend -- the chart consumes secret values/refs the same way it consumes an external DB connection URL (see #206's ground rules).

## What's in the chart

- One `Deployment` + `Service` per service (`auth`, `central`, `edge`, `gateway`). `auth`/`central`/`edge` are structurally identical (same `VersolaApp.scala` shape), so `templates/deployment.yaml` and `templates/service.yaml` loop over `values.yaml`'s `services` map instead of repeating a near-identical template three times.
- Probes wired to the diagnostics endpoints (`/liveness`, `/readiness` on `DPORT`), separate from app traffic on `PORT` -- see `VersolaApp.scala`. `gateway` is nginx with `central-ui`'s static build baked in (see `docker/Dockerfile.gateway`), not a `VersolaApp` service, so it has no `DPORT`; it gets a plain `tcpSocket` readiness/liveness probe against its own listener instead.
- `BIND_HOST=0.0.0.0` is hardcoded in the Deployment template, not exposed as a `values.yaml` knob -- prod's VPS sets this to `127.0.0.1` because of `network_mode: host` (see `deploy.md`), and inheriting that would make every pod unreachable.
- `terminationGracePeriodSeconds` + a `preStop` sleep on every Deployment, sized to cover both the `preStop` delay (letting endpoints converge before SIGTERM is sent) and the app's own `gracefulShutdownTimeout` (15s, see `VersolaApp.scala`) plus a margin for JVM exit.
- Resource requests/limits per service, configurable via `values.yaml`, defaulted from the current VPS `mem_limit`s in `deploy.md`.
- Config delivery: `services.<name>.config.existingSecret` mounts an existing Secret's `env.conf` key at `CONFIG_PATH`; `extraEnv`/`extraEnvFrom` pass through the `${?VAR}` secret placeholders `gen-env.scala` already produces (`JWT_PRIVATE_KEY`, `ACCESS_TOKENS_SECRET`, `POSTGRES_PASSWORD`, ...). The chart never generates these itself. `gateway`'s `nginx.conf`/`proxy_params.conf` default to a chart-rendered `ConfigMap` (routing adapted from `docker/versola-tools/nginx.conf.template` for in-cluster Service DNS instead of Compose service names) or an `existingConfigMap` if you'd rather manage routing outside the chart.
- `RUN_MIGRATIONS=false` on every Deployment (migration Job + wiring is #209).

## Explicitly out of scope (per the issue)

- Postgres itself.
- Ingress/routing (#210).
- HPA/PDB/topology spread (#211, milestone 2).

## Validation

```
helm lint k8s/versola
helm template k8s/versola
kubeconform -strict -summary -kubernetes-version 1.29.0 <rendered output>
```

Also exercised: disabling individual services (`services.central.enabled=false`, `gateway.enabled=false`), `config.existingSecret` + `extraEnv`/`extraEnvFrom`, and `gateway.nginxConfig.existingConfigMap` -- all render valid, schema-conformant manifests.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M0QXC4STYHJ2A5QDEMG0JCNB&panel=chat)