### PR TITLE
auth: bound requested scope by the client registration and by the grant

### DIFF
--- a/auth/open-api/authorize.yaml
+++ b/auth/open-api/authorize.yaml
@@ -124,10 +124,11 @@ components:
       required: false
       description: |
         Space-delimited scope tokens. Include `openid` to obtain an ID token from `/token`
-        and to be allowed to call `/userinfo`. Required unless `request_uri` is used.
+        and to be allowed to call `/userinfo`. Omitting it defaults to the client's full
+        registered scope, both here and when the request arrives via `request_uri`.
 
         Every token must be one the client is registered for; naming any other fails the
-        request with `invalid_scope`. When omitted, the client's full registered scope is used.
+        request with `invalid_scope`.
       schema:
         type: string
       example: openid profile email

--- a/auth/open-api/authorize.yaml
+++ b/auth/open-api/authorize.yaml
@@ -125,6 +125,9 @@ components:
       description: |
         Space-delimited scope tokens. Include `openid` to obtain an ID token from `/token`
         and to be allowed to call `/userinfo`. Required unless `request_uri` is used.
+
+        Every token must be one the client is registered for; naming any other fails the
+        request with `invalid_scope`. When omitted, the client's full registered scope is used.
       schema:
         type: string
       example: openid profile email

--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
@@ -146,10 +146,20 @@ object AuthorizeRequestParser:
           }
 
         scope <- getParam(params, "scope")
-          .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "scope"))
-          .map:
-            case None => client.scope
-            case Some(value) => value.split(' ').toSet.filter(_.nonEmpty).map(ScopeToken(_))
+          .orElseFail[Error](Error.MultipleValuesProvided(redirectUri, state, "scope"))
+          .flatMap:
+            case None => ZIO.succeed(client.scope)
+            case Some(value) =>
+              // RFC 6749 §3.3: the request may only name scopes the client is registered for.
+              // Unfiltered, the requested set reaches the access token's `scope` claim and
+              // /userinfo releases whatever claims the registry maps those scopes to.
+              val requested = value.split(' ').toSet.filter(_.nonEmpty).map(ScopeToken(_))
+              val unregistered = (requested -- client.scope).toList.sorted
+              ZIO.cond(
+                unregistered.isEmpty,
+                requested,
+                Error.ScopeNotGranted(redirectUri, state, unregistered.mkString(" ")),
+              )
 
         uiLocales <- getParam(params, "ui_locales")
           .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "ui_locales"))

--- a/auth/src/main/scala/versola/oauth/authorize/model/Error.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/model/Error.scala
@@ -93,6 +93,16 @@ private[authorize] object Error:
       errorUri = Some("https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1"),
     )
 
+  /** Only the scopes the client is not registered for are named back, not the whole requested
+    * set: the unregistered ones are the reason the request failed, and echoing the rest would
+    * grow the redirect URI for no benefit.
+    */
+  case class ScopeNotGranted(uri: URL, state: Option[State], value: String) extends RedirectError(
+      error = ErrorCode.InvalidScope,
+      errorDescription = s"The requested scope is not registered for this client - $value",
+      errorUri = Some("https://datatracker.ietf.org/doc/html/rfc6749#section-3.3"),
+    )
+
   case class InvalidClaims(uri: URL, state: Option[State]) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "Invalid claims parameter - must be valid JSON",

--- a/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
+++ b/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
@@ -152,8 +152,11 @@ object OAuthTokenService:
         _ <- Observability.setSessionId(tokenRecord.publicSessionId)
         _ <- Observability.setUserId(tokenRecord.userId.toString)
 
+        // RFC 6749 §6: the request may narrow the underlying grant but never widen it, so the
+        // comparison is against what was granted, not against the client's registration —
+        // which would hand back every scope the user deselected at consent on the first refresh.
         _ <- ZIO.fail(TokenEndpointError.InvalidScope)
