### PR TITLE
feat: add iss to authorization response (RFC 9207) #191

### DIFF
--- a/auth/open-api/metadata.yaml
+++ b/auth/open-api/metadata.yaml
@@ -131,6 +131,11 @@ components:
             of `/authorize`, `/par` and `/token` only if it is also registered for the
             requesting client's own tenant; otherwise the request fails with
             `invalid_authorization_details`.
+        authorization_response_iss_parameter_supported:
+          type: boolean
+          description: |
+            RFC 9207 — the iss parameter is included in every authorization response
+            (both successful and error redirects).
 
   responses:
     Metadata:
@@ -140,6 +145,7 @@ components:
           schema:
             $ref: '#/components/schemas/ServerMetadata'
           example:
+            authorization_response_iss_parameter_supported: true
             issuer: https://auth.example.com
             authorization_endpoint: https://auth.example.com/authorize
             token_endpoint: https://auth.example.com/token

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointController.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointController.scala
@@ -38,9 +38,11 @@ object AuthorizeEndpointController extends Controller:
                 .as(Response.badRequest(Error.BadRequest.description)))
 
           case error: Error.RedirectError =>
-            AuthMetrics.authorizeError(error.error.toString) *>
-              (Observability.setError(error.error, Some(error.errorDescription))
-                .as(Response.seeOther(error.redirectUriWithErrorParams)))
+            for
+              config <- ZIO.service[CoreConfig]
+              _ <- AuthMetrics.authorizeError(error.error.toString)
+              _ <- Observability.setError(error.error, Some(error.errorDescription))
+            yield Response.seeOther(error.redirectUriWithErrorParams(config.jwt.issuer))
         }
     }
 
@@ -53,7 +55,7 @@ object AuthorizeEndpointController extends Controller:
       response <- authService.authorize(request).tap(AuthMetrics.authorizeOutcome).map:
         case AuthorizeResponse.Authorized(code, idToken) =>
           Response.seeOther(
-            AuthorizeRedirect.responseUrl(request.redirectUri, Base64Url.encode(code), request.state, idToken),
+            AuthorizeRedirect.responseUrl(request.redirectUri, Base64Url.encode(code), request.state, idToken, config.jwt.issuer),
           )
 
         case AuthorizeResponse.Initialize(authId) =>

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeRedirect.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeRedirect.scala
@@ -14,9 +14,9 @@ object AuthorizeRedirect:
     * so all parameters are placed in the URL fragment. For the plain authorization-code
     * flow the parameters are placed in the query string.
     */
-  def responseUrl(redirectUri: URL, code: String, state: Option[State], idToken: Option[String]): URL =
+  def responseUrl(redirectUri: URL, code: String, state: Option[State], idToken: Option[String], iss: String): URL =
     val params: List[(String, String)] =
-      List("code" -> code) ++
+      List("code" -> code, "iss" -> iss) ++
         idToken.map("id_token" -> _) ++
         state.map("state" -> _)
     idToken match

--- a/auth/src/main/scala/versola/oauth/authorize/model/Error.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/model/Error.scala
@@ -17,11 +17,12 @@ private[authorize] object Error:
     def uri: URL
     def state: Option[State]
 
-    def redirectUriWithErrorParams: URL =
+    def redirectUriWithErrorParams(iss: String): URL =
       uri.addQueryParams(
         Iterable(
           "error" -> error,
           "error_description" -> errorDescription,
+          "iss" -> iss,
         )
           ++ errorUri.map("error_uri" -> _)
           ++ state.map("state" -> _),

--- a/auth/src/main/scala/versola/oauth/conversation/ConversationRenderService.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationRenderService.scala
@@ -192,7 +192,7 @@ object ConversationRenderService:
         error: String,
     ): Option[String] =
       URL.decode(redirectUri).toOption.map: url =>
-        url.addQueryParams(List("error" -> error) ++ state.map("state" -> _)).encode
+        url.addQueryParams(List("error" -> error, "iss" -> config.jwt.issuer) ++ state.map("state" -> _)).encode
 
     private def renderTerminal(clientId: ClientId, formId: String, step: StepView): Task[Response] =
       for
@@ -549,11 +549,11 @@ object ConversationRenderService:
             tosUri = client.flatMap(_.tosUri),
             scopes = rows,
             allowPartial = s.allowPartial,
-            denyUri = redirectUri.addQueryParams(List("error" -> "access_denied") ++ state.map("state" -> _)).encode,
+            denyUri = redirectUri.addQueryParams(List("error" -> "access_denied", "iss" -> config.jwt.issuer) ++ state.map("state" -> _)).encode,
           )
 
         case ConversationStep.AccessDenied =>
-          val params = List("error" -> "access_denied") ++ state.map("state" -> _)
+          val params = List("error" -> "access_denied", "iss" -> config.jwt.issuer) ++ state.map("state" -> _)
           ZIO.succeed(StepView.AccessDenied(redirectUri = redirectUri.addQueryParams(params).encode))
 
     private def availableClaimNames(record: ConversationRecord): Set[String] =

--- a/auth/src/main/scala/versola/oauth/conversation/ConversationRenderService.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationRenderService.scala
@@ -258,7 +258,7 @@ object ConversationRenderService:
                   token <- serializeIdToken(dataWithCHash, signingKey)
                 yield Some(token)
               case None => ZIO.none
