### PR TITLE
util: detect a notification connection that goes silent without failing

### DIFF
--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/DbMetrics.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/DbMetrics.scala
@@ -31,6 +31,13 @@ object DbMetrics:
   private val notificationListenerConnectedGauge =
     Metric.gauge("db_notification_listener_connected").tagged(MetricLabel("db_system", "postgresql"))
 
+  /** How many notifications were dropped because a subscriber fell far enough behind to fill
+    * the bounded queue between it and the polling fiber. Non-zero means that subscriber is
+    * now relying on its own periodic reload rather than the push path to catch up.
+    */
+  private val notificationListenerQueueOverflowTotal =
+    Metric.counter("db_notification_listener_queue_overflow_total").tagged(MetricLabel("db_system", "postgresql"))
+
   def notificationReceived: UIO[Unit] =
     notificationsReceivedTotal.increment
 
@@ -42,6 +49,9 @@ object DbMetrics:
 
   def notificationListenerConnected(connected: Boolean): UIO[Unit] =
     notificationListenerConnectedGauge.set(if connected then 1 else 0)
+
+  def notificationListenerQueueOverflow: UIO[Unit] =
+    notificationListenerQueueOverflowTotal.increment
 
   private def histogram(repository: String, operation: String, outcome: String) =
     Metric

--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/DbMetrics.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/DbMetrics.scala
@@ -16,9 +16,17 @@ object DbMetrics:
   private val notificationListenerReconnectsTotal =
     Metric.counter("db_notification_listener_reconnects_total").tagged(MetricLabel("db_system", "postgresql"))
 
-  /** Whether the `LISTEN` connection is currently up. Notifications failing to arrive is
-    * otherwise indistinguishable from nothing having happened, so this is the only signal
-    * that propagation has stopped.
+  /** How many times a connection was torn down for going silent: still open, never erroring,
+    * and no longer delivering. Distinct from a reconnect, which counts connections that
+    * failed loudly, and the only one of the two that can point at the network path rather
+    * than at the database.
+    */
+  private val notificationListenerSilentTotal =
+    Metric.counter("db_notification_listener_silent_total").tagged(MetricLabel("db_system", "postgresql"))
+
+  /** Whether the `LISTEN` connection is currently up, in the sense of proven to be
+    * delivering rather than merely open: a connection that stops carrying notifications is
+    * failed and replaced, so this reads 0 while that is happening.
     */
   private val notificationListenerConnectedGauge =
     Metric.gauge("db_notification_listener_connected").tagged(MetricLabel("db_system", "postgresql"))
@@ -28,6 +36,9 @@ object DbMetrics:
 
   def notificationListenerReconnected: UIO[Unit] =
     notificationListenerReconnectsTotal.increment
+
+  def notificationListenerWentSilent: UIO[Unit] =
+    notificationListenerSilentTotal.increment
 
   def notificationListenerConnected(connected: Boolean): UIO[Unit] =
     notificationListenerConnectedGauge.set(if connected then 1 else 0)

--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/DbMetrics.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/DbMetrics.scala
@@ -54,8 +54,8 @@ object DbMetrics:
   def notificationListenerConnected(connected: Boolean): UIO[Unit] =
     notificationListenerConnectedGauge.set(if connected then 1 else 0)
 
-  def notificationListenerQueueOverflow: UIO[Unit] =
-    notificationListenerQueueOverflowTotal.increment
+  def notificationListenerQueueOverflow(dropped: Int): UIO[Unit] =
+    notificationListenerQueueOverflowTotal.incrementBy(dropped.toLong)
 
   private def histogram(repository: String, operation: String, outcome: String) =
     Metric

--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/DbMetrics.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/DbMetrics.scala
@@ -27,6 +27,10 @@ object DbMetrics:
   /** Whether the `LISTEN` connection is currently up, in the sense of proven to be
     * delivering rather than merely open: a connection that stops carrying notifications is
     * failed and replaced, so this reads 0 while that is happening.
+    *
+    * Written by the fiber that owns the connection, not by the subscriber's error path, so it
+    * describes the connection rather than how promptly anyone noticed. A subscriber blocked
+    * on its own reload cannot hold this at 1 over a connection that has already died.
     */
   private val notificationListenerConnectedGauge =
     Metric.gauge("db_notification_listener_connected").tagged(MetricLabel("db_system", "postgresql"))