-          .when(scope.exists(!_.subsetOf(client.scope)))
+          .when(scope.exists(!_.subsetOf(tokenRecord.scope)))
 
         audience <- resolveTokenAudience(client, tokenRecord.audience, resources)
 

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeErrorSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeErrorSpec.scala
@@ -60,6 +60,15 @@ object AuthorizeErrorSpec extends ZIOSpecDefault:
       assertTrue(url.queryParams.map.get("error").exists(_.contains("access_denied")))
     },
 
+    test("ScopeNotGranted uses invalid_scope error code and names the offending scopes") {
+      val err = Error.ScopeNotGranted(redirectUri, state = None, value = "address phone")
+      val url = err.redirectUriWithErrorParams(testIss)
+      assertTrue(
+        url.queryParams.map.get("error").exists(_.contains("invalid_scope")),
+        url.queryParams.map.get("error_description").exists(_.exists(_.contains("address phone"))),
+      )
+    },
+
     test("base uri is preserved in error redirect") {
       val err = Error.ResponseTypeMissing(redirectUri, state = None)
       val url = err.redirectUriWithErrorParams(testIss)

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
@@ -414,6 +414,40 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
           assertTrue(result == Left(Error.StateInvalid(redirectUri)))
       }
     ),
+    suite("scope")(
+      test("accepts a subset of the scopes the client is registered for") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("scope" -> "openid")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request)
+        yield assertTrue(result.scope == Set(ScopeToken("openid")))
+      },
+      test("rejects a scope the client is not registered for") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("scope" -> "openid phone")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.ScopeNotGranted(redirectUri, Some(State("test-state")), "phone")))
+      },
+      test("names every unregistered scope, not only the first") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("scope" -> "openid phone address")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.ScopeNotGranted(redirectUri, Some(State("test-state")), "address phone")))
+      },
+      test("rejects an unregistered scope pushed through /par too") {
+        val env = Env()
+        val pushedParams = validParams.updated("scope", "openid phone").view.mapValues(List(_)).toMap
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.validate(pushedParams.view.mapValues(Chunk.fromIterable).toMap, Request.get(URL.root)).either
+        yield assertTrue(result == Left(Error.ScopeNotGranted(redirectUri, Some(State("test-state")), "phone")))
+      },
+    ),
     suite("code_challenge_method")(
       test("accepts S256") {
         val env = Env()

--- a/auth/src/test/scala/versola/oauth/token/OAuthTokenServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/token/OAuthTokenServiceSpec.scala
@@ -681,7 +681,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           result == Left(TokenEndpointError.InvalidGrant),
         )
       },