-            redirectUrl = AuthorizeRedirect.responseUrl(redirectUri, encodedCode, state, idToken)
+            redirectUrl = AuthorizeRedirect.responseUrl(redirectUri, encodedCode, state, idToken, config.jwt.issuer)
           yield Response.seeOther(redirectUrl)
             .addCookie(
               SessionCookie(

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeErrorSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeErrorSpec.scala
@@ -8,11 +8,12 @@ import zio.test.*
 object AuthorizeErrorSpec extends ZIOSpecDefault:
 
   private val redirectUri = URL.decode("https://example.com/callback").toOption.get
+  private val testIss = "https://auth.example.com"
 
   def spec = suite("AuthorizeError")(
     test("ResponseTypeMissing includes error and error_description query params") {
       val err = Error.ResponseTypeMissing(redirectUri, state = None)
-      val url = err.redirectUriWithErrorParams
+      val url = err.redirectUriWithErrorParams(testIss)
       val params = url.queryParams
       assertTrue(
         params.map.get("error").exists(_.contains("invalid_request")),
@@ -22,46 +23,52 @@ object AuthorizeErrorSpec extends ZIOSpecDefault:
 
     test("ResponseTypeMissing includes error_uri when defined") {
       val err = Error.ResponseTypeMissing(redirectUri, state = None)
-      val url = err.redirectUriWithErrorParams
+      val url = err.redirectUriWithErrorParams(testIss)
       val params = url.queryParams
       assertTrue(params.map.get("error_uri").exists(_.nonEmpty))
     },
 
     test("state is included when provided") {
       val err = Error.ResponseTypeMissing(redirectUri, state = Some(State("abc123")))
-      val url = err.redirectUriWithErrorParams
+      val url = err.redirectUriWithErrorParams(testIss)
       val params = url.queryParams
       assertTrue(params.map.get("state").exists(_.contains("abc123")))
     },
 
     test("state is absent when not provided") {
       val err = Error.ResponseTypeMissing(redirectUri, state = None)
-      val url = err.redirectUriWithErrorParams
+      val url = err.redirectUriWithErrorParams(testIss)
       val params = url.queryParams
       assertTrue(params.map.get("state").isEmpty)
     },
 
     test("UnsupportedResponseType uses correct error code") {
       val err = Error.UnsupportedResponseType(redirectUri, state = None, responseType = "token")
-      val url = err.redirectUriWithErrorParams
+      val url = err.redirectUriWithErrorParams(testIss)
       assertTrue(url.queryParams.map.get("error").exists(_.contains("unsupported_response_type")))
     },
 
     test("AuthFlowMissing has no error_uri") {
       val err = Error.AuthFlowMissing(redirectUri, state = None)
-      val url = err.redirectUriWithErrorParams
+      val url = err.redirectUriWithErrorParams(testIss)
       assertTrue(url.queryParams.map.get("error_uri").isEmpty)
     },
 
     test("AccessDenied uses access_denied error code") {
       val err = Error.AccessDenied(redirectUri, state = None)
-      val url = err.redirectUriWithErrorParams
+      val url = err.redirectUriWithErrorParams(testIss)
       assertTrue(url.queryParams.map.get("error").exists(_.contains("access_denied")))
     },
 
     test("base uri is preserved in error redirect") {
       val err = Error.ResponseTypeMissing(redirectUri, state = None)
-      val url = err.redirectUriWithErrorParams
+      val url = err.redirectUriWithErrorParams(testIss)
       assertTrue(url.host.contains("example.com"))
+    },
+
+    test("iss is included in error redirect") {
+      val err = Error.ResponseTypeMissing(redirectUri, state = None)
+      val url = err.redirectUriWithErrorParams(testIss)
+      assertTrue(url.queryParams.map.get("iss").exists(_.contains(testIss)))
     },
   )

--- a/edge/implementations/postgres/src/main/scala/versola/PostgresEdgeApp.scala
+++ b/edge/implementations/postgres/src/main/scala/versola/PostgresEdgeApp.scala
@@ -1,3 +1,4 @@
+
 package versola
 
 import com.augustnagro.magnum.magzio.TransactorZIO

--- a/scripts/gen-env.scala
+++ b/scripts/gen-env.scala
@@ -382,7 +382,8 @@ def writeGeneratedSecrets(dir: File, name: String, secrets: Seq[(String, String)
        |  "frontchannel_logout_supported": true,
        |  "frontchannel_logout_session_supported": true,
        |  "backchannel_logout_supported": true,
-       |  "backchannel_logout_session_supported": true
+       |  "backchannel_logout_session_supported": true,
+       |  "authorization_response_iss_parameter_supported": true
        |}""".stripMargin
 
   section("\n── Edge service ──────────────────────────────────────────────────────")


### PR DESCRIPTION
Closes #191
Part of #189

## Summary

Adds `iss` (issuer) as a query parameter to every authorization response, both successful and error redirects, as required by RFC 9207.

## Changes

- `AuthorizeRedirect.responseUrl` — accepts new `iss: String` parameter, included in both query-string (code flow) and fragment (hybrid flow) responses
- `AuthorizeEndpointController` — passes `config.jwt.issuer` to `responseUrl` on success; passes it to `redirectUriWithErrorParams` on error redirects
- `ConversationRenderService` — passes `config.jwt.issuer` to `responseUrl` in `renderSubmit` (post-conversation redirect)
- `Error.RedirectError.redirectUriWithErrorParams` — accepts `iss: String` and includes it in the error redirect query params
- `metadata.yaml` — adds `authorization_response_iss_parameter_supported: true` to the discovery document schema and example

## Testing

- Updated `AuthorizeErrorSpec` to pass `iss` to `redirectUriWithErrorParams` in all existing tests
- Added test asserting `iss` is present in error redirect params
- All tests pass