### PR TITLE
edge, util: fail closed on CEL evaluation failures, drop the tenant map

### DIFF
--- a/edge/src/main/scala/versola/edge/EdgeService.scala
+++ b/edge/src/main/scala/versola/edge/EdgeService.scala
@@ -337,16 +337,15 @@ object EdgeService:
         claims: PermissionsClaims,
         resourceIds: List[ResourceId],
     ): UIO[PermissionsResponse] =
-      val tenantId = claims.tenantId
       val roles = claims.roles.getOrElse(List.empty)
-      val rolesMap = tenantId.fold(Map.empty[TenantId, List[RoleId]])(tid => Map(tid -> roles))
 
       ZIO.foreach(resourceIds): resourceId =>
         for
           resource <- resourceService.findByResourceId(resourceId)
           endpointIds = resource.fold(Set.empty[ResourceEndpointId])(_.endpoints.map(_.id).toSet)
-          perms <- permissionService.getPermissionsForRoles(rolesMap, endpointIds)
-        yield Some(resourceId -> ResourcePermissions(perms))
+          // A token without a tenant claim cannot match a role grant, which is keyed by tenant.
+          perms <- ZIO.foreach(claims.tenantId)(permissionService.getPermissionsForRoles(_, roles, endpointIds))
+        yield Some(resourceId -> ResourcePermissions(perms.getOrElse(Set.empty)))
       .map(entries => PermissionsResponse(entries.flatten.toMap, env.isProd))
 
     override def frontChannelLogout(

--- a/edge/src/main/scala/versola/edge/EdgeService.scala
+++ b/edge/src/main/scala/versola/edge/EdgeService.scala
@@ -611,6 +611,15 @@ object EdgeService:
           case Some(expression) =>
             celEvaluator.compile(expression)
               .flatMap(_.evaluateBoolean(celContext))
+              .catchAll:
+                // The condition decides whether the stronger authentication is required, so an
+                // expression that can't say either way has to be read as "required": reading it
+                // as "not required" would let a token that can't be checked through on the
+                // weaker one it already has.
+                case CelEvaluator.EvaluationError.DataMissing => ZIO.succeed(true)
+                case CelEvaluator.EvaluationError.Broken =>
+                  Observability.setError("step_up_condition_failed", Some("cel condition could not be evaluated")) *>
+                    ZIO.fail(Outcome.InternalServerError)
 
         requiredAcr = Option.when(conditionPassed)(endpoint.stepUpAcr).flatten
         acrFailed = requiredAcr.flatMap(unsatisfied)
@@ -634,9 +643,19 @@ object EdgeService:
         celEvaluator.compile(expression)
           .flatMap(_.evaluateBoolean(context))
           .flatMap { allowed =>
-            (Observability.updateError(_.copy(code = "access_rule_denied")) *> ZIO.fail(Outcome.Forbidden))
-              .unless(allowed)
+            (Observability.setError("access_rule_denied") *> ZIO.fail(Outcome.Forbidden)).unless(allowed)
           }
+          .catchAll:
+            // A rule that reads a claim this token doesn't carry is unsatisfied, the same as one
+            // that evaluates cleanly to false -- same code, so a denial is one thing to alert
+            // on, with the description telling the two apart when someone looks.
+            case CelEvaluator.EvaluationError.DataMissing =>
+              Observability.setError("access_rule_denied", Some("cel rule read a value the request doesn't carry")) *>
+                ZIO.fail(Outcome.Forbidden)
+            case CelEvaluator.EvaluationError.Broken =>
+              Observability.setError("access_rule_failed", Some("cel rule could not be evaluated")) *>
+                ZIO.fail(Outcome.InternalServerError)
+            case outcome: Outcome => ZIO.fail(outcome)
       .as(context)
 
     private def refreshSession(
@@ -807,6 +826,10 @@ object EdgeService:
         body <- applyBodyInjects(request, parsedBody, bodyInjects, celContext)
       yield request.copy(url = finalUrl, headers = finalHeaders, body = body)
 
+    /** An inject rule that produces nothing is not forwarded as a request with the value simply
+      * missing: upstream has no way to tell an absent header from one it was never meant to
+      * get, and it may well be the value upstream scopes its own authorization by. A rule that
+      * is meant to be optional can evaluate to an empty string via `has(...)`. */
     private def evaluateAll(
         rules: Vector[InjectRule],
         context: Map[String, AnyRef],
@@ -815,6 +838,13 @@ object EdgeService:
         celEvaluator.compile(rule.expression)
           .flatMap(_.evaluateString(context))
           .map(_.map(rule.name -> _))
+          .catchAll:
+            case CelEvaluator.EvaluationError.DataMissing =>
+              Observability.setError("inject_rule_denied", Some("cel rule read a value the request doesn't carry")) *>
+                ZIO.fail(Outcome.Forbidden)
+            case CelEvaluator.EvaluationError.Broken =>
+              Observability.setError("inject_rule_failed", Some("cel rule could not be evaluated")) *>
+                ZIO.fail(Outcome.InternalServerError)
       .map(_.flatten)
 
     private def applyBodyInjects(

--- a/edge/src/main/scala/versola/edge/EdgeService.scala
+++ b/edge/src/main/scala/versola/edge/EdgeService.scala
@@ -634,7 +634,7 @@ object EdgeService:
         celEvaluator.compile(expression)
           .flatMap(_.evaluateBoolean(context))
           .flatMap { allowed =>
-            (Observability.setErrorForExpression("access_rule_denied", expression) *> ZIO.fail(Outcome.Forbidden))
+            (Observability.setErrorKeepingCelFailure("access_rule_denied") *> ZIO.fail(Outcome.Forbidden))
               .unless(allowed)
           }
       .as(context)

--- a/edge/src/main/scala/versola/edge/EdgeService.scala
+++ b/edge/src/main/scala/versola/edge/EdgeService.scala
@@ -634,7 +634,7 @@ object EdgeService:
         celEvaluator.compile(expression)
           .flatMap(_.evaluateBoolean(context))
           .flatMap { allowed =>
-            (Observability.setError("access_rule_denied", Some(expression)) *> ZIO.fail(Outcome.Forbidden))
+            (Observability.setErrorForExpression("access_rule_denied", expression) *> ZIO.fail(Outcome.Forbidden))
               .unless(allowed)
           }
       .as(context)

--- a/edge/src/main/scala/versola/edge/EdgeService.scala
+++ b/edge/src/main/scala/versola/edge/EdgeService.scala
@@ -634,7 +634,7 @@ object EdgeService:
         celEvaluator.compile(expression)
           .flatMap(_.evaluateBoolean(context))
           .flatMap { allowed =>
-            (Observability.setErrorKeepingCelFailure("access_rule_denied") *> ZIO.fail(Outcome.Forbidden))
+            (Observability.updateError(_.copy(code = "access_rule_denied")) *> ZIO.fail(Outcome.Forbidden))
               .unless(allowed)
           }
       .as(context)

--- a/edge/src/main/scala/versola/edge/PermissionService.scala
+++ b/edge/src/main/scala/versola/edge/PermissionService.scala
@@ -10,7 +10,8 @@ trait PermissionService:
   def getAllowedEndpointsForClient(clientId: ClientId): UIO[Set[ResourceEndpointId]]
 
   def getPermissionsForRoles(
-      roles: Map[TenantId, List[RoleId]],
+      tenantId: TenantId,
+      roles: List[RoleId],
       endpointIds: Set[ResourceEndpointId],
   ): UIO[Set[PermissionId]]
 
@@ -41,18 +42,17 @@ object PermissionService:
   ) extends PermissionService:
 
     private def permissionsFor(
-        roles: Map[TenantId, List[RoleId]],
+        tenantId: TenantId,
+        roles: List[RoleId],
         roleMap: Map[(TenantId, RoleId), Set[PermissionId]],
     ): Set[PermissionId] =
-      roles.iterator.flatMap { (tenantId, roleIds) =>
-        roleIds.flatMap(roleId => roleMap.getOrElse((tenantId, roleId), Set.empty))
-      }.toSet
+      roles.iterator.flatMap(roleId => roleMap.getOrElse((tenantId, roleId), Set.empty)).toSet
 
     override def getAllowedEndpointsForRoles(tenantId: TenantId, roles: List[RoleId]): UIO[Set[ResourceEndpointId]] =
       for
         roleMap <- rolesCache.get
         permMap <- permissionsCache.get
-        permIds = permissionsFor(Map(tenantId -> roles), roleMap)
+        permIds = permissionsFor(tenantId, roles, roleMap)
       yield permIds.flatMap(permMap.getOrElse(_, Set.empty))
 
     override def getAllowedEndpointsForClient(clientId: ClientId): UIO[Set[ResourceEndpointId]] =
@@ -63,11 +63,12 @@ object PermissionService:
       yield permIds.flatMap(permMap.getOrElse(_, Set.empty))
 
     override def getPermissionsForRoles(
-        roles: Map[TenantId, List[RoleId]],
+        tenantId: TenantId,
+        roles: List[RoleId],
         endpointIds: Set[ResourceEndpointId],
     ): UIO[Set[PermissionId]] =
       for
         roleMap <- rolesCache.get
         permMap <- permissionsCache.get
-        permIds = permissionsFor(roles, roleMap)
+        permIds = permissionsFor(tenantId, roles, roleMap)
       yield permIds.filter(permId => permMap.getOrElse(permId, Set.empty).exists(endpointIds.contains))

--- a/edge/src/test/scala/versola/edge/EdgeServiceProxySpec.scala
+++ b/edge/src/test/scala/versola/edge/EdgeServiceProxySpec.scala
@@ -456,6 +456,36 @@ object EdgeServiceProxySpec extends ZIOSpecDefault, ZIOStubs:
         response <- service.proxy(ResourceId("users-api"), Path.decode("/users"), request)
       yield assertTrue(response.status == Status.Forbidden)
     },
+    test("returns 403 when an allow expression reads a claim the token doesn't carry") {
+      val env = new Env
+      for
+        _ <- env.setupDefaults()
+        capture <- captureUpstream()
+        client <- ZIO.service[Client]
+        security <- ZIO.service[SecurityService]
+        _ <- env.withResources(usersResource(usersEndpoint(allow = Some("token.subscription == 'premium'"))))
+        token <- env.signToken()
+        request = Request.get(URL.empty / "users").addCookie(sessionCookie(token))
+        service = env.buildService(client, security)
+        response <- service.proxy(ResourceId("users-api"), Path.decode("/users"), request)
+        upstream <- capture.get
+      yield assertTrue(response.status == Status.Forbidden, upstream.isEmpty)
+    },
+    test("returns 500 when an allow expression cannot be evaluated at all") {
+      val env = new Env
+      for
+        _ <- env.setupDefaults()
+        capture <- captureUpstream()
+        client <- ZIO.service[Client]
+        security <- ZIO.service[SecurityService]
+        _ <- env.withResources(usersResource(usersEndpoint(allow = Some("1 / 0 == 0"))))
+        token <- env.signToken()
+        request = Request.get(URL.empty / "users").addCookie(sessionCookie(token))
+        service = env.buildService(client, security)
+        response <- service.proxy(ResourceId("users-api"), Path.decode("/users"), request)
+        upstream <- capture.get
+      yield assertTrue(response.status == Status.InternalServerError, upstream.isEmpty)
+    },
     test("returns 403 when public resource URI is absent from token audience") {
       val env = new Env
       for
@@ -530,7 +560,7 @@ object EdgeServiceProxySpec extends ZIOSpecDefault, ZIOStubs:
         upstream.exists(_.headers.get(Header.Cookie.name).isEmpty),
       )
     },
-    test("removes an injected header when its CEL expression has no value") {
+    test("refuses the request when an injected header's CEL expression reads an absent claim") {
       val env = new Env
       val endpoint = usersEndpoint(
         inject = Vector(InjectRule(InjectTarget.header, "x-optional", "token.missing")),
@@ -549,8 +579,31 @@ object EdgeServiceProxySpec extends ZIOSpecDefault, ZIOStubs:
         response <- service.proxy(ResourceId("users-api"), Path.decode("/users"), request)
         upstream <- capture.get
       yield assertTrue(
+        response.status == Status.Forbidden,
+        upstream.isEmpty,
+      )
+    },
+    test("injects an empty value when a has()-guarded expression finds no claim") {
+      val env = new Env
+      val endpoint = usersEndpoint(
+        inject = Vector(InjectRule(InjectTarget.header, "x-optional", "has(token.missing) ? token.missing : ''")),
+      )
+      for
+        _ <- env.setupDefaults()
+        capture <- captureUpstream()
+        client <- ZIO.service[Client]
+        security <- ZIO.service[SecurityService]
+        _ <- env.withResources(usersResource(endpoint))
+        token <- env.signToken()
+        request = Request.get(URL.empty / "users")
+          .addHeader(Header.Custom("x-optional", "attacker-controlled"))
+          .addCookie(sessionCookie(token))
+        service = env.buildService(client, security)
+        response <- service.proxy(ResourceId("users-api"), Path.decode("/users"), request)
+        upstream <- capture.get
+      yield assertTrue(
         response.status == Status.Ok,
-        upstream.exists(_.headers.get("x-optional").isEmpty),
+        upstream.exists(_.headers.get("x-optional").contains("")),
       )
     },
     test("returns 401 when access token is expired and no refresh token available") {
@@ -584,6 +637,49 @@ object EdgeServiceProxySpec extends ZIOSpecDefault, ZIOStubs:
         response.status == Status.Unauthorized,
         challenge.exists(_.contains("""error="insufficient_user_authentication"""")),
         challenge.exists(_.contains("""acr_values="passkey-level"""")),
+      )
+    },
+    test("requires step-up when the condition reads a claim the token doesn't carry") {
+      val env = new Env
+      val endpoint = usersEndpoint(
+        stepUpCondition = Some("token.risk_score > 50"),
+        stepUpAcr = Some("passkey-level"),
+      )
+      for
+        _ <- env.setupDefaults()
+        capture <- captureUpstream()
+        client <- ZIO.service[Client]
+        security <- ZIO.service[SecurityService]
+        _ <- env.withResources(usersResource(endpoint))
+        token <- env.signToken(acr = Some("otp-level"))
+        request = Request.get(URL.empty / "users").addCookie(sessionCookie(token))
+        service = env.buildService(client, security)
+        response <- service.proxy(ResourceId("users-api"), Path.decode("/users"), request)
+        challenge = response.headers.get("WWW-Authenticate")
+        upstream <- capture.get
+      yield assertTrue(
+        response.status == Status.Unauthorized,
+        challenge.exists(_.contains("""acr_values="passkey-level"""")),
+        upstream.isEmpty,
+      )
+    },
+    test("returns 500 when the step-up condition cannot be evaluated at all") {
+      val env = new Env
+      val endpoint = usersEndpoint(stepUpCondition = Some("1 / 0 == 0"), stepUpAcr = Some("passkey-level"))
+      for
+        _ <- env.setupDefaults()
+        capture <- captureUpstream()
+        client <- ZIO.service[Client]
+        security <- ZIO.service[SecurityService]
+        _ <- env.withResources(usersResource(endpoint))
+        token <- env.signToken(acr = Some("passkey-level"))
+        request = Request.get(URL.empty / "users").addCookie(sessionCookie(token))
+        service = env.buildService(client, security)
+        response <- service.proxy(ResourceId("users-api"), Path.decode("/users"), request)
+        upstream <- capture.get
+      yield assertTrue(
+        response.status == Status.InternalServerError,
+        upstream.isEmpty,
       )
     },
     test("forwards upstream when token acr satisfies endpoint requirement") {

--- a/edge/src/test/scala/versola/edge/EdgeServiceSpec.scala
+++ b/edge/src/test/scala/versola/edge/EdgeServiceSpec.scala
@@ -1038,7 +1038,7 @@ object EdgeServiceSpec extends ZIOSpecDefault, ZIOStubs:
       yield assertTrue(
         response.resources == Map("central" -> EdgeService.ResourcePermissions(Set(perm))),
         env.permissionService.getPermissionsForRoles.calls ==
-          List((Map(TenantId.default -> List(RoleId("oauth-admin"))), Set(centralEndpointId))),
+          List((TenantId.default, List(RoleId("oauth-admin")), Set(centralEndpointId))),
       )
     },
     test("central admin derives permissions from default-tenant roles") {
@@ -1062,7 +1062,7 @@ object EdgeServiceSpec extends ZIOSpecDefault, ZIOStubs:
       yield assertTrue(
         response.resources == Map("central" -> EdgeService.ResourcePermissions(Set(perm))),
         env.permissionService.getPermissionsForRoles.calls ==
-          List((Map(TenantId.default -> List(RoleId("operator"))), Set(centralEndpointId))),
+          List((TenantId.default, List(RoleId("operator")), Set(centralEndpointId))),
       )
     },
     test("central is NOT omitted when requested by a non-central client") {
@@ -1086,7 +1086,7 @@ object EdgeServiceSpec extends ZIOSpecDefault, ZIOStubs:
       yield assertTrue(
         response.resources == Map("central" -> EdgeService.ResourcePermissions(Set(perm))),
         env.permissionService.getPermissionsForRoles.calls ==
-          List((Map(TenantId.default -> List(RoleId("oauth-admin"))), Set(centralEndpointId))),
+          List((TenantId.default, List(RoleId("oauth-admin")), Set(centralEndpointId))),
       )
     },
     test("resource aliases map only to permissions whose endpoints belong to that resource") {
@@ -1210,11 +1210,11 @@ object EdgeServiceSpec extends ZIOSpecDefault, ZIOStubs:
         response <- service.getMyPermissions(claims, List(ResourceId("central")))
       yield assertTrue(
         env.permissionService.getPermissionsForRoles.calls ==
-          List((Map(TenantId.default -> List(RoleId("editor"))), Set(centralEndpointId))),
+          List((TenantId.default, List(RoleId("editor")), Set(centralEndpointId))),
         response.resources == Map("central" -> EdgeService.ResourcePermissions(Set(perm))),
       )
     },
-    test("tenantId=None yields empty roles map, resource aliases return empty permissions") {
+    test("tenantId=None is not resolved at all, resource aliases return empty permissions") {
       val env = new Env
       for
         _ <- env.withResources(ordersResource)
@@ -1233,9 +1233,7 @@ object EdgeServiceSpec extends ZIOSpecDefault, ZIOStubs:
         response <- service.getMyPermissions(claims, List(ResourceId("orders")))
       yield assertTrue(
         response.resources == Map("orders" -> EdgeService.ResourcePermissions(Set.empty)),
-        env.permissionService.getPermissionsForRoles.calls.map(_._1) == List(Map.empty),
-        env.permissionService.getPermissionsForRoles.calls.map(_._2) ==
-          List(Set(ordersEndpointId)),
+        env.permissionService.getPermissionsForRoles.calls.isEmpty,
       )
     },
   )

--- a/edge/src/test/scala/versola/edge/PermissionServiceSpec.scala
+++ b/edge/src/test/scala/versola/edge/PermissionServiceSpec.scala
@@ -118,7 +118,8 @@ object PermissionServiceSpec extends ZIOSpecDefault:
       test("returns permissions whose endpoint IDs intersect with the provided set") {
         val service = buildService()
         for permissions <- service.getPermissionsForRoles(
-          Map(defaultTenant -> List(adminRole)),
+          defaultTenant,
+          List(adminRole),
           Set(listUsersEndpoint),
         )
         yield assertTrue(permissions == Set(readPerm))
@@ -126,7 +127,8 @@ object PermissionServiceSpec extends ZIOSpecDefault:
       test("returns multiple permissions when several intersect") {
         val service = buildService()
         for permissions <- service.getPermissionsForRoles(
-          Map(defaultTenant -> List(adminRole)),
+          defaultTenant,
+          List(adminRole),
           Set(listUsersEndpoint, createUserEndpoint),
         )
         yield assertTrue(permissions == Set(readPerm, writePerm))
@@ -135,25 +137,27 @@ object PermissionServiceSpec extends ZIOSpecDefault:
         val service = buildService()
         val unrelatedEndpoint = ResourceEndpointId(java.util.UUID.fromString("018f0f2a-1c7b-7000-8000-000000000099"))
         for permissions <- service.getPermissionsForRoles(
-          Map(defaultTenant -> List(adminRole)),
+          defaultTenant,
+          List(adminRole),
           Set(unrelatedEndpoint),
         )
         yield assertTrue(permissions.isEmpty)
       },
-      test("returns empty set when role map is empty") {
+      test("returns empty set when role list is empty") {
         val service = buildService()
-        for permissions <- service.getPermissionsForRoles(Map.empty, Set(listUsersEndpoint))
+        for permissions <- service.getPermissionsForRoles(defaultTenant, Nil, Set(listUsersEndpoint))
         yield assertTrue(permissions.isEmpty)
       },
       test("returns empty set when endpointIds is empty") {
         val service = buildService()
         for permissions <- service.getPermissionsForRoles(
-          Map(defaultTenant -> List(adminRole)),
+          defaultTenant,
+          List(adminRole),
           Set.empty,
         )
         yield assertTrue(permissions.isEmpty)
       },
-      test("merges permissions across multiple tenants filtered by endpoints") {
+      test("does not leak permissions granted to the same role in a different tenant") {
         val tenantA = TenantId("tenant-a")
         val multiTenantRoles: Map[(TenantId, RoleId), Set[PermissionId]] = Map(
           (defaultTenant, viewerRole) -> Set(readPerm),
@@ -161,10 +165,11 @@ object PermissionServiceSpec extends ZIOSpecDefault:
         )
         val service = buildService(roles = multiTenantRoles)
         for permissions <- service.getPermissionsForRoles(
-          Map(defaultTenant -> List(viewerRole), tenantA -> List(editorRole)),
+          defaultTenant,
+          List(viewerRole, editorRole),
           Set(listUsersEndpoint, createUserEndpoint),
         )
-        yield assertTrue(permissions == Set(readPerm, writePerm))
+        yield assertTrue(permissions == Set(readPerm))
       },
     ),
   )

--- a/edge/src/test/scala/versola/edge/PermissionServiceSpec.scala
+++ b/edge/src/test/scala/versola/edge/PermissionServiceSpec.scala
@@ -217,7 +217,8 @@ object PermissionServiceSpec extends ZIOSpecDefault:
               PermissionService.live,
             )
             permissions <- service.getPermissionsForRoles(
-              Map(defaultTenant -> List(editorRole)),
+              defaultTenant,
+              List(editorRole),
               Set(listUsersEndpoint, createUserEndpoint),
             )
           yield assertTrue(permissions == Set(readPerm, writePerm))

--- a/util/src/main/scala/versola/util/cel/CelEvaluator.scala
+++ b/util/src/main/scala/versola/util/cel/CelEvaluator.scala
@@ -3,6 +3,7 @@ package versola.util.cel
 import dev.cel.common.types.{CelType, SimpleType}
 import dev.cel.compiler.CelCompilerFactory
 import dev.cel.runtime.{CelRuntime, CelRuntimeFactory}
+import versola.util.http.Observability
 import zio.{IO, Ref, UIO, ULayer, ZIO, ZLayer}
 
 import scala.jdk.CollectionConverters.MapHasAsJava
@@ -67,7 +68,7 @@ object CelEvaluator:
           if actualType != t && actualType != SimpleType.DYN then
             throw new IllegalArgumentException(s"Expected return type $t but got $actualType")
           actualType == SimpleType.DYN
-        (ProgramImpl(runtime.createProgram(ast)): Program, dynAccepted)
+        (ProgramImpl(expression, runtime.createProgram(ast)): Program, dynAccepted)
       .either
       .flatMap:
         case Right((program, true)) =>
@@ -81,18 +82,23 @@ object CelEvaluator:
         case Left(ex) =>
           ZIO.succeed(Left(CompileError(expression, Option(ex.getMessage).getOrElse(ex.getClass.getSimpleName))))
 
-  private class ProgramImpl(program: CelRuntime.Program) extends Program:
+  /** A failed evaluation is reported into the log context of the request that triggered it
+    * rather than as a warning line of its own: the degraded result (`false`, or no injected
+    * value) is what the caller acts on, and it is only interpretable next to the outcome that
+    * request ended with. */
+  private class ProgramImpl(expression: String, program: CelRuntime.Program) extends Program:
     override def evaluateBoolean(context: Map[String, AnyRef]): UIO[Boolean] =
       ZIO.attempt(program.eval(context.asJava))
         .flatMap:
           case b: java.lang.Boolean => ZIO.succeed(b.booleanValue)
           case other                =>
-            ZIO.logWarning(
-              s"CEL expression returned ${other.getClass.getSimpleName} instead of Boolean; " +
-              s"treating as false. Check that the expression is a valid boolean CEL expression."
+            Observability.addCelFailure(
+              expression,
+              s"returned ${other.getClass.getSimpleName} instead of Boolean, treated as false",
             ).as(false)
         .catchAll: ex =>
-          ZIO.logWarning(s"CEL evaluation failed: ${ex.getMessage}").as(false)
+          Observability.addCelFailure(expression, s"evaluation failed: ${errorMessage(ex)}, treated as false")
+            .as(false)
 
     override def evaluateString(context: Map[String, AnyRef]): UIO[Option[String]] =
       ZIO.attempt(program.eval(context.asJava))
@@ -101,4 +107,8 @@ object CelEvaluator:
           case s: String    => Some(s)
           case other        => Some(other.toString)
         .catchAll: ex =>
-          ZIO.logWarning(s"CEL evaluation failed: ${ex.getMessage}").as(None)
+          Observability.addCelFailure(expression, s"evaluation failed: ${errorMessage(ex)}, no value injected")
+            .as(None)
+
+  private def errorMessage(ex: Throwable): String =
+    Option(ex.getMessage).getOrElse(ex.getClass.getSimpleName)

--- a/util/src/main/scala/versola/util/cel/CelEvaluator.scala
+++ b/util/src/main/scala/versola/util/cel/CelEvaluator.scala
@@ -92,12 +92,12 @@ object CelEvaluator:
         .flatMap:
           case b: java.lang.Boolean => ZIO.succeed(b.booleanValue)
           case other                =>
-            Observability.addCelFailure(
+            Observability.annotateCelFailure(
               expression,
               s"returned ${other.getClass.getSimpleName} instead of Boolean, treated as false",
             ).as(false)
         .catchAll: ex =>
-          Observability.addCelFailure(expression, s"evaluation failed: ${errorMessage(ex)}, treated as false")
+          Observability.annotateCelFailure(expression, s"evaluation failed: ${errorMessage(ex)}, treated as false")
             .as(false)
 
     override def evaluateString(context: Map[String, AnyRef]): UIO[Option[String]] =
@@ -107,7 +107,7 @@ object CelEvaluator:
           case s: String    => Some(s)
           case other        => Some(other.toString)
         .catchAll: ex =>
-          Observability.addCelFailure(expression, s"evaluation failed: ${errorMessage(ex)}, no value injected")
+          Observability.annotateCelFailure(expression, s"evaluation failed: ${errorMessage(ex)}, no value injected")
             .as(None)
 
   private def errorMessage(ex: Throwable): String =

--- a/util/src/main/scala/versola/util/cel/CelEvaluator.scala
+++ b/util/src/main/scala/versola/util/cel/CelEvaluator.scala
@@ -94,9 +94,11 @@ object CelEvaluator:
       ZIO.attempt(program.eval(context.asJava))
         .flatMap:
           case b: java.lang.Boolean => ZIO.succeed(b.booleanValue)
-          case _                    => Observability.annotateCelFailure("non-boolean result, treated as false").as(false)
+          case _ =>
+            Observability.updateError(_.copy(description = Some("cel rule evaluated to non-boolean result, treated as false")))
+              .as(false)
         .catchAll: _ =>
-          Observability.annotateCelFailure("evaluation failed, treated as false").as(false)
+          Observability.updateError(_.copy(description = Some("cel rule evaluation failed, treated as false"))).as(false)
 
     override def evaluateString(context: Map[String, AnyRef]): UIO[Option[String]] =
       ZIO.attempt(program.eval(context.asJava))
@@ -105,4 +107,4 @@ object CelEvaluator:
           case s: String    => Some(s)
           case other        => Some(other.toString)
         .catchAll: _ =>
-          Observability.annotateCelFailure("evaluation failed, no value injected").as(None)
+          Observability.updateError(_.copy(description = Some("cel rule evaluation failed, no value injected"))).as(None)

--- a/util/src/main/scala/versola/util/cel/CelEvaluator.scala
+++ b/util/src/main/scala/versola/util/cel/CelEvaluator.scala
@@ -1,9 +1,10 @@
 package versola.util.cel
 
+import dev.cel.common.{CelErrorCode, CelException}
 import dev.cel.common.types.{CelType, SimpleType}
 import dev.cel.compiler.CelCompilerFactory
+import dev.cel.parser.CelStandardMacro
 import dev.cel.runtime.{CelRuntime, CelRuntimeFactory}
-import versola.util.http.Observability
 import zio.{IO, Ref, UIO, ULayer, ZIO, ZLayer}
 
 import scala.jdk.CollectionConverters.MapHasAsJava
@@ -15,9 +16,29 @@ trait CelEvaluator:
 object CelEvaluator:
   case class CompileError(expression: String, message: String)
 
+  /** Why an expression produced no usable result. The distinction is the caller's whole
+    * decision: [[DataMissing]] is an ordinary property of live request data and belongs on the
+    * request's authorization path, [[Broken]] is an operator mistake and belongs in the 5xx
+    * budget. Neither carries the expression or the underlying exception text: which rule is
+    * configured on an endpoint is discoverable from the console once the request's endpoint is
+    * known, and the exception text varies in shape with the value that tripped it. */
+  enum EvaluationError:
+    /** The expression read a claim, field or key the request doesn't carry -- CEL's
+      * `ATTRIBUTE_NOT_FOUND`. Expected in production: tokens for different users legitimately
+      * carry different claims. The rule cannot be satisfied, which is not the same as the rule
+      * being wrong, so the request is refused rather than errored. An expression that should
+      * tolerate absence can say so with `has(...)`. */
+    case DataMissing
+
+    /** The expression could not be evaluated at all: any other CEL error code (a division by
+      * zero, a numeric overflow, an unresolved overload), a boolean rule that returned
+      * something other than a boolean, or an expression that failed to compile. The
+      * configuration is wrong, not the request. */
+    case Broken
+
   trait Program:
-    def evaluateBoolean(context: Map[String, AnyRef]): UIO[Boolean]
-    def evaluateString(context: Map[String, AnyRef]): UIO[Option[String]]
+    def evaluateBoolean(context: Map[String, AnyRef]): IO[EvaluationError, Boolean]
+    def evaluateString(context: Map[String, AnyRef]): IO[EvaluationError, Option[String]]
 
   val live: ULayer[CelEvaluator] =
     ZLayer:
@@ -25,6 +46,9 @@ object CelEvaluator:
 
   private val compiler =
     CelCompilerFactory.standardCelCompilerBuilder()
+      // `has(user.plan)` is how an expression guards a claim that only some tokens carry;
+      // without the macros an absent claim can only ever be an [[EvaluationError.DataMissing]].
+      .setStandardMacros(CelStandardMacro.STANDARD_MACROS)
       .addVar("token", SimpleType.DYN)
       .addVar("user", SimpleType.DYN)
       .addVar("request", SimpleType.DYN)
@@ -33,9 +57,15 @@ object CelEvaluator:
   private val runtime: CelRuntime =
     CelRuntimeFactory.standardCelRuntimeBuilder().build()
 
+  /** Stands in for an expression that didn't compile, so a configuration mistake surfaces the
+    * same way at every call site as one that only shows up at evaluation time. Evaluating to
+    * `false`/no value instead would let a rule that doesn't compile pass silently: a step-up
+    * condition would stop requiring step-up, an inject rule would stop injecting. */
   private val FailSafe: Program = new Program:
-    override def evaluateBoolean(context: Map[String, AnyRef]): UIO[Boolean] = ZIO.succeed(false)
-    override def evaluateString(context: Map[String, AnyRef]): UIO[Option[String]] = ZIO.none
+    override def evaluateBoolean(context: Map[String, AnyRef]): IO[EvaluationError, Boolean] =
+      ZIO.fail(EvaluationError.Broken)
+    override def evaluateString(context: Map[String, AnyRef]): IO[EvaluationError, Option[String]] =
+      ZIO.fail(EvaluationError.Broken)
 
   class Impl(cache: Ref[Map[String, Either[CompileError, Program]]]) extends CelEvaluator:
     override def compile(expression: String): UIO[Program] =
@@ -82,29 +112,23 @@ object CelEvaluator:
         case Left(ex) =>
           ZIO.succeed(Left(CompileError(expression, Option(ex.getMessage).getOrElse(ex.getClass.getSimpleName))))
 
-  /** A failed evaluation is reported into the log context of the request that triggered it
-    * rather than as a warning line of its own: the degraded result (`false`, or no injected
-    * value) is what the caller acts on, and it is only interpretable next to the outcome that
-    * request ended with. The report names neither the expression nor the underlying exception --
-    * the expression is discoverable from the endpoint's configured rules in the console once
-    * the request's endpoint is known, and the exception text can vary in shape depending on
-    * the value that tripped it. */
+  /** A failure is returned to the caller rather than degraded to `false`/no value here: the
+    * caller is the only one that knows what an unevaluated expression means for the request it
+    * is handling (a denial, a step-up challenge, a request that must not be forwarded), and it
+    * is the only one that can record the outcome against that request. */
   private class ProgramImpl(program: CelRuntime.Program) extends Program:
-    override def evaluateBoolean(context: Map[String, AnyRef]): UIO[Boolean] =
-      ZIO.attempt(program.eval(context.asJava))
-        .flatMap:
-          case b: java.lang.Boolean => ZIO.succeed(b.booleanValue)
-          case _ =>
-            Observability.updateError(_.copy(description = Some("cel rule evaluated to non-boolean result, treated as false")))
-              .as(false)
-        .catchAll: _ =>
-          Observability.updateError(_.copy(description = Some("cel rule evaluation failed, treated as false"))).as(false)
+    override def evaluateBoolean(context: Map[String, AnyRef]): IO[EvaluationError, Boolean] =
+      evaluate(context).flatMap:
+        case b: java.lang.Boolean => ZIO.succeed(b.booleanValue)
+        case _                    => ZIO.fail(EvaluationError.Broken)
 
-    override def evaluateString(context: Map[String, AnyRef]): UIO[Option[String]] =
-      ZIO.attempt(program.eval(context.asJava))
-        .map:
-          case null         => None
-          case s: String    => Some(s)
-          case other        => Some(other.toString)
-        .catchAll: _ =>
-          Observability.updateError(_.copy(description = Some("cel rule evaluation failed, no value injected"))).as(None)
+    override def evaluateString(context: Map[String, AnyRef]): IO[EvaluationError, Option[String]] =
+      evaluate(context).map:
+        case null      => None
+        case s: String => Some(s)
+        case other     => Some(other.toString)
+
+    private def evaluate(context: Map[String, AnyRef]): IO[EvaluationError, AnyRef] =
+      ZIO.attempt(program.eval(context.asJava)).mapError:
+        case ex: CelException if ex.getErrorCode == CelErrorCode.ATTRIBUTE_NOT_FOUND => EvaluationError.DataMissing
+        case _                                                                      => EvaluationError.Broken

--- a/util/src/main/scala/versola/util/cel/CelEvaluator.scala
+++ b/util/src/main/scala/versola/util/cel/CelEvaluator.scala
@@ -68,7 +68,7 @@ object CelEvaluator:
           if actualType != t && actualType != SimpleType.DYN then
             throw new IllegalArgumentException(s"Expected return type $t but got $actualType")
           actualType == SimpleType.DYN
-        (ProgramImpl(expression, runtime.createProgram(ast)): Program, dynAccepted)
+        (ProgramImpl(runtime.createProgram(ast)): Program, dynAccepted)
       .either
       .flatMap:
         case Right((program, true)) =>
@@ -85,20 +85,18 @@ object CelEvaluator:
   /** A failed evaluation is reported into the log context of the request that triggered it
     * rather than as a warning line of its own: the degraded result (`false`, or no injected
     * value) is what the caller acts on, and it is only interpretable next to the outcome that
-    * request ended with. */
-  private class ProgramImpl(expression: String, program: CelRuntime.Program) extends Program:
+    * request ended with. The report names neither the expression nor the underlying exception --
+    * the expression is discoverable from the endpoint's configured rules in the console once
+    * the request's endpoint is known, and the exception text can vary in shape depending on
+    * the value that tripped it. */
+  private class ProgramImpl(program: CelRuntime.Program) extends Program:
     override def evaluateBoolean(context: Map[String, AnyRef]): UIO[Boolean] =
       ZIO.attempt(program.eval(context.asJava))
         .flatMap:
           case b: java.lang.Boolean => ZIO.succeed(b.booleanValue)
-          case other                =>
-            Observability.annotateCelFailure(
-              expression,
-              s"returned ${other.getClass.getSimpleName} instead of Boolean, treated as false",
-            ).as(false)
-        .catchAll: ex =>
-          Observability.annotateCelFailure(expression, s"evaluation failed: ${errorMessage(ex)}, treated as false")
-            .as(false)
+          case _                    => Observability.annotateCelFailure("non-boolean result, treated as false").as(false)
+        .catchAll: _ =>
+          Observability.annotateCelFailure("evaluation failed, treated as false").as(false)
 
     override def evaluateString(context: Map[String, AnyRef]): UIO[Option[String]] =
       ZIO.attempt(program.eval(context.asJava))
@@ -106,9 +104,5 @@ object CelEvaluator:
           case null         => None
           case s: String    => Some(s)
           case other        => Some(other.toString)
-        .catchAll: ex =>
-          Observability.annotateCelFailure(expression, s"evaluation failed: ${errorMessage(ex)}, no value injected")
-            .as(None)
-
-  private def errorMessage(ex: Throwable): String =
-    Option(ex.getMessage).getOrElse(ex.getClass.getSimpleName)
+        .catchAll: _ =>
+          Observability.annotateCelFailure("evaluation failed, no value injected").as(None)

--- a/util/src/main/scala/versola/util/http/Observability.scala
+++ b/util/src/main/scala/versola/util/http/Observability.scala
@@ -91,30 +91,27 @@ object Observability:
   def setError(code: String, description: Option[String] = None): UIO[Unit] =
     logContext.update(_.annotate(error, ErrorDetails(code, description)))
 
-  /** Records that the CEL expression `expression` failed to evaluate, folding the rule and the
-    * failure reason into a single `error.description` (e.g. `` `token.role`: returned String
-    * instead of Boolean, treated as false ``) instead of a context of its own: a failed
-    * expression degrades to `false`/absent rather than to an error response, so the request's
-    * own outcome is indistinguishable from a legitimate denial without this, and `error` is
-    * already the request's one place for that kind of explanation.
+  /** Records that a CEL expression failed to evaluate for this request, under `error`, without
+    * naming the expression or repeating the underlying exception text: which rule it was is
+    * discoverable from the endpoint's configured rules in the console once the request's
+    * endpoint is known, and an exception's own message can vary in shape. `outcome` says only
+    * what the caller did as a result (e.g. `"treated as false"`, `"no value injected"`) -- a
+    * failed expression degrades silently rather than erroring, so the request's own outcome is
+    * indistinguishable from a legitimate denial without at least that much.
     *
     * Left under [[CelEvaluationFailedCode]] until the check that ran this expression decides
-    * the request's real outcome. [[setErrorForExpression]] is how a check that denies based on
-    * this same expression (`access_rule_denied`) keeps this description while replacing the
-    * code; a check that doesn't run afterward (e.g. a failed inject rule, which doesn't fail
-    * the request) leaves this as the final `error` entry. */
-  def annotateCelFailure(expression: String, message: String): UIO[Unit] =
-    logContext.update(_.annotate(error, ErrorDetails(CelEvaluationFailedCode, Some(s"`$expression`: $message"))))
+    * the request's real outcome. [[setErrorKeepingCelFailure]] is how a check that denies as a
+    * result (`access_rule_denied`) keeps this description while replacing the code; a check
+    * that doesn't run afterward (e.g. a failed inject rule, which doesn't fail the request)
+    * leaves this as the final `error` entry. */
+  def annotateCelFailure(outcome: String): UIO[Unit] =
+    logContext.update(_.annotate(error, ErrorDetails(CelEvaluationFailedCode, Some(outcome))))
 
-  /** Sets the request's error to `code`, described by the CEL expression that produced it. If
-    * evaluating `expression` already failed and left a reason via [[annotateCelFailure]], keeps
-    * that richer description instead of replacing it with the bare expression: the failure
-    * reason is why the rule denied the request in the first place. */
-  def setErrorForExpression(code: String, expression: String): UIO[Unit] =
-    logContext.update { context =>
-      val description = context.get(error).flatMap(_.description).getOrElse(s"`$expression`")
-      context.annotate(error, ErrorDetails(code, Some(description)))
-    }
+  /** Sets the request's error to `code`, keeping the description already there if one was left
+    * by [[annotateCelFailure]] for this request instead of clearing it: that's why the check
+    * denied the request in the first place. Falls back to no description otherwise. */
+  def setErrorKeepingCelFailure(code: String): UIO[Unit] =
+    logContext.update(context => context.annotate(error, ErrorDetails(code, context.get(error).flatMap(_.description))))
 
   val clientLogging: FiberRef[HttpObservabilityConfig.Client] = zio.Unsafe.unsafe { case given zio.Unsafe =>
     FiberRef.unsafe.make(HttpObservabilityConfig.Client.default)

--- a/util/src/main/scala/versola/util/http/Observability.scala
+++ b/util/src/main/scala/versola/util/http/Observability.scala
@@ -30,13 +30,10 @@ object Observability:
     * request/redirect that carried the failure). */
   val error = LogAnnotation[ErrorDetails]("error", (_, r) => r, _.toJson)
 
-  /** CEL expressions that could not be evaluated while handling the request, rendered under
-    * the `cel` key. A failed expression degrades to `false`/absent rather than to an error
-    * response, so the request's own outcome (e.g. `access_rule_denied`) is indistinguishable
-    * from a legitimate denial without this. Kept separate from [[error]] for that reason: the
-    * expression is the cause, not the outcome, and both have to survive to the log line.
-    */
-  val cel = LogAnnotation[Vector[CelFailure]]("cel", (_, r) => r, _.toJson)
+  /** Code recorded under `error` when a CEL expression throws or returns the wrong type while
+    * being evaluated for a request, before whatever check ran it has decided the request's
+    * real outcome. */
+  val CelEvaluationFailedCode = "cel_evaluation_failed"
 
   val cause = zio.Unsafe.unsafe { case given zio.Unsafe =>
     FiberRef.unsafe.make(Option.empty[Cause[Any]])
@@ -94,13 +91,30 @@ object Observability:
   def setError(code: String, description: Option[String] = None): UIO[Unit] =
     logContext.update(_.annotate(error, ErrorDetails(code, description)))
 
-  /** Records an expression that failed to evaluate, under the `cel` key. Appends rather than
-    * replaces, since one request can evaluate several expressions (an allow rule, a step-up
-    * condition, one per inject rule) and each failure explains a different degraded result. */
-  def addCelFailure(expression: String, message: String): UIO[Unit] =
-    logContext.update(context =>
-      context.annotate(cel, context.get(cel).getOrElse(Vector.empty) :+ CelFailure(expression, message)),
-    )
+  /** Records that the CEL expression `expression` failed to evaluate, folding the rule and the
+    * failure reason into a single `error.description` (e.g. `` `token.role`: returned String
+    * instead of Boolean, treated as false ``) instead of a context of its own: a failed
+    * expression degrades to `false`/absent rather than to an error response, so the request's
+    * own outcome is indistinguishable from a legitimate denial without this, and `error` is
+    * already the request's one place for that kind of explanation.
+    *
+    * Left under [[CelEvaluationFailedCode]] until the check that ran this expression decides
+    * the request's real outcome. [[setErrorForExpression]] is how a check that denies based on
+    * this same expression (`access_rule_denied`) keeps this description while replacing the
+    * code; a check that doesn't run afterward (e.g. a failed inject rule, which doesn't fail
+    * the request) leaves this as the final `error` entry. */
+  def annotateCelFailure(expression: String, message: String): UIO[Unit] =
+    logContext.update(_.annotate(error, ErrorDetails(CelEvaluationFailedCode, Some(s"`$expression`: $message"))))
+
+  /** Sets the request's error to `code`, described by the CEL expression that produced it. If
+    * evaluating `expression` already failed and left a reason via [[annotateCelFailure]], keeps
+    * that richer description instead of replacing it with the bare expression: the failure
+    * reason is why the rule denied the request in the first place. */
+  def setErrorForExpression(code: String, expression: String): UIO[Unit] =
+    logContext.update { context =>
+      val description = context.get(error).flatMap(_.description).getOrElse(s"`$expression`")
+      context.annotate(error, ErrorDetails(code, Some(description)))
+    }
 
   val clientLogging: FiberRef[HttpObservabilityConfig.Client] = zio.Unsafe.unsafe { case given zio.Unsafe =>
     FiberRef.unsafe.make(HttpObservabilityConfig.Client.default)
@@ -544,13 +558,6 @@ object Observability:
   case class ErrorDetails(
       code: String,
       description: Option[String] = None,
-  ) derives JsonEncoder
-
-  /** A CEL expression that failed while handling the request, and why. */
-  @jsonMemberNames(SnakeCase)
-  case class CelFailure(
-      expression: String,
-      message: String,
   ) derives JsonEncoder
 
   val logCause = zio.logging.LogAnnotation[Throwable](

--- a/util/src/main/scala/versola/util/http/Observability.scala
+++ b/util/src/main/scala/versola/util/http/Observability.scala
@@ -30,6 +30,14 @@ object Observability:
     * request/redirect that carried the failure). */
   val error = LogAnnotation[ErrorDetails]("error", (_, r) => r, _.toJson)
 
+  /** CEL expressions that could not be evaluated while handling the request, rendered under
+    * the `cel` key. A failed expression degrades to `false`/absent rather than to an error
+    * response, so the request's own outcome (e.g. `access_rule_denied`) is indistinguishable
+    * from a legitimate denial without this. Kept separate from [[error]] for that reason: the
+    * expression is the cause, not the outcome, and both have to survive to the log line.
+    */
+  val cel = LogAnnotation[Vector[CelFailure]]("cel", (_, r) => r, _.toJson)
+
   val cause = zio.Unsafe.unsafe { case given zio.Unsafe =>
     FiberRef.unsafe.make(Option.empty[Cause[Any]])
   }
@@ -85,6 +93,14 @@ object Observability:
     * be used for alerting/metrics without risking unbounded cardinality. */
   def setError(code: String, description: Option[String] = None): UIO[Unit] =
     logContext.update(_.annotate(error, ErrorDetails(code, description)))
+
+  /** Records an expression that failed to evaluate, under the `cel` key. Appends rather than
+    * replaces, since one request can evaluate several expressions (an allow rule, a step-up
+    * condition, one per inject rule) and each failure explains a different degraded result. */
+  def addCelFailure(expression: String, message: String): UIO[Unit] =
+    logContext.update(context =>
+      context.annotate(cel, context.get(cel).getOrElse(Vector.empty) :+ CelFailure(expression, message)),
+    )
 
   val clientLogging: FiberRef[HttpObservabilityConfig.Client] = zio.Unsafe.unsafe { case given zio.Unsafe =>
     FiberRef.unsafe.make(HttpObservabilityConfig.Client.default)
@@ -528,6 +544,13 @@ object Observability:
   case class ErrorDetails(
       code: String,
       description: Option[String] = None,
+  ) derives JsonEncoder
+
+  /** A CEL expression that failed while handling the request, and why. */
+  @jsonMemberNames(SnakeCase)
+  case class CelFailure(
+      expression: String,
+      message: String,
   ) derives JsonEncoder
 
   val logCause = zio.logging.LogAnnotation[Throwable](

--- a/util/src/main/scala/versola/util/http/Observability.scala
+++ b/util/src/main/scala/versola/util/http/Observability.scala
@@ -30,11 +30,6 @@ object Observability:
     * request/redirect that carried the failure). */
   val error = LogAnnotation[ErrorDetails]("error", (_, r) => r, _.toJson)
 
-  /** Code recorded under `error` when a CEL expression throws or returns the wrong type while
-    * being evaluated for a request, before whatever check ran it has decided the request's
-    * real outcome. */
-  val CelEvaluationFailedCode = "cel_evaluation_failed"
-
   val cause = zio.Unsafe.unsafe { case given zio.Unsafe =>
     FiberRef.unsafe.make(Option.empty[Cause[Any]])
   }
@@ -87,31 +82,20 @@ object Observability:
 
   /** Records the outcome of a request that ended in an error, under the `error` key. `code`
     * should come from a stable, closed vocabulary (e.g. `stepErrorKey`, `ErrorCode`) so it can
-    * be used for alerting/metrics without risking unbounded cardinality. */
+    * be used for alerting/metrics without risking unbounded cardinality. Replaces whatever
+    * error context the request already had; see [[updateError]] to change only part of it. */
   def setError(code: String, description: Option[String] = None): UIO[Unit] =
     logContext.update(_.annotate(error, ErrorDetails(code, description)))
 
-  /** Records that a CEL expression failed to evaluate for this request, under `error`, without
-    * naming the expression or repeating the underlying exception text: which rule it was is
-    * discoverable from the endpoint's configured rules in the console once the request's
-    * endpoint is known, and an exception's own message can vary in shape. `outcome` says only
-    * what the caller did as a result (e.g. `"treated as false"`, `"no value injected"`) -- a
-    * failed expression degrades silently rather than erroring, so the request's own outcome is
-    * indistinguishable from a legitimate denial without at least that much.
-    *
-    * Left under [[CelEvaluationFailedCode]] until the check that ran this expression decides
-    * the request's real outcome. [[setErrorKeepingCelFailure]] is how a check that denies as a
-    * result (`access_rule_denied`) keeps this description while replacing the code; a check
-    * that doesn't run afterward (e.g. a failed inject rule, which doesn't fail the request)
-    * leaves this as the final `error` entry. */
-  def annotateCelFailure(outcome: String): UIO[Unit] =
-    logContext.update(_.annotate(error, ErrorDetails(CelEvaluationFailedCode, Some(outcome))))
-
-  /** Sets the request's error to `code`, keeping the description already there if one was left
-    * by [[annotateCelFailure]] for this request instead of clearing it: that's why the check
-    * denied the request in the first place. Falls back to no description otherwise. */
-  def setErrorKeepingCelFailure(code: String): UIO[Unit] =
-    logContext.update(context => context.annotate(error, ErrorDetails(code, context.get(error).flatMap(_.description))))
+  /** Applies `f` to the request's current error context (an empty one, `code = ""`, if none is
+    * set yet), so one part of it can be filled in without knowing or disturbing the rest. Used
+    * where the reason for an outcome is known before the outcome itself is: e.g. a CEL
+    * evaluation failure discovers *why* a rule will read as denied before the caller that ran
+    * it, a few lines later, decides *that* it's `access_rule_denied` -- each fills in its own
+    * half of the same [[ErrorDetails]] with `updateError`, instead of the second call
+    * overwriting the first's via [[setError]]. */
+  def updateError(f: ErrorDetails => ErrorDetails): UIO[Unit] =
+    logContext.update(context => context.annotate(error, f(context.get(error).getOrElse(ErrorDetails(code = "")))))
 
   val clientLogging: FiberRef[HttpObservabilityConfig.Client] = zio.Unsafe.unsafe { case given zio.Unsafe =>
     FiberRef.unsafe.make(HttpObservabilityConfig.Client.default)

--- a/util/src/main/scala/versola/util/http/Observability.scala
+++ b/util/src/main/scala/versola/util/http/Observability.scala
@@ -82,20 +82,9 @@ object Observability:
 
   /** Records the outcome of a request that ended in an error, under the `error` key. `code`
     * should come from a stable, closed vocabulary (e.g. `stepErrorKey`, `ErrorCode`) so it can
-    * be used for alerting/metrics without risking unbounded cardinality. Replaces whatever
-    * error context the request already had; see [[updateError]] to change only part of it. */
+    * be used for alerting/metrics without risking unbounded cardinality. */
   def setError(code: String, description: Option[String] = None): UIO[Unit] =
     logContext.update(_.annotate(error, ErrorDetails(code, description)))
-
-  /** Applies `f` to the request's current error context (an empty one, `code = ""`, if none is
-    * set yet), so one part of it can be filled in without knowing or disturbing the rest. Used
-    * where the reason for an outcome is known before the outcome itself is: e.g. a CEL
-    * evaluation failure discovers *why* a rule will read as denied before the caller that ran
-    * it, a few lines later, decides *that* it's `access_rule_denied` -- each fills in its own
-    * half of the same [[ErrorDetails]] with `updateError`, instead of the second call
-    * overwriting the first's via [[setError]]. */
-  def updateError(f: ErrorDetails => ErrorDetails): UIO[Unit] =
-    logContext.update(context => context.annotate(error, f(context.get(error).getOrElse(ErrorDetails(code = "")))))
 
   val clientLogging: FiberRef[HttpObservabilityConfig.Client] = zio.Unsafe.unsafe { case given zio.Unsafe =>
     FiberRef.unsafe.make(HttpObservabilityConfig.Client.default)

--- a/util/src/test/scala/versola/util/cel/CelEvaluatorSpec.scala
+++ b/util/src/test/scala/versola/util/cel/CelEvaluatorSpec.scala
@@ -1,6 +1,8 @@
 package versola.util.cel
 
+import versola.util.http.Observability
 import zio.*
+import zio.logging.{LogContext, logContext}
 import zio.test.*
 import zio.test.Assertion.*
 
@@ -11,6 +13,14 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
   private def make: UIO[CelEvaluator] =
     Ref.make(Map.empty[String, Either[CelEvaluator.CompileError, CelEvaluator.Program]])
       .map(CelEvaluator.Impl(_))
+
+  private def celFailures: UIO[Vector[Observability.CelFailure]] =
+    logContext.get.map(_.get(Observability.cel).getOrElse(Vector.empty))
+
+  /** `logContext` is a `FiberRef` shared by tests running in the same fiber, so a test that
+    * asserts on annotations has to start from an empty one to see only its own. */
+  private def ownRequest[A](zio: UIO[A]): UIO[A] =
+    logContext.locally(LogContext.empty)(zio)
 
   private val tokenContext: Map[String, AnyRef] = Map(
     "token"   -> Map[String, AnyRef]("role" -> "admin", "scope" -> "read write").asJava,
@@ -89,6 +99,30 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
           result    <- program.evaluateBoolean(tokenContext)
         yield assertTrue(!result)
       },
+      test("evaluateBoolean reports a type mismatch into the request's log context") {
+        ownRequest:
+          for
+            evaluator <- make
+            program   <- evaluator.compile("token.role")
+            _         <- program.evaluateBoolean(tokenContext)
+            failures  <- celFailures
+          yield assertTrue(
+            failures.map(_.expression) == Vector("token.role"),
+            failures.exists(_.message.contains("instead of Boolean")),
+          )
+      },
+      test("evaluateBoolean reports an evaluation error into the request's log context") {
+        ownRequest:
+          for
+            evaluator <- make
+            program   <- evaluator.compile("token.missing.deep.path == 'x'")
+            result    <- program.evaluateBoolean(tokenContext)
+            failures  <- celFailures
+          yield assertTrue(
+            !result,
+            failures.map(_.expression) == Vector("token.missing.deep.path == 'x'"),
+          )
+      },
       test("evaluateString returns Some for string-typed expression") {
         for
           evaluator <- make
@@ -102,6 +136,29 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
           program   <- evaluator.compile("token.missing.deep.path")
           result    <- program.evaluateString(tokenContext)
         yield assertTrue(result.isEmpty)
+      },
+      test("evaluateString reports an evaluation error into the request's log context") {
+        ownRequest:
+          for
+            evaluator <- make
+            program   <- evaluator.compile("token.missing.deep.path")
+            _         <- program.evaluateString(tokenContext)
+            failures  <- celFailures
+          yield assertTrue(failures.map(_.expression) == Vector("token.missing.deep.path"))
+      },
+      test("failures of several expressions accumulate instead of replacing each other") {
+        ownRequest:
+          for
+            evaluator <- make
+            allow     <- evaluator.compile("token.missing.deep.path == 'x'")
+            inject    <- evaluator.compile("token.other.deep.path")
+            _         <- allow.evaluateBoolean(tokenContext)
+            _         <- inject.evaluateString(tokenContext)
+            failures  <- celFailures
+          yield assertTrue(
+            failures.map(_.expression) ==
+              Vector("token.missing.deep.path == 'x'", "token.other.deep.path"),
+          )
       },
     ),
     suite("cache")(

--- a/util/src/test/scala/versola/util/cel/CelEvaluatorSpec.scala
+++ b/util/src/test/scala/versola/util/cel/CelEvaluatorSpec.scala
@@ -99,7 +99,7 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
           result    <- program.evaluateBoolean(tokenContext)
         yield assertTrue(!result)
       },
-      test("evaluateBoolean folds a type mismatch into the request's error context") {
+      test("evaluateBoolean folds a type mismatch into the request's error context, without the expression") {
         ownRequest:
           for
             evaluator <- make
@@ -108,11 +108,10 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
             error     <- celError
           yield assertTrue(
             error.map(_.code).contains(Observability.CelEvaluationFailedCode),
-            error.flatMap(_.description).exists(_.startsWith("`token.role`: ")),
-            error.flatMap(_.description).exists(_.contains("instead of Boolean")),
+            error.flatMap(_.description).contains("non-boolean result, treated as false"),
           )
       },
-      test("evaluateBoolean folds an evaluation error into the request's error context") {
+      test("evaluateBoolean folds an evaluation error into the request's error context, without the expression") {
         ownRequest:
           for
             evaluator <- make
@@ -122,7 +121,7 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
           yield assertTrue(
             !result,
             error.map(_.code).contains(Observability.CelEvaluationFailedCode),
-            error.flatMap(_.description).exists(_.startsWith("`token.missing.deep.path == 'x'`: ")),
+            error.flatMap(_.description).contains("evaluation failed, treated as false"),
           )
       },
       test("evaluateString returns Some for string-typed expression") {
@@ -139,7 +138,7 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
           result    <- program.evaluateString(tokenContext)
         yield assertTrue(result.isEmpty)
       },
-      test("evaluateString folds an evaluation error into the request's error context") {
+      test("evaluateString folds an evaluation error into the request's error context, without the expression") {
         ownRequest:
           for
             evaluator <- make
@@ -148,7 +147,7 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
             error     <- celError
           yield assertTrue(
             error.map(_.code).contains(Observability.CelEvaluationFailedCode),
-            error.flatMap(_.description).exists(_.startsWith("`token.missing.deep.path`: ")),
+            error.flatMap(_.description).contains("evaluation failed, no value injected"),
           )
       },
       test("a later failure replaces the description left by an earlier one") {
@@ -160,7 +159,7 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
             _         <- allow.evaluateBoolean(tokenContext)
             _         <- inject.evaluateString(tokenContext)
             error     <- celError
-          yield assertTrue(error.flatMap(_.description).exists(_.startsWith("`token.other.deep.path`: ")))
+          yield assertTrue(error.flatMap(_.description).contains("evaluation failed, no value injected"))
       },
     ),
     suite("cache")(

--- a/util/src/test/scala/versola/util/cel/CelEvaluatorSpec.scala
+++ b/util/src/test/scala/versola/util/cel/CelEvaluatorSpec.scala
@@ -107,8 +107,7 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
             _         <- program.evaluateBoolean(tokenContext)
             error     <- celError
           yield assertTrue(
-            error.map(_.code).contains(Observability.CelEvaluationFailedCode),
-            error.flatMap(_.description).contains("non-boolean result, treated as false"),
+            error.flatMap(_.description).contains("cel rule evaluated to non-boolean result, treated as false"),
           )
       },
       test("evaluateBoolean folds an evaluation error into the request's error context, without the expression") {
@@ -120,8 +119,7 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
             error     <- celError
           yield assertTrue(
             !result,
-            error.map(_.code).contains(Observability.CelEvaluationFailedCode),
-            error.flatMap(_.description).contains("evaluation failed, treated as false"),
+            error.flatMap(_.description).contains("cel rule evaluation failed, treated as false"),
           )
       },
       test("evaluateString returns Some for string-typed expression") {
@@ -145,10 +143,7 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
             program   <- evaluator.compile("token.missing.deep.path")
             _         <- program.evaluateString(tokenContext)
             error     <- celError
-          yield assertTrue(
-            error.map(_.code).contains(Observability.CelEvaluationFailedCode),
-            error.flatMap(_.description).contains("evaluation failed, no value injected"),
-          )
+          yield assertTrue(error.flatMap(_.description).contains("cel rule evaluation failed, no value injected"))
       },
       test("a later failure replaces the description left by an earlier one") {
         ownRequest:
@@ -159,7 +154,7 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
             _         <- allow.evaluateBoolean(tokenContext)
             _         <- inject.evaluateString(tokenContext)
             error     <- celError
-          yield assertTrue(error.flatMap(_.description).contains("evaluation failed, no value injected"))
+          yield assertTrue(error.flatMap(_.description).contains("cel rule evaluation failed, no value injected"))
       },
     ),
     suite("cache")(

--- a/util/src/test/scala/versola/util/cel/CelEvaluatorSpec.scala
+++ b/util/src/test/scala/versola/util/cel/CelEvaluatorSpec.scala
@@ -1,8 +1,7 @@
 package versola.util.cel
 
-import versola.util.http.Observability
+import versola.util.cel.CelEvaluator.EvaluationError
 import zio.*
-import zio.logging.{LogContext, logContext}
 import zio.test.*
 import zio.test.Assertion.*
 
@@ -13,14 +12,6 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
   private def make: UIO[CelEvaluator] =
     Ref.make(Map.empty[String, Either[CelEvaluator.CompileError, CelEvaluator.Program]])
       .map(CelEvaluator.Impl(_))
-
-  private def celError: UIO[Option[Observability.ErrorDetails]] =
-    logContext.get.map(_.get(Observability.error))
-
-  /** `logContext` is a `FiberRef` shared by tests running in the same fiber, so a test that
-    * asserts on annotations has to start from an empty one to see only its own. */
-  private def ownRequest[A](zio: UIO[A]): UIO[A] =
-    logContext.locally(LogContext.empty)(zio)
 
   private val tokenContext: Map[String, AnyRef] = Map(
     "token"   -> Map[String, AnyRef]("role" -> "admin", "scope" -> "read write").asJava,
@@ -75,13 +66,16 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
           result    <- program.evaluateBoolean(tokenContext)
         yield assertTrue(result)
       },
-      test("returns FailSafe Program (false) for invalid expression") {
+      test("returns a Program that fails as Broken for an expression that doesn't compile") {
         for
           evaluator <- make
           program   <- evaluator.compile("(unterminated")
-          boolean   <- program.evaluateBoolean(tokenContext)
-          string    <- program.evaluateString(tokenContext)
-        yield assertTrue(!boolean, string.isEmpty)
+          boolean   <- program.evaluateBoolean(tokenContext).either
+          string    <- program.evaluateString(tokenContext).either
+        yield assertTrue(
+          boolean == Left(EvaluationError.Broken),
+          string == Left(EvaluationError.Broken),
+        )
       },
     ),
     suite("Program evaluation")(
@@ -92,35 +86,33 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
           result    <- program.evaluateBoolean(tokenContext)
         yield assertTrue(result)
       },
-      test("evaluateBoolean returns false on type mismatch instead of failing") {
+      test("evaluateBoolean fails as Broken when the expression returns a non-boolean") {
         for
           evaluator <- make
           program   <- evaluator.compile("token.role")
+          result    <- program.evaluateBoolean(tokenContext).either
+        yield assertTrue(result == Left(EvaluationError.Broken))
+      },
+      test("evaluateBoolean fails as DataMissing when the expression reads a claim the token lacks") {
+        for
+          evaluator <- make
+          program   <- evaluator.compile("token.missing.deep.path == 'x'")
+          result    <- program.evaluateBoolean(tokenContext).either
+        yield assertTrue(result == Left(EvaluationError.DataMissing))
+      },
+      test("evaluateBoolean fails as Broken for an evaluation error that isn't absent data") {
+        for
+          evaluator <- make
+          program   <- evaluator.compile("1 / 0 == 0")
+          result    <- program.evaluateBoolean(tokenContext).either
+        yield assertTrue(result == Left(EvaluationError.Broken))
+      },
+      test("an absent claim can be guarded with has(), leaving the rule evaluable") {
+        for
+          evaluator <- make
+          program   <- evaluator.compile("has(user.plan) && user.plan == 'premium'")
           result    <- program.evaluateBoolean(tokenContext)
         yield assertTrue(!result)
-      },
-      test("evaluateBoolean folds a type mismatch into the request's error context, without the expression") {
-        ownRequest:
-          for
-            evaluator <- make
-            program   <- evaluator.compile("token.role")
-            _         <- program.evaluateBoolean(tokenContext)
-            error     <- celError
-          yield assertTrue(
-            error.flatMap(_.description).contains("cel rule evaluated to non-boolean result, treated as false"),
-          )
-      },
-      test("evaluateBoolean folds an evaluation error into the request's error context, without the expression") {
-        ownRequest:
-          for
-            evaluator <- make
-            program   <- evaluator.compile("token.missing.deep.path == 'x'")
-            result    <- program.evaluateBoolean(tokenContext)
-            error     <- celError
-          yield assertTrue(
-            !result,
-            error.flatMap(_.description).contains("cel rule evaluation failed, treated as false"),
-          )
       },
       test("evaluateString returns Some for string-typed expression") {
         for
@@ -129,32 +121,19 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
           result    <- program.evaluateString(tokenContext)
         yield assertTrue(result.contains("admin"))
       },
-      test("evaluateString returns None when evaluation throws") {
+      test("evaluateString fails as DataMissing when the expression reads a claim the token lacks") {
         for
           evaluator <- make
           program   <- evaluator.compile("token.missing.deep.path")
+          result    <- program.evaluateString(tokenContext).either
+        yield assertTrue(result == Left(EvaluationError.DataMissing))
+      },
+      test("an absent claim can be guarded with has(), leaving an inject rule evaluable") {
+        for
+          evaluator <- make
+          program   <- evaluator.compile("has(user.plan) ? user.plan : ''")
           result    <- program.evaluateString(tokenContext)
-        yield assertTrue(result.isEmpty)
-      },
-      test("evaluateString folds an evaluation error into the request's error context, without the expression") {
-        ownRequest:
-          for
-            evaluator <- make
-            program   <- evaluator.compile("token.missing.deep.path")
-            _         <- program.evaluateString(tokenContext)
-            error     <- celError
-          yield assertTrue(error.flatMap(_.description).contains("cel rule evaluation failed, no value injected"))
-      },
-      test("a later failure replaces the description left by an earlier one") {
-        ownRequest:
-          for
-            evaluator <- make
-            allow     <- evaluator.compile("token.missing.deep.path == 'x'")
-            inject    <- evaluator.compile("token.other.deep.path")
-            _         <- allow.evaluateBoolean(tokenContext)
-            _         <- inject.evaluateString(tokenContext)
-            error     <- celError
-          yield assertTrue(error.flatMap(_.description).contains("cel rule evaluation failed, no value injected"))
+        yield assertTrue(result.contains(""))
       },
     ),
     suite("cache")(

--- a/util/src/test/scala/versola/util/cel/CelEvaluatorSpec.scala
+++ b/util/src/test/scala/versola/util/cel/CelEvaluatorSpec.scala
@@ -14,8 +14,8 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
     Ref.make(Map.empty[String, Either[CelEvaluator.CompileError, CelEvaluator.Program]])
       .map(CelEvaluator.Impl(_))
 
-  private def celFailures: UIO[Vector[Observability.CelFailure]] =
-    logContext.get.map(_.get(Observability.cel).getOrElse(Vector.empty))
+  private def celError: UIO[Option[Observability.ErrorDetails]] =
+    logContext.get.map(_.get(Observability.error))
 
   /** `logContext` is a `FiberRef` shared by tests running in the same fiber, so a test that
     * asserts on annotations has to start from an empty one to see only its own. */
@@ -99,28 +99,30 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
           result    <- program.evaluateBoolean(tokenContext)
         yield assertTrue(!result)
       },
-      test("evaluateBoolean reports a type mismatch into the request's log context") {
+      test("evaluateBoolean folds a type mismatch into the request's error context") {
         ownRequest:
           for
             evaluator <- make
             program   <- evaluator.compile("token.role")
             _         <- program.evaluateBoolean(tokenContext)
-            failures  <- celFailures
+            error     <- celError
           yield assertTrue(
-            failures.map(_.expression) == Vector("token.role"),
-            failures.exists(_.message.contains("instead of Boolean")),
+            error.map(_.code).contains(Observability.CelEvaluationFailedCode),
+            error.flatMap(_.description).exists(_.startsWith("`token.role`: ")),
+            error.flatMap(_.description).exists(_.contains("instead of Boolean")),
           )
       },
-      test("evaluateBoolean reports an evaluation error into the request's log context") {
+      test("evaluateBoolean folds an evaluation error into the request's error context") {
         ownRequest:
           for
             evaluator <- make
             program   <- evaluator.compile("token.missing.deep.path == 'x'")
             result    <- program.evaluateBoolean(tokenContext)
-            failures  <- celFailures
+            error     <- celError
           yield assertTrue(
             !result,
-            failures.map(_.expression) == Vector("token.missing.deep.path == 'x'"),
+            error.map(_.code).contains(Observability.CelEvaluationFailedCode),
+            error.flatMap(_.description).exists(_.startsWith("`token.missing.deep.path == 'x'`: ")),
           )
       },
       test("evaluateString returns Some for string-typed expression") {
@@ -137,16 +139,19 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
           result    <- program.evaluateString(tokenContext)
         yield assertTrue(result.isEmpty)
       },
-      test("evaluateString reports an evaluation error into the request's log context") {
+      test("evaluateString folds an evaluation error into the request's error context") {
         ownRequest:
           for
             evaluator <- make
             program   <- evaluator.compile("token.missing.deep.path")
             _         <- program.evaluateString(tokenContext)
-            failures  <- celFailures
-          yield assertTrue(failures.map(_.expression) == Vector("token.missing.deep.path"))
+            error     <- celError
+          yield assertTrue(
+            error.map(_.code).contains(Observability.CelEvaluationFailedCode),
+            error.flatMap(_.description).exists(_.startsWith("`token.missing.deep.path`: ")),
+          )
       },
-      test("failures of several expressions accumulate instead of replacing each other") {
+      test("a later failure replaces the description left by an earlier one") {
         ownRequest:
           for
             evaluator <- make
@@ -154,11 +159,8 @@ object CelEvaluatorSpec extends ZIOSpecDefault:
             inject    <- evaluator.compile("token.other.deep.path")
             _         <- allow.evaluateBoolean(tokenContext)
             _         <- inject.evaluateString(tokenContext)
-            failures  <- celFailures
-          yield assertTrue(
-            failures.map(_.expression) ==
-              Vector("token.missing.deep.path == 'x'", "token.other.deep.path"),
-          )
+            error     <- celError
+          yield assertTrue(error.flatMap(_.description).exists(_.startsWith("`token.other.deep.path`: ")))
       },
     ),
     suite("cache")(


### PR DESCRIPTION
## 1. CEL evaluation failures now fail closed

This started as an observability change (a failed CEL expression was logged as a context-free `ZIO.logWarning`, correlatable to its request only by timestamp). Chasing *why* a failure was hard to see turned up the actual bug: only one of the three call sites failed closed, and only by accident.

| call site | on evaluation failure | request outcome |
|---|---|---|
| `checkRules` allow rule | `false` | 403. Correct, coincidentally |
| `checkStepUp` condition | `false` | **step-up not required** -- proceeds on the weaker ACR the policy was trying to raise |
| inject rules | no value | **forwarded upstream** with the value missing, indistinguishable to upstream from one it was never meant to get |

A trusted expression that failed to *compile* took the same path, through a `FailSafe` program returning `false`/`None`.

### Two failure classes, split by CEL's own error code

A blanket 500 would be wrong: the most common runtime failure is an expression reading a claim that this particular token doesn't carry (`user.subscription == 'premium'` against a token with no `subscription`), which is ordinary production data, not broken config. `CelException.getErrorCode` gives a structured enum to split on, verified empirically against cel-java 0.12.0:

```
user.plan == 'premium'          -> ATTRIBUTE_NOT_FOUND  key 'plan' is not present in map.
request.body.total <= 50       -> ATTRIBUTE_NOT_FOUND  key 'body' is not present in map.
1/0 == 0                       -> DIVIDE_BY_ZERO
```

```scala
enum EvaluationError:
  case DataMissing  // ATTRIBUTE_NOT_FOUND: the request doesn't carry the value the rule reads
  case Broken       // any other error code, a non-boolean result, or a compile failure
```

`Program` returns these instead of a degraded value:

```scala
def evaluateBoolean(context: Map[String, AnyRef]): IO[EvaluationError, Boolean]
def evaluateString(context: Map[String, AnyRef]): IO[EvaluationError, Option[String]]
```

| call site | `DataMissing` | `Broken` |
|---|---|---|
| allow rule | 403 `access_rule_denied` | 500 `access_rule_failed` |
| step-up condition | step-up **required** -> challenge | 500 `step_up_condition_failed` |
| inject rule | 403 `inject_rule_denied` | 500 `inject_rule_failed` |

`DataMissing` is an authorization decision: the rule can't be satisfied, which isn't the same as the rule being wrong. `Broken` is an operator mistake, so it belongs in the 5xx budget rather than hidden among legitimate denials, where nobody alerts on it. An allow rule's `DataMissing` reuses `access_rule_denied` (same code as a clean `false`, with a description distinguishing them) so "policy denied this" stays one thing to alert on.

### `has()` is now available

The compiler was built without standard macros, so `has(user.plan)` didn't even parse -- an expression had no way to tolerate an absent claim. `setStandardMacros(CelStandardMacro.STANDARD_MACROS)` makes `DataMissing` a choice rather than an inevitability, and gives optional injects an escape hatch: `has(user.plan) ? user.plan : ''`.

### Error context

Each call site now sets its own full error context via the existing `setError`, so `Observability.updateError` (added earlier in this branch) is gone again and `CelEvaluator` no longer depends on `Observability` at all -- no hidden log-context side effect in a generic evaluator. Descriptions stay generic (`"cel rule read a value the request doesn't carry"`, `"cel rule could not be evaluated"`): the expression is a console lookup away once the endpoint is known, and the exception text varies in shape with the value that tripped it.

### Behavior change to be aware of

An inject rule referencing a sometimes-absent claim now **refuses the request** instead of forwarding it without the value. That's the fail-open case being closed, but it will 403 configs that were relying on the old silent skip; `has(x) ? x : ''` expresses an optional inject explicitly.

## 2. `getPermissionsForRoles` takes one tenant, not a map

`Map[TenantId, List[RoleId]]` was never constructible with more than one entry: the only caller (`EdgeService.getMyPermissions`) built it from a single optional tenant claim. Signature is now `(tenantId, roles, endpointIds)`, and `permissionsFor` loses its outer iteration. `getMyPermissions` skips the lookup entirely when the token has no tenant claim rather than calling through with an empty map. Response shape unchanged.

## Tests
- `CelEvaluatorSpec`: `DataMissing` vs `Broken` for both `evaluateBoolean` and `evaluateString`, a non-boolean result, a compile failure, and `has()`-guarded expressions evaluating cleanly against an absent claim.
- `EdgeServiceProxySpec`: 403 + nothing forwarded upstream for an allow rule reading an absent claim; 500 for one that can't be evaluated; step-up **challenged** (was: silently skipped) when the condition reads an absent claim; 500 for a broken condition; inject rule with an absent claim refused with nothing forwarded; `has()`-guarded inject forwarding an empty value.
- `PermissionServiceSpec` / `EdgeServiceSpec`: updated to the new signature; the multi-tenant merge case (no longer expressible) replaced by a cross-tenant isolation case.

`sbt Test/compile` clean across all modules; `util/test` (76) and `edge/test` (200) green on JDK 25. The postgres-backed suites need a database I don't have here.

## Noticed, deliberately not fixed here

CEL's `null` literal evaluates to protobuf `NullValue.NULL_VALUE`, not a Java null, so an inject rule written `has(x) ? x : null` injects the literal string `"NULL_VALUE"`. Pre-existing, and fixing it means either declaring protobuf-java as a direct dependency or validating inject rules against `SimpleType.STRING`. Worth a follow-up.