-      test("fail with InvalidScope when requested scope exceeds client scope") {
+      test("fail with InvalidScope when requested scope was never granted") {
         val env = new Env
         val invalidScope = Set(ScopeToken("admin"), ScopeToken.OfflineAccess)
         for
@@ -716,6 +716,49 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
 
           result <- env.service.refreshAccessToken(request, credentials).either
         yield assertTrue(
+          result == Left(TokenEndpointError.InvalidScope),
+        )
+      },
+      // RFC 6749 §6: the underlying grant, not the client registration, is the ceiling. A user
+      // who deselected a scope at consent must not have it handed back on the first refresh.
+      test("fail with InvalidScope when requested scope is registered for the client but was not granted") {
+        val env = new Env
+        val grantedScope = Set(ScopeToken("read"), ScopeToken.OfflineAccess)
+        val widenedScope = Set(ScopeToken("read"), ScopeToken("write"), ScopeToken.OfflineAccess)
+        for
+          now <- Clock.instant
+
+          tokenRecord = RefreshTokenRecord(
+            sessionId = sessionId1,
+            publicSessionId = publicSessionId1,
+            accessToken = accessToken1,
+            userId = userId1,
+            clientId = clientId1,
+            audience = List.empty,
+            authorizationDetails = None,
+            scope = grantedScope,
+            issuedAt = now.minusSeconds(3600),
+            expiresAt = now.plusSeconds(testClient.refreshTokenTtl.toSeconds),
+            requestedClaims = None,
+            uiLocales = None,
+            nonce = None,
+            previousRefreshToken = None,
+            amr = amr1,
+            authTime = authTime1,
+            acr = None,
+          )
+
+          _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
+          _ <- env.securityService.mac.succeedsWith(refreshTokenMac1)
+          _ <- env.tokenRepo.findToken.succeedsWith(Some(tokenRecord))
+
+          request = RefreshTokenRequest(refreshToken1, Some(widenedScope), None, None)
+          credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
+
+          result <- env.service.refreshAccessToken(request, credentials).either
+        yield assertTrue(
+          // `write` is registered for the client, so only the grant can reject it
+          widenedScope.subsetOf(testClient.scope),
           result == Left(TokenEndpointError.InvalidScope),
         )
       },


### PR DESCRIPTION
Fixes #234.

Two places accepted a scope the caller had no claim to.

## 1. `/authorize` did not check `scope` against the client registration

`AuthorizeRequestParser` took the `scope` parameter as given:

```scala
case Some(value) => value.split(' ').toSet.filter(_.nonEmpty).map(ScopeToken(_))
```

Whatever it named travelled into the authorization code, the access token's `scope` claim, and `/userinfo`, which releases the claims the registry maps those scopes to. A client registered for `openid` could request `openid email` and be issued it. `/par` shared the code path, so it was reachable there too.

The requested set is now required to be a subset of `client.scope`; anything else fails with `invalid_scope` on the redirect, naming the unregistered tokens. Omitting `scope` still defaults to the client's full registered scope.

## 2. The `refresh_token` grant compared against the registration, not the grant

```scala
_ <- ZIO.fail(TokenEndpointError.InvalidScope)
  .when(scope.exists(!_.subsetOf(client.scope)))
```

The ceiling was the client registration rather than the scope stored on the refresh token record, so every scope a user deselected at the consent screen came back on the next refresh — the consent screen was advisory. The comparison is now against `tokenRecord.scope`, which is what RFC 6749 §6 requires and what `auth/open-api/token.yaml` already documented ("the requested scope exceeds what was granted"). The docs were right; the code was not.

Consent submission was already bounded (`submittedScope.subsetOf(requestedScope)` in `ConsentService.validateSubmission`), so with `/authorize` fixed the chain registration → request → consent → refresh only ever narrows.

## Changes

- `AuthorizeRequestParser` — subset check against `client.scope`
- `authorize/model/Error.scala` — new `ScopeNotGranted` redirect error (`invalid_scope`); `PushedAuthorizationError.from` already maps every `RedirectError` to the PAR JSON error shape, so `/par` needed no change
- `OAuthTokenService.refreshAccessToken` — compare against `tokenRecord.scope`
- `auth/open-api/authorize.yaml` — document the constraint on the `scope` parameter

## Tests

Four new cases in `AuthorizeRequestParserSpec` (subset accepted, unregistered scope rejected, all offending tokens named, same via `/par`), one in `AuthorizeErrorSpec`, and one in `OAuthTokenServiceSpec` covering the case that distinguishes the two predicates — a scope that *is* registered for the client but was not granted. The pre-existing refresh test was renamed to say what it actually checks.

All green: auth 846, central 365, edge 195, util 72. `e2e/Test/compile` passes and no e2e fixture needed widening — every spec that requests `openid email [offline_access]` uses `Id.EmailOtp` or `Id.Consent`, both already registered for those scopes.

## Compatibility

A client that today requests scopes beyond its registration starts getting `invalid_scope`. That is the point of the change, but it is a behavioural break for any such client, so it is worth a note in the release notes. Central's bootstrap and `SSOClient` were checked and both request only registered scopes.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M1PDVNZJ2WTH0M6Y0ATVC117&panel=chat)