### PR TITLE
central-ui: runtime console-mode instead of build-time CONSOLE_PREFIX

### DIFF
--- a/central-ui/src/components/admin-app.ts
+++ b/central-ui/src/components/admin-app.ts
@@ -33,6 +33,13 @@ export class VersolaAdmin extends LitElement {
   // central-admin preset's edge login; override only if this console is ever
   // wired to a different preset.
   @property({ type: String, attribute: 'login-url' }) loginUrl: string | null = null;
+  // 'prefix' (default): the console is reached via the /central/{x} shortcut,
+  // relying on an external proxy (Vite dev server / gateway nginx) to rewrite
+  // it to edge's real /resources/central/{x} route -- local dev, docker-local,
+  // and path-based prod all use this. 'direct': the console has its own
+  // origin (e.g. k8s, see #222) and calls edge's real route outright. See
+  // centralResourcePath in central-api.ts.
+  @property({ type: String, attribute: 'console-mode' }) consoleMode: 'prefix' | 'direct' = 'prefix';
   @state() private currentView: NavItem = 'clients';
   /** Mobile drawer state; ignored by the layout above the 768px breakpoint. */
   @state() private navOpen = false;
@@ -121,7 +128,7 @@ export class VersolaAdmin extends LitElement {
   }
 
   updated(changed: Map<string, unknown>) {
-    if (changed.has('apiUrl') || changed.has('loginUrl')) {
+    if (changed.has('apiUrl') || changed.has('loginUrl') || changed.has('consoleMode')) {
       this.applyApiConfig();
       void this.loadPermissions();
     }
@@ -406,6 +413,7 @@ export class VersolaAdmin extends LitElement {
     configureCentralApi({
       baseUrl: this.apiUrl,
       loginUrl: this.loginUrl,
+      consoleMode: this.consoleMode,
     });
   }
 

--- a/central-ui/src/utils/central-api.ts
+++ b/central-ui/src/utils/central-api.ts
@@ -41,7 +41,8 @@ const DEFAULT_LOGIN_URL = '/login/central-admin';
 type LocalizedDescription = Record<string, string>;
 type PagedResult<T> = { items: T[]; total: number; hasNext: boolean };
 type QueryValue = string | number | undefined | null;
-type CentralApiConfig = { baseUrl: string | null; loginUrl: string };
+type ConsoleMode = 'prefix' | 'direct';
+type CentralApiConfig = { baseUrl: string | null; loginUrl: string; consoleMode: ConsoleMode };
 
 type ClientSecretResponse = { secret: string };
 type AuthorizationPresetResponse = {
@@ -136,7 +137,7 @@ type AuthorizationDetailTypesResponse = {
   types: Array<{ type: string; description: LocalizedDescription; schema: Record<string, unknown> }>;
 };
 
-const apiConfig: CentralApiConfig = { baseUrl: null, loginUrl: DEFAULT_LOGIN_URL };
+const apiConfig: CentralApiConfig = { baseUrl: null, loginUrl: DEFAULT_LOGIN_URL, consoleMode: 'prefix' };
 const permissionStore = new Map<string, Permission>();
 const clientSupplementStore = new Map<string, { accessTokenTtl: number; refreshTokenTtl: number; hasPreviousSecret: boolean }>();
 const roleSupplementStore = new Map<string, { active: boolean; createdAt: string; updatedAt: string }>();
@@ -246,20 +247,33 @@ export function resolveBaseUrl(): string {
   return apiConfig.baseUrl?.trim() || window.location.origin;
 }
 
-// Everything the console talks to lives under this prefix. It exists so the
-// EDGE_SESSION cookie can be scoped to a path (Path=/central) and thereby
-// belong to this application alone rather than to the whole domain — and a
-// cookie is only sent to URLs beneath its path, so the console's assets
-// (/central/admin/, see vite.config.ts) and its API calls have to share one
-// prefix. nginx rewrites /central/{x} back to edge's real /resources/central/{x}
-// route, so edge itself is unaware of this prefix.
-export const CONSOLE_PREFIX = 'central';
+// Everything the console talks to is edge's "central" resource (see
+// EdgeController.scala's /resources/{resourceId}/... proxy route --
+// "central" is the literal resourceId, not a prefix edge understands).
+//
+// In 'prefix' mode (the default -- local dev, docker-local, path-based prod;
+// see vite.config.ts and docker/versola-tools/nginx.conf.template) the
+// console takes a /central/{x} shortcut instead of calling that route
+// outright, so the EDGE_SESSION cookie can be scoped to a path (Path=/central)
+// and thereby belong to this application alone rather than to the whole
+// domain -- a cookie is only sent to URLs beneath its path, so the console's
+// assets (/central/admin/) and its API calls have to share one prefix. An
+// external proxy (the Vite dev server / gateway nginx) rewrites /central/{x}
+// back to /resources/central/{x} before anything reaches edge.
+//
+// In 'direct' mode (the console hosted on its own domain, e.g. k8s -- see
+// #222) there is no such proxy and no shared origin to scope a cookie path
+// against, so the console calls edge's real route directly. Set via the
+// console-mode attribute on <versola-admin> (see admin-app.ts).
+export function centralResourcePath(path: string): string {
+  return apiConfig.consoleMode === 'direct' ? `resources/central/${path}` : `central/${path}`;
+}
 
 function buildUrl(path: string, query?: Record<string, QueryValue>): string {
   const baseUrl = resolveBaseUrl();
   const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
   const normalizedPath = path.replace(/^\//, '');
-  const proxiedPath = `${CONSOLE_PREFIX}/${normalizedPath}`;
+  const proxiedPath = centralResourcePath(normalizedPath);
   const url = new URL(proxiedPath, normalizedBase);
   Object.entries(query ?? {}).forEach(([key, value]) => {
     if (value !== undefined && value !== null) {
@@ -320,12 +334,15 @@ function buildErrorMessage(status: number, bodyText: string): string {
 // null/empty for either field resets it to its default (host origin for baseUrl,
 // DEFAULT_LOGIN_URL for loginUrl) rather than leaving a previously-set value
 // stuck — so clearing the api-url / login-url attribute reverts to defaults.
-export function configureCentralApi(config: { baseUrl?: string | null; loginUrl?: string | null }): void {
+export function configureCentralApi(config: { baseUrl?: string | null; loginUrl?: string | null; consoleMode?: ConsoleMode | null }): void {
   if ('baseUrl' in config) {
     apiConfig.baseUrl = config.baseUrl?.trim() || null;
   }
   if ('loginUrl' in config) {
     apiConfig.loginUrl = config.loginUrl?.trim() || DEFAULT_LOGIN_URL;
+  }
+  if ('consoleMode' in config) {
+    apiConfig.consoleMode = config.consoleMode === 'direct' ? 'direct' : 'prefix';
   }
   invalidateReadCache();
   invalidateAllRefData();
@@ -1315,12 +1332,14 @@ export type MyPermissionsResponse = {
 export async function fetchMyPermissions(): Promise<MyPermissionsResponse> {
   const baseUrl = resolveBaseUrl();
   const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
-  // edge serves this at /permissions/me, outside any resource prefix — but the
-  // call has to carry EDGE_SESSION, and that cookie is scoped to /central, so
-  // the browser would withhold it from a root-level URL and every load would
-  // bounce to login. It's requested under the prefix instead, and nginx
-  // rewrites /central/permissions/me back to /permissions/me.
-  const url = new URL(`${CONSOLE_PREFIX}/permissions/me`, normalizedBase);
+  // edge serves this at /permissions/me, outside any resource prefix. In
+  // 'prefix' mode the call has to carry EDGE_SESSION, and that cookie is
+  // scoped to /central, so the browser would withhold it from a root-level
+  // URL and every load would bounce to login -- it's requested under the
+  // prefix instead, and an external proxy rewrites /central/permissions/me
+  // back to /permissions/me. In 'direct' mode there's no such cookie-path
+  // scoping to route around, so it's called outright.
+  const url = new URL(apiConfig.consoleMode === 'direct' ? 'permissions/me' : 'central/permissions/me', normalizedBase);
   url.searchParams.set('resource', 'central');
 
   const response = await fetch(url.toString(), {

--- a/central-ui/src/utils/users-api.ts
+++ b/central-ui/src/utils/users-api.ts
@@ -1,5 +1,5 @@
 import type { PasskeyInfo, SessionClientEntry, User, UserRoleAssignment, UserSearchField, UserSession } from '../types';
-import { CONSOLE_PREFIX, resolveBaseUrl } from './central-api';
+import { centralResourcePath, resolveBaseUrl } from './central-api';
 
 type UserSearchRecordDto = {
   id: string;
@@ -24,16 +24,15 @@ function toUser(record: UserSearchRecordDto): User {
   };
 }
 
-// Route through the console's /central prefix (see CONSOLE_PREFIX in
-// central-api.ts) rather than calling edge's resources/central/ route
-// directly, so this shares the EDGE_SESSION cookie's path scope with the rest
-// of the console. Uses the same base URL as central-api.ts (respects
-// configureCentralApi / api-url attribute).
+// Shares central-api.ts's centralResourcePath so this switches between
+// 'prefix' and 'direct' console modes the same way (see that function's
+// comment) -- and the same base URL (respects configureCentralApi / api-url
+// attribute).
 function proxyUrl(path: string): URL {
   const base = resolveBaseUrl();
   const normalizedBase = base.endsWith('/') ? base : `${base}/`;
   const normalizedPath = path.replace(/^\//, '');
-  return new URL(`${CONSOLE_PREFIX}/${normalizedPath}`, normalizedBase);
+  return new URL(centralResourcePath(normalizedPath), normalizedBase);
 }
 
 export async function searchUsers(field: UserSearchField, query: string): Promise<User[]> {

--- a/central-ui/vite.config.ts
+++ b/central-ui/vite.config.ts
@@ -2,16 +2,14 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { defineConfig, type Plugin } from 'vite';
 
-// The admin console is served at https://id.versola.kz/central/admin/ in
-// production (see deploy.md / nginx routing), so every asset URL baked into
-// the built index.html must be prefixed with this path — otherwise the browser
-// looks for them at the domain root and gets a 404.
-//
-// The /central segment isn't cosmetic: the EDGE_SESSION cookie is scoped to
-// that path so each app behind edge gets its own session, and a cookie is only
-// sent to URLs beneath its path. Both the console's assets and its API calls
-// therefore have to live under the same prefix — see central-api.ts.
-const BASE_PATH = '/central/admin/';
+// The admin console is mounted at different paths depending on the
+// deployment target -- /central/admin/ in local dev, docker-local, and
+// path-based prod (see deploy.md / nginx routing); the docroot itself for a
+// domain-hosted console (e.g. k8s, see #222). A relative base means the same
+// dist/ works unmodified at either mount point: asset URLs baked into
+// index.html resolve against wherever the HTML itself was served from,
+// instead of assuming a fixed absolute path.
+const BASE_PATH = './';
 
 function distIndexHtmlPlugin(): Plugin {
   return {

--- a/docker/Dockerfile.gateway
+++ b/docker/Dockerfile.gateway
@@ -5,12 +5,11 @@
 # central-ui/ (a CI build step, not something this Dockerfile does itself,
 # to keep the image simple and avoid needing Node in the build context).
 #
-# vite.config.ts bakes BASE_PATH = "/central/admin/" into every asset URL
-# in dist/index.html (the console is only ever served under that path, and
-# EDGE_SESSION's cookie scope depends on it -- see that file's comments).
-# So dist/ is copied here to /central/admin/ rather than the docroot root:
-# that's the only way a request for GET /central/admin/versola-admin.js
-# resolves, matching what's already baked into the built HTML.
+# vite.config.ts bakes a relative BASE_PATH into every asset URL in
+# dist/index.html, so the same dist/ resolves correctly at whatever path it's
+# mounted under. This image mounts it at /central/admin/ -- the path
+# EDGE_SESSION's cookie scope (and central-api.ts's default 'prefix' console
+# mode) assumes -- rather than the docroot root.
 #
 # Routing (nginx.conf) is still supplied at runtime, not baked in here --
 # see versola-cli/versola-tools' nginx.conf.template and


### PR DESCRIPTION
Closes #222. Part of #206.

`CONSOLE_PREFIX` (`central-api.ts`) and `BASE_PATH` (`vite.config.ts`) were both compile-time constants that assumed the console is always served at `/central/admin/` behind a proxy rewriting `/central/{x}` back to edge's real `/resources/{resourceId}/...` route (`resourceId="central"` -- it's not a prefix edge itself understands, see `EdgeController.scala`). True for local dev, docker-local, and today's prod; not true for a domain-hosted console (e.g. k8s -- no proxy, no shared origin to scope `EDGE_SESSION`'s cookie path against -- see discussion on #207/#218).

## Changes

- **`central-api.ts`**: `centralResourcePath()` and the `/permissions/me` call now switch on a runtime `consoleMode: 'prefix' | 'direct'`, defaulting to `'prefix'` -- byte-for-byte the same output as the old hardcoded `CONSOLE_PREFIX` for every existing caller. `'direct'` calls edge's real route outright (`resources/central/...`, plain `permissions/me`), no proxy needed. `configureCentralApi()` accepts the new field the same way it already accepts `baseUrl`/`loginUrl`.
- **`users-api.ts`**: `proxyUrl()` reuses the exported `centralResourcePath` instead of duplicating the old `CONSOLE_PREFIX` concatenation.
- **`admin-app.ts`**: new `console-mode` attribute on `<versola-admin>`, mirroring the existing `api-url`/`login-url` attributes, threaded into `configureCentralApi`.
- **`vite.config.ts`**: `BASE_PATH` -> relative (`'./'`) so the same `dist/` mounts correctly whether served at `/central/admin/` or at a docroot root, instead of one absolute path baked in per build.
- **`Dockerfile.gateway`**: comment update only -- still mounts `dist/` at `/central/admin/`, still defaults to `'prefix'` mode, no behavior change.

An auto-detect-from-`window.location.pathname` approach was considered and rejected: local dev already serves the console at `/` (relying on Vite's dev-proxy to do the `/central` rewrite), so pathname alone can't distinguish "root-served with an external proxy" from "root-served, no proxy" (k8s) -- it would have silently flipped local dev's request shape and broken every `tests/mocks.ts`-based Playwright test, which hardcodes the `'prefix'`-mode shortcut path. An explicit attribute avoids that ambiguity and keeps every existing environment's behavior unchanged unless it opts in.

## Validation

- `npm run type-check`, `npm run test:unit` pass.
- Full Playwright suite (`npx playwright test`) passes at the same rate as `main` (3 pre-existing flaky/failing tests, reproduced identically on `main` before this change, unrelated to this diff).
- `npm run build`: confirmed `dist/index.html` now references `./versola-admin.js` / `./logo-shield.svg` (relative).
- Manually verified `'direct'` mode end-to-end by serving `<versola-admin console-mode="direct">` against `tests/mocks.ts`: requests land on `/permissions/me` and `/resources/central/configuration/tenants` with no `/central/*` shortcut anywhere.

## Out of scope (per #222)

Wiring `console-mode="direct"` into an actual k8s console Deployment/index.html is #218's job (or a follow-up) -- this PR only makes the capability available.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M0QXC4STYHJ2A5QDEMG0JCNB&panel=chat)