--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
@@ -38,16 +38,16 @@ class PostgresNotificationListener(
   import PostgresNotificationListener.*
 
   /** Notifications from every channel this listener subscribes to, for as long as the
-    * returned stream is pulled -- reconnecting is not conditional on that, though: it runs on
+    * returned stream is pulled — reconnecting is not conditional on that, though: it runs on
     * a fiber of its own, [[daemon]], which this only ever reads from.
     *
     * That split matters because a subscriber's own handler is realistically a synchronous
-    * reload against the same database whose trouble is why a connection just died -- exactly
+    * reload against the same database whose trouble is why a connection just died — exactly
     * the moment reconnecting cannot afford to wait on whatever is slow about that reload. A
     * subscriber stalled inside one no longer holds a proven-dead connection open, or delays
     * the new one: [[daemon]] never awaits `delivery`, only offers to it.
     *
-    * A dropped connection is expected rather than exceptional -- Postgres restarts, network
+    * A dropped connection is expected rather than exceptional — Postgres restarts, network
     * blips, and poolers that recycle idle server connections all produce one, and an idle
     * `LISTEN` connection is the first thing an idle timeout reaps. Whatever was published
     * while the connection was gone is not redelivered on reconnect, so each (re)connect opens
@@ -65,7 +65,7 @@ class PostgresNotificationListener(
         _ <- daemon(delivery).forkScoped
       yield ZStream.fromQueue(delivery)
 
-  /** Connects, polls, reconnects, and hands every event to `delivery` -- forever, and
+  /** Connects, polls, reconnects, and hands every event to `delivery` — forever, and
     * regardless of whether, or how quickly, anything is pulling from it.
     *
     * [[reconnectSchedule]] retries without end, so this only ever stops on an unhandled bug:
@@ -93,7 +93,7 @@ class PostgresNotificationListener(
         )
 
   /** Hands one event to whatever pulls [[notifications]], dropping rather than blocking when
-    * it is not keeping up -- the same tolerance every subscriber already has for a missed
+    * it is not keeping up — the same tolerance every subscriber already has for a missed
     * notification, since [[NotificationEvent.Resubscribed]] is what tells it to reload
     * regardless of how it fell behind, and blocking here would be [[daemon]] inheriting the
     * exact stall this queue exists to keep it out of.
@@ -295,7 +295,7 @@ class PostgresNotificationListener(
       // A socket timeout on this send is the same silent connection revealing itself through
       // the write side instead of the read-side deadline above, so it is folded into the same
       // failure rather than left to read as a loud one. Anything else that can fail a NOTIFY
-      // -- an admin shutdown, a terminated backend -- is a real database failure and stays
+      // — an admin shutdown, a terminated backend — is a real database failure and stays
       // one: only the specific failure this heartbeat exists to catch gets relabeled.
       _ <- ZIO.when(due)(
         ZIO
@@ -330,7 +330,7 @@ object PostgresNotificationListener:
     */
   private val SocketTimeout = 30.seconds
 
-  /** Whether `cause`, anywhere in its chain, is the socket timing out on a write -- what a
+  /** Whether `cause`, anywhere in its chain, is the socket timing out on a write — what a
     * black-holed connection does on this send, since nothing between here and the peer will
     * ever produce a real response or a closed-connection error. Any other failure reached the
     * driver in the ordinary way a loud one does, and is left to be counted as one, not

--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
@@ -102,9 +102,10 @@ class PostgresNotificationListener(
     )
 
   /** The queue [[connect]] already has [[pollLoop]] filling, turned into what a subscriber
-    * sees. The queue is unbounded because a bounded one would eventually apply the same
-    * backpressure the fiber in `connect` exists to avoid: it would just move where a slow
-    * subscriber stalls polling from "immediately" to "once the queue fills up".
+    * sees. The queue drops rather than backpressures when full, because blocking on a full
+    * buffer would apply the same backpressure the fiber in `connect` exists to avoid: it
+    * would just move where a slow subscriber stalls polling from "immediately" to "once the
+    * queue fills up".
     */
   private def read(session: Session, queue: Queue[Take[Throwable, PGNotification]]): Stream[Throwable, NotificationEvent] =
     ZStream
@@ -129,12 +130,27 @@ class PostgresNotificationListener(
 
   private def pollLoop(session: Session, queue: Queue[Take[Throwable, PGNotification]]): UIO[Unit] =
     poll(session).foldCauseZIO(
-      // A failure always gets in: `Queue.dropping` only drops what a full buffer has no room
-      // for, and this is the one element that must never be the one dropped, or a subscriber
-      // stuck behind a slow reload would never learn the connection under it died either.
-      cause => queue.offer(Take.failCause(cause)).unit,
+      cause => offerFailure(queue, cause),
       notifications => offer(queue, notifications) *> pollLoop(session, queue),
     )
+
+  /** Gets the failure in whatever it takes, because this is the one element that must not be
+    * dropped: [[pollLoop]] stops after it, so a failure lost to a full queue would leave the
+    * stream waiting on a queue nothing will ever fill again — no error to retry on, and the
+    * reconnect that a subscriber is waiting for never happens.
+    *
+    * A full queue is exactly the case where dropping it is most likely and least acceptable:
+    * the subscriber is already behind, and the connection under it just died. Evicting the
+    * oldest notification to make room trades an event that is already covered by the
+    * subscriber's periodic reload for the one signal that is not recoverable any other way.
+    */
+  private def offerFailure(queue: Queue[Take[Throwable, PGNotification]], cause: Cause[Throwable]): UIO[Unit] =
+    queue.offer(Take.failCause(cause)).flatMap: accepted =>
+      ZIO.unless(accepted):
+        // Non-blocking: the queue can only reject when it is full, so there is something to
+        // take, and this fiber is the only producer, so the space it frees stays free.
+        queue.take *> offerFailure(queue, cause)
+      .unit
 
   private def offer(queue: Queue[Take[Throwable, PGNotification]], notifications: List[PGNotification]): UIO[Unit] =
     if notifications.isEmpty then ZIO.unit

--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
@@ -4,6 +4,7 @@ import org.postgresql.{PGConnection, PGNotification}
 import zio.*
 import zio.stream.{Stream, Take, ZStream}
 
+import java.net.SocketTimeoutException
 import java.nio.charset.StandardCharsets
 import java.sql.{Connection, DriverManager}
 import java.time.Instant
@@ -172,13 +173,25 @@ class PostgresNotificationListener(
   private def supersede(queue: Queue[Take[Throwable, PGNotification]], cause: Cause[Throwable]): UIO[Unit] =
     queue.takeAll *> queue.offer(Take.failCause(cause)).unit
 
+  /** One queue slot per notification, offered one at a time, rather than the whole batch
+    * `getNotifications` handed back as a single [[Take]].
+    *
+    * [[Queue.dropping]] bounds the number of elements, not what they contain, and
+    * `Take.chunk` can hold arbitrarily many notifications in one element: Postgres can return
+    * every currently pending notification in a single batch, so one slot filled with that
+    * batch does not bound the memory a blocked subscriber leaves retained the way
+    * [[queueCapacity]] elements of one notification each does. Offering individually is what
+    * makes the queue's element count actually mean a notification count.
+    */
   private def offer(queue: Queue[Take[Throwable, PGNotification]], notifications: List[PGNotification]): UIO[Unit] =
-    if notifications.isEmpty then ZIO.unit
-    else
-      queue.offer(Take.chunk(Chunk.fromIterable(notifications))).flatMap: accepted =>
-        ZIO.unless(accepted):
-          ZIO.logWarning(s"Notification queue full; dropping ${notifications.size} notification(s)") *>
-            DbMetrics.notificationListenerQueueOverflow(notifications.size)
+    ZIO
+      .foldLeft(notifications)(0):
+        (dropped, notification) =>
+          queue.offer(Take.single(notification)).map(accepted => if accepted then dropped else dropped + 1)
+      .flatMap: dropped =>
+        ZIO.when(dropped > 0):
+          ZIO.logWarning(s"Notification queue full; dropping $dropped notification(s)") *>
+            DbMetrics.notificationListenerQueueOverflow(dropped)
         .unit
 
   /** One wait for notifications, and the liveness bookkeeping that goes with an empty one.
@@ -235,13 +248,15 @@ class PostgresNotificationListener(
         ZIO.fail(SilentConnection(livenessTimeout)),
       )
       due <- session.beat.modify(sent => if now.isAfter(sent.plus(heartbeatInterval)) then (true, now) else (false, sent))
-      // A write that fails outright is the same silent connection revealing itself through
-      // the socket timeout on this send instead of through the read-side deadline above, so
-      // it is folded into the same failure rather than left to read as a loud one.
+      // A socket timeout on this send is the same silent connection revealing itself through
+      // the write side instead of the read-side deadline above, so it is folded into the same
+      // failure rather than left to read as a loud one. Anything else that can fail a NOTIFY
+      // -- an admin shutdown, a terminated backend -- is a real database failure and stays
+      // one: only the specific failure this heartbeat exists to catch gets relabeled.
       _ <- ZIO.when(due)(
         ZIO
           .attemptBlocking(execute(session.connection, List(s"NOTIFY ${session.heartbeatChannel}")))
-          .mapError(cause => SilentConnection(livenessTimeout, Some(cause))),
+          .catchAll(cause => ZIO.fail(if isSocketTimeout(cause) then SilentConnection(livenessTimeout, Some(cause)) else cause)),
       )
     yield ()
 
@@ -270,6 +285,18 @@ object PostgresNotificationListener:
     * instead of the read it was added to catch.
     */
   private val SocketTimeout = 30.seconds
+
+  /** Whether `cause`, anywhere in its chain, is the socket timing out on a write -- what a
+    * black-holed connection does on this send, since nothing between here and the peer will
+    * ever produce a real response or a closed-connection error. Any other failure reached the
+    * driver in the ordinary way a loud one does, and is left to be counted as one, not
+    * relabeled as the specific silent case this exists to catch.
+    */
+  private[postgres] def isSocketTimeout(cause: Throwable): Boolean =
+    // Bounded rather than followed to null, in case a driver ever hands back a cause chain
+    // that cycles back on itself: this is a classification, not a diagnostic, so a chain long
+    // enough to matter here would be a bug elsewhere, not a reason to hang finding out.
+    Iterator.iterate(Option(cause))(_.flatMap(t => Option(t.getCause))).take(16).takeWhile(_.isDefined).flatten.exists(_.isInstanceOf[SocketTimeoutException])
 
   private val ReconnectMinBackoff = 100.millis
   private val ReconnectMaxBackoff = 10.seconds

--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
@@ -30,6 +30,7 @@ class PostgresNotificationListener(
     channels: List[String],
     heartbeatInterval: Duration = PostgresNotificationListener.HeartbeatInterval,
     livenessTimeout: Duration = PostgresNotificationListener.LivenessTimeout,
+    pollTimeout: Duration = PostgresNotificationListener.PollTimeout,
 ):
   import PostgresNotificationListener.*
 
@@ -85,17 +86,20 @@ class PostgresNotificationListener(
       .filter(_.getName != session.heartbeatChannel)
       .tap(_ => DbMetrics.notificationReceived)
       .map(NotificationEvent.Received(_))
+      // Counted apart from a loud failure rather than as well as one: a connection that went
+      // silent is the only one of the two that points at the network path rather than at the
+      // database, and summing them would hide exactly that.
       .tapError:
         case silent: SilentConnection =>
           ZIO.logWarningCause("Notification connection went silent; reconnecting", Cause.fail(silent)) *>
-            DbMetrics.notificationListenerWentSilent *> DbMetrics.notificationListenerReconnected
+            DbMetrics.notificationListenerWentSilent
         case cause =>
           ZIO.logWarningCause("Notification connection lost; reconnecting", Cause.fail(cause)) *>
             DbMetrics.notificationListenerReconnected
 
   /** One wait for notifications, and the liveness bookkeeping that goes with an empty one.
     *
-    * Blocks for up to NotificationTimeoutMillis waiting for a notification (pgjdbc's own
+    * Blocks for up to [[pollTimeout]] waiting for a notification (pgjdbc's own
     * recommended pattern) instead of busy-polling. The blocking socket read does not respond
     * to a plain thread interrupt, so on fiber interruption (graceful shutdown, or the retry
     * above tearing this attempt down) the connection is closed out from under the read by the
@@ -104,7 +108,7 @@ class PostgresNotificationListener(
   private def poll(session: Session): Task[List[PGNotification]] =
     for
       notifications <- ZIO.attemptBlockingCancelable(
-        Option(session.pg.getNotifications(NotificationTimeoutMillis)).map(_.toList).getOrElse(Nil),
+        Option(session.pg.getNotifications(pollTimeout.toMillis.toInt)).map(_.toList).getOrElse(Nil),
       )(cancel = ZIO.unit)
       now <- Clock.instant
       _ <- if notifications.nonEmpty then session.delivered.set(now) else heartbeat(session, now)
@@ -149,7 +153,18 @@ enum NotificationEvent:
 object PostgresNotificationListener:
   // pgjdbc's own getNotifications(timeout) example uses 10s; see
   // https://access.crunchydata.com/documentation/pgjdbc/42.1.1/listennotify.html
-  private val NotificationTimeoutMillis = 10000
+  private val PollTimeout = 10.seconds
+
+  /** Bounds every read on this connection that isn't the wait for notifications.
+    *
+    * `getNotifications` takes its own timeout, and pgjdbc restores this one underneath it
+    * afterwards, so what this covers is the statements: `LISTEN` at connect time and the
+    * heartbeat's `NOTIFY`. Both are sent on the same connection the liveness check runs on,
+    * and a write to a black-holed socket is accepted locally and then waits forever for a
+    * response, so without a bound here the heartbeat is where a dead connection would hang
+    * instead of the read it was added to catch.
+    */
+  private val SocketTimeout = 30.seconds
 
   private val ReconnectMinBackoff = 100.millis
   private val ReconnectMaxBackoff = 10.seconds
@@ -216,6 +231,7 @@ object PostgresNotificationListener:
     // a plain String, so it's decoded back here at the point of use only.
     properties.setProperty("password", new String(config.password, StandardCharsets.UTF_8))
     properties.setProperty("tcpKeepAlive", "true")
+    properties.setProperty("socketTimeout", SocketTimeout.toSeconds.toString)
     properties.setProperty("ApplicationName", "versola-notification-listener")
     DriverManager.getConnection(config.notificationsUrl.getOrElse(config.url), properties)
 

--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
@@ -178,7 +178,7 @@ class PostgresNotificationListener(
       queue.offer(Take.chunk(Chunk.fromIterable(notifications))).flatMap: accepted =>
         ZIO.unless(accepted):
           ZIO.logWarning(s"Notification queue full; dropping ${notifications.size} notification(s)") *>
-            DbMetrics.notificationListenerQueueOverflow
+            DbMetrics.notificationListenerQueueOverflow(notifications.size)
         .unit
 
   /** One wait for notifications, and the liveness bookkeeping that goes with an empty one.

--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
@@ -31,6 +31,7 @@ class PostgresNotificationListener(
     heartbeatInterval: Duration = PostgresNotificationListener.HeartbeatInterval,
     livenessTimeout: Duration = PostgresNotificationListener.LivenessTimeout,
     pollTimeout: Duration = PostgresNotificationListener.PollTimeout,
+    queueCapacity: Int = PostgresNotificationListener.QueueCapacity,
 ):
   import PostgresNotificationListener.*
 
@@ -84,7 +85,14 @@ class PostgresNotificationListener(
       _ <- ZIO.addFinalizer(DbMetrics.notificationListenerConnected(false))
       _ <- ZIO.logInfo(s"Listening for notifications on ${channels.mkString(", ")}")
       session = Session(connection, pg, heartbeatChannel, now, delivered, beat)
-      queue <- Queue.unbounded[Take[Throwable, PGNotification]]
+      // Bounded and dropping rather than unbounded: a subscriber stuck behind its own slow
+      // reload is exactly the situation this fiber exists to keep polling through, so it
+      // must never suspend trying to hand off a result, and a queue that backpressures on a
+      // full buffer would do just that. Dropping the newest arrival instead of growing
+      // forever costs nothing this listener's subscribers do not already tolerate: every one
+      // of them treats a missed notification as covered by its own periodic reload against
+      // the same table, the same tolerance a lost connection relies on.
+      queue <- Queue.dropping[Take[Throwable, PGNotification]](queueCapacity)
       _ <- pollLoop(session, queue).forkScoped
     yield (session, queue)
 
@@ -121,9 +129,21 @@ class PostgresNotificationListener(
 
   private def pollLoop(session: Session, queue: Queue[Take[Throwable, PGNotification]]): UIO[Unit] =
     poll(session).foldCauseZIO(
+      // A failure always gets in: `Queue.dropping` only drops what a full buffer has no room
+      // for, and this is the one element that must never be the one dropped, or a subscriber
+      // stuck behind a slow reload would never learn the connection under it died either.
       cause => queue.offer(Take.failCause(cause)).unit,
-      notifications => queue.offer(Take.chunk(Chunk.fromIterable(notifications))) *> pollLoop(session, queue),
+      notifications => offer(queue, notifications) *> pollLoop(session, queue),
     )
+
+  private def offer(queue: Queue[Take[Throwable, PGNotification]], notifications: List[PGNotification]): UIO[Unit] =
+    if notifications.isEmpty then ZIO.unit
+    else
+      queue.offer(Take.chunk(Chunk.fromIterable(notifications))).flatMap: accepted =>
+        ZIO.unless(accepted):
+          ZIO.logWarning(s"Notification queue full; dropping ${notifications.size} notification(s)") *>
+            DbMetrics.notificationListenerQueueOverflow
+        .unit
 
   /** One wait for notifications, and the liveness bookkeeping that goes with an empty one.
     *
@@ -230,6 +250,14 @@ object PostgresNotificationListener:
     */
   private val HeartbeatInterval = 30.seconds
   private val LivenessTimeout = 90.seconds
+
+  /** Caps the backlog between the polling fiber and a subscriber that has fallen behind.
+    * Payloads here are a few hundred bytes each (see [[PostgresRevocationNotifications]]),
+    * so this bounds the worst case at a few megabytes, not a number picked to match any
+    * expected burst size: staying bounded at all is the property that matters, since falling
+    * behind this far already means the subscriber is relying on its periodic reload anyway.
+    */
+  private val QueueCapacity = 10_000
 
   /** A connection that is open, has never failed, and is no longer delivering — whether that
     * shows up as the read-side liveness deadline elapsing, or as the heartbeat's own write

--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
@@ -2,7 +2,7 @@ package versola.util.postgres
 
 import org.postgresql.{PGConnection, PGNotification}
 import zio.*
-import zio.stream.{Stream, ZStream}
+import zio.stream.{Stream, Take, ZStream}
 
 import java.nio.charset.StandardCharsets
 import java.sql.{Connection, DriverManager}
@@ -51,11 +51,21 @@ class PostgresNotificationListener(
   def notifications: Stream[Throwable, NotificationEvent] =
     ZStream
       .scoped(connect)
-      .flatMap: session =>
-        ZStream.succeed(NotificationEvent.Resubscribed) ++ read(session)
+      .flatMap: (session, queue) =>
+        ZStream.succeed(NotificationEvent.Resubscribed) ++ read(session, queue)
       .retry(reconnectSchedule)
 
-  private def connect: ZIO[Scope, Throwable, Session] =
+  /** Opens the connection, `LISTEN`s, and starts polling it on a fiber of its own before
+    * this returns — not lazily on the first pull of the resulting stream.
+    *
+    * That distinction matters because the first thing downstream ever does with a fresh
+    * connection is react to [[NotificationEvent.Resubscribed]], and in practice that handler
+    * is a synchronous reload against the same database this listener depends on. Deferring
+    * the fork until [[read]] is first pulled would start polling only once that handler
+    * returns, which is exactly backwards during the trouble this exists to survive: the
+    * heartbeat would not run precisely while the database is why it needs to.
+    */
+  private def connect: ZIO[Scope, Throwable, (Session, Queue[Take[Throwable, PGNotification]])] =
     for
       connection <- open
       // Unique per connection: what comes back on this channel proves that this session is
@@ -64,31 +74,43 @@ class PostgresNotificationListener(
       _ <- ZIO.attemptBlocking(execute(connection, (heartbeatChannel :: channels).map(channel => s"LISTEN $channel")))
       pg <- ZIO.attempt(connection.unwrap(classOf[PGConnection]))
       now <- Clock.instant
-      delivered <- Ref.make(now)
-      beat <- Ref.make(now)
-      _ <- DbMetrics.notificationListenerConnected(true)
+      // None until something actually round-trips: see DbMetrics.notificationListenerConnected
+      // for why LISTEN succeeding is not that proof.
+      delivered <- Ref.make(Option.empty[Instant])
+      // Already due, rather than due after a full heartbeatInterval: a freshly opened
+      // connection is proven, or shown broken, within the first poll cycle instead of only
+      // after sitting quiet for one interval first.
+      beat <- Ref.make(now.minus(heartbeatInterval))
       _ <- ZIO.addFinalizer(DbMetrics.notificationListenerConnected(false))
       _ <- ZIO.logInfo(s"Listening for notifications on ${channels.mkString(", ")}")
-    yield Session(connection, pg, heartbeatChannel, delivered, beat)
+      session = Session(connection, pg, heartbeatChannel, now, delivered, beat)
+      queue <- Queue.unbounded[Take[Throwable, PGNotification]]
+      _ <- pollLoop(session, queue).forkScoped
+    yield (session, queue)
 
   private def open: ZIO[Scope, Throwable, Connection] =
     ZIO.acquireRelease(ZIO.attemptBlocking(PostgresNotificationListener.open(config)))(connection =>
       ZIO.attemptBlocking(connection.close()).ignoreLogged,
     )
 
-  private def read(session: Session): Stream[Throwable, NotificationEvent] =
+  /** The queue [[connect]] already has [[pollLoop]] filling, turned into what a subscriber
+    * sees. The queue is unbounded because a bounded one would eventually apply the same
+    * backpressure the fiber in `connect` exists to avoid: it would just move where a slow
+    * subscriber stalls polling from "immediately" to "once the queue fills up".
+    */
+  private def read(session: Session, queue: Queue[Take[Throwable, PGNotification]]): Stream[Throwable, NotificationEvent] =
     ZStream
-      .repeatZIO(poll(session))
-      .flattenIterables
-      // The heartbeat is this listener talking to itself. It proves the connection is live and
-      // says nothing about the data, so subscribers never see it and it is not counted as a
-      // notification received.
+      .fromQueue(queue)
+      .flattenTake
+      // The heartbeat is this listener talking to itself. It proves the connection is live
+      // and says nothing about the data, so subscribers never see it and it is not counted
+      // as a notification received.
       .filter(_.getName != session.heartbeatChannel)
       .tap(_ => DbMetrics.notificationReceived)
       .map(NotificationEvent.Received(_))
-      // Counted apart from a loud failure rather than as well as one: a connection that went
-      // silent is the only one of the two that points at the network path rather than at the
-      // database, and summing them would hide exactly that.
+      // Counted apart from a loud failure rather than as well as one: a connection that
+      // went silent is the only one of the two that points at the network path rather than
+      // at the database, and summing them would hide exactly that.
       .tapError:
         case silent: SilentConnection =>
           ZIO.logWarningCause("Notification connection went silent; reconnecting", Cause.fail(silent)) *>
@@ -96,6 +118,12 @@ class PostgresNotificationListener(
         case cause =>
           ZIO.logWarningCause("Notification connection lost; reconnecting", Cause.fail(cause)) *>
             DbMetrics.notificationListenerReconnected
+
+  private def pollLoop(session: Session, queue: Queue[Take[Throwable, PGNotification]]): UIO[Unit] =
+    poll(session).foldCauseZIO(
+      cause => queue.offer(Take.failCause(cause)).unit,
+      notifications => queue.offer(Take.chunk(Chunk.fromIterable(notifications))) *> pollLoop(session, queue),
+    )
 
   /** One wait for notifications, and the liveness bookkeeping that goes with an empty one.
     *
@@ -111,8 +139,17 @@ class PostgresNotificationListener(
         Option(session.pg.getNotifications(pollTimeout.toMillis.toInt)).map(_.toList).getOrElse(Nil),
       )(cancel = ZIO.unit)
       now <- Clock.instant
-      _ <- if notifications.nonEmpty then session.delivered.set(now) else heartbeat(session, now)
+      _ <- if notifications.nonEmpty then proven(session, now) else heartbeat(session, now)
     yield notifications
+
+  /** Records that something (a real notification or this listener's own heartbeat, both
+    * arrive the same way) has round-tripped, and flips the gauge the first time that happens
+    * on this connection rather than optimistically at connect.
+    */
+  private def proven(session: Session, now: Instant): UIO[Unit] =
+    session.delivered.get.flatMap:
+      case Some(_) => session.delivered.set(Some(now))
+      case None    => session.delivered.set(Some(now)) *> DbMetrics.notificationListenerConnected(true)
 
   /** Proves the connection still delivers, by giving it something to deliver.
     *
@@ -135,9 +172,21 @@ class PostgresNotificationListener(
   private def heartbeat(session: Session, now: Instant): Task[Unit] =
     for
       delivered <- session.delivered.get
-      _ <- ZIO.when(now.isAfter(delivered.plus(livenessTimeout)))(ZIO.fail(SilentConnection(livenessTimeout)))
+      // Nothing has round-tripped since connecting: measured from connect, not from now, so
+      // a session that never manages a single delivery still gets exactly livenessTimeout
+      // before it is given up on, the same as one that has been failing for a while.
+      _ <- ZIO.when(now.isAfter(delivered.getOrElse(session.connectedAt).plus(livenessTimeout)))(
+        ZIO.fail(SilentConnection(livenessTimeout)),
+      )
       due <- session.beat.modify(sent => if now.isAfter(sent.plus(heartbeatInterval)) then (true, now) else (false, sent))
-      _ <- ZIO.when(due)(ZIO.attemptBlocking(execute(session.connection, List(s"NOTIFY ${session.heartbeatChannel}"))))
+      // A write that fails outright is the same silent connection revealing itself through
+      // the socket timeout on this send instead of through the read-side deadline above, so
+      // it is folded into the same failure rather than left to read as a loud one.
+      _ <- ZIO.when(due)(
+        ZIO
+          .attemptBlocking(execute(session.connection, List(s"NOTIFY ${session.heartbeatChannel}")))
+          .mapError(cause => SilentConnection(livenessTimeout, Some(cause))),
+      )
     yield ()
 
 /** What a subscriber sees on the notification stream. */
@@ -182,10 +231,15 @@ object PostgresNotificationListener:
   private val HeartbeatInterval = 30.seconds
   private val LivenessTimeout = 90.seconds
 
-  /** A connection that is open, has never failed, and is no longer delivering. */
-  private final class SilentConnection(timeout: Duration)
+  /** A connection that is open, has never failed, and is no longer delivering — whether that
+    * shows up as the read-side liveness deadline elapsing, or as the heartbeat's own write
+    * failing outright, which a socket timeout on a NAT- or firewall-blackholed connection
+    * does before the deadline otherwise would.
+    */
+  private final class SilentConnection(timeout: Duration, cause: Option[Throwable] = None)
       extends RuntimeException(
         s"No notification on this connection in $timeout, including this listener's own heartbeat",
+        cause.orNull,
       )
 
   /** The listener's connection, and what has to be remembered per connection to tell a quiet
@@ -195,7 +249,8 @@ object PostgresNotificationListener:
       connection: Connection,
       pg: PGConnection,
       heartbeatChannel: String,
-      delivered: Ref[Instant],
+      connectedAt: Instant,
+      delivered: Ref[Option[Instant]],
       beat: Ref[Instant],
   )
 

--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
@@ -144,12 +144,18 @@ class PostgresNotificationListener(
     * oldest notification to make room trades an event that is already covered by the
     * subscriber's periodic reload for the one signal that is not recoverable any other way.
     */
-  private def offerFailure(queue: Queue[Take[Throwable, PGNotification]], cause: Cause[Throwable]): UIO[Unit] =
+  private[postgres] def offerFailure(
+      queue: Queue[Take[Throwable, PGNotification]],
+      cause: Cause[Throwable],
+  ): UIO[Unit] =
     queue.offer(Take.failCause(cause)).flatMap: accepted =>
       ZIO.unless(accepted):
-        // Non-blocking: the queue can only reject when it is full, so there is something to
-        // take, and this fiber is the only producer, so the space it frees stays free.
-        queue.take *> offerFailure(queue, cause)
+        // `poll` rather than `take`, because the queue being full is only true at the moment
+        // the offer is rejected: the consumer can drain it in between, and a blocking take
+        // would then wait on an empty queue that this fiber is the only producer for, which
+        // is the deadlock the eviction exists to prevent. Polling an empty queue returns
+        // nothing and the retry below simply succeeds, since draining freed the space.
+        queue.poll *> offerFailure(queue, cause)
       .unit
 
   private def offer(queue: Queue[Take[Throwable, PGNotification]], notifications: List[PGNotification]): UIO[Unit] =

--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
@@ -33,13 +33,21 @@ class PostgresNotificationListener(
     livenessTimeout: Duration = PostgresNotificationListener.LivenessTimeout,
     pollTimeout: Duration = PostgresNotificationListener.PollTimeout,
     queueCapacity: Int = PostgresNotificationListener.QueueCapacity,
+    deliveryCapacity: Int = PostgresNotificationListener.QueueCapacity,
 ):
   import PostgresNotificationListener.*
 
-  /** Notifications from every channel this listener subscribes to, reconnecting for as long
-    * as the stream is consumed.
+  /** Notifications from every channel this listener subscribes to, for as long as the
+    * returned stream is pulled -- reconnecting is not conditional on that, though: it runs on
+    * a fiber of its own, [[daemon]], which this only ever reads from.
     *
-    * A dropped connection is expected rather than exceptional \u2014 Postgres restarts, network
+    * That split matters because a subscriber's own handler is realistically a synchronous
+    * reload against the same database whose trouble is why a connection just died -- exactly
+    * the moment reconnecting cannot afford to wait on whatever is slow about that reload. A
+    * subscriber stalled inside one no longer holds a proven-dead connection open, or delays
+    * the new one: [[daemon]] never awaits `delivery`, only offers to it.
+    *
+    * A dropped connection is expected rather than exceptional -- Postgres restarts, network
     * blips, and poolers that recycle idle server connections all produce one, and an idle
     * `LISTEN` connection is the first thing an idle timeout reaps. Whatever was published
     * while the connection was gone is not redelivered on reconnect, so each (re)connect opens
@@ -51,24 +59,60 @@ class PostgresNotificationListener(
     * database that simply has nothing to say.
     */
   def notifications: Stream[Throwable, NotificationEvent] =
-    ZStream
-      // Reported here as well as from the polling fiber, because failing to get a connection
-      // up is a reconnect too, and it is the one kind the fiber never sees: there is no poll
-      // loop yet to fail.
-      .scoped(connect.tapErrorCause(lost))
-      .flatMap: (session, queue) =>
-        ZStream.succeed(NotificationEvent.Resubscribed) ++ read(session, queue)
+    ZStream.unwrapScoped:
+      for
+        delivery <- Queue.dropping[NotificationEvent](deliveryCapacity)
+        _ <- daemon(delivery).forkScoped
+      yield ZStream.fromQueue(delivery)
+
+  /** Connects, polls, reconnects, and hands every event to `delivery` -- forever, and
+    * regardless of whether, or how quickly, anything is pulling from it.
+    *
+    * [[reconnectSchedule]] retries without end, so this only ever stops on an unhandled bug:
+    * reaching the fallback below means that invariant broke, not that the database is down.
+    *
+    * Draining `delivery` on failure is what [[NotificationEvent.Resubscribed]] promises a
+    * subscriber that has fallen behind: whatever this connection already handed over but
+    * `delivery` is still holding is exactly the stale view a resubscribe exists to replace,
+    * so it goes with the connection rather than sitting in front of the event that says so.
+    */
+  private def daemon(delivery: Queue[NotificationEvent]): UIO[Unit] =
+    ZIO
+      .scoped:
+        connect.tapErrorCause(lost).flatMap: (session, queue) =>
+          (ZStream.succeed(NotificationEvent.Resubscribed) ++ read(session, queue))
+            .runForeach(deliver(delivery, _))
+      .tapErrorCause(_ => delivery.takeAll.unit)
       .retry(reconnectSchedule)
+      .catchAllCause: cause =>
+        ZIO.logFatalCause(
+          "Notification listener stopped reconnecting; reconnectSchedule retries without end, " +
+            "so reaching this is a bug in it, not an outage, and no further connections will be " +
+            "attempted on this listener",
+          cause,
+        )
+
+  /** Hands one event to whatever pulls [[notifications]], dropping rather than blocking when
+    * it is not keeping up -- the same tolerance every subscriber already has for a missed
+    * notification, since [[NotificationEvent.Resubscribed]] is what tells it to reload
+    * regardless of how it fell behind, and blocking here would be [[daemon]] inheriting the
+    * exact stall this queue exists to keep it out of.
+    */
+  private def deliver(delivery: Queue[NotificationEvent], event: NotificationEvent): UIO[Unit] =
+    delivery.offer(event).flatMap: accepted =>
+      ZIO.unless(accepted):
+        ZIO.logWarning("Notification delivery queue full; dropping a notification") *>
+          DbMetrics.notificationListenerQueueOverflow(1)
+    .unit
+
 
   /** Opens the connection, `LISTEN`s, and starts polling it on a fiber of its own before
     * this returns — not lazily on the first pull of the resulting stream.
     *
-    * That distinction matters because the first thing downstream ever does with a fresh
-    * connection is react to [[NotificationEvent.Resubscribed]], and in practice that handler
-    * is a synchronous reload against the same database this listener depends on. Deferring
-    * the fork until [[read]] is first pulled would start polling only once that handler
-    * returns, which is exactly backwards during the trouble this exists to survive: the
-    * heartbeat would not run precisely while the database is why it needs to.
+    * [[daemon]] pulls [[read]] immediately after this returns, so in practice the two happen
+    * back to back regardless; forking here rather than there just keeps the heartbeat cadence
+    * exact from the moment the connection exists, free of however this fiber happens to get
+    * scheduled once it does.
     */
   private def connect: ZIO[Scope, Throwable, (Session, Queue[Take[Throwable, PGNotification]])] =
     for
@@ -105,15 +149,15 @@ class PostgresNotificationListener(
       ZIO.attemptBlocking(connection.close()).ignoreLogged,
     )
 
-  /** The queue [[connect]] already has [[pollLoop]] filling, turned into what a subscriber
-    * sees. The queue drops rather than backpressures when full, because blocking on a full
+  /** The queue [[connect]] already has [[pollLoop]] filling, turned into what [[daemon]] pulls
+    * from. The queue drops rather than backpressures when full, because blocking on a full
     * buffer would apply the same backpressure the fiber in `connect` exists to avoid: it
-    * would just move where a slow subscriber stalls polling from "immediately" to "once the
-    * queue fills up".
+    * would just move where a slow drain stalls polling from "immediately" to "once the queue
+    * fills up" — and now that [[daemon]] never blocks on anything downstream of it either,
+    * that slow drain can only be this fiber itself falling behind actual poll throughput.
     *
-    * Nothing about the connection's health is recorded from here. What a subscriber has
-    * gotten around to observing is not when the connection died, and [[lost]] runs at the
-    * latter.
+    * Nothing about the connection's health is recorded from here. What has gotten around to
+    * being pulled is not when the connection died, and [[lost]] runs at the latter.
     */
   private def read(session: Session, queue: Queue[Take[Throwable, PGNotification]]): Stream[Throwable, NotificationEvent] =
     ZStream

--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
@@ -6,6 +6,7 @@ import zio.stream.{Stream, ZStream}
 
 import java.nio.charset.StandardCharsets
 import java.sql.{Connection, DriverManager}
+import java.time.Instant
 import java.util.Properties
 
 /** A dedicated connection parked on `LISTEN`, exposing everything Postgres pushes to it as a
@@ -24,7 +25,12 @@ import java.util.Properties
   * need a session that outlives a transaction, so [[PostgresConfig.notificationsUrl]] can
   * point past the pooler while everything else goes through it.
   */
-class PostgresNotificationListener(config: PostgresConfig, channels: List[String]):
+class PostgresNotificationListener(
+    config: PostgresConfig,
+    channels: List[String],
+    heartbeatInterval: Duration = PostgresNotificationListener.HeartbeatInterval,
+    livenessTimeout: Duration = PostgresNotificationListener.LivenessTimeout,
+):
   import PostgresNotificationListener.*
 
   /** Notifications from every channel this listener subscribes to, reconnecting for as long
@@ -36,6 +42,10 @@ class PostgresNotificationListener(config: PostgresConfig, channels: List[String
     * while the connection was gone is not redelivered on reconnect, so each (re)connect opens
     * with [[NotificationEvent.Resubscribed]]: subscribers treat it as "your view may have
     * gaps" and reload from the table, which is the source of truth in every case here.
+    *
+    * A connection that stops delivering without ever failing is treated as the same event,
+    * because that is what it is to a subscriber. [[heartbeat]] is what tells one apart from a
+    * database that simply has nothing to say.
     */
   def notifications: Stream[Throwable, NotificationEvent] =
     ZStream
@@ -44,37 +54,87 @@ class PostgresNotificationListener(config: PostgresConfig, channels: List[String
         ZStream.succeed(NotificationEvent.Resubscribed) ++ read(session)
       .retry(reconnectSchedule)
 
-  private def connect: ZIO[Scope, Throwable, PGConnection] =
+  private def connect: ZIO[Scope, Throwable, Session] =
     for
       connection <- open
-      _ <- ZIO.attemptBlocking(execute(connection, channels.map(channel => s"LISTEN $channel")))
-      session <- ZIO.attempt(connection.unwrap(classOf[PGConnection]))
+      // Unique per connection: what comes back on this channel proves that this session is
+      // being delivered to, not that some other replica's session is.
+      heartbeatChannel = s"versola_listener_heartbeat_${java.util.UUID.randomUUID().toString.replace("-", "_")}"
+      _ <- ZIO.attemptBlocking(execute(connection, (heartbeatChannel :: channels).map(channel => s"LISTEN $channel")))
+      pg <- ZIO.attempt(connection.unwrap(classOf[PGConnection]))
+      now <- Clock.instant
+      delivered <- Ref.make(now)
+      beat <- Ref.make(now)
       _ <- DbMetrics.notificationListenerConnected(true)
       _ <- ZIO.addFinalizer(DbMetrics.notificationListenerConnected(false))
       _ <- ZIO.logInfo(s"Listening for notifications on ${channels.mkString(", ")}")
-    yield session
+    yield Session(connection, pg, heartbeatChannel, delivered, beat)
 
   private def open: ZIO[Scope, Throwable, Connection] =
     ZIO.acquireRelease(ZIO.attemptBlocking(PostgresNotificationListener.open(config)))(connection =>
       ZIO.attemptBlocking(connection.close()).ignoreLogged,
     )
 
-  private def read(session: PGConnection): Stream[Throwable, NotificationEvent] =
+  private def read(session: Session): Stream[Throwable, NotificationEvent] =
     ZStream
-      .repeatZIO(
-        // Blocks for up to NotificationTimeoutMillis waiting for a notification (pgjdbc's own
-        // recommended pattern) instead of busy-polling. The blocking socket read does not respond
-        // to a plain thread interrupt, so on fiber interruption (graceful shutdown, or the retry
-        // above tearing this attempt down) the connection is closed out from under the read by the
-        // finalizer in `open`, which is what unblocks it.
-        ZIO.attemptBlockingCancelable(
-          Option(session.getNotifications(NotificationTimeoutMillis)).map(_.toList).getOrElse(Nil),
-        )(cancel = ZIO.unit),
-      )
+      .repeatZIO(poll(session))
       .flattenIterables
+      // The heartbeat is this listener talking to itself. It proves the connection is live and
+      // says nothing about the data, so subscribers never see it and it is not counted as a
+      // notification received.
+      .filter(_.getName != session.heartbeatChannel)
       .tap(_ => DbMetrics.notificationReceived)
       .map(NotificationEvent.Received(_))
-      .tapError(cause => ZIO.logWarningCause("Notification connection lost; reconnecting", Cause.fail(cause)) *> DbMetrics.notificationListenerReconnected)
+      .tapError:
+        case silent: SilentConnection =>
+          ZIO.logWarningCause("Notification connection went silent; reconnecting", Cause.fail(silent)) *>
+            DbMetrics.notificationListenerWentSilent *> DbMetrics.notificationListenerReconnected
+        case cause =>
+          ZIO.logWarningCause("Notification connection lost; reconnecting", Cause.fail(cause)) *>
+            DbMetrics.notificationListenerReconnected
+
+  /** One wait for notifications, and the liveness bookkeeping that goes with an empty one.
+    *
+    * Blocks for up to NotificationTimeoutMillis waiting for a notification (pgjdbc's own
+    * recommended pattern) instead of busy-polling. The blocking socket read does not respond
+    * to a plain thread interrupt, so on fiber interruption (graceful shutdown, or the retry
+    * above tearing this attempt down) the connection is closed out from under the read by the
+    * finalizer in `open`, which is what unblocks it.
+    */
+  private def poll(session: Session): Task[List[PGNotification]] =
+    for
+      notifications <- ZIO.attemptBlockingCancelable(
+        Option(session.pg.getNotifications(NotificationTimeoutMillis)).map(_.toList).getOrElse(Nil),
+      )(cancel = ZIO.unit)
+      now <- Clock.instant
+      _ <- if notifications.nonEmpty then session.delivered.set(now) else heartbeat(session, now)
+    yield notifications
+
+  /** Proves the connection still delivers, by giving it something to deliver.
+    *
+    * Nothing arriving is the ambiguous case: a database with nothing to say and a connection
+    * that has stopped carrying anything look identical from here, and the second one produces
+    * no error to react to. A socket killed by a NAT or firewall idle timeout is never closed
+    * from either end, so the read below simply blocks forever on a path nothing will ever
+    * write to again; `tcpKeepAlive` is set, but when it notices is the operating system's
+    * default, which is measured in hours on a stock Linux.
+    *
+    * So the listener notifies its own channel, and requires it back. Silence past
+    * [[livenessTimeout]] is taken as the connection being gone and fails the stream, which
+    * puts it through the same reconnect and [[NotificationEvent.Resubscribed]] path as a
+    * connection that dropped loudly.
+    *
+    * Sent from this fiber, in between reads, rather than from a second fiber or a second
+    * connection: a pgjdbc connection is not safe to use from two threads at once, and one
+    * that is blocked in `getNotifications` is exactly the case that would break.
+    */
+  private def heartbeat(session: Session, now: Instant): Task[Unit] =
+    for
+      delivered <- session.delivered.get
+      _ <- ZIO.when(now.isAfter(delivered.plus(livenessTimeout)))(ZIO.fail(SilentConnection(livenessTimeout)))
+      due <- session.beat.modify(sent => if now.isAfter(sent.plus(heartbeatInterval)) then (true, now) else (false, sent))
+      _ <- ZIO.when(due)(ZIO.attemptBlocking(execute(session.connection, List(s"NOTIFY ${session.heartbeatChannel}"))))
+    yield ()
 
 /** What a subscriber sees on the notification stream. */
 enum NotificationEvent:
@@ -93,6 +153,36 @@ object PostgresNotificationListener:
 
   private val ReconnectMinBackoff = 100.millis
   private val ReconnectMaxBackoff = 10.seconds
+
+  /** How often an otherwise idle connection is asked to prove itself, and how long it may
+    * stay silent before it is replaced.
+    *
+    * The timeout is a multiple of the interval rather than equal to it, so a single heartbeat
+    * lost to a slow moment is not read as a dead connection. Both are only checked when a
+    * read comes back empty, so what either one actually resolves to is the next read
+    * boundary. What the gap costs is bounded anyway: a subscriber's own periodic
+    * reconciliation is what covers the interval, and this only decides how quickly the push
+    * path comes back.
+    */
+  private val HeartbeatInterval = 30.seconds
+  private val LivenessTimeout = 90.seconds
+
+  /** A connection that is open, has never failed, and is no longer delivering. */
+  private final class SilentConnection(timeout: Duration)
+      extends RuntimeException(
+        s"No notification on this connection in $timeout, including this listener's own heartbeat",
+      )
+
+  /** The listener's connection, and what has to be remembered per connection to tell a quiet
+    * one from a dead one. Replaced wholesale on every reconnect, along with the timers.
+    */
+  private final case class Session(
+      connection: Connection,
+      pg: PGConnection,
+      heartbeatChannel: String,
+      delivered: Ref[Instant],
+      beat: Ref[Instant],
+  )
 
   /** Backs off up to [[ReconnectMaxBackoff]] between attempts, and never stops attempting.
     *

--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresNotificationListener.scala
@@ -51,7 +51,10 @@ class PostgresNotificationListener(
     */
   def notifications: Stream[Throwable, NotificationEvent] =
     ZStream
-      .scoped(connect)
+      // Reported here as well as from the polling fiber, because failing to get a connection
+      // up is a reconnect too, and it is the one kind the fiber never sees: there is no poll
+      // loop yet to fail.
+      .scoped(connect.tapErrorCause(lost))
       .flatMap: (session, queue) =>
         ZStream.succeed(NotificationEvent.Resubscribed) ++ read(session, queue)
       .retry(reconnectSchedule)
@@ -106,6 +109,10 @@ class PostgresNotificationListener(
     * buffer would apply the same backpressure the fiber in `connect` exists to avoid: it
     * would just move where a slow subscriber stalls polling from "immediately" to "once the
     * queue fills up".
+    *
+    * Nothing about the connection's health is recorded from here. What a subscriber has
+    * gotten around to observing is not when the connection died, and [[lost]] runs at the
+    * latter.
     */
   private def read(session: Session, queue: Queue[Take[Throwable, PGNotification]]): Stream[Throwable, NotificationEvent] =
     ZStream
@@ -117,46 +124,53 @@ class PostgresNotificationListener(
       .filter(_.getName != session.heartbeatChannel)
       .tap(_ => DbMetrics.notificationReceived)
       .map(NotificationEvent.Received(_))
-      // Counted apart from a loud failure rather than as well as one: a connection that
-      // went silent is the only one of the two that points at the network path rather than
-      // at the database, and summing them would hide exactly that.
-      .tapError:
-        case silent: SilentConnection =>
-          ZIO.logWarningCause("Notification connection went silent; reconnecting", Cause.fail(silent)) *>
-            DbMetrics.notificationListenerWentSilent
-        case cause =>
-          ZIO.logWarningCause("Notification connection lost; reconnecting", Cause.fail(cause)) *>
-            DbMetrics.notificationListenerReconnected
 
   private def pollLoop(session: Session, queue: Queue[Take[Throwable, PGNotification]]): UIO[Unit] =
     poll(session).foldCauseZIO(
-      cause => offerFailure(queue, cause),
+      cause => lost(cause) *> supersede(queue, cause),
       notifications => offer(queue, notifications) *> pollLoop(session, queue),
     )
 
-  /** Gets the failure in whatever it takes, because this is the one element that must not be
-    * dropped: [[pollLoop]] stops after it, so a failure lost to a full queue would leave the
-    * stream waiting on a queue nothing will ever fill again — no error to retry on, and the
-    * reconnect that a subscriber is waiting for never happens.
+  /** Records that this connection is gone, when the polling fiber finds out rather than when
+    * a subscriber gets around to observing it.
     *
-    * A full queue is exactly the case where dropping it is most likely and least acceptable:
-    * the subscriber is already behind, and the connection under it just died. Evicting the
-    * oldest notification to make room trades an event that is already covered by the
-    * subscriber's periodic reload for the one signal that is not recoverable any other way.
+    * These describe the connection, not a subscriber's view of it, and the two come apart in
+    * the exact case this fiber exists for: a subscriber blocked on its own reload against the
+    * same database would hold `db_notification_listener_connected` at 1 for as long as it
+    * stayed blocked, reporting a working push path that is already dead.
     */
-  private[postgres] def offerFailure(
-      queue: Queue[Take[Throwable, PGNotification]],
-      cause: Cause[Throwable],
-  ): UIO[Unit] =
-    queue.offer(Take.failCause(cause)).flatMap: accepted =>
-      ZIO.unless(accepted):
-        // `poll` rather than `take`, because the queue being full is only true at the moment
-        // the offer is rejected: the consumer can drain it in between, and a blocking take
-        // would then wait on an empty queue that this fiber is the only producer for, which
-        // is the deadlock the eviction exists to prevent. Polling an empty queue returns
-        // nothing and the retry below simply succeeds, since draining freed the space.
-        queue.poll *> offerFailure(queue, cause)
-      .unit
+  private def lost(cause: Cause[Throwable]): UIO[Unit] =
+    val silent = cause.failures.exists(_.isInstanceOf[SilentConnection])
+    ZIO.logWarningCause(
+      if silent then "Notification connection went silent; reconnecting"
+      else "Notification connection lost; reconnecting",
+      cause,
+    ) *>
+      // Counted apart from a loud failure rather than as well as one: a connection that went
+      // silent is the only one of the two that points at the network path rather than at the
+      // database, and summing them would hide exactly that.
+      (if silent then DbMetrics.notificationListenerWentSilent else DbMetrics.notificationListenerReconnected) *>
+      DbMetrics.notificationListenerConnected(false)
+
+  /** Puts the failure in the queue in place of whatever was still waiting there, rather than
+    * behind it.
+    *
+    * FIFO would land it after the backlog, and a subscriber only has a backlog because it is
+    * behind, so the reconnect would wait out however long that subscriber takes — on a
+    * connection that is already dead. Ordering it ahead is also free of anything to weigh
+    * against: [[pollLoop]] stops here, so the reconnect opens with
+    * [[NotificationEvent.Resubscribed]], and every subscriber answers that by reloading from
+    * the table, which covers those notifications and any the queue dropped before them.
+    *
+    * Draining also removes the offer's failure case rather than coping with it: this fiber is
+    * the only producer and it has stopped polling, so nothing can refill the queue in
+    * between, and the one element that must never be dropped cannot be. Nothing counts these
+    * as overflow — they are discarded because the connection died, not because a subscriber
+    * was too slow for the buffer, and conflating the two would spoil the only signal that
+    * says which.
+    */
+  private def supersede(queue: Queue[Take[Throwable, PGNotification]], cause: Cause[Throwable]): UIO[Unit] =
+    queue.takeAll *> queue.offer(Take.failCause(cause)).unit
 
   private def offer(queue: Queue[Take[Throwable, PGNotification]], notifications: List[PGNotification]): UIO[Unit] =
     if notifications.isEmpty then ZIO.unit

--- a/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
+++ b/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
@@ -2,8 +2,10 @@ package versola.util.postgres
 
 import com.augustnagro.magnum.magzio.TransactorZIO
 import com.augustnagro.magnum.sql
+import org.postgresql.PGNotification
 import zio.*
 import zio.metrics.*
+import zio.stream.Take
 import zio.test.*
 
 import java.time.OffsetDateTime
@@ -213,6 +215,26 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
         // through the full queue, failed the stream, and drove a reconnect.
         resubscribes.exists(_.size == 2),
       )
+    },
+    test("gets the failure in even when the consumer empties the queue first") {
+      // The eviction that makes room for a failure cannot assume the queue is still full: the
+      // consumer may drain it entirely between the rejected offer and the eviction. Taking
+      // blockingly there would wait on an empty queue whose only producer has already stopped
+      // (pollLoop ends at the failure), stranding the reconnect in the one case that needs it.
+      // Racing a drainer against the offer hits that window; a failure to make room shows up
+      // as this never completing rather than as a wrong value, hence the timeout.
+      val listener = PostgresNotificationListener(config = null, channels = Nil)
+      ZIO
+        .foreachDiscard(1 to 200): _ =>
+          for
+            queue <- Queue.dropping[Take[Throwable, PGNotification]](1)
+            _ <- queue.offer(Take.chunk(Chunk.empty))
+            drainer <- queue.takeAll.fork
+            _ <- listener.offerFailure(queue, Cause.fail(RuntimeException("connection lost")))
+            _ <- drainer.join
+          yield ()
+        .timeout(30.seconds)
+        .map(completed => assertTrue(completed.isDefined))
     },
     test("refuses to start when notifications cannot be delivered") {
       for

--- a/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
+++ b/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
@@ -181,6 +181,39 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
         after.count - before.count >= 3.0,
       )
     },
+    test("still reports a connection that dies while the queue is full") {
+      // The two failure modes compound here: the subscriber is far enough behind to have
+      // filled the queue, and then the connection under it dies. Dropping that failure the
+      // way an ordinary notification is dropped would strand the stream — pollLoop stops
+      // after a failure, so nothing would ever fill the queue again, and the subscriber would
+      // wait on it forever rather than seeing the error and reconnecting.
+      //
+      // The overflow and the kill both happen inside the handler for the first Resubscribed,
+      // which is what guarantees the ordering: polling carries on while the handler is
+      // blocked, so the queue is already full by the time the connection is killed.
+      for
+        config <- ZIO.service[PostgresConfig]
+        listener = PostgresNotificationListener(config, List(channel), pollTimeout = 50.millis, queueCapacity = 2)
+        first <- Ref.make(true)
+        resubscribes <- listener
+          .notifications
+          .tap:
+            case NotificationEvent.Resubscribed =>
+              first.getAndSet(false).flatMap: isFirst =>
+                ZIO.when(isFirst):
+                  ZIO.foreachDiscard(1 to 5)(i => notify(s"stranded-$i").delay(150.millis)) *>
+                    killListener *> ZIO.sleep(300.millis)
+            case _ => ZIO.unit
+          .filter(_ == NotificationEvent.Resubscribed)
+          .take(2)
+          .runCollect
+          .timeout(30.seconds)
+      yield assertTrue(
+        // A second Resubscribed at all is the point: it can only happen if the failure got
+        // through the full queue, failed the stream, and drove a reconnect.
+        resubscribes.exists(_.size == 2),
+      )
+    },
     test("refuses to start when notifications cannot be delivered") {
       for
         config <- ZIO.service[PostgresConfig]

--- a/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
+++ b/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
@@ -77,6 +77,24 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
         delays.forall(_ <= 10.seconds * 1.2),
       )
     },
+    test("tells a black-holed heartbeat write apart from an ordinary loud one") {
+      // The heartbeat's own NOTIFY relabels a failure as the connection going silent only for
+      // the one case that actually is: a socket timing out on a write nothing will ever get a
+      // response to. Anything else that can fail a NOTIFY -- an admin shutdown, a terminated
+      // backend -- reached the driver the way a loud failure ordinarily does, and must stay
+      // one, or a real database incident gets counted and alerted on as a network problem.
+      assertTrue(
+        PostgresNotificationListener.isSocketTimeout(java.net.SocketTimeoutException("Read timed out")),
+        // Wrapped by an intermediate exception, the way pgjdbc wraps a socket-level failure
+        // in a PSQLException: still found, because it is the chain that is classified.
+        PostgresNotificationListener.isSocketTimeout(
+          RuntimeException("wrapped", java.net.SocketTimeoutException("Read timed out")),
+        ),
+        // A loud failure with no timeout anywhere in its chain is left alone.
+        !PostgresNotificationListener.isSocketTimeout(RuntimeException("FATAL: terminating connection due to administrator command")),
+        !PostgresNotificationListener.isSocketTimeout(RuntimeException("connection closed")),
+      )
+    },
     test("holds a quiet connection open on its heartbeat, and keeps that heartbeat to itself") {
       // Nothing is published here at all, so every poll comes back empty and the heartbeat is
       // the only thing keeping the connection alive. The liveness timeout is several
@@ -171,6 +189,41 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
         _ <- fiber.interrupt
         count <- resubscribes.get
       yield assertTrue(count == 1)
+    },
+    test("bounds memory by notification, not by the batch Postgres happens to hand back") {
+      // Sent as fast as this fiber can issue them, with a poll timeout long enough to cover
+      // the whole burst, rather than the spaced-out sends the next test uses to force one
+      // notification per poll cycle: the point here is specifically what happens when several
+      // arrive in the same getNotifications() call, since Queue.dropping bounds the number of
+      // elements offered to it, not what those elements contain. A single element wrapping
+      // Postgres's whole batch would let a burst this size occupy one of queueCapacity slots
+      // regardless of how many notifications were in it, so the bound this exists to enforce
+      // would not hold. Offered individually, capacity elements are accepted and the rest are
+      // rejected regardless of how pgjdbc happened to batch them, which is what makes the
+      // dropped count below exact rather than just a lower bound.
+      val overflow =
+        Metric.counter("db_notification_listener_queue_overflow_total").tagged(MetricLabel("db_system", "postgresql"))
+      val sent = 50
+      val capacity = 3
+      for
+        config <- ZIO.service[PostgresConfig]
+        listener = PostgresNotificationListener(config, List(channel), pollTimeout = 5.seconds, queueCapacity = capacity)
+        before <- overflow.value
+        fiber <- listener.notifications.runForeach {
+          case NotificationEvent.Resubscribed => ZIO.never
+          case _ => ZIO.unit
+        }.fork
+        _ <- ZIO.sleep(300.millis)
+        _ <- ZIO.foreachDiscard(1 to sent)(i => notify(s"burst-$i"))
+        _ <- ZIO.sleep(1.second)
+        after <- overflow.value
+        _ <- fiber.interrupt
+      yield assertTrue(
+        // Exact, not a lower bound: with a 5s poll timeout against a burst that lands well
+        // inside it, every poll before the burst is drained comes back non-empty, so the
+        // heartbeat never fires and never competes for a slot either.
+        after.count - before.count == (sent - capacity).toDouble,
+      )
     },
     test("drops rather than grows without bound when a subscriber never catches up") {
       // A subscriber stuck on the opening Resubscribed forever, rather than merely slow: it

--- a/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
+++ b/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
@@ -2,10 +2,8 @@ package versola.util.postgres
 
 import com.augustnagro.magnum.magzio.TransactorZIO
 import com.augustnagro.magnum.sql
-import org.postgresql.PGNotification
 import zio.*
 import zio.metrics.*
-import zio.stream.Take
 import zio.test.*
 
 import java.time.OffsetDateTime
@@ -97,12 +95,32 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
           livenessTimeout = 1.second,
           pollTimeout = 100.millis,
         )
-        events <- listener.notifications.take(2).runCollect.timeout(4.seconds)
+        connected = Metric
+          .gauge("db_notification_listener_connected")
+          .tagged(MetricLabel("db_system", "postgresql"))
+        events <- Ref.make(Chunk.empty[NotificationEvent])
+        fiber <- listener.notifications.runForeach(event => events.update(_ :+ event)).fork
+        _ <- ZIO.sleep(4.seconds)
+        // Read before the interrupt, which tears the connection down and sets this back to 0.
+        proven <- connected.value
+        _ <- fiber.interrupt
+        collected <- events.get
       yield assertTrue(
-        // Timed out waiting for a second event rather than collecting one: the connection
-        // stayed up across every liveness deadline in those four seconds, and the heartbeats
-        // that kept it up are filtered out before a subscriber sees them.
-        events.isEmpty,
+        // Asserted as what did arrive rather than as a timeout: nothing arriving is also what
+        // a connection that never came up at all looks like, so an empty collection would
+        // have passed for a listener that spent the whole four seconds failing to connect.
+        //
+        // Exactly one Resubscribed: it came up once, and stayed up across every liveness
+        // deadline in four seconds — at a 100ms poll and a 1s timeout, a heartbeat that was
+        // not making the round trip would have failed the connection and shown up here as a
+        // second one.
+        collected == Chunk(NotificationEvent.Resubscribed),
+        // And the gauge only flips on something actually round-tripping. Nothing is published
+        // in this test, so the heartbeat is the only thing that can have flipped it, which is
+        // the round trip asserted directly rather than inferred from the absence of a
+        // reconnect. Read after a four-second window rather than at the moment of a flip, so
+        // there is nothing here to race.
+        proven.value == 1.0,
       )
     },
     test("replaces a connection that stops delivering, without it ever failing") {
@@ -183,58 +201,43 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
         after.count - before.count >= 3.0,
       )
     },
-    test("still reports a connection that dies while the queue is full") {
+    test("reconnects ahead of the backlog a subscriber has not caught up on") {
       // The two failure modes compound here: the subscriber is far enough behind to have
-      // filled the queue, and then the connection under it dies. Dropping that failure the
-      // way an ordinary notification is dropped would strand the stream — pollLoop stops
-      // after a failure, so nothing would ever fill the queue again, and the subscriber would
-      // wait on it forever rather than seeing the error and reconnecting.
+      // filled the queue, and then the connection under it dies. Both happen inside the
+      // handler for the first Resubscribed, which is what fixes the ordering rather than
+      // racing it: polling carries on while that handler is blocked, so the queue is full and
+      // the connection is dead before the subscriber pulls again.
       //
-      // The overflow and the kill both happen inside the handler for the first Resubscribed,
-      // which is what guarantees the ordering: polling carries on while the handler is
-      // blocked, so the queue is already full by the time the connection is killed.
+      // What the subscriber must see on its next pull is the reconnect, not the leftovers of
+      // the connection that died. Queued behind them, the failure would only surface once the
+      // subscriber had worked through a backlog it is by definition slow to work through, and
+      // the reconnect would wait that long on an already-dead connection. Ordered ahead of
+      // them, nothing is lost that the Resubscribed's own reload does not cover.
       for
         config <- ZIO.service[PostgresConfig]
         listener = PostgresNotificationListener(config, List(channel), pollTimeout = 50.millis, queueCapacity = 2)
+        events <- Ref.make(Chunk.empty[NotificationEvent])
         first <- Ref.make(true)
-        resubscribes <- listener
+        fiber <- listener
           .notifications
-          .tap:
-            case NotificationEvent.Resubscribed =>
+          .runForeach: event =>
+            events.update(_ :+ event) *> ZIO.when(event == NotificationEvent.Resubscribed):
               first.getAndSet(false).flatMap: isFirst =>
                 ZIO.when(isFirst):
-                  ZIO.foreachDiscard(1 to 5)(i => notify(s"stranded-$i").delay(150.millis)) *>
+                  ZIO.foreachDiscard(1 to 5)(i => notify(s"backlog-$i").delay(150.millis)) *>
                     killListener *> ZIO.sleep(300.millis)
-            case _ => ZIO.unit
-          .filter(_ == NotificationEvent.Resubscribed)
-          .take(2)
-          .runCollect
-          .timeout(30.seconds)
+          .fork
+        _ <- ZIO.sleep(5.seconds)
+        _ <- fiber.interrupt
+        collected <- events.get
       yield assertTrue(
-        // A second Resubscribed at all is the point: it can only happen if the failure got
-        // through the full queue, failed the stream, and drove a reconnect.
-        resubscribes.exists(_.size == 2),
+        // Two of them, so the failure got out of a full queue at all: pollLoop stops after
+        // the failure, so one that was dropped for want of room would leave the subscriber
+        // waiting on a queue nothing will ever fill again.
+        collected.count(_ == NotificationEvent.Resubscribed) == 2,
+        // And immediately, with none of the dead connection's notifications in between.
+        collected.take(2) == Chunk(NotificationEvent.Resubscribed, NotificationEvent.Resubscribed),
       )
-    },
-    test("gets the failure in even when the consumer empties the queue first") {
-      // The eviction that makes room for a failure cannot assume the queue is still full: the
-      // consumer may drain it entirely between the rejected offer and the eviction. Taking
-      // blockingly there would wait on an empty queue whose only producer has already stopped
-      // (pollLoop ends at the failure), stranding the reconnect in the one case that needs it.
-      // Racing a drainer against the offer hits that window; a failure to make room shows up
-      // as this never completing rather than as a wrong value, hence the timeout.
-      val listener = PostgresNotificationListener(config = null, channels = Nil)
-      ZIO
-        .foreachDiscard(1 to 200): _ =>
-          for
-            queue <- Queue.dropping[Take[Throwable, PGNotification]](1)
-            _ <- queue.offer(Take.chunk(Chunk.empty))
-            drainer <- queue.takeAll.fork
-            _ <- listener.offerFailure(queue, Cause.fail(RuntimeException("connection lost")))
-            _ <- drainer.join
-          yield ()
-        .timeout(30.seconds)
-        .map(completed => assertTrue(completed.isDefined))
     },
     test("refuses to start when notifications cannot be delivered") {
       for

--- a/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
+++ b/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
@@ -120,6 +120,35 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
         events <- listener.notifications.take(3).runCollect.timeout(30.seconds)
       yield assertTrue(events.exists(_.forall(_ == NotificationEvent.Resubscribed)))
     },
+    test("keeps polling behind a subscriber slow to react to its own Resubscribed") {
+      // The realistic version of a slow subscriber reloads from the database precisely when
+      // it sees Resubscribed — the same database this listener depends on — which is the one
+      // moment polling must not wait on it: starting it only after that handler returns would
+      // stop the heartbeat from running exactly while the database is why it needs to.
+      // livenessTimeout is short enough that if polling waited here anyway, the connection
+      // would look quiet for far longer than livenessTimeout the moment the handler finally
+      // returns, and get torn down for a reason that has nothing to do with it actually
+      // failing. Not waiting keeps this a healthy connection the whole time, resubscribing
+      // exactly once.
+      for
+        config <- ZIO.service[PostgresConfig]
+        listener = PostgresNotificationListener(
+          config,
+          List(channel),
+          heartbeatInterval = 200.millis,
+          livenessTimeout = 1.second,
+          pollTimeout = 100.millis,
+        )
+        resubscribes <- Ref.make(0)
+        fiber <- listener.notifications.runForeach {
+          case NotificationEvent.Resubscribed => resubscribes.update(_ + 1) *> ZIO.sleep(3.seconds)
+          case _ => ZIO.unit
+        }.fork
+        _ <- ZIO.sleep(4.seconds)
+        _ <- fiber.interrupt
+        count <- resubscribes.get
+      yield assertTrue(count == 1)
+    },
     test("refuses to start when notifications cannot be delivered") {
       for
         config <- ZIO.service[PostgresConfig]

--- a/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
+++ b/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
@@ -3,6 +3,7 @@ package versola.util.postgres
 import com.augustnagro.magnum.magzio.TransactorZIO
 import com.augustnagro.magnum.sql
 import zio.*
+import zio.metrics.*
 import zio.test.*
 
 import java.time.OffsetDateTime
@@ -103,11 +104,13 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
       )
     },
     test("replaces a connection that stops delivering, without it ever failing") {
-      // A heartbeat interval longer than the liveness timeout means none is ever sent, which
-      // leaves the connection in the state this is about: open, never erroring, and no longer
-      // carrying anything, exactly as a socket killed by a NAT or firewall idle timeout would
-      // be. Repeated resubscribes are the listener noticing and reconnecting anyway, which is
-      // what a subscriber needs in order to reload.
+      // A heartbeat interval longer than the liveness timeout does not mean no heartbeat is
+      // ever sent: `beat` starts already-due, so each fresh connection gets exactly one right
+      // after connecting. It means no *second* one arrives before livenessTimeout elapses, so
+      // every connection goes quiet after that first round trip and is replaced, exactly as a
+      // socket killed by a NAT or firewall idle timeout would be. Repeated resubscribes are
+      // the listener noticing and reconnecting anyway, which is what a subscriber needs in
+      // order to reload.
       for
         config <- ZIO.service[PostgresConfig]
         listener = PostgresNotificationListener(
@@ -148,6 +151,35 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
         _ <- fiber.interrupt
         count <- resubscribes.get
       yield assertTrue(count == 1)
+    },
+    test("drops rather than grows without bound when a subscriber never catches up") {
+      // A subscriber stuck on the opening Resubscribed forever, rather than merely slow: it
+      // never pulls again, so nothing but a bounded queue stands between a publisher that
+      // keeps going and unbounded memory growth. queueCapacity is set far below what gets
+      // published, and pollTimeout short enough that each notification lands in its own poll
+      // cycle (spaced well past it), so each becomes a separate queued item instead of
+      // batching into one and the overflow is forced deterministically rather than raced.
+      val overflow =
+        Metric.counter("db_notification_listener_queue_overflow_total").tagged(MetricLabel("db_system", "postgresql"))
+      for
+        config <- ZIO.service[PostgresConfig]
+        listener = PostgresNotificationListener(config, List(channel), pollTimeout = 50.millis, queueCapacity = 2)
+        before <- overflow.value
+        fiber <- listener.notifications.runForeach {
+          case NotificationEvent.Resubscribed => ZIO.never
+          case _ => ZIO.unit
+        }.fork
+        _ <- ZIO.sleep(300.millis)
+        _ <- ZIO.foreachDiscard(1 to 5)(i => notify(s"overflow-$i").delay(150.millis))
+        _ <- ZIO.sleep(300.millis)
+        after <- overflow.value
+        _ <- fiber.interrupt
+      yield assertTrue(
+        // At least 3, not exactly: a queue slot can also be consumed by the listener's own
+        // heartbeat (which starts already-due, so one always fires), and that consumption
+        // legitimately competes with real notifications for the same bounded capacity.
+        after.count - before.count >= 3.0,
+      )
     },
     test("refuses to start when notifications cannot be delivered") {
       for

--- a/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
+++ b/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
@@ -76,31 +76,38 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
         delays.forall(_ <= 10.seconds * 1.2),
       )
     },
-    test("holds a quiet connection open, without telling subscribers about its own heartbeat") {
-      // Nothing is published here at all. A listener that only reacted to traffic could not
-      // tell this apart from a dead connection, and the point of the heartbeat is that this
-      // case stays up: the liveness timeout is well short of the runtime, so it would have
-      // fired several times over if the heartbeat were not coming back.
+    test("holds a quiet connection open on its heartbeat, and keeps that heartbeat to itself") {
+      // Nothing is published here at all, so every poll comes back empty and the heartbeat is
+      // the only thing keeping the connection alive. The liveness timeout is several
+      // heartbeats short of the runtime, so a heartbeat that was not making the round trip
+      // would fail the connection and show up below as a second Resubscribed.
+      //
+      // The poll timeout has to be shorter than the liveness timeout for any of that to be
+      // reached: liveness is only evaluated when a poll returns, so at the 10s default the
+      // first evaluation would land after this test had already finished.
       for
         config <- ZIO.service[PostgresConfig]
         listener = PostgresNotificationListener(
           config,
           List(channel),
           heartbeatInterval = 100.millis,
-          livenessTimeout = 500.millis,
+          livenessTimeout = 1.second,
+          pollTimeout = 100.millis,
         )
-        events <- listener.notifications.take(2).runCollect.timeout(3.seconds)
+        events <- listener.notifications.take(2).runCollect.timeout(4.seconds)
       yield assertTrue(
-        // Timed out waiting for a second event rather than collecting one, because the
-        // heartbeats it round-tripped in the meantime are filtered out of the stream.
+        // Timed out waiting for a second event rather than collecting one: the connection
+        // stayed up across every liveness deadline in those four seconds, and the heartbeats
+        // that kept it up are filtered out before a subscriber sees them.
         events.isEmpty,
       )
     },
     test("replaces a connection that stops delivering, without it ever failing") {
-      // A heartbeat that cannot arrive within the liveness timeout is the same situation as a
-      // socket killed by a NAT or firewall idle timeout: open, never erroring, and no longer
-      // carrying anything. Repeated resubscribes are the listener noticing and reconnecting,
-      // which is what a subscriber needs in order to reload.
+      // A heartbeat interval longer than the liveness timeout means none is ever sent, which
+      // leaves the connection in the state this is about: open, never erroring, and no longer
+      // carrying anything, exactly as a socket killed by a NAT or firewall idle timeout would
+      // be. Repeated resubscribes are the listener noticing and reconnecting anyway, which is
+      // what a subscriber needs in order to reload.
       for
         config <- ZIO.service[PostgresConfig]
         listener = PostgresNotificationListener(
@@ -108,6 +115,7 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
           List(channel),
           heartbeatInterval = 1.hour,
           livenessTimeout = 300.millis,
+          pollTimeout = 100.millis,
         )
         events <- listener.notifications.take(3).runCollect.timeout(30.seconds)
       yield assertTrue(events.exists(_.forall(_ == NotificationEvent.Resubscribed)))

--- a/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
+++ b/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
@@ -76,6 +76,42 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
         delays.forall(_ <= 10.seconds * 1.2),
       )
     },
+    test("holds a quiet connection open, without telling subscribers about its own heartbeat") {
+      // Nothing is published here at all. A listener that only reacted to traffic could not
+      // tell this apart from a dead connection, and the point of the heartbeat is that this
+      // case stays up: the liveness timeout is well short of the runtime, so it would have
+      // fired several times over if the heartbeat were not coming back.
+      for
+        config <- ZIO.service[PostgresConfig]
+        listener = PostgresNotificationListener(
+          config,
+          List(channel),
+          heartbeatInterval = 100.millis,
+          livenessTimeout = 500.millis,
+        )
+        events <- listener.notifications.take(2).runCollect.timeout(3.seconds)
+      yield assertTrue(
+        // Timed out waiting for a second event rather than collecting one, because the
+        // heartbeats it round-tripped in the meantime are filtered out of the stream.
+        events.isEmpty,
+      )
+    },
+    test("replaces a connection that stops delivering, without it ever failing") {
+      // A heartbeat that cannot arrive within the liveness timeout is the same situation as a
+      // socket killed by a NAT or firewall idle timeout: open, never erroring, and no longer
+      // carrying anything. Repeated resubscribes are the listener noticing and reconnecting,
+      // which is what a subscriber needs in order to reload.
+      for
+        config <- ZIO.service[PostgresConfig]
+        listener = PostgresNotificationListener(
+          config,
+          List(channel),
+          heartbeatInterval = 1.hour,
+          livenessTimeout = 300.millis,
+        )
+        events <- listener.notifications.take(3).runCollect.timeout(30.seconds)
+      yield assertTrue(events.exists(_.forall(_ == NotificationEvent.Resubscribed)))
+    },
     test("refuses to start when notifications cannot be delivered") {
       for
         config <- ZIO.service[PostgresConfig]

--- a/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
+++ b/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
@@ -29,7 +29,7 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
       )
 
   /** The backend pid(s) currently serving the listener's own connection, independent of
-    * anything the listener's public API exposes -- proof that a reconnect actually opened a
+    * anything the listener's public API exposes — proof that a reconnect actually opened a
     * new session, rather than an inference from what a subscriber happened to observe.
     */
   private def listenerPid =
@@ -92,8 +92,8 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
     test("tells a black-holed heartbeat write apart from an ordinary loud one") {
       // The heartbeat's own NOTIFY relabels a failure as the connection going silent only for
       // the one case that actually is: a socket timing out on a write nothing will ever get a
-      // response to. Anything else that can fail a NOTIFY -- an admin shutdown, a terminated
-      // backend -- reached the driver the way a loud failure ordinarily does, and must stay
+      // response to. Anything else that can fail a NOTIFY — an admin shutdown, a terminated
+      // backend — reached the driver the way a loud failure ordinarily does, and must stay
       // one, or a real database incident gets counted and alerted on as a network problem.
       assertTrue(
         PostgresNotificationListener.isSocketTimeout(java.net.SocketTimeoutException("Read timed out")),
@@ -178,26 +178,30 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
       // it sees Resubscribed — the same database this listener depends on — which is the one
       // moment polling must not wait on it: starting it only after that handler returns would
       // stop the heartbeat from running exactly while the database is why it needs to.
-      // livenessTimeout is short enough that if polling waited here anyway, the connection
-      // would look quiet for far longer than livenessTimeout the moment the handler finally
-      // returns, and get torn down for a reason that has nothing to do with it actually
-      // failing. Not waiting keeps this a healthy connection the whole time, resubscribing
-      // exactly once.
+      // The handler blocks for longer than livenessTimeout, which is what gives this teeth: if
+      // polling waited here anyway, the connection would look quiet past the deadline and get
+      // torn down for a reason that has nothing to do with it actually failing. Not waiting
+      // keeps this a healthy connection the whole time, resubscribing exactly once.
+      //
+      // The deadline is generous relative to the heartbeat — sixteen round trips fit inside
+      // it — because the one thing that also resubscribes exactly when it should is a real
+      // liveness trip, and a shared runner stalling a single round trip past a tight deadline
+      // would be indistinguishable here from the failure this is looking for.
       for
         config <- ZIO.service[PostgresConfig]
         listener = PostgresNotificationListener(
           config,
           List(channel),
-          heartbeatInterval = 200.millis,
-          livenessTimeout = 1.second,
+          heartbeatInterval = 250.millis,
+          livenessTimeout = 4.seconds,
           pollTimeout = 100.millis,
         )
         resubscribes <- Ref.make(0)
         fiber <- listener.notifications.runForeach {
-          case NotificationEvent.Resubscribed => resubscribes.update(_ + 1) *> ZIO.sleep(3.seconds)
+          case NotificationEvent.Resubscribed => resubscribes.update(_ + 1) *> ZIO.sleep(6.seconds)
           case _ => ZIO.unit
         }.fork
-        _ <- ZIO.sleep(4.seconds)
+        _ <- ZIO.sleep(7.seconds)
         _ <- fiber.interrupt
         count <- resubscribes.get
       yield assertTrue(count == 1)
@@ -210,8 +214,8 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
       // elements offered to it, not what those elements contain. A single element wrapping
       // Postgres's whole batch would let a burst this size occupy one of deliveryCapacity
       // slots regardless of how many notifications were in it, so the bound this exists to
-      // enforce would not hold. Offered individually -- both into the queue daemon fills and,
-      // from there, into delivery -- capacity elements are accepted and the rest are rejected
+      // enforce would not hold. Offered individually — both into the queue daemon fills and,
+      // from there, into delivery — capacity elements are accepted and the rest are rejected
       // regardless of how pgjdbc happened to batch them, which is what makes the dropped count
       // below exact rather than just a lower bound.
       val overflow =
@@ -271,8 +275,8 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
       // The two failure modes compound here: the subscriber is far enough behind to have
       // filled delivery, and then the connection under it dies. Both happen inside the
       // handler for the first Resubscribed, which is what fixes the ordering rather than
-      // racing it: daemon keeps running regardless of that handler -- polling, and delivering
-      // what it polls -- so delivery is full of the dying connection's backlog and the
+      // racing it: daemon keeps running regardless of that handler — polling, and delivering
+      // what it polls — so delivery is full of the dying connection's backlog and the
       // connection is dead before the subscriber pulls again.
       //
       // What the subscriber must see on its next pull is the reconnect, not the leftovers of
@@ -309,7 +313,7 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
       )
     },
     test("reconnects even while a subscriber is stalled inside its own handler indefinitely") {
-      // Not merely slow, as the tests above exercise, but never returning at all -- which is
+      // Not merely slow, as the tests above exercise, but never returning at all — which is
       // exactly what a synchronous reload against a database already struggling enough to
       // have cost this listener its connection can do. Reconnecting cannot be conditional on
       // that handler ever returning, and this is verified independent of what a subscriber

--- a/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
+++ b/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresNotificationListenerSpec.scala
@@ -28,6 +28,18 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
               WHERE application_name = 'versola-notification-listener'""".query[Boolean].run(),
       )
 
+  /** The backend pid(s) currently serving the listener's own connection, independent of
+    * anything the listener's public API exposes -- proof that a reconnect actually opened a
+    * new session, rather than an inference from what a subscriber happened to observe.
+    */
+  private def listenerPid =
+    ZIO.serviceWithZIO[TransactorZIO]:
+      _.connect(
+        sql"SELECT pid FROM pg_stat_activity WHERE application_name = 'versola-notification-listener'"
+          .query[Int]
+          .run(),
+      )
+
   def spec = suite("PostgresNotificationListener")(
     test("delivers notifications, opening with the resubscribe that tells subscribers to reload") {
       for
@@ -196,18 +208,19 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
       // notification per poll cycle: the point here is specifically what happens when several
       // arrive in the same getNotifications() call, since Queue.dropping bounds the number of
       // elements offered to it, not what those elements contain. A single element wrapping
-      // Postgres's whole batch would let a burst this size occupy one of queueCapacity slots
-      // regardless of how many notifications were in it, so the bound this exists to enforce
-      // would not hold. Offered individually, capacity elements are accepted and the rest are
-      // rejected regardless of how pgjdbc happened to batch them, which is what makes the
-      // dropped count below exact rather than just a lower bound.
+      // Postgres's whole batch would let a burst this size occupy one of deliveryCapacity
+      // slots regardless of how many notifications were in it, so the bound this exists to
+      // enforce would not hold. Offered individually -- both into the queue daemon fills and,
+      // from there, into delivery -- capacity elements are accepted and the rest are rejected
+      // regardless of how pgjdbc happened to batch them, which is what makes the dropped count
+      // below exact rather than just a lower bound.
       val overflow =
         Metric.counter("db_notification_listener_queue_overflow_total").tagged(MetricLabel("db_system", "postgresql"))
       val sent = 50
       val capacity = 3
       for
         config <- ZIO.service[PostgresConfig]
-        listener = PostgresNotificationListener(config, List(channel), pollTimeout = 5.seconds, queueCapacity = capacity)
+        listener = PostgresNotificationListener(config, List(channel), pollTimeout = 5.seconds, deliveryCapacity = capacity)
         before <- overflow.value
         fiber <- listener.notifications.runForeach {
           case NotificationEvent.Resubscribed => ZIO.never
@@ -227,16 +240,16 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
     },
     test("drops rather than grows without bound when a subscriber never catches up") {
       // A subscriber stuck on the opening Resubscribed forever, rather than merely slow: it
-      // never pulls again, so nothing but a bounded queue stands between a publisher that
-      // keeps going and unbounded memory growth. queueCapacity is set far below what gets
-      // published, and pollTimeout short enough that each notification lands in its own poll
-      // cycle (spaced well past it), so each becomes a separate queued item instead of
-      // batching into one and the overflow is forced deterministically rather than raced.
+      // never pulls again, so nothing but a bounded queue stands between daemon, which keeps
+      // running regardless, and unbounded memory growth. deliveryCapacity is set far below
+      // what gets published, and pollTimeout short enough that each notification lands in its
+      // own poll cycle (spaced well past it), so each becomes a separate queued item instead
+      // of batching into one and the overflow is forced deterministically rather than raced.
       val overflow =
         Metric.counter("db_notification_listener_queue_overflow_total").tagged(MetricLabel("db_system", "postgresql"))
       for
         config <- ZIO.service[PostgresConfig]
-        listener = PostgresNotificationListener(config, List(channel), pollTimeout = 50.millis, queueCapacity = 2)
+        listener = PostgresNotificationListener(config, List(channel), pollTimeout = 50.millis, deliveryCapacity = 2)
         before <- overflow.value
         fiber <- listener.notifications.runForeach {
           case NotificationEvent.Resubscribed => ZIO.never
@@ -256,19 +269,22 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
     },
     test("reconnects ahead of the backlog a subscriber has not caught up on") {
       // The two failure modes compound here: the subscriber is far enough behind to have
-      // filled the queue, and then the connection under it dies. Both happen inside the
+      // filled delivery, and then the connection under it dies. Both happen inside the
       // handler for the first Resubscribed, which is what fixes the ordering rather than
-      // racing it: polling carries on while that handler is blocked, so the queue is full and
-      // the connection is dead before the subscriber pulls again.
+      // racing it: daemon keeps running regardless of that handler -- polling, and delivering
+      // what it polls -- so delivery is full of the dying connection's backlog and the
+      // connection is dead before the subscriber pulls again.
       //
       // What the subscriber must see on its next pull is the reconnect, not the leftovers of
-      // the connection that died. Queued behind them, the failure would only surface once the
-      // subscriber had worked through a backlog it is by definition slow to work through, and
-      // the reconnect would wait that long on an already-dead connection. Ordered ahead of
-      // them, nothing is lost that the Resubscribed's own reload does not cover.
+      // the connection that died. Left in delivery, those leftovers would surface first, and
+      // only once the subscriber had worked through a backlog it is by definition slow to
+      // work through. daemon drains delivery on every failure for exactly this: nothing is
+      // lost that the Resubscribed's own reload does not cover, and what the subscriber pulls
+      // next is that Resubscribed, not what a connection already known to be dead sent before
+      // it died.
       for
         config <- ZIO.service[PostgresConfig]
-        listener = PostgresNotificationListener(config, List(channel), pollTimeout = 50.millis, queueCapacity = 2)
+        listener = PostgresNotificationListener(config, List(channel), pollTimeout = 50.millis, deliveryCapacity = 2)
         events <- Ref.make(Chunk.empty[NotificationEvent])
         first <- Ref.make(true)
         fiber <- listener
@@ -291,6 +307,28 @@ object PostgresNotificationListenerSpec extends ZIOSpecDefault:
         // And immediately, with none of the dead connection's notifications in between.
         collected.take(2) == Chunk(NotificationEvent.Resubscribed, NotificationEvent.Resubscribed),
       )
+    },
+    test("reconnects even while a subscriber is stalled inside its own handler indefinitely") {
+      // Not merely slow, as the tests above exercise, but never returning at all -- which is
+      // exactly what a synchronous reload against a database already struggling enough to
+      // have cost this listener its connection can do. Reconnecting cannot be conditional on
+      // that handler ever returning, and this is verified independent of what a subscriber
+      // observes, since a subscriber stuck like this by definition never observes anything
+      // again: a fresh backend pid is what a new connection looks like from outside either of
+      // them.
+      for
+        listener <- PostgresNotificationListener.make(List(channel))
+        fiber <- listener.notifications.runForeach {
+          case NotificationEvent.Resubscribed => ZIO.never
+          case _ => ZIO.unit
+        }.fork
+        before <- (listenerPid <* ZIO.sleep(50.millis)).repeatUntil(_.nonEmpty).map(_.head)
+        _ <- killListener
+        after <- (listenerPid.map(_.headOption) <* ZIO.sleep(50.millis))
+          .repeatUntil(pid => pid.isDefined && pid != Some(before))
+          .timeout(15.seconds)
+        _ <- fiber.interrupt
+      yield assertTrue(after.flatten.exists(_ != before))
     },
     test("refuses to start when notifications cannot be delivered") {
       for


### PR DESCRIPTION
## Problem

`PostgresNotificationListener` reconnects when its connection **fails**. A connection can stop delivering without ever failing:

- A socket killed by a NAT or firewall idle timeout is closed from neither end. `getNotifications` blocks forever on a path nothing will ever write to again, and no exception is raised, so `.retry(reconnectSchedule)` never fires.
- `tcpKeepAlive` is set, but only as the bare flag with no interval or probe count, so detection falls back to OS defaults (`tcp_keepalive_time` is 7200s on a stock Linux).

Nothing distinguished that from a database with nothing to say. That is what made it silent:

- Propagation quietly degraded to each subscriber's periodic reconciliation. For `edge` revocation that is `reloadInterval`, so a revoked token stayed accepted for up to ten minutes instead of about a second.
- `db_notification_listener_connected` still read `1`, because the connection was, technically, open. The gauge's own doc comment claimed it was "the only signal that propagation has stopped" — it could not detect this case.
- `revocation_cache_staleness_seconds` could not detect it either: it resets on every successful periodic resync, and that resync queries Postgres directly, independent of whether `LISTEN` delivers anything.

## Fix

Each connection `LISTEN`s on a channel unique to itself, and the listener notifies itself on that channel whenever a read comes back empty, requiring it back within `LivenessTimeout` (90s, heartbeat every 30s). Silence past the timeout fails the stream, which routes through the reconnect and `Resubscribed` path already there, so subscribers reload exactly as they do after a connection that dropped loudly.

The heartbeat is sent from the polling fiber, in between reads, not from a second fiber or a second connection: a pgjdbc connection blocked in `getNotifications` is precisely what a second thread must not touch. A unique channel per connection means what comes back proves *this* session is being delivered to, not some other replica's. Heartbeats are filtered out before subscribers see them, and are not counted as notifications received.

## Architecture: reconnecting no longer runs through the subscriber's own stream

Every fix below made reconnecting independent of how *slow* a subscriber is. None of them, on their own, survived a subscriber whose handler never returns at all — a synchronous reload against a database already struggling enough to have cost this listener its connection, which is not a hypothetical here. `ZStream.fromQueue(queue).flattenTake` cannot be pulled again until `runForeach`'s callback for the current element returns, so a handler stuck forever left the failure `supersede` had placed sitting unpulled, the dead connection's scope unreleased, and no new connection ever attempted, no matter how quickly the polling fiber itself had detected the trouble.

`notifications` no longer runs connect/poll/reconnect itself. A new fiber, `daemon`, does that, forever, publishing into a `delivery` queue that `notifications` just reads from. `daemon` never awaits `delivery` — offering is non-blocking, drop-on-full, the same pattern used everywhere else in this file — so nothing downstream of it, including a handler stuck in `ZIO.never`, can hold it back from noticing a connection died or bringing up the next one. `delivery` gets its own drain-on-failure, for the same reason the per-connection queue already has one: whatever `daemon` already handed over but `delivery` is still holding is the stale view `Resubscribed` exists to replace.

Review turned up seven ways the detection could be defeated, or the fix for one gap undermined by another, each fixed here:

- **Reconnecting depended on the subscriber's own handler returning.** Described above. Fixed by splitting `daemon` (connect/poll/reconnect, independent of any subscriber) from `notifications` (a thin read of what `daemon` published).
- **The heartbeat's own write could hang.** `getNotifications` installs its timeout only for the duration of the call and pgjdbc restores the connection's underneath it, so the `NOTIFY` ran unbounded: on a black-holed socket the write is accepted locally and then waits forever, and liveness is only evaluated on the poll *after* an empty one, so the deadline was never reached at all. Fixed with `socketTimeout` (30s), which bounds the heartbeat and the `LISTEN` at connect while leaving the notification wait alone.
- **A loud NOTIFY failure could be relabeled as a silent one.** The heartbeat's write wrapped every exception as `SilentConnection`, so an admin shutdown or a terminated backend hitting the heartbeat's write instead of the next read was counted and logged as a network-path issue rather than the database failure it is. Now only a cause chain containing a `SocketTimeoutException` — what a black-holed write actually produces — is relabeled; everything else propagates through the ordinary reconnect path, counted in `reconnects_total`.
- **Polling was paced by the subscriber.** `ZStream` is pull-driven, so no poll ran while a downstream handler did. Polling now runs on a fiber forked in `connect`, feeding a bounded dropping queue that `read` turns back into a stream.
- **The bounded queue didn't bound what it claimed to.** A single element could hold a whole `getNotifications()` batch, so a large enough burst put far more in memory than `queueCapacity` was meant to cap, with the overflow counter never incrementing. Notifications are now offered one at a time, each its own queue element.
- **The failure that ends the poll loop could be dropped, or arrive late.** It now supersedes the per-connection queue rather than queueing behind it (drain, then offer), so `daemon`'s own inner loop reaches the failure immediately rather than working through a backlog first.
- **The gauge was written from the subscriber's error path.** It is now written by the fiber that owns the connection, at the moment it finds out, whether or not anything downstream is even listening.

## Metrics

`db_notification_listener_silent_total` counts connections replaced for going silent, kept separate from `db_notification_listener_reconnects_total` — it is the only one of the two that points at the network path rather than at the database. `db_notification_listener_connected` now means "proven to be delivering" rather than "open." `db_notification_listener_queue_overflow_total` counts notifications dropped, one per notification, from either of two points now: the per-connection queue (`daemon`'s own ingestion, essentially never full since nothing downstream of it can block it) or `delivery` (a subscriber falling behind or stalling, now the realistic place this fires).

## Tests

All against a real Postgres except one, in `PostgresNotificationListenerSpec`:

- **`holds a quiet connection open on its heartbeat, and keeps that heartbeat to itself`**
- **`replaces a connection that stops delivering, without it ever failing`**
- **`tells a black-holed heartbeat write apart from an ordinary loud one`** — a pure, deterministic test of the classification, the same way `reconnectSchedule` is already tested directly.
- **`keeps polling behind a subscriber slow to react to its own Resubscribed`**
- **`reconnects even while a subscriber is stalled inside its own handler indefinitely`** — `ZIO.never` on the first `Resubscribed`, forever. Verified via the listener's own backend pid in `pg_stat_activity` rather than anything the subscriber could report, since a subscriber stalled like this by construction never observes anything again. Confirmed this fails against the pre-`daemon` design: no second pid within 15s.
- **`bounds memory by notification, not by the batch Postgres happens to hand back`** — a 50-notification burst against `deliveryCapacity = 3`, asserting the dropped count exactly.
- **`drops rather than grows without bound when a subscriber never catches up`**
- **`reconnects ahead of the backlog a subscriber has not caught up on`** — the queue is full *and* the connection then dies, both forced inside the first `Resubscribed` handler rather than raced.

Each regression test was checked to fail against the behavior it covers, not assumed to. `util-postgres` run three times in a row to check for flakiness in the new timing-sensitive tests.

Full runs: `util-postgres` 36, `util` 72, `edge` 193, `edge-postgres-impl` 9, `auth-postgres-impl` 128 — all green.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M0FNHRH69B4FTHCMX20XZVVV&panel=chat)