### PR TITLE
Fix step-up OTP submissions sharing a single rate-limit bucket across all users

### DIFF
--- a/auth/src/main/scala/versola/oauth/conversation/ConversationService.scala
+++ b/auth/src/main/scala/versola/oauth/conversation/ConversationService.scala
@@ -258,6 +258,26 @@ object ConversationService:
         case LimitStatus.RateLimited(retryAfter) => renderStep(authId, conversation, step(Some(retryAfter)))
         case LimitStatus.Allowed => renderStep(authId, conversation, step(None))
 
+    /** The subject to throttle an OTP submission against.
+      *
+      * Normally this is the credential entered this conversation (`conversation.credential`).
+      * But when the credential step was skipped because the user was already known — step-up
+      * and any other silent/id_token_hint-driven re-authorization — `credential` is never set
+      * (see AuthorizeEndpointService.createConversation), so falling back to it alone would
+      * make `subject` the empty string for *every* such conversation: every user's step-up OTP
+      * attempts for a client would share one throttle bucket instead of one each, so one
+      * person's wrong codes (or a banned bucket) blocks everyone else's step-up.
+      *
+      * The fallback mirrors exactly what ConversationRouter.afterFactor already used to *send*
+      * the OTP in this situation (userEmail/userPhone per authFlow.otpType), so submit is
+      * throttled against the same identity the request was.
+      */
+    private def otpSubject(conversation: ConversationRecord): String =
+      val fallback = conversation.authFlow.otpType match
+        case OtpType.email => conversation.userEmail.map(_.toString)
+        case OtpType.sms => conversation.userPhone.map(_.toString)
+      conversation.credential.map(_.merge).orElse(fallback).getOrElse("")
+
     override def prepareInitialOtp(
         authId: AuthId,
         conversation: ConversationRecord,
@@ -370,7 +390,7 @@ object ConversationService:
         submittedCode: OtpCode,
         authId: AuthId,
     ): Task[ConversationResult] =
-      val subject = conversation.credential.map(_.merge).getOrElse("")
+      val subject = otpSubject(conversation)
       submissionLimiter.isBanned(conversation.clientId, subject, ChallengeType.OtpSubmit).flatMap:
         case LimitStatus.Banned =>
           accessDenied(authId, conversation)


### PR DESCRIPTION
Fix step-up OTP submissions sharing a single rate-limit bucket across all users

Problem

ConversationService.checkOtp derives the rate-limit subject from conversation.credential:

scala
val subject = conversation.credential.map(_.merge).getOrElse("")

During step-up (and any other flow where the credential step is skipped because the user is already known via id_token_hint — see AuthorizeEndpointService.createConversation), credential is never populated, so subject resolves to the empty string "" for every such conversation. As a result, all step-up OTP submissions for a client — across every user — are throttled against one shared bucket instead of one per person: a handful of wrong codes from any single user (including test/debug traffic) trips the rate limit or ban for everyone else's step-up attempts on that client.

This also makes it unrecoverable from the admin console: central's "Reset Limits" only clears throttle records keyed by userId/email/phone (UserController.resetLimitsEndpoint), so it can never target the "" subject — the only fix available today is a manual DELETE FROM challenge_throttle WHERE subject = '' in the DB.

Fix

Added a private otpSubject(conversation) helper in ConversationService that falls back to userEmail/userPhone (picked by authFlow.otpType) when credential is unset — mirroring exactly what ConversationRouter.afterFactor already uses to send the OTP in this same situation. checkOtp now calls otpSubject(conversation) instead of reading conversation.credential directly, so submit is throttled against the same identity the request was, restoring per-user throttling for step-up.

Small, targeted diff — one file, +21/-1, no other behavior changed.