### PR TITLE
fix: use fragment response mode for error redirects in hybrid/implici…

### DIFF
--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointController.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointController.scala
@@ -67,6 +67,7 @@ object AuthorizeEndpointController extends Controller:
                   request.clientId,
                   redirectUri = request.redirectUri.encode,
                   state = request.state,
+                  useFragment = Some(request.responseType.contains(ResponseTypeEntry.IdToken)),
                 ),
                 authConversationTtl,
                 config.security.conversationCookieSecret,

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointController.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointController.scala
@@ -67,7 +67,7 @@ object AuthorizeEndpointController extends Controller:
                   request.clientId,
                   redirectUri = request.redirectUri.encode,
                   state = request.state,
-                  useFragment = Some(request.responseType.contains(ResponseTypeEntry.IdToken)),
+                  useFragment = Some(request.isHybrid),
                 ),
                 authConversationTtl,
                 config.security.conversationCookieSecret,

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
@@ -76,13 +76,13 @@ object AuthorizeEndpointService:
         registrationFlow = client.flatMap(_.registrationFlow)
         flow <- ZIO
           .fromOption(authFlow)
-          .orElseFail(Error.AuthFlowMissing(request.redirectUri, request.state))
+          .orElseFail(Error.AuthFlowMissing(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
         // Unreachable when authFlow resolved: the flow came off this very record.
         clientRecord <- ZIO
           .fromOption(client)
-          .orElseFail(Error.AuthFlowMissing(request.redirectUri, request.state))
+          .orElseFail(Error.AuthFlowMissing(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
 
-        _ <- ZIO.fail(Error.ConflictingHints(request.redirectUri, request.state))
+        _ <- ZIO.fail(Error.ConflictingHints(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
           .when(request.loginHint.isDefined && request.idTokenHint.isDefined)
 
         idTokenUserId <- extractHintSub(request)
@@ -96,14 +96,14 @@ object AuthorizeEndpointService:
 
         response <- (sessionInfo, idTokenUserId) match
           case (None, _) if request.promptNone =>
-            ZIO.fail(Error.LoginRequired(request.redirectUri, request.state))
+            ZIO.fail(Error.LoginRequired(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
 
           case (None, Some(userId)) =>
             request.acrValues match
               case Some(values) =>
                 acrResolutionService.resolveAchievableAcr(userId, values, request.clientId, flow, Set.empty).flatMap:
                   case None =>
-                    ZIO.fail(Error.UnmetAuthenticationRequirements(request.redirectUri, request.state))
+                    ZIO.fail(Error.UnmetAuthenticationRequirements(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
                   case Some(targetAcr) =>
                     createConversation(
                       authId,
@@ -158,7 +158,7 @@ object AuthorizeEndpointService:
 
               result <-
                 if (forceReauth || !acrSatisfied || !factorsSatisfied) && request.promptNone then
-                  ZIO.fail(Error.LoginRequired(request.redirectUri, request.state))
+                  ZIO.fail(Error.LoginRequired(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
                 else if forceReauth then
                   val targetUserId = if request.promptLogin then idTokenUserId else idTokenUserId.orElse(Some(session.userId))
                   // Re-verifying the existing session identity must deny on a missing user; switching to a
@@ -170,7 +170,7 @@ object AuthorizeEndpointService:
                     case Some(values) if targetUserId.isDefined =>
                       acrResolutionService.resolveAchievableAcr(targetUserId.get, values, request.clientId, flow, Set.empty).flatMap:
                         case None =>
-                          ZIO.fail(Error.UnmetAuthenticationRequirements(request.redirectUri, request.state))
+                          ZIO.fail(Error.UnmetAuthenticationRequirements(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
                         case Some(targetAcr) =>
                           createConversation(
                             authId,
@@ -202,7 +202,7 @@ object AuthorizeEndpointService:
                   // return None → UnmetAuthenticationRequirements instead of AccessDenied.
                   // Check existence first so the right error is returned.
                   userRepository.find(session.userId).flatMap:
-                    case None => ZIO.fail(Error.AccessDenied(request.redirectUri, request.state))
+                    case None => ZIO.fail(Error.AccessDenied(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
                     case Some(_) =>
                       acrResolutionService.resolveAchievableAcr(
                         session.userId,
@@ -212,7 +212,7 @@ object AuthorizeEndpointService:
                         session.amr.keySet,
                       ).flatMap:
                         case None =>
-                          ZIO.fail(Error.UnmetAuthenticationRequirements(request.redirectUri, request.state))
+                          ZIO.fail(Error.UnmetAuthenticationRequirements(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
                         case Some(targetAcr) =>
                           createConversation(
                             authId,
@@ -251,7 +251,7 @@ object AuthorizeEndpointService:
                   // for it, taking precedence over the generic interaction_required.
                   consentService.decide(session.userId, clientRecord, request.scope, request.prompt).flatMap:
                     case ConsentDecision.Required(_) if request.promptNone =>
-                      ZIO.fail(Error.ConsentRequired(request.redirectUri, request.state))
+                      ZIO.fail(Error.ConsentRequired(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
                     case ConsentDecision.Required(_) =>
                       // The conversation's factors are all satisfied, so advancing it lands
                       // directly on the consent step.
@@ -307,7 +307,7 @@ object AuthorizeEndpointService:
         effectiveUserId <- (knownUserId, userOpt) match
           case (Some(_), None) =>
             missingUser match
-              case MissingUserBehavior.Deny => ZIO.fail(Error.AccessDenied(request.redirectUri, request.state))
+              case MissingUserBehavior.Deny => ZIO.fail(Error.AccessDenied(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
               case _ => ZIO.none
           case _ => ZIO.succeed(knownUserId)
         _ <- ZIO.foreachDiscard(effectiveUserId)(uid => Observability.setUserId(uid.toString))
@@ -431,7 +431,7 @@ object AuthorizeEndpointService:
         userOpt <- userRepository.find(session.userId)
         user <- ZIO
           .fromOption(userOpt)
-          .orElseFail(Error.AccessDenied(request.redirectUri, request.state))
+          .orElseFail(Error.AccessDenied(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
         userInfo <- userInfoService.getUserInfoForIdToken(
           user = user,
           scope = grantedScope,
@@ -467,7 +467,7 @@ object AuthorizeEndpointService:
         case Some(token) =>
           jwksService.getPublicKeys.flatMap: keys =>
             JWT.deserialize[HintClaims](token, keys, JWT.Type.JWT, validateExpiry = false)
-              .orElseFail(Error.IdTokenHintInvalid(request.redirectUri, request.state))
+              .orElseFail(Error.IdTokenHintInvalid(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
               .flatMap: claims =>
                 val audList = claims.aud match
                   case None => List.empty
@@ -480,7 +480,7 @@ object AuthorizeEndpointService:
                 if audValid && issValid then
                   ZIO.some(claims.sub)
                 else
-                  ZIO.fail(Error.IdTokenHintInvalid(request.redirectUri, request.state))
+                  ZIO.fail(Error.IdTokenHintInvalid(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
 
     /** Narrows the requested ui_locales to those configured in central, preserving the client's
      * preference order. Rejects the request when none of the requested locales are available.
@@ -495,5 +495,7 @@ object AuthorizeEndpointService:
             ZIO.cond(
               intersection.nonEmpty,
               Some(intersection),
-              Error.UnsupportedUiLocales(request.redirectUri, request.state),
+              Error.UnsupportedUiLocales(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)),
             )
+    private def isHybrid(responseType: NonEmptySet[ResponseTypeEntry]): Boolean =
+      responseType.contains(ResponseTypeEntry.IdToken)

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeEndpointService.scala
@@ -76,13 +76,13 @@ object AuthorizeEndpointService:
         registrationFlow = client.flatMap(_.registrationFlow)
         flow <- ZIO
           .fromOption(authFlow)
-          .orElseFail(Error.AuthFlowMissing(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
+          .orElseFail(Error.AuthFlowMissing(request.redirectUri, request.state, useFragment = request.isHybrid))
         // Unreachable when authFlow resolved: the flow came off this very record.
         clientRecord <- ZIO
           .fromOption(client)
-          .orElseFail(Error.AuthFlowMissing(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
+          .orElseFail(Error.AuthFlowMissing(request.redirectUri, request.state, useFragment = request.isHybrid))
 
-        _ <- ZIO.fail(Error.ConflictingHints(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
+        _ <- ZIO.fail(Error.ConflictingHints(request.redirectUri, request.state, useFragment = request.isHybrid))
           .when(request.loginHint.isDefined && request.idTokenHint.isDefined)
 
         idTokenUserId <- extractHintSub(request)
@@ -96,14 +96,14 @@ object AuthorizeEndpointService:
 
         response <- (sessionInfo, idTokenUserId) match
           case (None, _) if request.promptNone =>
-            ZIO.fail(Error.LoginRequired(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
+            ZIO.fail(Error.LoginRequired(request.redirectUri, request.state, useFragment = request.isHybrid))
 
           case (None, Some(userId)) =>
             request.acrValues match
               case Some(values) =>
                 acrResolutionService.resolveAchievableAcr(userId, values, request.clientId, flow, Set.empty).flatMap:
                   case None =>
-                    ZIO.fail(Error.UnmetAuthenticationRequirements(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
+                    ZIO.fail(Error.UnmetAuthenticationRequirements(request.redirectUri, request.state, useFragment = request.isHybrid))
                   case Some(targetAcr) =>
                     createConversation(
                       authId,
@@ -158,7 +158,7 @@ object AuthorizeEndpointService:
 
               result <-
                 if (forceReauth || !acrSatisfied || !factorsSatisfied) && request.promptNone then
-                  ZIO.fail(Error.LoginRequired(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
+                  ZIO.fail(Error.LoginRequired(request.redirectUri, request.state, useFragment = request.isHybrid))
                 else if forceReauth then
                   val targetUserId = if request.promptLogin then idTokenUserId else idTokenUserId.orElse(Some(session.userId))
                   // Re-verifying the existing session identity must deny on a missing user; switching to a
@@ -170,7 +170,7 @@ object AuthorizeEndpointService:
                     case Some(values) if targetUserId.isDefined =>
                       acrResolutionService.resolveAchievableAcr(targetUserId.get, values, request.clientId, flow, Set.empty).flatMap:
                         case None =>
-                          ZIO.fail(Error.UnmetAuthenticationRequirements(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
+                          ZIO.fail(Error.UnmetAuthenticationRequirements(request.redirectUri, request.state, useFragment = request.isHybrid))
                         case Some(targetAcr) =>
                           createConversation(
                             authId,
@@ -202,7 +202,7 @@ object AuthorizeEndpointService:
                   // return None → UnmetAuthenticationRequirements instead of AccessDenied.
                   // Check existence first so the right error is returned.
                   userRepository.find(session.userId).flatMap:
-                    case None => ZIO.fail(Error.AccessDenied(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
+                    case None => ZIO.fail(Error.AccessDenied(request.redirectUri, request.state, useFragment = request.isHybrid))
                     case Some(_) =>
                       acrResolutionService.resolveAchievableAcr(
                         session.userId,
@@ -212,7 +212,7 @@ object AuthorizeEndpointService:
                         session.amr.keySet,
                       ).flatMap:
                         case None =>
-                          ZIO.fail(Error.UnmetAuthenticationRequirements(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
+                          ZIO.fail(Error.UnmetAuthenticationRequirements(request.redirectUri, request.state, useFragment = request.isHybrid))
                         case Some(targetAcr) =>
                           createConversation(
                             authId,
@@ -251,7 +251,7 @@ object AuthorizeEndpointService:
                   // for it, taking precedence over the generic interaction_required.
                   consentService.decide(session.userId, clientRecord, request.scope, request.prompt).flatMap:
                     case ConsentDecision.Required(_) if request.promptNone =>
-                      ZIO.fail(Error.ConsentRequired(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
+                      ZIO.fail(Error.ConsentRequired(request.redirectUri, request.state, useFragment = request.isHybrid))
                     case ConsentDecision.Required(_) =>
                       // The conversation's factors are all satisfied, so advancing it lands
                       // directly on the consent step.
@@ -307,7 +307,7 @@ object AuthorizeEndpointService:
         effectiveUserId <- (knownUserId, userOpt) match
           case (Some(_), None) =>
             missingUser match
-              case MissingUserBehavior.Deny => ZIO.fail(Error.AccessDenied(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
+              case MissingUserBehavior.Deny => ZIO.fail(Error.AccessDenied(request.redirectUri, request.state, useFragment = request.isHybrid))
               case _ => ZIO.none
           case _ => ZIO.succeed(knownUserId)
         _ <- ZIO.foreachDiscard(effectiveUserId)(uid => Observability.setUserId(uid.toString))
@@ -431,7 +431,7 @@ object AuthorizeEndpointService:
         userOpt <- userRepository.find(session.userId)
         user <- ZIO
           .fromOption(userOpt)
-          .orElseFail(Error.AccessDenied(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
+          .orElseFail(Error.AccessDenied(request.redirectUri, request.state, useFragment = request.isHybrid))
         userInfo <- userInfoService.getUserInfoForIdToken(
           user = user,
           scope = grantedScope,
@@ -467,7 +467,7 @@ object AuthorizeEndpointService:
         case Some(token) =>
           jwksService.getPublicKeys.flatMap: keys =>
             JWT.deserialize[HintClaims](token, keys, JWT.Type.JWT, validateExpiry = false)
-              .orElseFail(Error.IdTokenHintInvalid(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
+              .orElseFail(Error.IdTokenHintInvalid(request.redirectUri, request.state, useFragment = request.isHybrid))
               .flatMap: claims =>
                 val audList = claims.aud match
                   case None => List.empty
@@ -480,7 +480,7 @@ object AuthorizeEndpointService:
                 if audValid && issValid then
                   ZIO.some(claims.sub)
                 else
-                  ZIO.fail(Error.IdTokenHintInvalid(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)))
+                  ZIO.fail(Error.IdTokenHintInvalid(request.redirectUri, request.state, useFragment = request.isHybrid))
 
     /** Narrows the requested ui_locales to those configured in central, preserving the client's
      * preference order. Rejects the request when none of the requested locales are available.
@@ -495,7 +495,5 @@ object AuthorizeEndpointService:
             ZIO.cond(
               intersection.nonEmpty,
               Some(intersection),
-              Error.UnsupportedUiLocales(request.redirectUri, request.state, useFragment = isHybrid(request.responseType)),
+              Error.UnsupportedUiLocales(request.redirectUri, request.state, useFragment = request.isHybrid),
             )
-    private def isHybrid(responseType: NonEmptySet[ResponseTypeEntry]): Boolean =
-      responseType.contains(ResponseTypeEntry.IdToken)

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeRedirect.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeRedirect.scala
@@ -1,10 +1,8 @@
 package versola.oauth.authorize
 
 import versola.oauth.model.State
+import versola.util.encodeQueryParam
 import zio.http.URL
-
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 
 object AuthorizeRedirect:
   /** Builds the authorization response redirect URI.
@@ -23,8 +21,5 @@ object AuthorizeRedirect:
       case None =>
         redirectUri.addQueryParams(params)
       case Some(_) =>
-        val raw = params.map((k, v) => s"$k=${enc(v)}").mkString("&")
+        val raw = params.map((k, v) => s"$k=${encodeQueryParam(v)}").mkString("&")
         URL.decode(s"${redirectUri.encode}#$raw").getOrElse(redirectUri)
-
-  private def enc(value: String): String =
-    URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20")

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
@@ -139,8 +139,6 @@ object AuthorizeRequestParser:
           )
           .filterOrFail(_.forall(_.length <= MaxStateLength))(Error.StateInvalid(redirectUri, useFragment = useFragment))
 
-        val useFragment = responseTypeEntries.contains(ResponseTypeEntry.IdToken)
-
         codeChallenge <- getParam(params, "code_challenge")
           .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "code_challenge", useFragment = useFragment))
           .someOrFail(Error.CodeChallengeMissing(redirectUri, state, useFragment = useFragment))

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
@@ -139,6 +139,8 @@ object AuthorizeRequestParser:
           )
           .filterOrFail(_.forall(_.length <= MaxStateLength))(Error.StateInvalid(redirectUri, useFragment = useFragment))
 
+        val useFragment = responseTypeEntries.contains(ResponseTypeEntry.IdToken)
+
         codeChallenge <- getParam(params, "code_challenge")
           .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "code_challenge", useFragment = useFragment))
           .someOrFail(Error.CodeChallengeMissing(redirectUri, state, useFragment = useFragment))
@@ -239,9 +241,9 @@ object AuthorizeRequestParser:
         idTokenHint <- getParam(params, "id_token_hint")
           .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "id_token_hint", useFragment = useFragment))
 
-        resources <- resolveResources(params, client, redirectUri, state)
+        resources <- resolveResources(params, client, redirectUri, state, useFragment)
 
-        authorizationDetails <- resolveAuthorizationDetails(params, client, redirectUri, state)
+        authorizationDetails <- resolveAuthorizationDetails(params, client, redirectUri, state, useFragment)
 
         authorizeRequest = AuthorizeRequest(
           clientId = clientId,
@@ -278,6 +280,7 @@ object AuthorizeRequestParser:
         client: OAuthClientRecord,
         redirectUri: URL,
         state: Option[State],
+        useFragment: Boolean,
     ): IO[Error, Option[List[AuthorizationDetail]]] =
       getParam(params, AuthorizationDetail.Parameter)
         .orElseFail(Error.MultipleValuesProvided(redirectUri, state, AuthorizationDetail.Parameter, useFragment = useFragment))
@@ -306,6 +309,7 @@ object AuthorizeRequestParser:
         client: OAuthClientRecord,
         redirectUri: URL,
         state: Option[State],
+        useFragment: Boolean,
     ): IO[Error, List[ResourceUri]] =
       params.getOrElse("resource", Chunk.empty).toList match
         case Nil =>

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
@@ -111,42 +111,52 @@ object AuthorizeRequestParser:
         ip = request.headers.get(ipHeader).map(_.split(',').head.trim).filter(_.nonEmpty)
         _ <- ZIO.foreachDiscard(ip)(Observability.setIp)
 
-        state <- getParam(params, "state")
-          .mapBoth(
-            _ => Error.MultipleValuesProvided(redirectUri, None, "state"),
-            _.map(State(_)),
-          )
-          .filterOrFail(_.forall(_.length <= MaxStateLength))(Error.StateInvalid(redirectUri))
+        stateForErrors = params.get("state")
+          .flatMap(chunk => if chunk.size == 1 then chunk.headOption else None)
+          .filter(_.length <= MaxStateLength)
+          .map(State(_))
+
+        useFragmentForErrors = params.get("response_type")
+          .exists(_.exists(_.split(" ").contains("id_token")))
 
         responseTypeEntries <- getParam(params, "response_type")
-          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "response_type"))
-          .someOrFail(Error.ResponseTypeMissing(redirectUri, state))
+          .orElseFail(Error.MultipleValuesProvided(redirectUri, stateForErrors, "response_type", useFragment = useFragmentForErrors))
+          .someOrFail(Error.ResponseTypeMissing(redirectUri, stateForErrors, useFragment = useFragmentForErrors))
           .flatMap:
             case "code" =>
               ZIO.succeed(NonEmptySet(ResponseTypeEntry.Code))
             case "code id_token" =>
               ZIO.succeed(NonEmptySet(ResponseTypeEntry.Code, ResponseTypeEntry.IdToken))
             case other =>
-              ZIO.fail(Error.UnsupportedResponseType(redirectUri, state, other))
+              ZIO.fail(Error.UnsupportedResponseType(redirectUri, stateForErrors, other, useFragment = other.split(" ").contains("id_token")))
+
+        useFragment = responseTypeEntries.contains(ResponseTypeEntry.IdToken)
+
+        state <- getParam(params, "state")
+          .mapBoth(
+            _ => Error.MultipleValuesProvided(redirectUri, None, "state", useFragment = useFragment),
+            _.map(State(_)),
+          )
+          .filterOrFail(_.forall(_.length <= MaxStateLength))(Error.StateInvalid(redirectUri, useFragment = useFragment))
 
         codeChallenge <- getParam(params, "code_challenge")
-          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "code_challenge"))
-          .someOrFail(Error.CodeChallengeMissing(redirectUri, state))
+          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "code_challenge", useFragment = useFragment))
+          .someOrFail(Error.CodeChallengeMissing(redirectUri, state, useFragment = useFragment))
           .flatMap { string =>
             ZIO.fromEither(CodeChallenge.from(string))
-              .orElseFail(Error.CodeChallengeInvalid(redirectUri, state, string))
+              .orElseFail(Error.CodeChallengeInvalid(redirectUri, state, string, useFragment = useFragment))
           }
 
         codeChallengeMethod <- getParam(params, "code_challenge_method")
-          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "code_challenge_method"))
-          .someOrFail(Error.CodeChallengeMethodMissing(redirectUri, state))
+          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "code_challenge_method", useFragment = useFragment))
+          .someOrFail(Error.CodeChallengeMethodMissing(redirectUri, state, useFragment = useFragment))
           .flatMap {
             case "S256" => ZIO.succeed(CodeChallengeMethod.S256)
-            case other => ZIO.fail(Error.CodeChallengeMethodInvalid(redirectUri, state, other))
+            case other => ZIO.fail(Error.CodeChallengeMethodInvalid(redirectUri, state, other, useFragment = useFragment))
           }
 
         scope <- getParam(params, "scope")
-          .orElseFail[Error](Error.MultipleValuesProvided(redirectUri, state, "scope"))
+          .orElseFail[Error](Error.MultipleValuesProvided(redirectUri, state, "scope", useFragment = useFragment))
           .flatMap:
             case None => ZIO.succeed(client.scope)
             case Some(value) =>
@@ -158,30 +168,30 @@ object AuthorizeRequestParser:
               ZIO.cond(
                 unregistered.isEmpty,
                 requested,
-                Error.ScopeNotGranted(redirectUri, state, unregistered.mkString(" ")),
+                Error.ScopeNotGranted(redirectUri, state, unregistered.mkString(" "), useFragment = useFragment),
               )
 
         uiLocales <- getParam(params, "ui_locales")
-          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "ui_locales"))
+          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "ui_locales", useFragment = useFragment))
           .map(_.map(_.split(' ').toList))
 
         requestedClaims <- getParam(params, "claims")
-          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "claims"))
+          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "claims", useFragment = useFragment))
           .flatMap {
             case Some(claimsJson) =>
               ZIO.fromEither(claimsJson.fromJson[RequestedClaims])
-                .orElseFail(Error.InvalidClaims(redirectUri, state))
+                .orElseFail(Error.InvalidClaims(redirectUri, state, useFragment = useFragment))
                 .map(Some(_))
             case None =>
               ZIO.none
           }
 
         nonce <- getParam(params, "nonce")
-          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "nonce"))
+          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "nonce", useFragment = useFragment))
           .map(_.map(Nonce(_)))
 
         prompt <- getParam(params, "prompt")
-          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "prompt"))
+          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "prompt", useFragment = useFragment))
           .flatMap {
             case None => ZIO.succeed(Set.empty[Prompt])
             case Some(raw) =>
@@ -189,21 +199,21 @@ object AuthorizeRequestParser:
               ZIO.cond(
                 !(prompts.contains(Prompt.none) && prompts.size > 1),
                 prompts,
-                Error.PromptInvalid(redirectUri, state),
+                Error.PromptInvalid(redirectUri, state, useFragment = useFragment),
               )
           }
 
         maxAge <- getParam(params, "max_age")
-          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "max_age"))
+          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "max_age", useFragment = useFragment))
           .map(_.flatMap(_.toLongOption))
 
         acrValues <- getParam(params, "acr_values")
-          .orElseFail[Error](Error.MultipleValuesProvided(redirectUri, state, "acr_values"))
+          .orElseFail[Error](Error.MultipleValuesProvided(redirectUri, state, "acr_values", useFragment = useFragment))
           .flatMap:
             case None => ZIO.none
             case Some(values) =>
               ZIO.fromOption(NonEmptyList.fromIterableOption(values.split(' ').map(Acr(_)).toList))
-                .orElseFail(Error.NoValuesProvided(redirectUri, state, "acr_values"))
+                .orElseFail(Error.NoValuesProvided(redirectUri, state, "acr_values", useFragment = useFragment))
                 .asSome
 
         userAgent =
@@ -219,15 +229,15 @@ object AuthorizeRequestParser:
             .flatMap(c => UserAgentCookie.parse(c.content, config.security.userAgentCookieSecret).toOption)
 
         loginHint <- getParam(params, "login_hint")
-          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "login_hint"))
+          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "login_hint", useFragment = useFragment))
           .flatMap {
             case None => ZIO.none
-            case Some(value) if value.startsWith("+") && value.drop(1).forall(_.isDigit) => parsePhoneLoginHint(value, client, redirectUri, state)
-            case Some(value) => parseEmailLoginHint(value, client, redirectUri, state)
+            case Some(value) if value.startsWith("+") && value.drop(1).forall(_.isDigit) => parsePhoneLoginHint(value, client, redirectUri, state, useFragment)
+            case Some(value) => parseEmailLoginHint(value, client, redirectUri, state, useFragment)
           }
 
         idTokenHint <- getParam(params, "id_token_hint")
-          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "id_token_hint"))
+          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "id_token_hint", useFragment = useFragment))
 
         resources <- resolveResources(params, client, redirectUri, state)
 
@@ -270,16 +280,16 @@ object AuthorizeRequestParser:
         state: Option[State],
     ): IO[Error, Option[List[AuthorizationDetail]]] =
       getParam(params, AuthorizationDetail.Parameter)
-        .orElseFail(Error.MultipleValuesProvided(redirectUri, state, AuthorizationDetail.Parameter))
+        .orElseFail(Error.MultipleValuesProvided(redirectUri, state, AuthorizationDetail.Parameter, useFragment = useFragment))
         .flatMap:
           case None => ZIO.none
           case Some(raw) =>
             ZIO.fromEither(AuthorizationDetail.parseAll(raw))
-              .mapError(reason => Error.InvalidAuthorizationDetails(redirectUri, state, reason))
+              .mapError(reason => Error.InvalidAuthorizationDetails(redirectUri, state, reason, useFragment = useFragment))
               .flatMap: details =>
                 AuthorizationDetailResolver.resolve(oauthClientService, schemaValidator, client, details)
                   .mapError(rejected =>
-                    Error.InvalidAuthorizationDetails(redirectUri, state, s"${rejected.`type`} - ${rejected.reason}"),
+                    Error.InvalidAuthorizationDetails(redirectUri, state, s"${rejected.`type`} - ${rejected.reason}", useFragment = useFragment),
                   )
                   .asSome
 
@@ -300,14 +310,14 @@ object AuthorizeRequestParser:
       params.getOrElse("resource", Chunk.empty).toList match
         case Nil =>
           ResourceResolver.resolve(oauthClientService, client, None)
-            .mapError(resource => Error.InvalidTarget(redirectUri, state, resource.toString))
+            .mapError(resource => Error.InvalidTarget(redirectUri, state, resource.toString, useFragment = useFragment))
         case values =>
           ZIO.foreach(values)(value =>
             ZIO.fromEither(ResourceUri.parse(value))
-              .orElseFail(Error.InvalidTarget(redirectUri, state, value)),
+              .orElseFail(Error.InvalidTarget(redirectUri, state, value, useFragment = useFragment)),
           ).flatMap(resources =>
             ResourceResolver.resolve(oauthClientService, client, Some(resources))
-              .mapError(resource => Error.InvalidTarget(redirectUri, state, resource.toString)),
+              .mapError(resource => Error.InvalidTarget(redirectUri, state, resource.toString, useFragment = useFragment)),
           )
 
     private def parseEmailLoginHint(
@@ -315,27 +325,29 @@ object AuthorizeRequestParser:
         client: OAuthClientRecord,
         redirectUri: URL,
         state: Option[State],
+        useFragment: Boolean,
     ): IO[Error.LoginHintInvalid, Option[Either[Email, Phone]]] =
       val allowed = client.authFlow.exists(_.primary.credentials.contains(PrimaryCredential.email))
-      if !allowed then ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
+      if !allowed then ZIO.fail(Error.LoginHintInvalid(redirectUri, state, useFragment = useFragment))
       else
         ZIO.fromEither(Email.from(value))
-          .mapBoth(_ => Error.LoginHintInvalid(redirectUri, state), e => Some(Left(e)))
+          .mapBoth(_ => Error.LoginHintInvalid(redirectUri, state, useFragment = useFragment), e => Some(Left(e)))
 
     private def parsePhoneLoginHint(
         value: String,
         client: OAuthClientRecord,
         redirectUri: URL,
         state: Option[State],
+        useFragment: Boolean,
     ): IO[Error.LoginHintInvalid, Option[Either[Email, Phone]]] =
       val allowed = client.authFlow.exists(_.primary.credentials.contains(PrimaryCredential.phone))
-      if !allowed then ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
+      if !allowed then ZIO.fail(Error.LoginHintInvalid(redirectUri, state, useFragment = useFragment))
       else if value.drop(1).forall(_.isDigit) then
         oauthClientService.getAllowedPhonePrefixes(client.id).flatMap: prefixes =>
           if prefixes.isEmpty || prefixes.exists(value.startsWith) then
-            ZIO.fromEither(Phone.parse(value)).mapBoth(_ => Error.LoginHintInvalid(redirectUri, state), p => Some(Right(p)))
-          else ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
-      else ZIO.fail(Error.LoginHintInvalid(redirectUri, state))
+            ZIO.fromEither(Phone.parse(value)).mapBoth(_ => Error.LoginHintInvalid(redirectUri, state, useFragment = useFragment), p => Some(Right(p)))
+          else ZIO.fail(Error.LoginHintInvalid(redirectUri, state, useFragment = useFragment))
+      else ZIO.fail(Error.LoginHintInvalid(redirectUri, state, useFragment = useFragment))
 
     private def parseRedirectUri(params: Map[String, Chunk[String]]): IO[Error, (URL, String)] =
       getParam(params, "redirect_uri")

--- a/auth/src/main/scala/versola/oauth/authorize/model/AuthorizeRequest.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/model/AuthorizeRequest.scala
@@ -36,6 +36,7 @@ private[authorize] case class AuthorizeRequest(
     authorizationDetails: Option[List[AuthorizationDetail]],
     ip: Option[String] = None,
 ):
-  def promptNone: Boolean = prompt.contains(Prompt.none)
-  def promptLogin: Boolean = prompt.contains(Prompt.login)
+  def promptNone: Boolean    = prompt.contains(Prompt.none)
+  def promptLogin: Boolean   = prompt.contains(Prompt.login)
   def promptConsent: Boolean = prompt.contains(Prompt.consent)
+  def isHybrid: Boolean      = responseType.contains(ResponseTypeEntry.IdToken)

--- a/auth/src/main/scala/versola/oauth/authorize/model/Error.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/model/Error.scala
@@ -1,6 +1,7 @@
 package versola.oauth.authorize.model
 
 import versola.oauth.model.State
+import versola.util.encodeQueryParam
 import zio.http.URL
 
 private[authorize] sealed trait Error extends Exception
@@ -28,13 +29,11 @@ private[authorize] object Error:
         ++ state.map("state" -> _)
 
       if useFragment then
-        val raw = params.map((k, v) => s"$k=${enc(v)}").mkString("&")
+        val raw = params.map((k, v) => s"$k=${encodeQueryParam(v)}").mkString("&")
         URL.decode(s"${uri.encode}#$raw").getOrElse(uri)
       else
         uri.addQueryParams(params)
 
-    private def enc(value: String): String =
-      java.net.URLEncoder.encode(value, java.nio.charset.StandardCharsets.UTF_8).replace("+", "%20")
 
   case class MultipleValuesProvided(uri: URL, state: Option[State], queryParamName: String, useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.InvalidRequest,

--- a/auth/src/main/scala/versola/oauth/authorize/model/Error.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/model/Error.scala
@@ -35,13 +35,13 @@ private[authorize] object Error:
         uri.addQueryParams(params)
 
 
-  case class MultipleValuesProvided(uri: URL, state: Option[State], queryParamName: String, useFragment: Boolean = false) extends RedirectError(
+  case class MultipleValuesProvided(uri: URL, state: Option[State], queryParamName: String, useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = s"Parameter is included more than once - $queryParamName",
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1"),
     )
 
-  case class NoValuesProvided(uri: URL, state: Option[State], queryParamName: String, useFragment: Boolean = false) extends RedirectError(
+  case class NoValuesProvided(uri: URL, state: Option[State], queryParamName: String, useFragment: Boolean) extends RedirectError(
     error = ErrorCode.InvalidRequest,
     errorDescription = s"At least one value should be provided - $queryParamName",
     errorUri = Some("https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1"),
@@ -51,44 +51,44 @@ private[authorize] object Error:
     * is too long, and echoing it would grow the redirect URI further (and could push a
     * later ConversationCookie past the ~4 KiB per-cookie limit).
     */
-  case class StateInvalid(uri: URL, useFragment: Boolean = false) extends RedirectError(
+  case class StateInvalid(uri: URL, useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "The state parameter exceeds the maximum allowed length of 128 characters",
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1"),
     ):
     val state: Option[State] = None
 
-  case class ResponseTypeMissing(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
+  case class ResponseTypeMissing(uri: URL, state: Option[State], useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "Missing required parameter - response_type",
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1"),
     )
 
-  case class CodeChallengeMissing(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
+  case class CodeChallengeMissing(uri: URL, state: Option[State], useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "Missing required parameter - code_challenge",
       errorUri = Some("https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1#name-authorization-request"),
     )
 
-  case class CodeChallengeMethodMissing(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
+  case class CodeChallengeMethodMissing(uri: URL, state: Option[State], useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "Missing required parameter - code_challenge_method",
       errorUri = Some("https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1#name-authorization-request"),
     )
 
-  case class CodeChallengeInvalid(uri: URL, state: Option[State], value: String, useFragment: Boolean = false) extends RedirectError(
+  case class CodeChallengeInvalid(uri: URL, state: Option[State], value: String, useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = s"Invalid code challenge alphabet or size - $value",
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc7636#section-4.3"),
     )
 
-  case class CodeChallengeMethodInvalid(uri: URL, state: Option[State], value: String, useFragment: Boolean = false) extends RedirectError(
+  case class CodeChallengeMethodInvalid(uri: URL, state: Option[State], value: String, useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = s"Code challenge method is not supported - $value",
       errorUri = Some("https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1#name-authorization-request"),
     )
 
-  case class UnsupportedResponseType(uri: URL, state: Option[State], responseType: String, useFragment: Boolean = false) extends RedirectError(
+  case class UnsupportedResponseType(uri: URL, state: Option[State], responseType: String, useFragment: Boolean) extends RedirectError(
       error = ErrorCode.UnsupportedResponseType,
       errorDescription = s"Unsupported response type - $responseType",
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1"),
@@ -110,84 +110,85 @@ private[authorize] object Error:
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc6749#section-3.3"),
     )
 
+
   case class InvalidClaims(uri: URL, state: Option[State], useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "Invalid claims parameter - must be valid JSON",
       errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter"),
     )
 
-  case class UnsupportedUiLocales(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
+  case class UnsupportedUiLocales(uri: URL, state: Option[State], useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "None of the requested ui_locales are supported",
       errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest"),
     )
 
-  case class AuthFlowMissing(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
+  case class AuthFlowMissing(uri: URL, state: Option[State], useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "Client is not configured for sign-in - missing auth flow",
       errorUri = None,
     )
 
-  case class LoginRequired(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
+  case class LoginRequired(uri: URL, state: Option[State], useFragment: Boolean) extends RedirectError(
       error = ErrorCode.LoginRequired,
       errorDescription = "Authentication is required but prompt=none was requested",
       errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest"),
     )
 
-  case class ConsentRequired(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
+  case class ConsentRequired(uri: URL, state: Option[State], useFragment: Boolean) extends RedirectError(
       error = ErrorCode.ConsentRequired,
       errorDescription = "Consent is required but prompt=none was requested",
       errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest"),
     )
 
-  case class InteractionRequired(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
+  case class InteractionRequired(uri: URL, state: Option[State], useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InteractionRequired,
       errorDescription = "End-user interaction is required but prompt=none was requested",
       errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest"),
     )
 
-  case class AccessDenied(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
+  case class AccessDenied(uri: URL, state: Option[State], useFragment: Boolean) extends RedirectError(
       error = ErrorCode.AccessDenied,
       errorDescription = "The resource owner could not be resolved for the existing session",
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1"),
     )
 
-  case class UnmetAuthenticationRequirements(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
+  case class UnmetAuthenticationRequirements(uri: URL, state: Option[State], useFragment: Boolean) extends RedirectError(
       error = ErrorCode.UnmetAuthenticationRequirements,
       errorDescription = "The requested Authentication Context Class cannot be satisfied",
       errorUri = Some("https://openid.net/specs/openid-connect-unmet-authentication-requirements-1_0.html"),
     )
 
-  case class PromptInvalid(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
+  case class PromptInvalid(uri: URL, state: Option[State], useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "Invalid prompt parameter - none must not be combined with other values",
       errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest"),
     )
-  case class IdTokenHintInvalid(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
+  case class IdTokenHintInvalid(uri: URL, state: Option[State], useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "The id_token_hint could not be verified or is invalid (invalid signature, audience, or issuer)",
       errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest"),
     )
 
-  case class ConflictingHints(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
+  case class ConflictingHints(uri: URL, state: Option[State], useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "login_hint and id_token_hint must not be used together",
       errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest"),
     )
 
-  case class LoginHintInvalid(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
+  case class LoginHintInvalid(uri: URL, state: Option[State], useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "The login_hint parameter is invalid or not supported by the client auth flow",
       errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest"),
     )
 
-  case class InvalidTarget(uri: URL, state: Option[State], value: String, useFragment: Boolean = false) extends RedirectError(
+  case class InvalidTarget(uri: URL, state: Option[State], value: String, useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidTarget,
       errorDescription = s"The requested resource is invalid, malformed, or unknown - $value",
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc8707#section-2"),
     )
 
-  case class InvalidAuthorizationDetails(uri: URL, state: Option[State], value: String, useFragment: Boolean = false) extends RedirectError(
+  case class InvalidAuthorizationDetails(uri: URL, state: Option[State], value: String, useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidAuthorizationDetails,
       errorDescription = s"The authorization_details parameter is invalid, malformed, or unknown - $value",
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc9396#section-5"),

--- a/auth/src/main/scala/versola/oauth/authorize/model/Error.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/model/Error.scala
@@ -16,25 +16,33 @@ private[authorize] object Error:
   ) extends Error:
     def uri: URL
     def state: Option[State]
+    def useFragment: Boolean
 
     def redirectUriWithErrorParams(iss: String): URL =
-      uri.addQueryParams(
-        Iterable(
-          "error" -> error,
-          "error_description" -> errorDescription,
-          "iss" -> iss,
-        )
-          ++ errorUri.map("error_uri" -> _)
-          ++ state.map("state" -> _),
+      val params = Iterable(
+        "error" -> error.toString,
+        "error_description" -> errorDescription,
+        "iss" -> iss,
       )
+        ++ errorUri.map("error_uri" -> _)
+        ++ state.map("state" -> _)
 
-  case class MultipleValuesProvided(uri: URL, state: Option[State], queryParamName: String) extends RedirectError(
+      if useFragment then
+        val raw = params.map((k, v) => s"$k=${enc(v)}").mkString("&")
+        URL.decode(s"${uri.encode}#$raw").getOrElse(uri)
+      else
+        uri.addQueryParams(params)
+
+    private def enc(value: String): String =
+      java.net.URLEncoder.encode(value, java.nio.charset.StandardCharsets.UTF_8).replace("+", "%20")
+
+  case class MultipleValuesProvided(uri: URL, state: Option[State], queryParamName: String, useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = s"Parameter is included more than once - $queryParamName",
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1"),
     )
 
-  case class NoValuesProvided(uri: URL, state: Option[State], queryParamName: String) extends RedirectError(
+  case class NoValuesProvided(uri: URL, state: Option[State], queryParamName: String, useFragment: Boolean = false) extends RedirectError(
     error = ErrorCode.InvalidRequest,
     errorDescription = s"At least one value should be provided - $queryParamName",
     errorUri = Some("https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1"),
@@ -44,50 +52,50 @@ private[authorize] object Error:
     * is too long, and echoing it would grow the redirect URI further (and could push a
     * later ConversationCookie past the ~4 KiB per-cookie limit).
     */
-  case class StateInvalid(uri: URL) extends RedirectError(
+  case class StateInvalid(uri: URL, useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "The state parameter exceeds the maximum allowed length of 128 characters",
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1"),
     ):
     val state: Option[State] = None
 
-  case class ResponseTypeMissing(uri: URL, state: Option[State]) extends RedirectError(
+  case class ResponseTypeMissing(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "Missing required parameter - response_type",
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1"),
     )
 
-  case class CodeChallengeMissing(uri: URL, state: Option[State]) extends RedirectError(
+  case class CodeChallengeMissing(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "Missing required parameter - code_challenge",
       errorUri = Some("https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1#name-authorization-request"),
     )
 
-  case class CodeChallengeMethodMissing(uri: URL, state: Option[State]) extends RedirectError(
+  case class CodeChallengeMethodMissing(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "Missing required parameter - code_challenge_method",
       errorUri = Some("https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1#name-authorization-request"),
     )
 
-  case class CodeChallengeInvalid(uri: URL, state: Option[State], value: String) extends RedirectError(
+  case class CodeChallengeInvalid(uri: URL, state: Option[State], value: String, useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = s"Invalid code challenge alphabet or size - $value",
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc7636#section-4.3"),
     )
 
-  case class CodeChallengeMethodInvalid(uri: URL, state: Option[State], value: String) extends RedirectError(
+  case class CodeChallengeMethodInvalid(uri: URL, state: Option[State], value: String, useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = s"Code challenge method is not supported - $value",
       errorUri = Some("https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1#name-authorization-request"),
     )
 
-  case class UnsupportedResponseType(uri: URL, state: Option[State], responseType: String) extends RedirectError(
+  case class UnsupportedResponseType(uri: URL, state: Option[State], responseType: String, useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.UnsupportedResponseType,
       errorDescription = s"Unsupported response type - $responseType",
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1"),
     )
 
-  case class ScopeMissing(uri: URL, state: Option[State]) extends RedirectError(
+  case class ScopeMissing(uri: URL, state: Option[State], useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidScope,
       errorDescription = "Missing required parameter - scope",
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1"),
@@ -97,90 +105,90 @@ private[authorize] object Error:
     * set: the unregistered ones are the reason the request failed, and echoing the rest would
     * grow the redirect URI for no benefit.
     */
-  case class ScopeNotGranted(uri: URL, state: Option[State], value: String) extends RedirectError(
+  case class ScopeNotGranted(uri: URL, state: Option[State], value: String, useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidScope,
       errorDescription = s"The requested scope is not registered for this client - $value",
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc6749#section-3.3"),
     )
 
-  case class InvalidClaims(uri: URL, state: Option[State]) extends RedirectError(
+  case class InvalidClaims(uri: URL, state: Option[State], useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "Invalid claims parameter - must be valid JSON",
       errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter"),
     )
 
-  case class UnsupportedUiLocales(uri: URL, state: Option[State]) extends RedirectError(
+  case class UnsupportedUiLocales(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "None of the requested ui_locales are supported",
       errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest"),
     )
 
-  case class AuthFlowMissing(uri: URL, state: Option[State]) extends RedirectError(
+  case class AuthFlowMissing(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "Client is not configured for sign-in - missing auth flow",
       errorUri = None,
     )
 
-  case class LoginRequired(uri: URL, state: Option[State]) extends RedirectError(
+  case class LoginRequired(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.LoginRequired,
       errorDescription = "Authentication is required but prompt=none was requested",
       errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest"),
     )
 
-  case class ConsentRequired(uri: URL, state: Option[State]) extends RedirectError(
+  case class ConsentRequired(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.ConsentRequired,
       errorDescription = "Consent is required but prompt=none was requested",
       errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest"),
     )
 
-  case class InteractionRequired(uri: URL, state: Option[State]) extends RedirectError(
+  case class InteractionRequired(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.InteractionRequired,
       errorDescription = "End-user interaction is required but prompt=none was requested",
       errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest"),
     )
 
-  case class AccessDenied(uri: URL, state: Option[State]) extends RedirectError(
+  case class AccessDenied(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.AccessDenied,
       errorDescription = "The resource owner could not be resolved for the existing session",
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1"),
     )
 
-  case class UnmetAuthenticationRequirements(uri: URL, state: Option[State]) extends RedirectError(
+  case class UnmetAuthenticationRequirements(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.UnmetAuthenticationRequirements,
       errorDescription = "The requested Authentication Context Class cannot be satisfied",
       errorUri = Some("https://openid.net/specs/openid-connect-unmet-authentication-requirements-1_0.html"),
     )
 
-  case class PromptInvalid(uri: URL, state: Option[State]) extends RedirectError(
+  case class PromptInvalid(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "Invalid prompt parameter - none must not be combined with other values",
       errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest"),
     )
-  case class IdTokenHintInvalid(uri: URL, state: Option[State]) extends RedirectError(
+  case class IdTokenHintInvalid(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "The id_token_hint could not be verified or is invalid (invalid signature, audience, or issuer)",
       errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest"),
     )
 
-  case class ConflictingHints(uri: URL, state: Option[State]) extends RedirectError(
+  case class ConflictingHints(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "login_hint and id_token_hint must not be used together",
       errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest"),
     )
 
-  case class LoginHintInvalid(uri: URL, state: Option[State]) extends RedirectError(
+  case class LoginHintInvalid(uri: URL, state: Option[State], useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "The login_hint parameter is invalid or not supported by the client auth flow",
       errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest"),
     )
 
-  case class InvalidTarget(uri: URL, state: Option[State], value: String) extends RedirectError(
+  case class InvalidTarget(uri: URL, state: Option[State], value: String, useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.InvalidTarget,
       errorDescription = s"The requested resource is invalid, malformed, or unknown - $value",
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc8707#section-2"),
     )
 
-  case class InvalidAuthorizationDetails(uri: URL, state: Option[State], value: String) extends RedirectError(
+  case class InvalidAuthorizationDetails(uri: URL, state: Option[State], value: String, useFragment: Boolean = false) extends RedirectError(
       error = ErrorCode.InvalidAuthorizationDetails,
       errorDescription = s"The authorization_details parameter is invalid, malformed, or unknown - $value",
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc9396#section-5"),

--- a/auth/src/main/scala/versola/oauth/conversation/ConversationController.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationController.scala
@@ -44,7 +44,7 @@ object ConversationController extends Controller:
           _ <- Observability.setAuth(cookie.authId.toString, cookie.clientId)
           record <- router.getConversation(cookie.authId)
           response <- record match
-            case None => formService.renderExpired(cookie.clientId, cookie.redirectUri, cookie.state)
+            case None => formService.renderExpired(cookie.clientId, cookie.redirectUri, cookie.state, cookie.useFragment.getOrElse(false))
             case Some(record) =>
               val ifNoneMatch = request.headers.get(Header.IfNoneMatch)
               formService.renderStep(record, ifNoneMatch.map(_.renderedValue))
@@ -195,14 +195,14 @@ object ConversationController extends Controller:
     for
       formService <- ZIO.service[ConversationRenderService]
       cookie <- extractCookie(request)
-      response <- formService.renderExpired(cookie.clientId, cookie.redirectUri, cookie.state)
+      response <- formService.renderExpired(cookie.clientId, cookie.redirectUri, cookie.state, cookie.useFragment.getOrElse(false))
     yield response
 
   private def serviceUnavailableResponse(request: Request): ZIO[ConversationRenderService & CoreConfig, Throwable, Response] =
     for
       formService <- ZIO.service[ConversationRenderService]
       cookie <- extractCookie(request)
-      response <- formService.renderServiceUnavailable(cookie.clientId, cookie.redirectUri, cookie.state)
+      response <- formService.renderServiceUnavailable(cookie.clientId, cookie.redirectUri, cookie.state, cookie.useFragment.getOrElse(false))
     yield response
 
   /** Extracts the client IP from the header configured in submission limits. Returns None when no

--- a/auth/src/main/scala/versola/oauth/conversation/ConversationRenderService.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationRenderService.scala
@@ -11,7 +11,7 @@ import versola.oauth.model.State
 import versola.oauth.model.{ConversationCookie, SessionCookie, UserAgentCookie}
 import versola.oauth.session.model.SessionInfo
 import versola.util.http.Observability
-import versola.util.{Base64, Base64Url, CoreConfig, Email, JWT, Phone, escapeCssForStyle, escapeHtml}
+import versola.util.{Base64, Base64Url, CoreConfig, Email, JWT, Phone, encodeQueryParam, escapeCssForStyle, escapeHtml}
 import zio.http.{Body, Header, Headers, MediaType, Path, Response, Status, URL}
 import zio.json.*
 import zio.json.ast.Json
@@ -238,13 +238,11 @@ object ConversationRenderService:
       URL.decode(redirectUri).toOption.map: url =>
         val params = List("error" -> error, "iss" -> config.jwt.issuer) ++ state.map("state" -> _)
         if useFragment then
-          val raw = params.map((k, v) => s"$k=${enc(v)}").mkString("&")
+          val raw = params.map((k, v) => s"$k=${encodeQueryParam(v)}").mkString("&")
           URL.decode(s"${url.encode}#$raw").getOrElse(url).encode
         else
           url.addQueryParams(params).encode
 
-    private def enc(value: String): String =
-      java.net.URLEncoder.encode(value, java.nio.charset.StandardCharsets.UTF_8).replace("+", "%20")
 
     private def renderTerminal(clientId: ClientId, formId: String, step: StepView): Task[Response] =
       for
@@ -638,24 +636,12 @@ object ConversationRenderService:
             tosUri = client.flatMap(_.tosUri),
             scopes = rows,
             allowPartial = s.allowPartial,
-            denyUri = {
-              val params = List("error" -> "access_denied", "iss" -> config.jwt.issuer) ++ state.map("state" -> _)
-              if useFragment then
-                val raw = params.map((k, v) => s"$k=${enc(v)}").mkString("&")
-                URL.decode(s"${redirectUri.encode}#$raw").getOrElse(redirectUri).encode
-              else
-                redirectUri.addQueryParams(params).encode
-            },
+            denyUri = returnUri(redirectUri.encode, state, "access_denied", useFragment).getOrElse(redirectUri.encode),
           )
 
         case ConversationStep.AccessDenied =>
-          val params = List("error" -> "access_denied", "iss" -> config.jwt.issuer) ++ state.map("state" -> _)
           ZIO.succeed(StepView.AccessDenied(redirectUri =
-            if useFragment then
-              val raw = params.map((k, v) => s"$k=${enc(v)}").mkString("&")
-              URL.decode(s"${redirectUri.encode}#$raw").getOrElse(redirectUri).encode
-            else
-              redirectUri.addQueryParams(params).encode
+            returnUri(redirectUri.encode, state, "access_denied", useFragment).getOrElse(redirectUri.encode)
           ))
 
     private def availableClaimNames(record: ConversationRecord): Set[String] =

--- a/auth/src/main/scala/versola/oauth/conversation/ConversationRenderService.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationRenderService.scala
@@ -17,6 +17,7 @@ import zio.json.*
 import zio.json.ast.Json
 import zio.json.{jsonDiscriminator, jsonHint}
 import zio.{Chunk, Clock, Task, UIO, ZIO, ZLayer, durationInt}
+import versola.oauth.authorize.model.ResponseTypeEntry
 
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
@@ -25,9 +26,9 @@ import java.time.Instant
 trait ConversationRenderService:
   def renderStep(record: ConversationRecord, ifNoneMatch: Option[String], errorKey: Option[String] = None): Task[Response]
 
-  def renderExpired(clientId: ClientId, redirectUri: String, state: Option[String]): Task[Response]
+  def renderExpired(clientId: ClientId, redirectUri: String, state: Option[String], useFragment: Boolean): Task[Response]
 
-  def renderServiceUnavailable(clientId: ClientId, redirectUri: String, state: Option[String]): Task[Response]
+  def renderServiceUnavailable(clientId: ClientId, redirectUri: String, state: Option[String], useFragment: Boolean): Task[Response]
 
   def renderSubmit(
       result: ConversationResult.Render,
@@ -196,6 +197,7 @@ object ConversationRenderService:
             record.csrfToken,
             availableClaims = availableClaimNames(record),
             errorOverride = errorKey,
+            useFragment = record.responseType.contains(ResponseTypeEntry.IdToken),
           )
         response <- maybeInfo match
           case None =>
@@ -213,27 +215,36 @@ object ConversationRenderService:
               )
       yield response
 
-    override def renderExpired(clientId: ClientId, redirectUri: String, state: Option[String]): Task[Response] =
+    override def renderExpired(clientId: ClientId, redirectUri: String, state: Option[String], useFragment: Boolean): Task[Response] =
       renderTerminal(
         clientId,
         "conversation-expired",
-        StepView.ConversationExpired(returnUri(redirectUri, state, "login_required")),
+        StepView.ConversationExpired(returnUri(redirectUri, state, "login_required", useFragment)),
       )
 
-    override def renderServiceUnavailable(clientId: ClientId, redirectUri: String, state: Option[String]): Task[Response] =
+    override def renderServiceUnavailable(clientId: ClientId, redirectUri: String, state: Option[String], useFragment: Boolean): Task[Response] =
       renderTerminal(
         clientId,
         "service-unavailable",
-        StepView.ServiceUnavailable(returnUri(redirectUri, state, "temporarily_unavailable")),
+        StepView.ServiceUnavailable(returnUri(redirectUri, state, "temporarily_unavailable", useFragment)),
       )
 
     private def returnUri(
         redirectUri: String,
         state: Option[String],
         error: String,
+        useFragment: Boolean,
     ): Option[String] =
       URL.decode(redirectUri).toOption.map: url =>
-        url.addQueryParams(List("error" -> error, "iss" -> config.jwt.issuer) ++ state.map("state" -> _)).encode
+        val params = List("error" -> error, "iss" -> config.jwt.issuer) ++ state.map("state" -> _)
+        if useFragment then
+          val raw = params.map((k, v) => s"$k=${enc(v)}").mkString("&")
+          URL.decode(s"${url.encode}#$raw").getOrElse(url).encode
+        else
+          url.addQueryParams(params).encode
+
+    private def enc(value: String): String =
+      java.net.URLEncoder.encode(value, java.nio.charset.StandardCharsets.UTF_8).replace("+", "%20")
 
     private def renderTerminal(clientId: ClientId, formId: String, step: StepView): Task[Response] =
       for
@@ -455,6 +466,7 @@ object ConversationRenderService:
         csrfToken: String,
         availableClaims: Set[String],
         errorOverride: Option[String] = None,
+        useFragment: Boolean = false,
     ): Task[Option[FormRenderInfo]] =
       val formId = step match
         case _: ConversationStep.Credential => "credential"
@@ -465,7 +477,7 @@ object ConversationRenderService:
         case _: ConversationStep.Consent => "consent"
         case ConversationStep.AccessDenied => "access-denied"
       for
-        view <- stepView(step, credential, clientId, locale, redirectUri, state, availableClaims)
+        view <- stepView(step, credential, clientId, locale, redirectUri, state, availableClaims, useFragment)
         formOpt <- configuration.getForm(formId)
         locales <- configuration.getLocales
         errorMessage = errorOverride.orElse(stepErrorKey(step))
@@ -549,6 +561,7 @@ object ConversationRenderService:
         redirectUri: URL,
         state: Option[State],
         availableClaims: Set[String],
+        useFragment: Boolean,
     ): UIO[StepView] =
       step match
         case ConversationStep.Credential(primaryCredentials, inlinePassword, passkey, registration, _, _, _) =>
@@ -625,12 +638,25 @@ object ConversationRenderService:
             tosUri = client.flatMap(_.tosUri),
             scopes = rows,
             allowPartial = s.allowPartial,
-            denyUri = redirectUri.addQueryParams(List("error" -> "access_denied", "iss" -> config.jwt.issuer) ++ state.map("state" -> _)).encode,
+            denyUri = {
+              val params = List("error" -> "access_denied", "iss" -> config.jwt.issuer) ++ state.map("state" -> _)
+              if useFragment then
+                val raw = params.map((k, v) => s"$k=${enc(v)}").mkString("&")
+                URL.decode(s"${redirectUri.encode}#$raw").getOrElse(redirectUri).encode
+              else
+                redirectUri.addQueryParams(params).encode
+            },
           )
 
         case ConversationStep.AccessDenied =>
           val params = List("error" -> "access_denied", "iss" -> config.jwt.issuer) ++ state.map("state" -> _)
-          ZIO.succeed(StepView.AccessDenied(redirectUri = redirectUri.addQueryParams(params).encode))
+          ZIO.succeed(StepView.AccessDenied(redirectUri =
+            if useFragment then
+              val raw = params.map((k, v) => s"$k=${enc(v)}").mkString("&")
+              URL.decode(s"${redirectUri.encode}#$raw").getOrElse(redirectUri).encode
+            else
+              redirectUri.addQueryParams(params).encode
+          ))
 
     private def availableClaimNames(record: ConversationRecord): Set[String] =
       val customClaims = record.userClaims.toList

--- a/auth/src/main/scala/versola/oauth/model/cookies.scala
+++ b/auth/src/main/scala/versola/oauth/model/cookies.scala
@@ -18,7 +18,7 @@ case class ConversationCookie(
     clientId: ClientId,
     redirectUri: String,
     state: Option[String],
-    useFragment: Option[Boolean] = None,
+    useFragment: Option[Boolean],
 ) derives JsonCodec
 
 object ConversationCookie:

--- a/auth/src/main/scala/versola/oauth/model/cookies.scala
+++ b/auth/src/main/scala/versola/oauth/model/cookies.scala
@@ -18,6 +18,7 @@ case class ConversationCookie(
     clientId: ClientId,
     redirectUri: String,
     state: Option[String],
+    useFragment: Option[Boolean] = None,
 ) derives JsonCodec
 
 object ConversationCookie:

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
@@ -315,7 +315,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         _ <- env.userRepository.find.succeedsWith(None)
         _ <- env.secureRandom.nextUUIDv7.succeedsWith(UUID.randomUUID())
         result <- env.service.authorize(hybridRequest).flip
-      yield assertTrue(result == Error.AccessDenied(redirectUri, baseRequest.state))
+      yield assertTrue(result == Error.AccessDenied(redirectUri, baseRequest.state, useFragment = true))
     },
     test("silently authorize when passkey satisfies otp via equivalents") {
       val env = Env()
@@ -943,7 +943,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         _ <- env.secureRandom.nextAlphanumeric.succeedsWith("testcsrf1")
         _ <- env.userRepository.find.succeedsWith(None)
         result <- env.service.authorize(baseRequest.copy(sessionId = Some(rawSessionId))).flip
-      yield assertTrue(result == Error.AccessDenied(redirectUri, baseRequest.state))
+      yield assertTrue(result == Error.AccessDenied(redirectUri, baseRequest.state, useFragment = false))
     },
     test("fail with AccessDenied when max_age forces re-auth and session user no longer exists") {
       val env = Env()
@@ -966,7 +966,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         _ <- env.secureRandom.nextAlphanumeric.succeedsWith("testcsrf1")
         _ <- env.userRepository.find.succeedsWith(None)
         result <- env.service.authorize(baseRequest.copy(sessionId = Some(rawSessionId), maxAge = Some(0))).flip
-      yield assertTrue(result == Error.AccessDenied(redirectUri, baseRequest.state))
+      yield assertTrue(result == Error.AccessDenied(redirectUri, baseRequest.state, useFragment = false))
     },
     test("fall back to credential entry when id_token_hint user no longer exists") {
       val env = Env()
@@ -1121,7 +1121,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         result <- env.service.authorize(baseRequest.copy(sessionId = Some(rawSessionId), prompt = Set(Prompt.none))).flip
         createTimes = env.conversationRepository.create.times
       yield assertTrue(
-        result == Error.ConsentRequired(redirectUri, baseRequest.state),
+        result == Error.ConsentRequired(redirectUri, baseRequest.state, useFragment = false),
         createTimes == 0,
       )
     },

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
@@ -1168,4 +1168,54 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         decideTimes = env.consentService.decide.times
       yield assertTrue(decideTimes == 0)
     },
+    test("fail with LoginRequired with useFragment=true when no session, prompt=none, and hybrid response_type") {
+      val env = Env()
+      val hybridRequest = baseRequest.copy(
+        prompt = Set(Prompt.none),
+        responseType = NonEmptySet(ResponseTypeEntry.Code, ResponseTypeEntry.IdToken),
+      )
+      for
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(UUID.randomUUID())
+        result <- env.service.authorize(hybridRequest).flip
+      yield assertTrue(result == Error.LoginRequired(redirectUri, baseRequest.state, useFragment = true))
+    },
+    test("fail with LoginRequired with useFragment=true when session not satisfied, prompt=none, and hybrid response_type") {
+      val env = Env()
+      val session = sessionWithAmr(Map.empty)
+      val hybridRequest = baseRequest.copy(
+        sessionId = Some(rawSessionId),
+        prompt = Set(Prompt.none),
+        responseType = NonEmptySet(ResponseTypeEntry.Code, ResponseTypeEntry.IdToken),
+      )
+      for
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
+        _ <- env.sessionService.find.succeedsWith(Some(SessionInfo(sessionMac, session)))
+        _ <- env.configurationService.getAcrVocabulary.succeedsWith(Map.empty)
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(UUID.randomUUID())
+        result <- env.service.authorize(hybridRequest).flip
+      yield assertTrue(result == Error.LoginRequired(redirectUri, baseRequest.state, useFragment = true))
+    },
+    test("fail with ConsentRequired with useFragment=true when consent needed, prompt=none, and hybrid response_type") {
+      val env = Env()
+      val session = sessionWithAmr(Map(PassedAuthFactor.otp -> PassedFactorRecord(now, Set(AuthMethodRef.otp))))
+      val hybridRequest = baseRequest.copy(
+        sessionId = Some(rawSessionId),
+        prompt = Set(Prompt.none),
+        responseType = NonEmptySet(ResponseTypeEntry.Code, ResponseTypeEntry.IdToken),
+      )
+      for
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithConsent))
+        _ <- env.sessionService.find.succeedsWith(Some(SessionInfo(sessionMac, session)))
+        _ <- env.configurationService.getAcrVocabulary.succeedsWith(Map.empty)
+        _ <- env.configurationService.getSessionIdleTtl.succeedsWith(Option.empty[zio.Duration])
+        _ <- env.consentService.decide.succeedsWith(ConsentDecision.Required(Set(ScopeToken.OpenId)))
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(UUID.randomUUID())
+        result <- env.service.authorize(hybridRequest).flip
+        createTimes = env.conversationRepository.create.times
+      yield assertTrue(
+        result == Error.ConsentRequired(redirectUri, baseRequest.state, useFragment = true),
+        createTimes == 0,
+      )
+    },
   )

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeErrorSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeErrorSpec.scala
@@ -12,7 +12,7 @@ object AuthorizeErrorSpec extends ZIOSpecDefault:
 
   def spec = suite("AuthorizeError")(
     test("ResponseTypeMissing includes error and error_description query params") {
-      val err = Error.ResponseTypeMissing(redirectUri, state = None)
+      val err = Error.ResponseTypeMissing(redirectUri, state = None, useFragment = false)
       val url = err.redirectUriWithErrorParams(testIss)
       val params = url.queryParams
       assertTrue(
@@ -22,46 +22,46 @@ object AuthorizeErrorSpec extends ZIOSpecDefault:
     },
 
     test("ResponseTypeMissing includes error_uri when defined") {
-      val err = Error.ResponseTypeMissing(redirectUri, state = None)
+      val err = Error.ResponseTypeMissing(redirectUri, state = None, useFragment = false)
       val url = err.redirectUriWithErrorParams(testIss)
       val params = url.queryParams
       assertTrue(params.map.get("error_uri").exists(_.nonEmpty))
     },
 
     test("state is included when provided") {
-      val err = Error.ResponseTypeMissing(redirectUri, state = Some(State("abc123")))
+      val err = Error.ResponseTypeMissing(redirectUri, state = Some(State("abc123")), useFragment = false)
       val url = err.redirectUriWithErrorParams(testIss)
       val params = url.queryParams
       assertTrue(params.map.get("state").exists(_.contains("abc123")))
     },
 
     test("state is absent when not provided") {
-      val err = Error.ResponseTypeMissing(redirectUri, state = None)
+      val err = Error.ResponseTypeMissing(redirectUri, state = None, useFragment = false)
       val url = err.redirectUriWithErrorParams(testIss)
       val params = url.queryParams
       assertTrue(params.map.get("state").isEmpty)
     },
 
     test("UnsupportedResponseType uses correct error code") {
-      val err = Error.UnsupportedResponseType(redirectUri, state = None, responseType = "token")
+      val err = Error.UnsupportedResponseType(redirectUri, state = None, responseType = "token", useFragment = false)
       val url = err.redirectUriWithErrorParams(testIss)
       assertTrue(url.queryParams.map.get("error").exists(_.contains("unsupported_response_type")))
     },
 
     test("AuthFlowMissing has no error_uri") {
-      val err = Error.AuthFlowMissing(redirectUri, state = None)
+      val err = Error.AuthFlowMissing(redirectUri, state = None, useFragment = false)
       val url = err.redirectUriWithErrorParams(testIss)
       assertTrue(url.queryParams.map.get("error_uri").isEmpty)
     },
 
     test("AccessDenied uses access_denied error code") {
-      val err = Error.AccessDenied(redirectUri, state = None)
+      val err = Error.AccessDenied(redirectUri, state = None, useFragment = false)
       val url = err.redirectUriWithErrorParams(testIss)
       assertTrue(url.queryParams.map.get("error").exists(_.contains("access_denied")))
     },
 
     test("ScopeNotGranted uses invalid_scope error code and names the offending scopes") {
-      val err = Error.ScopeNotGranted(redirectUri, state = None, value = "address phone")
+      val err = Error.ScopeNotGranted(redirectUri, state = None, value = "address phone", useFragment = false)
       val url = err.redirectUriWithErrorParams(testIss)
       assertTrue(
         url.queryParams.map.get("error").exists(_.contains("invalid_scope")),
@@ -70,13 +70,13 @@ object AuthorizeErrorSpec extends ZIOSpecDefault:
     },
 
     test("base uri is preserved in error redirect") {
-      val err = Error.ResponseTypeMissing(redirectUri, state = None)
+      val err = Error.ResponseTypeMissing(redirectUri, state = None, useFragment = false)
       val url = err.redirectUriWithErrorParams(testIss)
       assertTrue(url.host.contains("example.com"))
     },
 
     test("iss is included in error redirect") {
-      val err = Error.ResponseTypeMissing(redirectUri, state = None)
+      val err = Error.ResponseTypeMissing(redirectUri, state = None, useFragment = false)
       val url = err.redirectUriWithErrorParams(testIss)
       assertTrue(url.queryParams.map.get("iss").exists(_.contains(testIss)))
     },

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeErrorSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeErrorSpec.scala
@@ -80,4 +80,35 @@ object AuthorizeErrorSpec extends ZIOSpecDefault:
       val url = err.redirectUriWithErrorParams(testIss)
       assertTrue(url.queryParams.map.get("iss").exists(_.contains(testIss)))
     },
+
+    suite("fragment response mode (useFragment = true)")(
+      test("params go to URL fragment, not query string") {
+        val err = Error.LoginRequired(redirectUri, state = None, useFragment = true)
+        val url = err.redirectUriWithErrorParams(testIss)
+        assertTrue(
+          url.queryParams.map.isEmpty,
+          url.fragment.exists(_.contains("error=login_required")),
+          url.fragment.exists(_.contains("iss=")),
+        )
+      },
+
+      test("state is included in fragment when provided") {
+        val err = Error.LoginRequired(redirectUri, state = Some(State("mystate")), useFragment = true)
+        val url = err.redirectUriWithErrorParams(testIss)
+        assertTrue(url.fragment.exists(_.contains("state=mystate")))
+      },
+
+      test("state is absent from fragment when not provided") {
+        val err = Error.LoginRequired(redirectUri, state = None, useFragment = true)
+        val url = err.redirectUriWithErrorParams(testIss)
+        assertTrue(!url.fragment.exists(_.contains("state=")))
+      },
+
+      test("error_description is percent-encoded in fragment") {
+        val err = Error.LoginRequired(redirectUri, state = None, useFragment = true)
+        val url = err.redirectUriWithErrorParams(testIss)
+        // spaces must not appear raw in the fragment — must be %20 or +
+        assertTrue(url.fragment.forall(!_.contains(" ")))
+      },
+    ),
   )

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeErrorSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeErrorSpec.scala
@@ -87,28 +87,28 @@ object AuthorizeErrorSpec extends ZIOSpecDefault:
         val url = err.redirectUriWithErrorParams(testIss)
         assertTrue(
           url.queryParams.map.isEmpty,
-          url.fragment.exists(_.contains("error=login_required")),
-          url.fragment.exists(_.contains("iss=")),
+          url.fragment.exists(_.raw.contains("error=login_required")),
+          url.fragment.exists(_.raw.contains("iss=")),
         )
       },
 
       test("state is included in fragment when provided") {
         val err = Error.LoginRequired(redirectUri, state = Some(State("mystate")), useFragment = true)
         val url = err.redirectUriWithErrorParams(testIss)
-        assertTrue(url.fragment.exists(_.contains("state=mystate")))
+        assertTrue(url.fragment.exists(_.raw.contains("state=mystate")))
       },
 
       test("state is absent from fragment when not provided") {
         val err = Error.LoginRequired(redirectUri, state = None, useFragment = true)
         val url = err.redirectUriWithErrorParams(testIss)
-        assertTrue(!url.fragment.exists(_.contains("state=")))
+        assertTrue(!url.fragment.exists(_.raw.contains("state=")))
       },
 
       test("error_description is percent-encoded in fragment") {
         val err = Error.LoginRequired(redirectUri, state = None, useFragment = true)
         val url = err.redirectUriWithErrorParams(testIss)
         // spaces must not appear raw in the fragment — must be %20 or +
-        assertTrue(url.fragment.forall(!_.contains(" ")))
+        assertTrue(url.fragment.forall(!_.raw.contains(" ")))
       },
     ),
   )

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
@@ -227,7 +227,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
       for
         _ <- env.configuration.find.succeedsWith(Some(clientRecord))
         result <- env.parser.parse(request).either
-      yield assertTrue(result == Left(Error.InvalidTarget(redirectUri, Some(State("test-state")), edgeResource.toString)))
+      yield assertTrue(result == Left(Error.InvalidTarget(redirectUri, Some(State("test-state")), edgeResource.toString, useFragment = false)))
     },
     suite("parse POST")(
       test("successfully parses valid form-urlencoded request") {
@@ -304,6 +304,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
           redirectUri,
           Some(State("test-state")),
           "unknown_type - unknown authorization details type",
+          useFragment = false,
         )))
       },
       test("rejects an unknown member of a registered type") {
@@ -315,7 +316,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
           _ <- env.configuration.findAuthorizationDetailType.succeedsWith(Some(paymentType))
           result <- env.parser.parse(request).either
         yield assertTrue(result.left.exists {
-          case Error.InvalidAuthorizationDetails(_, _, reason) => reason.startsWith("payment_initiation - ")
+          case Error.InvalidAuthorizationDetails(_, _, reason, _) => reason.startsWith("payment_initiation - ")
           case _ => false
         })
       },
@@ -329,6 +330,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
           redirectUri,
           Some(State("test-state")),
           "Authorization detail is missing the required type member",
+          useFragment = false,
         )))
       },
       test("rejects a value that is not a JSON array") {
@@ -341,6 +343,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
           redirectUri,
           Some(State("test-state")),
           "authorization_details must be a JSON array",
+          useFragment = false,
         )))
       },
       test("rejects a location that is not a registered resource") {
@@ -357,6 +360,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
           redirectUri,
           Some(State("test-state")),
           "payment_initiation - unknown location - https://unknown.example.com",
+          useFragment = false,
         )))
       },
       test("accepts a location that is a registered resource") {
@@ -399,6 +403,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
           redirectUri,
           Some(State("test-state")),
           s"payment_initiation - unknown location - $edgeResource",
+          useFragment = false,
         )))
       },
     ),
@@ -419,7 +424,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request).either
-        yield assertTrue(result == Left(Error.StateInvalid(redirectUri)))
+        yield assertTrue(result == Left(Error.StateInvalid(redirectUri, useFragment = false)))
       },
     ),
     suite("scope")(
@@ -437,7 +442,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request).either
-        yield assertTrue(result == Left(Error.ScopeNotGranted(redirectUri, Some(State("test-state")), "phone")))
+        yield assertTrue(result == Left(Error.ScopeNotGranted(redirectUri, Some(State("test-state")), "phone", useFragment = false)))
       },
       test("names every unregistered scope, not only the first") {
         val env = Env()
@@ -445,7 +450,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request).either
-        yield assertTrue(result == Left(Error.ScopeNotGranted(redirectUri, Some(State("test-state")), "address phone")))
+        yield assertTrue(result == Left(Error.ScopeNotGranted(redirectUri, Some(State("test-state")), "address phone", useFragment = false)))
       },
       test("rejects an unregistered scope pushed through /par too") {
         val env = Env()
@@ -453,7 +458,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.validate(pushedParams.view.mapValues(Chunk.fromIterable).toMap, Request.get(URL.root)).either
-        yield assertTrue(result == Left(Error.ScopeNotGranted(redirectUri, Some(State("test-state")), "phone")))
+        yield assertTrue(result == Left(Error.ScopeNotGranted(redirectUri, Some(State("test-state")), "phone", useFragment = false)))
       },
     ),
     suite("code_challenge_method")(
@@ -471,7 +476,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request).either
-        yield assertTrue(result == Left(Error.CodeChallengeMethodInvalid(redirectUri, Some(State("test-state")), "plain")))
+        yield assertTrue(result == Left(Error.CodeChallengeMethodInvalid(redirectUri, Some(State("test-state")), "plain", useFragment = false)))
       },
       test("rejects a missing code_challenge_method instead of defaulting to plain") {
         val env = Env()
@@ -479,7 +484,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request).either
-        yield assertTrue(result == Left(Error.CodeChallengeMethodMissing(redirectUri, Some(State("test-state")))))
+        yield assertTrue(result == Left(Error.CodeChallengeMethodMissing(redirectUri, Some(State("test-state")), useFragment = false)))
       },
     ),
     suite("ip")(

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
@@ -574,7 +574,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.validate(params, Request.get(URL.root)).either
-        yield assertTrue(result == Left(Error.ResponseTypeMissing(redirectUri, Some(State("test-state")))))
+        yield assertTrue(result == Left(Error.ResponseTypeMissing(redirectUri, Some(State("test-state")), useFragment = false)))
       },
     ),
     suite("ip")(

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
@@ -487,6 +487,36 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         yield assertTrue(result == Left(Error.CodeChallengeMethodMissing(redirectUri, Some(State("test-state")), useFragment = false)))
       },
     ),
+    suite("hybrid flow useFragment propagation")(
+      test("useFragment=true on CodeChallengeMethodMissing when response_type=code id_token") {
+        val env = Env()
+        val hybridParams = validParams ++ Map("response_type" -> "code id_token") - "code_challenge_method"
+        val request = Request.get(URL.root.addQueryParams(hybridParams))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.CodeChallengeMethodMissing(redirectUri, Some(State("test-state")), useFragment = true)))
+      },
+
+      test("useFragment=true on CodeChallengeMissing when response_type=code id_token") {
+        val env = Env()
+        val hybridParams = validParams ++ Map("response_type" -> "code id_token") - "code_challenge" - "code_challenge_method"
+        val request = Request.get(URL.root.addQueryParams(hybridParams))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.CodeChallengeMissing(redirectUri, Some(State("test-state")), useFragment = true)))
+      },
+
+      test("useFragment=false on CodeChallengeMethodMissing when response_type=code") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams - "code_challenge_method"))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.CodeChallengeMethodMissing(redirectUri, Some(State("test-state")), useFragment = false)))
+      },
+    ),
     suite("ip")(
       test("extracts the ip from the tenant-configured header") {
         val env = Env()

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
@@ -516,6 +516,66 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
           result <- env.parser.parse(request).either
         yield assertTrue(result == Left(Error.CodeChallengeMethodMissing(redirectUri, Some(State("test-state")), useFragment = false)))
       },
+
+      test("useFragment=true on UnsupportedResponseType when response_type contains id_token") {
+        val env = Env()
+        val params = validParams.view.mapValues(Chunk(_)).toMap + ("response_type" -> Chunk("id_token"))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.validate(params, Request.get(URL.root)).either
+        yield assertTrue(result == Left(Error.UnsupportedResponseType(redirectUri, Some(State("test-state")), "id_token", useFragment = true)))
+      },
+
+      test("useFragment=false on UnsupportedResponseType when response_type does not contain id_token") {
+        val env = Env()
+        val params = validParams.view.mapValues(Chunk(_)).toMap + ("response_type" -> Chunk("token"))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.validate(params, Request.get(URL.root)).either
+        yield assertTrue(result == Left(Error.UnsupportedResponseType(redirectUri, Some(State("test-state")), "token", useFragment = false)))
+      },
+
+      test("useFragment=true on MultipleValuesProvided(state) when response_type=code id_token") {
+        val env = Env()
+        val params = validParams.view.mapValues(Chunk(_)).toMap
+          + ("response_type" -> Chunk("code id_token"))
+          + ("state" -> Chunk("a", "b"))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.validate(params, Request.get(URL.root)).either
+        yield assertTrue(result == Left(Error.MultipleValuesProvided(redirectUri, None, "state", useFragment = true)))
+      },
+
+      test("useFragment=true on MultipleValuesProvided(response_type) when any value contains id_token") {
+        val env = Env()
+        val params = validParams.view.mapValues(Chunk(_)).toMap
+          + ("response_type" -> Chunk("code id_token", "code"))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.validate(params, Request.get(URL.root)).either
+        yield assertTrue(result == Left(Error.MultipleValuesProvided(redirectUri, Some(State("test-state")), "response_type", useFragment = true)))
+      },
+
+      test("oversized state is not echoed in response_type error") {
+        val env = Env()
+        val longState = "a" * 129
+        val params = validParams.view.mapValues(Chunk(_)).toMap
+          + ("response_type" -> Chunk("unsupported"))
+          + ("state" -> Chunk(longState))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.validate(params, Request.get(URL.root)).either
+        yield assertTrue(result == Left(Error.UnsupportedResponseType(redirectUri, None, "unsupported", useFragment = false)))
+      },
+
+      test("ResponseTypeMissing echoes valid state") {
+        val env = Env()
+        val params = validParams.view.mapValues(Chunk(_)).toMap - "response_type"
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.validate(params, Request.get(URL.root)).either
+        yield assertTrue(result == Left(Error.ResponseTypeMissing(redirectUri, Some(State("test-state")))))
+      },
     ),
     suite("ip")(
       test("extracts the ip from the tenant-configured header") {

--- a/auth/src/test/scala/versola/oauth/authorize/PushedAuthorizationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/PushedAuthorizationServiceSpec.scala
@@ -192,7 +192,7 @@ object PushedAuthorizationServiceSpec extends UnitSpecBase:
       val env = Env()
       for
         _ <- env.configuration.verifySecret.succeedsWith(Some(clientRecord))
-        _ <- env.parser.validate.failsWith(Error.ScopeMissing(redirectUri, None))
+        _ <- env.parser.validate.failsWith(Error.ScopeMissing(redirectUri, None, useFragment = false))
         service <- env.service
         result <- service.push(validParams(), credentials, request).either
       yield assertTrue(result.left.toOption.exists(_.asInstanceOf[PushedAuthorizationError].error == "invalid_scope"))

--- a/auth/src/test/scala/versola/oauth/authorize/model/ErrorSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/model/ErrorSpec.scala
@@ -27,19 +27,19 @@ object ErrorSpec extends ZIOSpecDefault:
     suite("prompt=none rejections")(
       check(
         "LoginRequired",
-        Error.LoginRequired(uri, state),
+        Error.LoginRequired(uri, state, useFragment = false),
         ErrorCode.LoginRequired,
         "Authentication is required but prompt=none was requested",
       ),
       check(
         "InteractionRequired",
-        Error.InteractionRequired(uri, state),
+        Error.InteractionRequired(uri, state, useFragment = false),
         ErrorCode.InteractionRequired,
         "End-user interaction is required but prompt=none was requested",
       ),
       check(
         "PromptInvalid",
-        Error.PromptInvalid(uri, state),
+        Error.PromptInvalid(uri, state, useFragment = false),
         ErrorCode.InvalidRequest,
         "Invalid prompt parameter - none must not be combined with other values",
       ),
@@ -47,19 +47,19 @@ object ErrorSpec extends ZIOSpecDefault:
     suite("hint rejections")(
       check(
         "IdTokenHintInvalid",
-        Error.IdTokenHintInvalid(uri, state),
+        Error.IdTokenHintInvalid(uri, state, useFragment = false),
         ErrorCode.InvalidRequest,
         "The id_token_hint could not be verified or is invalid (invalid signature, audience, or issuer)",
       ),
       check(
         "ConflictingHints",
-        Error.ConflictingHints(uri, state),
+        Error.ConflictingHints(uri, state, useFragment = false),
         ErrorCode.InvalidRequest,
         "login_hint and id_token_hint must not be used together",
       ),
       check(
         "LoginHintInvalid",
-        Error.LoginHintInvalid(uri, state),
+        Error.LoginHintInvalid(uri, state, useFragment = false),
         ErrorCode.InvalidRequest,
         "The login_hint parameter is invalid or not supported by the client auth flow",
       ),
@@ -67,31 +67,31 @@ object ErrorSpec extends ZIOSpecDefault:
     suite("request rejections")(
       check(
         "CodeChallengeMissing",
-        Error.CodeChallengeMissing(uri, state),
+        Error.CodeChallengeMissing(uri, state, useFragment = false),
         ErrorCode.InvalidRequest,
         "Missing required parameter - code_challenge",
       ),
       check(
         "CodeChallengeInvalid",
-        Error.CodeChallengeInvalid(uri, state, "short"),
+        Error.CodeChallengeInvalid(uri, state, "short", useFragment = false),
         ErrorCode.InvalidRequest,
         "Invalid code challenge alphabet or size - short",
       ),
       check(
         "InvalidClaims",
-        Error.InvalidClaims(uri, state),
+        Error.InvalidClaims(uri, state, useFragment = false),
         ErrorCode.InvalidRequest,
         "Invalid claims parameter - must be valid JSON",
       ),
       check(
         "UnsupportedUiLocales",
-        Error.UnsupportedUiLocales(uri, state),
+        Error.UnsupportedUiLocales(uri, state, useFragment = false),
         ErrorCode.InvalidRequest,
         "None of the requested ui_locales are supported",
       ),
       check(
         "UnmetAuthenticationRequirements",
-        Error.UnmetAuthenticationRequirements(uri, state),
+        Error.UnmetAuthenticationRequirements(uri, state, useFragment = false),
         ErrorCode.UnmetAuthenticationRequirements,
         "The requested Authentication Context Class cannot be satisfied",
       ),
@@ -99,20 +99,20 @@ object ErrorSpec extends ZIOSpecDefault:
     suite("parameter arity")(
       check(
         "MultipleValuesProvided names the offending parameter",
-        Error.MultipleValuesProvided(uri, state, "scope"),
+        Error.MultipleValuesProvided(uri, state, "scope", useFragment = false),
         ErrorCode.InvalidRequest,
         "Parameter is included more than once - scope",
       ),
       check(
         "NoValuesProvided names the offending parameter",
-        Error.NoValuesProvided(uri, state, "scope"),
+        Error.NoValuesProvided(uri, state, "scope", useFragment = false),
         ErrorCode.InvalidRequest,
         "At least one value should be provided - scope",
       ),
     ),
     test("the redirect keeps query parameters the client already put on its redirect_uri") {
       val withQuery = zio.http.URL.decode("https://example.com/callback?tenant=acme").toOption.get
-      val redirect = Error.LoginRequired(withQuery, state).redirectUriWithErrorParams("https://issuer.example")
+      val redirect = Error.LoginRequired(withQuery, state, useFragment = false).redirectUriWithErrorParams("https://issuer.example")
       assertTrue(
         redirect.queryParams.queryParam("tenant") == Some("acme"),
         redirect.queryParams.queryParam("error") == Some(ErrorCode.LoginRequired.toString),

--- a/auth/src/test/scala/versola/oauth/conversation/ConversationControllerSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/ConversationControllerSpec.scala
@@ -319,7 +319,7 @@ object ConversationControllerSpec extends UnitSpecBase:
       yield assertTrue(
         response.status == Status.Ok,
         body == "<html>Unavailable</html>",
-        renderService.renderServiceUnavailable.calls == List((clientId, "https://example.com/callback", Some("test-state"))),
+        renderService.renderServiceUnavailable.calls == List((clientId, "https://example.com/callback", Some("test-state"), false)),
       )
     }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
     test("GET /challenge renders step") {
@@ -368,7 +368,7 @@ object ConversationControllerSpec extends UnitSpecBase:
       yield assertTrue(
         response.status == Status.Ok,
         body == "<html>Expired</html>",
-        renderService.renderExpired.calls == List((clientId, "https://example.com/callback", Some("test-state"))),
+        renderService.renderExpired.calls == List((clientId, "https://example.com/callback", Some("test-state"), false)),
       )
     }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
 
@@ -394,7 +394,7 @@ object ConversationControllerSpec extends UnitSpecBase:
       yield assertTrue(
         response.status == Status.Ok,
         body == "<html>Unavailable</html>",
-        renderService.renderServiceUnavailable.calls == List((clientId, "https://example.com/callback", Some("test-state"))),
+        renderService.renderServiceUnavailable.calls == List((clientId, "https://example.com/callback", Some("test-state"), false)),
       )
     }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
 

--- a/auth/src/test/scala/versola/oauth/conversation/ConversationControllerSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/ConversationControllerSpec.scala
@@ -37,6 +37,7 @@ object ConversationControllerSpec extends UnitSpecBase:
             clientId,
             redirectUri = "https://example.com/callback",
             state = Some("test-state"),
+            useFragment = None,
           ),
           Duration.Zero,
           TestEnvConfig.coreConfig.security.conversationCookieSecret,

--- a/auth/src/test/scala/versola/oauth/conversation/ConversationRenderServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/ConversationRenderServiceSpec.scala
@@ -500,7 +500,7 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           _ <- env.configuration.getForm.succeedsWith(Some(expiredForm))
           _ <- env.configuration.getLocales.succeedsWith(locales)
           _ <- env.configuration.getIdentityProviderLogo.succeedsWith(Some("https://acme.test/logo.svg"))
-          response <- env.service.renderExpired(clientId, redirectUri.encode, Some("test-state"))
+          response <- env.service.renderExpired(clientId, redirectUri.encode, Some("test-state"), false)
           body <- response.body.asString
         yield
           assertTrue(response.status == Status.Ok) &&
@@ -524,7 +524,7 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           _ <- env.configuration.getForm.succeedsWith(Some(unavailableForm))
           _ <- env.configuration.getLocales.succeedsWith(locales)
           _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
-          response <- env.service.renderServiceUnavailable(clientId, redirectUri.encode, Some("test-state"))
+          response <- env.service.renderServiceUnavailable(clientId, redirectUri.encode, Some("test-state"), false)
           body <- response.body.asString
         yield
           assertTrue(response.status == Status.Ok) &&

--- a/auth/src/test/scala/versola/oauth/model/CookiesSpec.scala
+++ b/auth/src/test/scala/versola/oauth/model/CookiesSpec.scala
@@ -30,8 +30,8 @@ object CookiesSpec extends ZIOSpecDefault:
   def spec = suite("CookiesSpec")(
     suite("ConversationCookie")(
       test("responseCookie creates a secure cookie with valid signature") {
-        val cookie = ConversationCookie(authId, clientId, "https://example.com/callback", None)
-        val resp = ConversationCookie.responseCookie(cookie, 15.minutes, secret)
+        val cookie = ConversationCookie(authId, clientId, "https://example.com/callback", None, None)
+        val resp   = ConversationCookie.responseCookie(cookie, 15.minutes, secret)
         assertTrue(
           resp.name == ConversationCookie.name,
           resp.path.nonEmpty,
@@ -47,20 +47,21 @@ object CookiesSpec extends ZIOSpecDefault:
           clientId,
           redirectUri = "https://example.com/callback",
           state = Some("state-1"),
+          useFragment = None,
         )
         val content = ConversationCookie.responseCookie(cookie, 15.minutes, secret).content
         assertTrue(ConversationCookie.parse(content, secret) == Right(cookie))
       },
       test("parse fails with wrong secret") {
-        val cookie = ConversationCookie(authId, clientId, "https://example.com/callback", None)
-        val content = ConversationCookie.responseCookie(cookie, 15.minutes, secret).content
+        val cookie      = ConversationCookie(authId, clientId, "https://example.com/callback", None, None)
+        val content     = ConversationCookie.responseCookie(cookie, 15.minutes, secret).content
         val wrongSecret = Secret.Bytes32(Array.fill(32)(9.toByte))
         assertTrue(ConversationCookie.parse(content, wrongSecret).isLeft)
       },
       test("parse fails with tampered payload") {
-        val cookie = ConversationCookie(authId, clientId, "https://example.com/callback", None)
-        val content = ConversationCookie.responseCookie(cookie, 15.minutes, secret).content
-        val parts = content.split('.')
+        val cookie          = ConversationCookie(authId, clientId, "https://example.com/callback", None, None)
+        val content         = ConversationCookie.responseCookie(cookie, 15.minutes, secret).content
+        val parts           = content.split('.')
         val tamperedPayload = "eyJhdXRoSWQiOiJiYmJiYmJiYi1iYmJiLWJiYmItYmJiYi1iYmJiYmJiYmJiYmIiLCJjbGllbnRJZCI6InRlc3QtY2xpZW50In0"
         val tamperedContent = s"$tamperedPayload.${parts(1)}"
         assertTrue(ConversationCookie.parse(tamperedContent, secret).isLeft)

--- a/auth/src/test/scala/versola/oauth/model/CookiesSpec.scala
+++ b/auth/src/test/scala/versola/oauth/model/CookiesSpec.scala
@@ -143,7 +143,7 @@ object CookiesSpec extends ZIOSpecDefault:
         // reach the decoding step -- re-signing an arbitrary payload isn't possible from
         // outside, since computeMac is private.
         val content = ConversationCookie.responseCookie(
-          ConversationCookie(authId, clientId, "https://example.com/callback", None),
+          ConversationCookie(authId, clientId, "https://example.com/callback", None, None),
           15.minutes,
           secret,
         ).content
@@ -161,7 +161,7 @@ object CookiesSpec extends ZIOSpecDefault:
       },
       test("ConversationCookie.parse rejects a payload that is not base64url") {
         val content = ConversationCookie.responseCookie(
-          ConversationCookie(authId, clientId, "https://example.com/callback", None),
+          ConversationCookie(authId, clientId, "https://example.com/callback", None, None),
           15.minutes,
           secret,
         ).content

--- a/e2e/src/test/scala/versola/e2e/flows/basic/AuthorizeNegativeSpec.scala
+++ b/e2e/src/test/scala/versola/e2e/flows/basic/AuthorizeNegativeSpec.scala
@@ -84,4 +84,16 @@ object AuthorizeNegativeSpec extends E2ESpec:
       yield assertCompletes
     },
 
+    test("prompt=none without session redirects with fragment error=login_required for hybrid response_type") {
+      for
+        (s, auth) <- setup(Flows.Id.LoginPassword)
+        _ <- auth.authorizeRaw(
+          clientId = s.clientId,
+          redirectUri = s.redirectUri,
+          responseType = Some("code id_token"),
+          prompt = Some("none"),
+        ).assertFragmentErrorRedirect("login_required")
+      yield assertCompletes
+    },
+
   ) @@ TestAspect.sequential @@ TestAspect.timeout(60.seconds)

--- a/e2e/src/test/scala/versola/e2e/support/OAuthClient.scala
+++ b/e2e/src/test/scala/versola/e2e/support/OAuthClient.scala
@@ -49,11 +49,33 @@ case class AuthorizeResult(
           if actualError == expectedError then ZIO.unit
           else ZIO.fail(RuntimeException(s"Expected error='$expectedError', got error='$actualError'"))
 
+  /** Assert a 303 fragment-error redirect (hybrid / implicit flow): error is in `#error=…`, not `?error=…`. */
+  def assertFragmentErrorRedirect(expectedError: String): Task[Unit] =
+    if response.status != Status.SeeOther then
+      ZIO.fail(RuntimeException(s"Expected 303 fragment error redirect, got status=${response.status}"))
+    else
+      val fragmentPart = location.dropWhile(_ != '#').drop(1)
+      if fragmentPart.isEmpty then
+        ZIO.fail(RuntimeException(s"Expected fragment in redirect location, got: $location"))
+      else
+        val params = fragmentPart.split('&').collect:
+          case s if s.contains('=') =>
+            val i = s.indexOf('=')
+            s.substring(0, i) -> java.net.URLDecoder.decode(s.substring(i + 1), "UTF-8")
+        .toMap
+        params.get("error") match
+          case Some(actual) if actual == expectedError => ZIO.unit
+          case Some(actual) =>
+            ZIO.fail(RuntimeException(s"Expected fragment error='$expectedError', got '$actual'; location=$location"))
+          case None =>
+            ZIO.fail(RuntimeException(s"No 'error' param in fragment; location=$location"))
+
 extension (task: Task[AuthorizeResult])
   def assertRedirectTo(path: String): Task[AuthorizeResult] = task.flatMap(_.assertRedirectTo(path))
   def assertChallengeRedirect: Task[AuthorizeResult] = task.flatMap(_.assertChallengeRedirect)
   def assertCodeRedirect: Task[String] = task.flatMap(_.assertCodeRedirect)
   def assertErrorRedirect(expectedError: String): Task[Unit] = task.flatMap(_.assertErrorRedirect(expectedError))
+  def assertFragmentErrorRedirect(expectedError: String): Task[Unit] = task.flatMap(_.assertFragmentErrorRedirect(expectedError))
 
 case class ChallengeResult(response: Response, html: String):
   val step: Option[ConversationStep] = ConversationStep.fromHtml(html)

--- a/util/src/main/scala/versola/util/escaping.scala
+++ b/util/src/main/scala/versola/util/escaping.scala
@@ -32,3 +32,9 @@ def escapeJsonForScript(json: String): String =
   */
 def escapeCssForStyle(css: String): String =
   css.replace("<", "\\3c ")
+
+/** Percent-encodes a query-parameter value for use in a URI fragment or query string.
+  * Produces RFC 3986 output with spaces as `%20` (not `+`).
+  */
+def encodeQueryParam(value: String): String =
+  java.net.URLEncoder.encode(value, java.nio.charset.StandardCharsets.UTF_8).replace("+", "%20")


### PR DESCRIPTION
Closes #221 

fix: use fragment response mode for error redirects in hybrid/implicit flows (#221)

## Problem

OIDC Core §3.3.2.9 (Hybrid Flow) and §3.2.2.9 (Implicit Flow) require that
when response_type includes id_token, ALL responses from the authorization
endpoint — including error responses — must use the URL fragment (#) instead
of the query string (?).

Previously, error redirects always used query string regardless of response_type:
  https://example.com/callback?error=login_required&state=xyz

For hybrid/implicit flows the correct format is:
  https://example.com/callback#error=login_required&state=xyz

## Changes

- **Error.scala** — added `useFragment: Boolean = false` to all `RedirectError`
  case classes; `redirectUriWithErrorParams` now branches on this flag to build
  either a query-string or fragment redirect URL

- **AuthorizeEndpointService.scala** — all `ZIO.fail(Error.XYZ(...))` calls
  pass `useFragment = isHybrid(request.responseType)` via a new private helper

- **AuthorizeEndpointController.scala** — `ConversationCookie` is created with
  `useFragment = Some(request.responseType.contains(ResponseTypeEntry.IdToken))`
  so the flag survives across the conversation lifecycle

- **ConversationCookie** — added `useFragment: Option[Boolean] = None`
  (`Option` for backwards compatibility: existing cookies without this field
  still decode correctly via ZIO JSON)

- **ConversationController.scala** — `renderExpired` and
  `renderServiceUnavailable` now receive `cookie.useFragment.getOrElse(false)`

- **ConversationRenderService.scala** — `renderExpired`,
  `renderServiceUnavailable`, and `formFor` accept `useFragment: Boolean`;
  error return URIs in rendered pages use fragment when appropriate

- Test files updated accordingly