### PR TITLE
auth: revoke the whole refresh-token family on replay

### DIFF
--- a/auth/implementations/postgres/migrations/V0004__tokens_tables.sql
+++ b/auth/implementations/postgres/migrations/V0004__tokens_tables.sql
@@ -7,6 +7,11 @@ CREATE TABLE refresh_tokens(
     -- Set when the token is exchanged for its successor. The row stays behind as the record
     -- of that exchange: unusable, but still resolvable to its family.
     rotated_at TIMESTAMP WITH TIME ZONE,
+    -- MAC of the Idempotency-Key the exchange carried, if any. Lets the client that never
+    -- received its response retry: presenting this token again with the same key continues
+    -- the chain instead of being read as a replay. Only honoured while this row is the
+    -- family's most recent exchange, so the key stops working the moment the chain moves on.
+    idempotency_key BYTEA,
     access_token BYTEA UNIQUE NOT NULL,
     session_id BYTEA NOT NULL,
     public_session_id TEXT NOT NULL,

--- a/auth/implementations/postgres/migrations/V0004__tokens_tables.sql
+++ b/auth/implementations/postgres/migrations/V0004__tokens_tables.sql
@@ -1,6 +1,12 @@
 CREATE TABLE refresh_tokens(
     id BYTEA PRIMARY KEY,
-    previous_id BYTEA UNIQUE,
+    -- Root token of the rotation chain this token belongs to; a freshly issued token is its
+    -- own family. Kept on rotated-away rows so a token replayed any number of generations
+    -- later still resolves to the family that has to be revoked.
+    family_id BYTEA NOT NULL,
+    -- Set when the token is exchanged for its successor. The row stays behind as the record
+    -- of that exchange: unusable, but still resolvable to its family.
+    rotated_at TIMESTAMP WITH TIME ZONE,
     access_token BYTEA UNIQUE NOT NULL,
     session_id BYTEA NOT NULL,
     public_session_id TEXT NOT NULL,
@@ -18,6 +24,7 @@ CREATE TABLE refresh_tokens(
     auth_time TIMESTAMP WITH TIME ZONE NOT NULL
 );
 
+CREATE INDEX refresh_tokens_family_id_idx ON refresh_tokens (family_id);
 CREATE INDEX refresh_tokens_user_id_idx ON refresh_tokens (user_id);
 CREATE INDEX refresh_tokens_session_id_idx ON refresh_tokens (session_id);
 CREATE INDEX refresh_tokens_expires_at_idx ON refresh_tokens (expires_at) where expires_at is not null;

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
@@ -225,6 +225,7 @@ class PostgresSessionRepository(xa: TransactorZIO)
       refreshToken: MAC.Of[RefreshToken],
       previous: Option[MAC.Of[RefreshToken]],
       record: RefreshTokenRecord,
+      idempotencyKey: Option[MAC],
   ): IO[Throwable | RefreshAlreadyExchanged, Unit] =
     Clock.instant.flatMap: now =>
       xa.transactMeasured("create-refresh-token") {
@@ -264,11 +265,24 @@ class PostgresSessionRepository(xa: TransactorZIO)
             // usefulness by up to refresh_token_ttl, multiplying storage for every rotation.
             val retired = sql"""
               UPDATE refresh_tokens
-              SET rotated_at = $now, expires_at = ${now.plus(PostgresSessionRepository.ReplayDetectionWindow)}
+              SET rotated_at = $now,
+                  expires_at = ${now.plus(PostgresSessionRepository.ReplayDetectionWindow)},
+                  idempotency_key = $idempotencyKey
               WHERE id = $previousToken AND rotated_at IS NULL AND expires_at > $now
             """.update.run()
 
             if retired == 0 then throw PostgresSessionRepository.RotationLost
+
+            // A key names the family's latest exchange and no other, so that recognising it
+            // is the same as asking whether the chain has moved on. Clearing it from wherever
+            // it sat before is what lets a client retry more than once: each retry carries the
+            // key forward, while any exchange under a different key -- the client finally
+            // getting through -- strands the old one and takes reuse detection back.
+            sql"""
+              UPDATE refresh_tokens
+              SET idempotency_key = NULL
+              WHERE family_id = $family AND id <> $previousToken AND idempotency_key IS NOT NULL
+            """.update.run()
 
             // Keep the root alive for as long as the family it anchors: it is the lock target
             // every later rotation and revocation depends on, and the sweep would otherwise
@@ -346,6 +360,37 @@ class PostgresSessionRepository(xa: TransactorZIO)
           .run()
           .headOption
     yield result
+
+  override def findIdempotentRetry(
+      token: MAC.Of[RefreshToken],
+      clientId: ClientId,
+      idempotencyKey: MAC,
+  ): Task[Option[(MAC.Of[RefreshToken], RefreshTokenRecord)]] =
+    Clock.instant.flatMap: now =>
+      xa.connectMeasured("find-idempotent-refresh-retry"):
+        // `exchanged` is the row the key names: the family's latest exchange, since a key is
+        // only ever on one. Requiring the presented token to share its family stops a leaked
+        // key from being usable on its own, and scoping to the client stops one client from
+        // reaching into another's chain.
+        sql"""
+          SELECT tip.id, tip.session_id, tip.public_session_id, tip.access_token, tip.user_id,
+                 tip.client_id, tip.audience, tip.authorization_details, tip.scope,
+                 tip.issued_at, tip.expires_at, tip.requested_claims, tip.ui_locales,
+                 tip.nonce, tip.amr, tip.auth_time, tip.acr
+          FROM refresh_tokens presented
+          JOIN refresh_tokens exchanged
+            ON exchanged.family_id = presented.family_id
+           AND exchanged.idempotency_key = $idempotencyKey
+           AND exchanged.rotated_at IS NOT NULL
+          JOIN refresh_tokens tip
+            ON tip.family_id = presented.family_id
+           AND tip.rotated_at IS NULL
+           AND tip.expires_at > $now
+          WHERE presented.id = $token AND presented.client_id = $clientId
+        """
+          .query[(MAC.Of[RefreshToken], RefreshTokenRecord)]
+          .run()
+          .headOption
 
   override def revokeFamily(
       token: MAC.Of[RefreshToken],

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
@@ -255,9 +255,16 @@ class PostgresSessionRepository(xa: TransactorZIO)
 
             // Retire the presented token. Zero rows means it was already exchanged -- either
             // earlier, or by a concurrent request that just released the lock above.
+            //
+            // expires_at here is not "when this token stops working" -- rotated_at already
+            // means that -- it is how long the row survives the cleanup sweep so a replay of
+            // this generation still resolves to its family. That only needs to outlast a
+            // plausible detection window, not the full refresh-token TTL: tying it to the
+            // latter (as the successor's own expiry would) makes retained rows outlive their
+            // usefulness by up to refresh_token_ttl, multiplying storage for every rotation.
             val retired = sql"""
               UPDATE refresh_tokens
-              SET rotated_at = $now, expires_at = ${record.expiresAt}
+              SET rotated_at = $now, expires_at = ${now.plus(PostgresSessionRepository.ReplayDetectionWindow)}
               WHERE id = $previousToken AND rotated_at IS NULL AND expires_at > $now
             """.update.run()
 
@@ -396,6 +403,25 @@ object PostgresSessionRepository:
 
   /** Signals a rotation that lost its race, from inside the transaction body. */
   private case object RotationLost extends RuntimeException("refresh token already exchanged")
+
+  /** How long a retired token's row is kept around after rotation so a replay of that
+    * generation still resolves to its family. Independent of refresh_token_ttl on purpose:
+    * that value governs how long an *unused* token stays valid, not how far back a replay
+    * has to be detectable. A replay older than this window falls back to a plain
+    * invalid_grant with no revocation -- the pre-fix behavior -- which is an accepted
+    * trade-off for keeping the table's steady-state size bounded by rotation frequency
+    * times this window rather than times the (typically much longer) refresh-token TTL.
+    *
+    * The case this exists for is an attacker rotating a stolen token before the legitimate
+    * client wakes up and presents the one it still holds -- that presentation is the only
+    * signal the chain leaked. 24h covers the common absence pattern (overnight, a closed
+    * laptop) at a bounded cost: retained rows per family are window / refresh interval, so
+    * this is ~1 row/family/day at an hourly refresh cadence rather than ~90 at the full
+    * refresh-token TTL. A client that goes quiet for longer than this loses detection for
+    * that gap; if that matters, retaining a narrow tombstone (id, family_id, user_id,
+    * client_id, issued_at) instead of the full row would make a much longer window cheap.
+    */
+  private val ReplayDetectionWindow: Duration = Duration.fromSeconds(24 * 3600)
 
   private val SerializationFailureSqlState = "40001"
   private val UniqueViolationSqlState      = "23505"

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
@@ -292,6 +292,16 @@ class PostgresSessionRepository(xa: TransactorZIO)
           .headOption
     yield result
 
+  override def markChainReplayed(token: MAC.Of[RefreshToken], clientId: ClientId): Task[Option[(UserId, AccessToken)]] =
+    Clock.instant.flatMap: now =>
+      xa.connectMeasured("mark-refresh-chain-replayed"):
+        sql"""
+          UPDATE refresh_tokens
+          SET expires_at = $now
+          WHERE previous_id = $token AND client_id = $clientId AND expires_at > $now
+          RETURNING user_id, access_token
+        """.query[(UserId, AccessToken)].run().headOption
+
   override def delete(token: MAC.Of[RefreshToken]): Task[Unit] =
     xa.connectMeasured("delete-refresh-token"):
       sql"""DELETE FROM refresh_tokens WHERE id = $token""".update.run()

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
@@ -6,7 +6,7 @@ import com.augustnagro.magnum.pg.json.JsonBDbCodec
 import com.augustnagro.magnum.pg.{PgCodec, SqlArrayCodec}
 import versola.oauth.client.model.{Acr, AuthMethodRef, AuthorizationDetail, ClientId, PassedAuthFactor, PassedFactorRecord, ResourceUri, ScopeToken}
 import versola.oauth.model.{AccessToken, Nonce, RefreshToken}
-import versola.oauth.session.model.{ClientEntry, PriorSession, PublicSessionId, RefreshAlreadyExchanged, RefreshTokenRecord, SessionId, SessionRecord, UserAgentId}
+import versola.oauth.session.model.{ClientEntry, PriorSession, PublicSessionId, RefreshAlreadyExchanged, RefreshTokenRecord, RevokedFamily, SessionId, SessionRecord, UserAgentId}
 import versola.oauth.userinfo.model.RequestedClaims
 import versola.user.model.UserId
 import versola.util.MAC
@@ -15,6 +15,7 @@ import zio.json.*
 import zio.{Clock, Duration, IO, Task, ZIO, ZLayer}
 
 import java.sql.{Connection, SQLException}
+import java.time.Instant
 import java.util.UUID
 
 class PostgresSessionRepository(xa: TransactorZIO)
@@ -222,59 +223,106 @@ class PostgresSessionRepository(xa: TransactorZIO)
 
   override def createRefreshToken(
       refreshToken: MAC.Of[RefreshToken],
+      previous: Option[MAC.Of[RefreshToken]],
       record: RefreshTokenRecord,
   ): IO[Throwable | RefreshAlreadyExchanged, Unit] =
-    xa.transactMeasured("create-refresh-token") {
-      record.previousRefreshToken
-        .foreach { oldToken => sql"""DELETE FROM refresh_tokens WHERE id = $oldToken""".update.run() }
+    Clock.instant.flatMap: now =>
+      xa.transactMeasured("create-refresh-token") {
+        val familyId = previous match
+          case None =>
+            // A fresh chain: the token is the root of its own family.
+            refreshToken
 
-      sql"""
-        INSERT INTO refresh_tokens (
-          id,
-          previous_id,
-          session_id,
-          public_session_id,
-          access_token,
-          user_id,
-          client_id,
-          audience,
-          authorization_details,
-          scope,
-          issued_at,
-          expires_at,
-          requested_claims,
-          ui_locales,
-          nonce,
-          amr,
-          auth_time,
-          acr
-        )
-        VALUES (
-          $refreshToken,
-          ${record.previousRefreshToken},
-          ${record.sessionId},
-          ${record.publicSessionId},
-          ${record.accessToken},
-          ${record.userId},
-          ${record.clientId},
-          ${record.audience},
-          ${record.authorizationDetails},
-          ${record.scope},
-          ${record.issuedAt},
-          ${record.expiresAt},
-          ${record.requestedClaims},
-          ${record.uiLocales}::text[],
-          ${record.nonce},
-          ${record.amr},
-          ${record.authTime},
-          ${record.acr}
-        )
-        """.update.run()
-      ()
-    }.catchSome {
-      case e if PostgresSessionRepository.isSerializationOrUniqueViolationFailure(e) =>
-        ZIO.fail(RefreshAlreadyExchanged())
-    }
+          case Some(previousToken) =>
+            val family = sql"""SELECT family_id FROM refresh_tokens WHERE id = $previousToken"""
+              .query[MAC.Of[RefreshToken]]
+              .run()
+              .headOption
+              .getOrElse(throw PostgresSessionRepository.RotationLost)
+
+            // Both this and revokeFamily take the root's lock before touching any member, so
+            // a rotation cannot slip a successor past a revocation running beside it: one of
+            // the two waits, and whichever goes second sees the other's committed state. The
+            // family is read unlocked above only because a token never changes families.
+            val rootLocked = sql"""SELECT 1 FROM refresh_tokens WHERE id = $family FOR UPDATE"""
+              .query[Int]
+              .run()
+              .nonEmpty
+
+            // No root left to lock (swept, or revoked through the token endpoint) means the
+            // family is gone and nothing here can be serialised against. Fail closed.
+            if !rootLocked then throw PostgresSessionRepository.RotationLost
+
+            // Retire the presented token. Zero rows means it was already exchanged -- either
+            // earlier, or by a concurrent request that just released the lock above.
+            val retired = sql"""
+              UPDATE refresh_tokens
+              SET rotated_at = $now, expires_at = ${record.expiresAt}
+              WHERE id = $previousToken AND rotated_at IS NULL AND expires_at > $now
+            """.update.run()
+
+            if retired == 0 then throw PostgresSessionRepository.RotationLost
+
+            // Keep the root alive for as long as the family it anchors: it is the lock target
+            // every later rotation and revocation depends on, and the sweep would otherwise
+            // collect it once the generation that retired it aged out.
+            sql"""
+              UPDATE refresh_tokens
+              SET expires_at = GREATEST(expires_at, ${record.expiresAt})
+              WHERE id = $family
+            """.update.run()
+
+            family
+
+        sql"""
+          INSERT INTO refresh_tokens (
+            id,
+            family_id,
+            session_id,
+            public_session_id,
+            access_token,
+            user_id,
+            client_id,
+            audience,
+            authorization_details,
+            scope,
+            issued_at,
+            expires_at,
+            requested_claims,
+            ui_locales,
+            nonce,
+            amr,
+            auth_time,
+            acr
+          )
+          VALUES (
+            $refreshToken,
+            $familyId,
+            ${record.sessionId},
+            ${record.publicSessionId},
+            ${record.accessToken},
+            ${record.userId},
+            ${record.clientId},
+            ${record.audience},
+            ${record.authorizationDetails},
+            ${record.scope},
+            ${record.issuedAt},
+            ${record.expiresAt},
+            ${record.requestedClaims},
+            ${record.uiLocales}::text[],
+            ${record.nonce},
+            ${record.amr},
+            ${record.authTime},
+            ${record.acr}
+          )
+          """.update.run()
+        ()
+      }.catchSome {
+        case PostgresSessionRepository.RotationLost =>
+          ZIO.fail(RefreshAlreadyExchanged())
+        case e if PostgresSessionRepository.isSerializationOrUniqueViolationFailure(e) =>
+          ZIO.fail(RefreshAlreadyExchanged())
+      }
 
   override def findToken(token: MAC.Of[RefreshToken]): Task[Option[RefreshTokenRecord]] =
     for
@@ -283,38 +331,71 @@ class PostgresSessionRepository(xa: TransactorZIO)
         sql"""
           SELECT session_id, public_session_id, access_token, user_id, client_id,
                  audience, authorization_details, scope, issued_at,
-                 expires_at, requested_claims, ui_locales, nonce, previous_id,
+                 expires_at, requested_claims, ui_locales, nonce,
                  amr, auth_time, acr
           FROM refresh_tokens
-          WHERE id = $token AND expires_at > $now"""
+          WHERE id = $token AND expires_at > $now AND rotated_at IS NULL"""
           .query[RefreshTokenRecord]
           .run()
           .headOption
     yield result
 
-  override def markChainReplayed(token: MAC.Of[RefreshToken], clientId: ClientId): Task[Option[(UserId, AccessToken)]] =
+  override def revokeFamily(
+      token: MAC.Of[RefreshToken],
+      clientId: ClientId,
+      accessTokensIssuedAfter: Instant,
+  ): Task[Option[RevokedFamily]] =
     Clock.instant.flatMap: now =>
-      xa.connectMeasured("mark-refresh-chain-replayed"):
+      xa.transactMeasured("revoke-refresh-token-family") {
         sql"""
-          UPDATE refresh_tokens
-          SET expires_at = $now
-          WHERE previous_id = $token AND client_id = $clientId AND expires_at > $now
-          RETURNING user_id, access_token
-        """.query[(UserId, AccessToken)].run().headOption
+          SELECT family_id, user_id
+          FROM refresh_tokens
+          WHERE id = $token AND client_id = $clientId AND rotated_at IS NOT NULL
+        """.query[(MAC.Of[RefreshToken], UserId)]
+          .run()
+          .headOption
+          .map: (family, userId) =>
+            // Same lock createRefreshToken takes, and for the same reason: a rotation in
+            // flight either commits first and has its successor expired by the update below,
+            // or waits here and then finds the token it meant to rotate already dead.
+            sql"""SELECT 1 FROM refresh_tokens WHERE id = $family FOR UPDATE""".query[Int].run()
+
+            val revoked = sql"""
+              UPDATE refresh_tokens
+              SET expires_at = $now
+              WHERE family_id = $family AND expires_at > $now
+              RETURNING access_token, issued_at
+            """.query[(AccessToken, Instant)].run()
+
+            RevokedFamily(
+              userId = userId,
+              // Older generations are past their access-token TTL, so pushing them to the
+              // client's back channel would revoke nothing.
+              accessTokens = revoked.view
+                .filter(_._2.isAfter(accessTokensIssuedAfter))
+                .map(_._1)
+                .toList,
+            )
+      }
 
   override def delete(token: MAC.Of[RefreshToken]): Task[Unit] =
-    xa.connectMeasured("delete-refresh-token"):
-      sql"""DELETE FROM refresh_tokens WHERE id = $token""".update.run()
-    .unit
+    Clock.instant.flatMap: now =>
+      xa.connectMeasured("delete-refresh-token"):
+        sql"""UPDATE refresh_tokens SET expires_at = $now WHERE id = $token""".update.run()
+      .unit
 
   override def deleteByAccessToken(token: AccessToken): Task[Unit] =
-    xa.connectMeasured("delete-refresh-token-by-access-token"):
-      sql"""DELETE FROM refresh_tokens WHERE access_token = $token""".update.run()
-    .unit
+    Clock.instant.flatMap: now =>
+      xa.connectMeasured("delete-refresh-token-by-access-token"):
+        sql"""UPDATE refresh_tokens SET expires_at = $now WHERE access_token = $token""".update.run()
+      .unit
 
 object PostgresSessionRepository:
   def live: ZLayer[TransactorZIO, Throwable, SessionRepository] =
     ZLayer.fromFunction(PostgresSessionRepository(_))
+
+  /** Signals a rotation that lost its race, from inside the transaction body. */
+  private case object RotationLost extends RuntimeException("refresh token already exchanged")
 
   private val SerializationFailureSqlState = "40001"
   private val UniqueViolationSqlState      = "23505"

--- a/auth/open-api/token.yaml
+++ b/auth/open-api/token.yaml
@@ -31,6 +31,35 @@ paths:
       security:
         - clientSecretBasic: []
         - {}
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: |
+            Makes a `refresh_token` request safely retryable; ignored for other grants.
+
+            Rotation is single-use, so a response lost in flight leaves the client holding a
+            token the server has already retired. Presenting it again is indistinguishable
+            from a replay: the whole rotation family is revoked and the user has to sign in
+            again. Repeating the request with the same key and the same refresh token instead
+            continues the chain, and may be repeated as often as the client needs to.
+
+            The reply to a retry carries a **new** refresh token, not the one the lost response
+            contained -- that token is never stored and cannot be reproduced. Use whatever the
+            latest reply gives you and discard earlier ones: acting on a response that arrives
+            late, after a retry already succeeded, means presenting a superseded token, which
+            is a replay and does revoke the chain.
+
+            Generate one value per logical attempt and reuse it for every retry of that
+            attempt. Treat it as secret: together with the refresh token it is what proves the
+            retry came from the original caller, and a request presenting the token without
+            the matching key is still treated as a replay.
+
+            A key is honoured only until the chain moves on. As soon as a refresh succeeds
+            under a different key -- the client having got through -- the old key stops working
+            and reuse detection applies to it again. Nothing has to expire for that to happen.
       requestBody:
         required: true
         content:

--- a/auth/src/main/scala/versola/oauth/session/SessionRepository.scala
+++ b/auth/src/main/scala/versola/oauth/session/SessionRepository.scala
@@ -56,12 +56,38 @@ trait SessionRepository:
     * a rotation cannot interleave with a [[revokeFamily]] and leave its successor behind.
     * Fails with `RefreshAlreadyExchanged` when the presented token was already retired --
     * either sequentially or by a concurrent request that won the lock first.
+    *
+    * `idempotencyKey` is recorded against the token being retired, so that the exchange can
+    * be recognised later if the client repeats it -- see [[findIdempotentRetry]].
     */
   def createRefreshToken(
       refreshToken: MAC.Of[RefreshToken],
       previous: Option[MAC.Of[RefreshToken]],
       record: RefreshTokenRecord,
+      idempotencyKey: Option[MAC],
   ): IO[Throwable | RefreshAlreadyExchanged, Unit]
+
+  /** Resolves a repeat of an exchange that already happened, for a client that never received
+    * its response. Returns the family's live tip, with its id, so the caller can continue the
+    * chain from there: the original response -- and the token inside it -- is not recoverable,
+    * only re-minted.
+    *
+    * Returns `None` unless the family's most recent exchange was made by this client carrying
+    * this exact key, and left a live tip behind. Only one row in a family holds a key at a
+    * time -- [[createRefreshToken]] moves it onto whichever token it retires -- so matching it
+    * is the same as asking whether the chain has moved on since. It has not while the client
+    * is still retrying, however many times; it has the moment the client gets through and
+    * refreshes under a new key, at which point the old one stops being honoured with nothing
+    * needing to expire or be cleared.
+    *
+    * A caller holding the token but not the key still reads as a replay, which is what keeps
+    * this from weakening reuse detection.
+    */
+  def findIdempotentRetry(
+      token: MAC.Of[RefreshToken],
+      clientId: ClientId,
+      idempotencyKey: MAC,
+  ): Task[Option[(MAC.Of[RefreshToken], RefreshTokenRecord)]]
 
   def findToken(token: MAC.Of[RefreshToken]): Task[Option[RefreshTokenRecord]]
 

--- a/auth/src/main/scala/versola/oauth/session/SessionRepository.scala
+++ b/auth/src/main/scala/versola/oauth/session/SessionRepository.scala
@@ -56,6 +56,19 @@ trait SessionRepository:
 
   def findToken(token: MAC.Of[RefreshToken]): Task[Option[RefreshTokenRecord]]
 
+  /** Detects refresh-token replay: `token` has no row of its own but is named as some other
+   *  row's `previous_id`, i.e. it was already rotated away and is now being presented a
+   *  second time -- by whoever stole it, or by its rightful owner after the thief's use
+   *  already won the rotation race. Either way neither party can be trusted with the
+   *  chain's live end anymore, so it is expired in place (picked up by the cleanup manager
+   *  like any other expired row, rather than deleted inline) and its access token returned
+   *  so the caller can push a revocation to the client.
+   *
+   *  Scoped to `clientId` so one client cannot use another client's already-rotated token
+   *  as an oracle to expire a chain it does not own.
+   */
+  def markChainReplayed(token: MAC.Of[RefreshToken], clientId: ClientId): Task[Option[(UserId, AccessToken)]]
+
   def delete(token: MAC.Of[RefreshToken]): Task[Unit]
 
   def deleteByAccessToken(token: AccessToken): Task[Unit]

--- a/auth/src/main/scala/versola/oauth/session/SessionRepository.scala
+++ b/auth/src/main/scala/versola/oauth/session/SessionRepository.scala
@@ -2,10 +2,12 @@ package versola.oauth.session
 
 import versola.oauth.client.model.ClientId
 import versola.oauth.model.{AccessToken, RefreshToken}
-import versola.oauth.session.model.{PriorSession, PublicSessionId, RefreshAlreadyExchanged, RefreshTokenRecord, SessionId, SessionRecord}
+import versola.oauth.session.model.{PriorSession, PublicSessionId, RefreshAlreadyExchanged, RefreshTokenRecord, RevokedFamily, SessionId, SessionRecord}
 import versola.user.model.UserId
 import versola.util.MAC
 import zio.*
+
+import java.time.Instant
 
 trait SessionRepository:
   /** Creates a new session in a single transaction.
@@ -49,25 +51,39 @@ trait SessionRepository:
 
   def invalidateByPublicIdForUser(publicId: PublicSessionId, userId: UserId): Task[Boolean]
 
+  /** Issues `refreshToken`. With `previous` set this is a rotation: the presented token is
+    * retired in place and the new one joins its family, both under the family's row lock, so
+    * a rotation cannot interleave with a [[revokeFamily]] and leave its successor behind.
+    * Fails with `RefreshAlreadyExchanged` when the presented token was already retired --
+    * either sequentially or by a concurrent request that won the lock first.
+    */
   def createRefreshToken(
       refreshToken: MAC.Of[RefreshToken],
+      previous: Option[MAC.Of[RefreshToken]],
       record: RefreshTokenRecord,
   ): IO[Throwable | RefreshAlreadyExchanged, Unit]
 
   def findToken(token: MAC.Of[RefreshToken]): Task[Option[RefreshTokenRecord]]
 
-  /** Detects refresh-token replay: `token` has no row of its own but is named as some other
-   *  row's `previous_id`, i.e. it was already rotated away and is now being presented a
-   *  second time -- by whoever stole it, or by its rightful owner after the thief's use
-   *  already won the rotation race. Either way neither party can be trusted with the
-   *  chain's live end anymore, so it is expired in place (picked up by the cleanup manager
-   *  like any other expired row, rather than deleted inline) and its access token returned
-   *  so the caller can push a revocation to the client.
-   *
-   *  Scoped to `clientId` so one client cannot use another client's already-rotated token
-   *  as an oracle to expire a chain it does not own.
-   */
-  def markChainReplayed(token: MAC.Of[RefreshToken], clientId: ClientId): Task[Option[(UserId, AccessToken)]]
+  /** Revokes the whole rotation family of an already-retired `token`, i.e. one presented
+    * after it was exchanged for its successor. That is a proven leak -- to whoever stole it,
+    * or back to its rightful owner after a thief's exchange won the race -- so no member of
+    * the family can be trusted anymore, however many generations have passed since.
+    *
+    * Every member is expired in place (collected by the cleanup manager's `expires_at` sweep
+    * like any other expiry in this table, rather than deleted inline). Members issued after
+    * `accessTokensIssuedAfter` are returned so the caller can push their access tokens to the
+    * client's back channel; older ones are past their access-token TTL and not worth pushing.
+    *
+    * Returns `None` when `token` is not a retired member of a family owned by `clientId`:
+    * unknown, still live, or belonging to someone else. Scoping to `clientId` keeps one
+    * client from using another's retired token as an oracle to kill a family it does not own.
+    */
+  def revokeFamily(
+      token: MAC.Of[RefreshToken],
+      clientId: ClientId,
+      accessTokensIssuedAfter: Instant,
+  ): Task[Option[RevokedFamily]]
 
   def delete(token: MAC.Of[RefreshToken]): Task[Unit]
 

--- a/auth/src/main/scala/versola/oauth/session/model/RefreshTokenRecord.scala
+++ b/auth/src/main/scala/versola/oauth/session/model/RefreshTokenRecord.scala
@@ -31,7 +31,6 @@ case class RefreshTokenRecord(
     requestedClaims: Option[RequestedClaims],
     uiLocales: Option[List[String]],
     nonce: Option[Nonce],
-    previousRefreshToken: Option[MAC.Of[RefreshToken]],
     amr: Set[AuthMethodRef],
     authTime: Instant,
     acr: Option[Acr],

--- a/auth/src/main/scala/versola/oauth/session/model/RevokedFamily.scala
+++ b/auth/src/main/scala/versola/oauth/session/model/RevokedFamily.scala
@@ -1,0 +1,11 @@
+package versola.oauth.session.model
+
+import versola.oauth.model.AccessToken
+import versola.user.model.UserId
+
+/** Outcome of revoking a leaked refresh-token family: the user the family belonged to, and
+  * the access tokens it issued that are recent enough to still be worth revoking. */
+case class RevokedFamily(
+    userId: UserId,
+    accessTokens: List[AccessToken],
+)

--- a/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
+++ b/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
@@ -66,10 +66,10 @@ object OAuthTokenService:
         codeMac <- securityService.mac(Secret(code), config.security.authCodesSecret)
 
         codeRecord <- authorizationCodeRepository.find(codeMac)
-          .someOrFail(TokenEndpointError.InvalidGrant)
-          .filterOrFail(_.clientId == client.id)(TokenEndpointError.InvalidGrant)
-          .filterOrFail(_.redirectUri == redirectUri)(TokenEndpointError.InvalidGrant)
-          .filterOrFail(_.verify(codeVerifier))(TokenEndpointError.InvalidGrant)
+          .someOrFail(TokenEndpointError.InvalidGrant.CodeNotFound)
+          .filterOrFail(_.clientId == client.id)(TokenEndpointError.InvalidGrant.CodeClientMismatch)
+          .filterOrFail(_.redirectUri == redirectUri)(TokenEndpointError.InvalidGrant.RedirectUriMismatch)
+          .filterOrFail(_.verify(codeVerifier))(TokenEndpointError.InvalidGrant.PkceMismatch)
 
         _ <- Observability.setSessionId(codeRecord.publicSessionId)
         _ <- Observability.setUserId(codeRecord.userId.toString)
@@ -87,7 +87,7 @@ object OAuthTokenService:
               )
             *>
               sessionRepository.deleteByAccessToken(at) *>
-              ZIO.fail(TokenEndpointError.InvalidGrant)
+              ZIO.fail(TokenEndpointError.InvalidGrant.CodeReplayed)
 
           case Right(_) =>
             ZIO.unit
@@ -122,7 +122,7 @@ object OAuthTokenService:
           accessTokenAuthorizationDetails = codeRecord.authorizationDetails.getOrElse(Nil),
         ).mapError {
           case ex: Throwable => ex
-          case _ => TokenEndpointError.InvalidGrant // illegal state
+          case _ => TokenEndpointError.InvalidGrant.RefreshChainAlreadyExchanged // illegal state
         }
       yield issuedTokens
 
@@ -149,9 +149,12 @@ object OAuthTokenService:
           case Some(record) if record.clientId == client.id =>
             ZIO.succeed(record)
           case Some(_) =>
-            ZIO.fail(TokenEndpointError.InvalidGrant)
+            ZIO.fail(TokenEndpointError.InvalidGrant.RefreshTokenClientMismatch)
           case None =>
-            detectReplay(client, refreshTokenMac) *> ZIO.fail(TokenEndpointError.InvalidGrant)
+            detectReplay(client, refreshTokenMac).flatMap: replayed =>
+              ZIO.fail:
+                if replayed then TokenEndpointError.InvalidGrant.RefreshTokenReplayed
+                else TokenEndpointError.InvalidGrant.RefreshTokenNotFound
 
         _ <- Observability.setSessionId(tokenRecord.publicSessionId)
         _ <- Observability.setUserId(tokenRecord.userId.toString)
@@ -194,8 +197,12 @@ object OAuthTokenService:
       * should not log the user out of every other client sharing the session, and a chain
       * that has already rotated past this token twice was already a dead end, so nothing is
       * revoked (there is nothing left alive to protect).
+      *
+      * Returns whether a chain was found and revoked, so the caller can tell a replay apart
+      * from a token that never existed -- both fail the request identically, but only the
+      * former is worth surfacing in the request's error context.
       */
-    private def detectReplay(client: OAuthClientRecord, replayed: MAC.Of[RefreshToken]): Task[Unit] =
+    private def detectReplay(client: OAuthClientRecord, replayed: MAC.Of[RefreshToken]): Task[Boolean] =
       sessionRepository.markChainReplayed(replayed, client.id).flatMap:
         case Some((userId, accessToken)) =>
           zio.Clock.instant.flatMap: now =>
@@ -207,12 +214,9 @@ object OAuthTokenService:
               subject = userId.toString,
               expiresAt = now.plus(client.accessTokenTtl),
             )
-          *> Observability.setError(
-            TokenEndpointError.InvalidGrant.error,
-            Some("Refresh token already exchanged for a successor (replay); chain revoked"),
-          )
+          .as(true)
         case None =>
-          ZIO.unit
+          ZIO.succeed(false)
 
     /** RFC 9396 §6: a token request may ask for the authorization details of the underlying
       * grant or fewer of them, never for more; §6.1 compares the requested objects with the
@@ -347,7 +351,7 @@ object OAuthTokenService:
             _ <- sessionRepository.createRefreshToken(mac, record)
               .mapError:
                 case ex: Throwable => ex
-                case _ => TokenEndpointError.InvalidGrant
+                case _ => TokenEndpointError.InvalidGrant.RefreshChainAlreadyExchanged
           yield token,
         )
 

--- a/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
+++ b/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
@@ -23,6 +23,9 @@ trait OAuthTokenService:
   def refreshAccessToken(
       refreshTokenRequest: RefreshTokenRequest,
       tokenCredentials: ClientCredentials,
+      /** `Idempotency-Key` header, when the client sent one. Lets a client that never received
+        * the response to an exchange repeat it instead of being read as replaying the token. */
+      idempotencyKey: Option[String],
   ): IO[Throwable | TokenEndpointError, IssuedTokens]
 
   def clientCredentials(
@@ -31,6 +34,16 @@ trait OAuthTokenService:
   ): IO[Throwable | TokenEndpointError, IssuedTokens]
 
 object OAuthTokenService:
+
+  /** Which token the refresh actually continues from, and whether getting there needed the
+    * idempotency key. Normally the one presented; for a retry, the family's live tip, since
+    * the token the original response carried is not recoverable.
+    */
+  private case class Resolved(
+      previousToken: MAC.Of[RefreshToken],
+      record: RefreshTokenRecord,
+      retried: Boolean,
+  )
   /** Admin-console client; admin roles are only embedded in tokens issued for it. */
   val centralAdminClientId: ClientId = ClientId("central-admin")
 
@@ -118,6 +131,7 @@ object OAuthTokenService:
             acr = codeRecord.acr,
           ),
           previousRefreshToken = None,
+          idempotencyKey = None,
           accessTokenAudience = codeRecord.resources,
           accessTokenAuthorizationDetails = codeRecord.authorizationDetails.getOrElse(Nil),
         ).mapError {
@@ -132,6 +146,7 @@ object OAuthTokenService:
     override def refreshAccessToken(
         refreshTokenRequest: RefreshTokenRequest,
         tokenCredentials: ClientCredentials,
+        idempotencyKey: Option[String],
     ): IO[Throwable | TokenEndpointError, IssuedTokens] =
       import refreshTokenRequest.{authorizationDetails, refreshToken, resources, scope}
       for
@@ -145,16 +160,17 @@ object OAuthTokenService:
 
         refreshTokenMac <- securityService.mac(Secret(refreshToken), config.security.refreshTokensSecret)
 
-        tokenRecord <- sessionRepository.findToken(refreshTokenMac).flatMap:
+        idempotencyKeyMac <- ZIO.foreach(idempotencyKey)(macOfIdempotencyKey)
+
+        resolved <- sessionRepository.findToken(refreshTokenMac).flatMap:
           case Some(record) if record.clientId == client.id =>
-            ZIO.succeed(record)
+            ZIO.succeed(Resolved(refreshTokenMac, record, retried = false))
           case Some(_) =>
             ZIO.fail(TokenEndpointError.InvalidGrant.RefreshTokenClientMismatch)
           case None =>
-            detectReplay(client, refreshTokenMac).flatMap: replayed =>
-              ZIO.fail:
-                if replayed then TokenEndpointError.InvalidGrant.RefreshTokenReplayed
-                else TokenEndpointError.InvalidGrant.RefreshTokenNotFound
+            resolveRetry(client, refreshTokenMac, idempotencyKeyMac)
+
+        tokenRecord = resolved.record
 
         _ <- Observability.setSessionId(tokenRecord.publicSessionId)
         _ <- Observability.setUserId(tokenRecord.userId.toString)
@@ -180,19 +196,55 @@ object OAuthTokenService:
             issuedAt = now,
             expiresAt = now.plusSeconds(client.refreshTokenTtl.toSeconds),
           ),
-          previousRefreshToken = Some(refreshTokenMac),
+          previousRefreshToken = Some(resolved.previousToken),
+          idempotencyKey = idempotencyKeyMac,
           accessTokenAudience = audience,
           accessTokenAuthorizationDetails = details,
         ).catchSome:
           // Losing the rotation race means this token was presented twice concurrently: the
           // winner's successor is live and the leak is just as proven as a sequential replay,
           // so it goes the same way rather than failing with a bare invalid_grant.
-          case TokenEndpointError.InvalidGrant.RefreshChainAlreadyExchanged =>
+          //
+          // Not so when the key already identified this as a retry: the request that beat us
+          // is another attempt at the very same exchange, which proves nothing was leaked.
+          case TokenEndpointError.InvalidGrant.RefreshChainAlreadyExchanged if !resolved.retried =>
             detectReplay(client, refreshTokenMac).flatMap: replayed =>
               ZIO.fail:
                 if replayed then TokenEndpointError.InvalidGrant.RefreshTokenReplayed
                 else TokenEndpointError.InvalidGrant.RefreshChainAlreadyExchanged
       yield issuedTokens
+
+    /** Distinguishes a repeat of an exchange the client never saw the response to from a
+      * genuine replay, when the presented token is no longer live.
+      *
+      * A matching key continues the chain from the family's live tip: the response cannot be
+      * reproduced -- the token in it was never stored -- so the client is given a fresh one
+      * instead. Without a key, or with one that no longer names the family's latest exchange,
+      * this is reuse of a retired token and goes to [[detectReplay]].
+      */
+    private def resolveRetry(
+        client: OAuthClientRecord,
+        refreshTokenMac: MAC.Of[RefreshToken],
+        idempotencyKeyMac: Option[MAC],
+    ): IO[Throwable | TokenEndpointError, Resolved] =
+      idempotencyKeyMac
+        .fold(ZIO.none)(sessionRepository.findIdempotentRetry(refreshTokenMac, client.id, _))
+        .flatMap:
+          case Some((tip, record)) =>
+            ZIO.succeed(Resolved(tip, record, retried = true))
+          case None =>
+            detectReplay(client, refreshTokenMac).flatMap: replayed =>
+              ZIO.fail:
+                if replayed then TokenEndpointError.InvalidGrant.RefreshTokenReplayed
+                else TokenEndpointError.InvalidGrant.RefreshTokenNotFound
+
+    /** Labelled so a key can never collide with the MAC of a refresh token under the same
+      * secret, which is what the same column is compared against elsewhere. */
+    private def macOfIdempotencyKey(key: String): Task[MAC] =
+      securityService.mac(
+        Secret("idempotency-key:".getBytes("UTF-8") ++ key.getBytes("UTF-8")),
+        config.security.refreshTokensSecret,
+      )
 
     /** RFC 9700 §4.14.2: a refresh token presented after it was already rotated away means the
       * chain leaked -- to an attacker who redeemed it first, or back to its rightful owner
@@ -349,6 +401,7 @@ object OAuthTokenService:
         client: OAuthClientRecord,
         record: RefreshTokenRecord,
         previousRefreshToken: Option[MAC.Of[RefreshToken]],
+        idempotencyKey: Option[MAC],
         accessTokenAudience: List[ResourceUri],
         accessTokenAuthorizationDetails: List[AuthorizationDetail],
     ): IO[Throwable | TokenEndpointError, IssuedTokens] =
@@ -358,7 +411,7 @@ object OAuthTokenService:
             token <- authPropertyGenerator.nextRefreshToken
             _ <- Observability.setRefreshToken(Base64.urlEncode(token))
             mac <- securityService.mac(Secret(token), config.security.refreshTokensSecret)
-            _ <- sessionRepository.createRefreshToken(mac, previousRefreshToken, record)
+            _ <- sessionRepository.createRefreshToken(mac, previousRefreshToken, record, idempotencyKey)
               .mapError:
                 case ex: Throwable => ex
                 case _ => TokenEndpointError.InvalidGrant.RefreshChainAlreadyExchanged

--- a/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
+++ b/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
@@ -207,7 +207,7 @@ object OAuthTokenService:
               subject = userId.toString,
               expiresAt = now.plus(client.accessTokenTtl),
             )
-          *> ZIO.logWarning(s"Refresh token replay detected for client '${client.id}': chain revoked")
+          *> ZIO.logError(s"Refresh token replay detected for client '${client.id}': chain revoked")
         case None =>
           ZIO.unit
 

--- a/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
+++ b/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
@@ -207,7 +207,8 @@ object OAuthTokenService:
               subject = userId.toString,
               expiresAt = now.plus(client.accessTokenTtl),
             )
-          *> ZIO.logError(s"Refresh token replay detected for client '${client.id}': chain revoked")
+          *> (ZIO.logWarning(s"Refresh token replay detected for client '${client.id}': chain revoked")
+            @@ Observability.error(Observability.ErrorDetails("refresh_token_replay", Some(s"chain revoked for user $userId"))))
         case None =>
           ZIO.unit
 

--- a/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
+++ b/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
@@ -207,8 +207,10 @@ object OAuthTokenService:
               subject = userId.toString,
               expiresAt = now.plus(client.accessTokenTtl),
             )
-          *> (ZIO.logWarning(s"Refresh token replay detected for client '${client.id}': chain revoked")
-            @@ Observability.error(Observability.ErrorDetails("refresh_token_replay", Some(s"chain revoked for user $userId"))))
+          *> Observability.setError(
+            TokenEndpointError.InvalidGrant.error,
+            Some("Refresh token already exchanged for a successor (replay); chain revoked"),
+          )
         case None =>
           ZIO.unit
 

--- a/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
+++ b/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
@@ -145,9 +145,13 @@ object OAuthTokenService:
 
         refreshTokenMac <- securityService.mac(Secret(refreshToken), config.security.refreshTokensSecret)
 
-        tokenRecord <- sessionRepository.findToken(refreshTokenMac)
-          .someOrFail(TokenEndpointError.InvalidGrant)
-          .filterOrFail(_.clientId == client.id)(TokenEndpointError.InvalidGrant)
+        tokenRecord <- sessionRepository.findToken(refreshTokenMac).flatMap:
+          case Some(record) if record.clientId == client.id =>
+            ZIO.succeed(record)
+          case Some(_) =>
+            ZIO.fail(TokenEndpointError.InvalidGrant)
+          case None =>
+            detectReplay(client, refreshTokenMac) *> ZIO.fail(TokenEndpointError.InvalidGrant)
 
         _ <- Observability.setSessionId(tokenRecord.publicSessionId)
         _ <- Observability.setUserId(tokenRecord.userId.toString)
@@ -178,6 +182,34 @@ object OAuthTokenService:
           accessTokenAuthorizationDetails = details,
         )
       yield issuedTokens
+
+    /** RFC 9700 §4.14.2: a refresh token presented after it was already rotated away means the
+      * chain leaked -- to an attacker who redeemed it first, or back to its rightful owner
+      * after an attacker's redemption already won the rotation race. Either way neither party
+      * can be trusted with the chain's live end anymore, so it is expired and its access token
+      * pushed to the client's back channel, forcing a full re-authorization instead of leaving
+      * a live session for whoever asks next.
+      *
+      * Scoped to this refresh-token chain, not the wider SSO session: one client's leak
+      * should not log the user out of every other client sharing the session, and a chain
+      * that has already rotated past this token twice was already a dead end, so nothing is
+      * revoked (there is nothing left alive to protect).
+      */
+    private def detectReplay(client: OAuthClientRecord, replayed: MAC.Of[RefreshToken]): Task[Unit] =
+      sessionRepository.markChainReplayed(replayed, client.id).flatMap:
+        case Some((userId, accessToken)) =>
+          zio.Clock.instant.flatMap: now =>
+            // As with authorization-code replay, the live access token itself is not in
+            // hand here, only its id, so its lifetime is bounded by the client's TTL.
+            accessTokenRevocationService.revoke(
+              client = client,
+              token = accessToken,
+              subject = userId.toString,
+              expiresAt = now.plus(client.accessTokenTtl),
+            )
+          *> ZIO.logWarning(s"Refresh token replay detected for client '${client.id}': chain revoked")
+        case None =>
+          ZIO.unit
 
     /** RFC 9396 §6: a token request may ask for the authorization details of the underlying
       * grant or fewer of them, never for more; §6.1 compares the requested objects with the

--- a/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
+++ b/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
@@ -113,11 +113,11 @@ object OAuthTokenService:
             requestedClaims = codeRecord.requestedClaims,
             uiLocales = codeRecord.uiLocales,
             nonce = codeRecord.nonce,
-            previousRefreshToken = None,
             amr = codeRecord.amr,
             authTime = codeRecord.authTime,
             acr = codeRecord.acr,
           ),
+          previousRefreshToken = None,
           accessTokenAudience = codeRecord.resources,
           accessTokenAuthorizationDetails = codeRecord.authorizationDetails.getOrElse(Nil),
         ).mapError {
@@ -177,13 +177,21 @@ object OAuthTokenService:
           record = tokenRecord.copy(
             accessToken = accessToken,
             scope = scope.getOrElse(tokenRecord.scope),
-            previousRefreshToken = Some(refreshTokenMac),
             issuedAt = now,
             expiresAt = now.plusSeconds(client.refreshTokenTtl.toSeconds),
           ),
+          previousRefreshToken = Some(refreshTokenMac),
           accessTokenAudience = audience,
           accessTokenAuthorizationDetails = details,
-        )
+        ).catchSome:
+          // Losing the rotation race means this token was presented twice concurrently: the
+          // winner's successor is live and the leak is just as proven as a sequential replay,
+          // so it goes the same way rather than failing with a bare invalid_grant.
+          case TokenEndpointError.InvalidGrant.RefreshChainAlreadyExchanged =>
+            detectReplay(client, refreshTokenMac).flatMap: replayed =>
+              ZIO.fail:
+                if replayed then TokenEndpointError.InvalidGrant.RefreshTokenReplayed
+                else TokenEndpointError.InvalidGrant.RefreshChainAlreadyExchanged
       yield issuedTokens
 
     /** RFC 9700 §4.14.2: a refresh token presented after it was already rotated away means the
@@ -193,30 +201,31 @@ object OAuthTokenService:
       * pushed to the client's back channel, forcing a full re-authorization instead of leaving
       * a live session for whoever asks next.
       *
-      * Scoped to this refresh-token chain, not the wider SSO session: one client's leak
-      * should not log the user out of every other client sharing the session, and a chain
-      * that has already rotated past this token twice was already a dead end, so nothing is
-      * revoked (there is nothing left alive to protect).
+      * Scoped to the leaked family, not the wider SSO session: one client's leak should not
+      * log the user out of every other client sharing the session. Within the family it is
+      * total -- every generation is expired, however far the chain has rotated since the
+      * replayed token was retired, because any of them could be the one in the wrong hands.
       *
-      * Returns whether a chain was found and revoked, so the caller can tell a replay apart
+      * Returns whether a family was found and revoked, so the caller can tell a replay apart
       * from a token that never existed -- both fail the request identically, but only the
       * former is worth surfacing in the request's error context.
       */
     private def detectReplay(client: OAuthClientRecord, replayed: MAC.Of[RefreshToken]): Task[Boolean] =
-      sessionRepository.markChainReplayed(replayed, client.id).flatMap:
-        case Some((userId, accessToken)) =>
-          zio.Clock.instant.flatMap: now =>
-            // As with authorization-code replay, the live access token itself is not in
-            // hand here, only its id, so its lifetime is bounded by the client's TTL.
-            accessTokenRevocationService.revoke(
-              client = client,
-              token = accessToken,
-              subject = userId.toString,
-              expiresAt = now.plus(client.accessTokenTtl),
-            )
-          .as(true)
-        case None =>
-          ZIO.succeed(false)
+      zio.Clock.instant.flatMap: now =>
+        sessionRepository.revokeFamily(replayed, client.id, now.minus(client.accessTokenTtl)).flatMap:
+          case Some(family) =>
+            ZIO.foreachDiscard(family.accessTokens): accessToken =>
+              // As with authorization-code replay, the live access tokens are not in hand
+              // here, only their ids, so their lifetime is bounded by the client's TTL.
+              accessTokenRevocationService.revoke(
+                client = client,
+                token = accessToken,
+                subject = family.userId.toString,
+                expiresAt = now.plus(client.accessTokenTtl),
+              )
+            .as(true)
+          case None =>
+            ZIO.succeed(false)
 
     /** RFC 9396 §6: a token request may ask for the authorization details of the underlying
       * grant or fewer of them, never for more; §6.1 compares the requested objects with the
@@ -339,6 +348,7 @@ object OAuthTokenService:
         accessToken: AccessToken,
         client: OAuthClientRecord,
         record: RefreshTokenRecord,
+        previousRefreshToken: Option[MAC.Of[RefreshToken]],
         accessTokenAudience: List[ResourceUri],
         accessTokenAuthorizationDetails: List[AuthorizationDetail],
     ): IO[Throwable | TokenEndpointError, IssuedTokens] =
@@ -348,7 +358,7 @@ object OAuthTokenService:
             token <- authPropertyGenerator.nextRefreshToken
             _ <- Observability.setRefreshToken(Base64.urlEncode(token))
             mac <- securityService.mac(Secret(token), config.security.refreshTokensSecret)
-            _ <- sessionRepository.createRefreshToken(mac, record)
+            _ <- sessionRepository.createRefreshToken(mac, previousRefreshToken, record)
               .mapError:
                 case ex: Throwable => ex
                 case _ => TokenEndpointError.InvalidGrant.RefreshChainAlreadyExchanged

--- a/auth/src/main/scala/versola/oauth/token/TokenEndpointController.scala
+++ b/auth/src/main/scala/versola/oauth/token/TokenEndpointController.scala
@@ -49,9 +49,7 @@ object TokenEndpointController extends Controller:
       yield Response.json(response.toJson))
         .catchAll {
           case error: TokenEndpointError =>
-            // setErrorIfAbsent: a service-layer detector (e.g. refresh-token replay) may
-            // have already recorded a more specific description under this same code.
-            Observability.setErrorIfAbsent(error.error, error.errorDescription).as:
+            Observability.setError(error.error, error.logDescription).as:
               val errorResponse = TokenErrorResponse.from(error)
               Response
                 .json(errorResponse.toJson)

--- a/auth/src/main/scala/versola/oauth/token/TokenEndpointController.scala
+++ b/auth/src/main/scala/versola/oauth/token/TokenEndpointController.scala
@@ -25,6 +25,10 @@ import java.util.Date
 object TokenEndpointController extends Controller:
   type Env = Tracing & OAuthTokenService & OAuthConfigurationService & UserInfoService & JwksService & CoreConfig
 
+  /** draft-ietf-httpapi-idempotency-key-header. Only honoured for `refresh_token`: that is
+    * the grant where losing a response costs the client its session rather than one request. */
+  private val IdempotencyKeyHeader = "Idempotency-Key"
+
   def routes: Routes[Env, Throwable] = Routes(
     tokenEndpoint,
   )
@@ -38,11 +42,16 @@ object TokenEndpointController extends Controller:
         form <- request.body.asURLEncodedForm.orElseFail(TokenEndpointError.InvalidRequest)
         tokenRequest <- parseRequest(form)
         credentials <- request.extractCredentials(form).orElseFail(TokenEndpointError.InvalidClient)
+
         issuedTokens <- tokenRequest match
           case codeExchangeRequest: CodeExchangeRequest =>
             oauthTokenService.exchangeAuthorizationCode(codeExchangeRequest, credentials)
           case refreshTokenRequest: RefreshTokenRequest =>
-            oauthTokenService.refreshAccessToken(refreshTokenRequest, credentials)
+            oauthTokenService.refreshAccessToken(
+              refreshTokenRequest,
+              credentials,
+              request.headers.get(IdempotencyKeyHeader),
+            )
           case clientCredentialsRequest: ClientCredentialsRequest =>
             oauthTokenService.clientCredentials(clientCredentialsRequest, credentials)
         response <- toTokenResponse(issuedTokens, config, signingKey)

--- a/auth/src/main/scala/versola/oauth/token/TokenEndpointController.scala
+++ b/auth/src/main/scala/versola/oauth/token/TokenEndpointController.scala
@@ -49,7 +49,9 @@ object TokenEndpointController extends Controller:
       yield Response.json(response.toJson))
         .catchAll {
           case error: TokenEndpointError =>
-            Observability.setError(error.error, error.errorDescription).as:
+            // setErrorIfAbsent: a service-layer detector (e.g. refresh-token replay) may
+            // have already recorded a more specific description under this same code.
+            Observability.setErrorIfAbsent(error.error, error.errorDescription).as:
               val errorResponse = TokenErrorResponse.from(error)
               Response
                 .json(errorResponse.toJson)

--- a/auth/src/main/scala/versola/oauth/token/model/TokenEndpointError.scala
+++ b/auth/src/main/scala/versola/oauth/token/model/TokenEndpointError.scala
@@ -11,6 +11,11 @@ sealed trait TokenEndpointError:
   def errorDescription: Option[String]
   def errorUri: Option[String]
 
+  /** Description recorded in the request's error context, which never leaves the server.
+    * Defaults to the client-facing [[errorDescription]]; errors whose response body is
+    * deliberately uniform across causes narrow this to the specific check that failed. */
+  def logDescription: Option[String] = errorDescription
+
 object TokenEndpointError:
   case object InvalidRequest extends TokenEndpointError:
     val status = Status.BadRequest
@@ -24,11 +29,26 @@ object TokenEndpointError:
     val errorDescription = Some("Client not exists, credentials not provided or otherwise invalid")
     val errorUri = Some("https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1")
 
-  case object InvalidGrant extends TokenEndpointError:
+  /** `reason` names the check that failed. It is logged, never returned: the response body
+    * stays identical across every cause, so a caller cannot tell an unknown grant from a
+    * replayed or misdirected one and use the endpoint as an oracle. */
+  case class InvalidGrant(reason: String) extends TokenEndpointError:
     val status = Status.BadRequest
     val error = ErrorCode.InvalidGrant
     val errorDescription = Some("Authorization code not found or expired, client_id or redirect_uri not match or PKCE validation failed")
     val errorUri = Some("https://datatracker.ietf.org/doc/html/rfc6749#section-5.2")
+    override def logDescription = Some(reason)
+
+  object InvalidGrant:
+    val CodeNotFound = InvalidGrant("authorization code not found or expired")
+    val CodeClientMismatch = InvalidGrant("authorization code was issued to a different client")
+    val RedirectUriMismatch = InvalidGrant("redirect_uri does not match the one the code was issued for")
+    val PkceMismatch = InvalidGrant("PKCE code_verifier does not match the code_challenge")
+    val CodeReplayed = InvalidGrant("authorization code already used; the token it issued was revoked")
+    val RefreshTokenNotFound = InvalidGrant("refresh token not found or expired")
+    val RefreshTokenClientMismatch = InvalidGrant("refresh token was issued to a different client")
+    val RefreshTokenReplayed = InvalidGrant("refresh token already exchanged for a successor; the chain was revoked")
+    val RefreshChainAlreadyExchanged = InvalidGrant("refresh token chain was already exchanged")
 
   case object UnsupportedGrantType extends TokenEndpointError:
     val status = Status.BadRequest

--- a/auth/src/test/scala/versola/oauth/introspect/IntrospectionServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/introspect/IntrospectionServiceSpec.scala
@@ -72,7 +72,6 @@ object IntrospectionServiceSpec extends UnitSpecBase:
     requestedClaims = None,
     uiLocales = None,
     nonce = None,
-    previousRefreshToken = None,
     amr = Set(AuthMethodRef.pwd),
     authTime = now,
     acr = None,

--- a/auth/src/test/scala/versola/oauth/revoke/RevocationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/revoke/RevocationServiceSpec.scala
@@ -73,7 +73,6 @@ object RevocationServiceSpec extends UnitSpecBase:
     requestedClaims = None,
     uiLocales = None,
     nonce = None,
-    previousRefreshToken = None,
     amr = Set(AuthMethodRef.pwd),
     authTime = now,
     acr = None,

--- a/auth/src/test/scala/versola/oauth/session/RefreshTokenRepositorySpec.scala
+++ b/auth/src/test/scala/versola/oauth/session/RefreshTokenRepositorySpec.scala
@@ -170,6 +170,60 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
           results.count(_.left.toOption.contains(())) == 5
         )
       },
+      test("markChainReplayed finds and expires the successor of an already-rotated token") {
+        for
+          now <- Clock.instant
+          record1 = tokenRecord1(now, refreshTtl)
+          record2 = record1.copy(previousRefreshToken = Some(refreshToken1), accessToken = accessToken2)
+          _ <- env.repository.createRefreshToken(refreshToken1, record1)
+          _ <- env.repository.createRefreshToken(refreshToken2, record2)
+
+          replayed <- env.repository.markChainReplayed(refreshToken1, clientId1)
+          successorAfter <- env.repository.findToken(refreshToken2)
+        yield assertTrue(
+          // Array-backed AccessToken has reference equality under `==`, hence `===`.
+          replayed.exists(r => r._1 == userId1 && r._2 === accessToken2),
+          // Expired, not deleted: the cleanup manager's expires_at sweep removes it later,
+          // rather than this call issuing its own DELETE inline.
+          successorAfter.isEmpty,
+        )
+      },
+      test("markChainReplayed ignores a token with no successor") {
+        for
+          now <- Clock.instant
+          record1 = tokenRecord1(now, refreshTtl)
+          _ <- env.repository.createRefreshToken(refreshToken1, record1)
+
+          replayed <- env.repository.markChainReplayed(refreshToken2, clientId1)
+        yield assertTrue(replayed.isEmpty)
+      },
+      test("markChainReplayed does not act on a chain owned by a different client") {
+        for
+          now <- Clock.instant
+          record1 = tokenRecord1(now, refreshTtl)
+          record2 = record1.copy(previousRefreshToken = Some(refreshToken1))
+          _ <- env.repository.createRefreshToken(refreshToken1, record1)
+          _ <- env.repository.createRefreshToken(refreshToken2, record2)
+
+          replayed <- env.repository.markChainReplayed(refreshToken1, clientId2)
+          successorAfter <- env.repository.findToken(refreshToken2)
+        yield assertTrue(
+          replayed.isEmpty,
+          successorAfter.isDefined,
+        )
+      },
+      test("markChainReplayed is idempotent: a second replay of the same token finds nothing left to expire") {
+        for
+          now <- Clock.instant
+          record1 = tokenRecord1(now, refreshTtl)
+          record2 = record1.copy(previousRefreshToken = Some(refreshToken1))
+          _ <- env.repository.createRefreshToken(refreshToken1, record1)
+          _ <- env.repository.createRefreshToken(refreshToken2, record2)
+
+          _ <- env.repository.markChainReplayed(refreshToken1, clientId1)
+          second <- env.repository.markChainReplayed(refreshToken1, clientId1)
+        yield assertTrue(second.isEmpty)
+      },
     )
 
 object RefreshTokenRepositorySpec:

--- a/auth/src/test/scala/versola/oauth/session/RefreshTokenRepositorySpec.scala
+++ b/auth/src/test/scala/versola/oauth/session/RefreshTokenRepositorySpec.scala
@@ -47,6 +47,9 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
 
   val refreshTtl = 30.days
 
+  val idempotencyKey1 = MAC(Array.fill(32)(40.toByte))
+  val idempotencyKey2 = MAC(Array.fill(32)(41.toByte))
+
   def tokenRecord1(now: Instant, ttl: Duration) = RefreshTokenRecord(
     sessionId = sessionId1,
     publicSessionId = publicSessionId1,
@@ -92,8 +95,8 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
           now <- Clock.instant
           record1 = tokenRecord1(now, refreshTtl)
           record2 = tokenRecord2(now, refreshTtl)
-          _ <- env.repository.createRefreshToken(refreshToken1, None, record1)
-          _ <- env.repository.createRefreshToken(refreshToken2, None, record2)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1, None)
+          _ <- env.repository.createRefreshToken(refreshToken2, None, record2, None)
           found1 <- env.repository.findToken(refreshToken1)
           found2 <- env.repository.findToken(refreshToken2)
         yield assertTrue(
@@ -109,7 +112,7 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
         for
           now <- Clock.instant
           record = tokenRecord1(now, refreshTtl).copy(authorizationDetails = Some(List(detail)))
-          _ <- env.repository.createRefreshToken(refreshToken1, None, record)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record, None)
           found <- env.repository.findToken(refreshToken1)
         yield assertTrue(found.map(_.authorizationDetails) == Some(Some(List(detail))))
       },
@@ -123,7 +126,7 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
         for
           now <- Clock.instant
           record = tokenRecord1(now, shortTtl)
-          _ <- env.repository.createRefreshToken(refreshToken1, None, record)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record, None)
           foundBefore <- env.repository.findToken(refreshToken1)
           _ <- TestClock.adjust(3.minutes)
           foundAfter <- env.repository.findToken(refreshToken1)
@@ -136,8 +139,8 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
         for
           now <- Clock.instant
           record1 = tokenRecord1(now, refreshTtl)
-          _ <- env.repository.createRefreshToken(refreshToken1, None, record1)
-          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2))
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1, None)
+          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2), None)
           oldTokenFound <- env.repository.findToken(refreshToken1)
           newTokenFound <- env.repository.findToken(refreshToken2)
         yield assertTrue(
@@ -151,7 +154,7 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
         for
           now <- Clock.instant
           record1 = tokenRecord1(now, refreshTtl)
-          _ <- env.repository.createRefreshToken(refreshToken1, None, record1)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1, None)
 
           refreshTokens = List(
             refreshToken2,
@@ -163,7 +166,7 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
           )
           results <- ZIO.foreachPar(refreshTokens.zipWithIndex)((token, i) =>
             env.repository
-              .createRefreshToken(token, Some(refreshToken1), record1.copy(accessToken = AccessToken(Array.fill(16)((30 + i).toByte))))
+              .createRefreshToken(token, Some(refreshToken1), record1.copy(accessToken = AccessToken(Array.fill(16)((30 + i).toByte))), None)
               .either,
           )
 
@@ -176,9 +179,9 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
         for
           now <- Clock.instant
           record1 = tokenRecord1(now, refreshTtl)
-          _ <- env.repository.createRefreshToken(refreshToken1, None, record1)
-          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2))
-          _ <- env.repository.createRefreshToken(refreshToken3, Some(refreshToken2), record1.copy(accessToken = accessToken3))
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1, None)
+          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2), None)
+          _ <- env.repository.createRefreshToken(refreshToken3, Some(refreshToken2), record1.copy(accessToken = accessToken3), None)
 
           // The replayed token was retired two rotations ago, so a lookup that only knew the
           // immediately following generation would have missed it and left the tip live.
@@ -196,7 +199,7 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
       test("revokeFamily ignores a token that was never issued") {
         for
           now <- Clock.instant
-          _ <- env.repository.createRefreshToken(refreshToken1, None, tokenRecord1(now, refreshTtl))
+          _ <- env.repository.createRefreshToken(refreshToken1, None, tokenRecord1(now, refreshTtl), None)
 
           revoked <- env.repository.revokeFamily(refreshToken2, clientId1, now.minusSeconds(300))
         yield assertTrue(revoked.isEmpty)
@@ -204,7 +207,7 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
       test("revokeFamily ignores a token that is still live") {
         for
           now <- Clock.instant
-          _ <- env.repository.createRefreshToken(refreshToken1, None, tokenRecord1(now, refreshTtl))
+          _ <- env.repository.createRefreshToken(refreshToken1, None, tokenRecord1(now, refreshTtl), None)
 
           // Presenting a token that was never rotated away is not a replay, whatever else is
           // wrong with the request.
@@ -219,8 +222,8 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
         for
           now <- Clock.instant
           record1 = tokenRecord1(now, refreshTtl)
-          _ <- env.repository.createRefreshToken(refreshToken1, None, record1)
-          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2))
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1, None)
+          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2), None)
 
           revoked <- env.repository.revokeFamily(refreshToken1, clientId2, now.minusSeconds(300))
           tipAfter <- env.repository.findToken(refreshToken2)
@@ -233,8 +236,8 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
         for
           now <- Clock.instant
           record1 = tokenRecord1(now, refreshTtl)
-          _ <- env.repository.createRefreshToken(refreshToken1, None, record1)
-          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2))
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1, None)
+          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2), None)
 
           revoked <- env.repository.revokeFamily(refreshToken1, clientId1, now.plusSeconds(60))
           tipAfter <- env.repository.findToken(refreshToken2)
@@ -248,24 +251,24 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
         for
           now <- Clock.instant
           record1 = tokenRecord1(now, refreshTtl)
-          _ <- env.repository.createRefreshToken(refreshToken1, None, record1)
-          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2))
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1, None)
+          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2), None)
           _ <- env.repository.revokeFamily(refreshToken1, clientId1, now.minusSeconds(300))
 
-          rotated <- env.repository.createRefreshToken(refreshToken3, Some(refreshToken2), record1.copy(accessToken = accessToken3)).either
+          rotated <- env.repository.createRefreshToken(refreshToken3, Some(refreshToken2), record1.copy(accessToken = accessToken3), None).either
         yield assertTrue(rotated.isLeft)
       },
       test("a rotation racing a revocation never leaves a live successor behind") {
         for
           now <- Clock.instant
           record1 = tokenRecord1(now, refreshTtl)
-          _ <- env.repository.createRefreshToken(refreshToken1, None, record1)
-          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2))
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1, None)
+          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2), None)
 
           // Whichever wins the family lock, the invariant holds: either the rotation commits
           // first and its successor is expired by the revocation, or it finds the token it
           // meant to rotate already dead.
-          _ <- env.repository.createRefreshToken(refreshToken3, Some(refreshToken2), record1.copy(accessToken = accessToken3)).either
+          _ <- env.repository.createRefreshToken(refreshToken3, Some(refreshToken2), record1.copy(accessToken = accessToken3), None).either
             .zipPar(env.repository.revokeFamily(refreshToken1, clientId1, now.minusSeconds(300)))
 
           live <- ZIO.foreach(List(refreshToken1, refreshToken2, refreshToken3))(env.repository.findToken)
@@ -275,12 +278,133 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
         for
           now <- Clock.instant
           record1 = tokenRecord1(now, refreshTtl)
-          _ <- env.repository.createRefreshToken(refreshToken1, None, record1)
-          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2))
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1, None)
+          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2), None)
 
           _ <- env.repository.revokeFamily(refreshToken1, clientId1, now.minusSeconds(300))
           second <- env.repository.revokeFamily(refreshToken1, clientId1, now.minusSeconds(300))
         yield assertTrue(second.exists(_.accessTokens.isEmpty))
+      },
+      test("findIdempotentRetry returns the live tip when the key names the family's last exchange") {
+        for
+          now <- Clock.instant
+          record1 = tokenRecord1(now, refreshTtl)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1, None)
+          // The exchange whose response the client never saw.
+          _ <- env.repository.createRefreshToken(
+            refreshToken2,
+            Some(refreshToken1),
+            record1.copy(accessToken = accessToken2),
+            Some(idempotencyKey1),
+          )
+
+          retry <- env.repository.findIdempotentRetry(refreshToken1, clientId1, idempotencyKey1)
+        yield assertTrue(
+          // The tip, not the token presented: the one the lost response carried cannot be
+          // reproduced, so the caller continues the chain from here.
+          retry.exists(found => java.util.Arrays.equals(found._1, refreshToken2)),
+          retry.exists(_._2.accessToken.sameElements(accessToken2)),
+        )
+      },
+      test("findIdempotentRetry ignores a key that was never used") {
+        for
+          now <- Clock.instant
+          record1 = tokenRecord1(now, refreshTtl)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1, None)
+          _ <- env.repository.createRefreshToken(
+            refreshToken2,
+            Some(refreshToken1),
+            record1.copy(accessToken = accessToken2),
+            Some(idempotencyKey1),
+          )
+
+          // Holding the token without the key it was exchanged under is a replay, not a retry.
+          retry <- env.repository.findIdempotentRetry(refreshToken1, clientId1, idempotencyKey2)
+        yield assertTrue(retry.isEmpty)
+      },
+      test("findIdempotentRetry ignores a key belonging to another client") {
+        for
+          now <- Clock.instant
+          record1 = tokenRecord1(now, refreshTtl)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1, None)
+          _ <- env.repository.createRefreshToken(
+            refreshToken2,
+            Some(refreshToken1),
+            record1.copy(accessToken = accessToken2),
+            Some(idempotencyKey1),
+          )
+
+          retry <- env.repository.findIdempotentRetry(refreshToken1, clientId2, idempotencyKey1)
+        yield assertTrue(retry.isEmpty)
+      },
+      test("the key survives repeated retries, each carrying it to the newest exchange") {
+        for
+          now <- Clock.instant
+          record1 = tokenRecord1(now, refreshTtl)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1, None)
+          _ <- env.repository.createRefreshToken(
+            refreshToken2,
+            Some(refreshToken1),
+            record1.copy(accessToken = accessToken2),
+            Some(idempotencyKey1),
+          )
+
+          // First retry: continues from the tip, and the key moves onto that exchange.
+          firstRetry <- env.repository.findIdempotentRetry(refreshToken1, clientId1, idempotencyKey1)
+          _ <- env.repository.createRefreshToken(
+            refreshToken3,
+            Some(refreshToken2),
+            record1.copy(accessToken = accessToken3),
+            Some(idempotencyKey1),
+          )
+
+          // Second retry, because that response was lost too. A backoff loop routinely gets
+          // this far, so failing here would mean the feature only ever worked once.
+          secondRetry <- env.repository.findIdempotentRetry(refreshToken1, clientId1, idempotencyKey1)
+        yield assertTrue(
+          firstRetry.exists(found => java.util.Arrays.equals(found._1, refreshToken2)),
+          secondRetry.exists(found => java.util.Arrays.equals(found._1, refreshToken3)),
+        )
+      },
+      test("a key stops being honoured once the chain moves on under a different one") {
+        for
+          now <- Clock.instant
+          record1 = tokenRecord1(now, refreshTtl)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1, None)
+          _ <- env.repository.createRefreshToken(
+            refreshToken2,
+            Some(refreshToken1),
+            record1.copy(accessToken = accessToken2),
+            Some(idempotencyKey1),
+          )
+          // The client got through and refreshed normally: the earlier attempt is finished
+          // business, and reuse detection takes the token back.
+          _ <- env.repository.createRefreshToken(
+            refreshToken3,
+            Some(refreshToken2),
+            record1.copy(accessToken = accessToken3),
+            Some(idempotencyKey2),
+          )
+
+          stale <- env.repository.findIdempotentRetry(refreshToken1, clientId1, idempotencyKey1)
+        yield assertTrue(stale.isEmpty)
+      },
+      test("a key is not honoured once the family has been revoked") {
+        for
+          now <- Clock.instant
+          record1 = tokenRecord1(now, refreshTtl)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1, None)
+          _ <- env.repository.createRefreshToken(
+            refreshToken2,
+            Some(refreshToken1),
+            record1.copy(accessToken = accessToken2),
+            Some(idempotencyKey1),
+          )
+          _ <- env.repository.revokeFamily(refreshToken1, clientId1, now.minusSeconds(300))
+
+          // No live tip left to continue from, so there is nothing to hand back.
+          retry <- env.repository.findIdempotentRetry(refreshToken1, clientId1, idempotencyKey1)
+        yield assertTrue(retry.isEmpty)
       },
     )
 

--- a/auth/src/test/scala/versola/oauth/session/RefreshTokenRepositorySpec.scala
+++ b/auth/src/test/scala/versola/oauth/session/RefreshTokenRepositorySpec.scala
@@ -40,6 +40,7 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
 
   val accessToken1 = AccessToken(Array.fill(16)(10.toByte))
   val accessToken2 = AccessToken(Array.fill(16)(11.toByte))
+  val accessToken3 = AccessToken(Array.fill(16)(12.toByte))
 
   val scope1 = Set(ScopeToken("read"), ScopeToken("write"))
   val scope2 = Set(ScopeToken("admin"))
@@ -60,7 +61,6 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
     requestedClaims = None,
     uiLocales = None,
     nonce = None,
-    previousRefreshToken = None,
     amr = Set(AuthMethodRef.pwd),
     authTime = now,
     acr = None,
@@ -80,7 +80,6 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
     requestedClaims = None,
     uiLocales = None,
     nonce = None,
-    previousRefreshToken = None,
     amr = Set(AuthMethodRef.pwd),
     authTime = now,
     acr = None,
@@ -93,8 +92,8 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
           now <- Clock.instant
           record1 = tokenRecord1(now, refreshTtl)
           record2 = tokenRecord2(now, refreshTtl)
-          _ <- env.repository.createRefreshToken(refreshToken1, record1)
-          _ <- env.repository.createRefreshToken(refreshToken2, record2)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1)
+          _ <- env.repository.createRefreshToken(refreshToken2, None, record2)
           found1 <- env.repository.findToken(refreshToken1)
           found2 <- env.repository.findToken(refreshToken2)
         yield assertTrue(
@@ -110,7 +109,7 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
         for
           now <- Clock.instant
           record = tokenRecord1(now, refreshTtl).copy(authorizationDetails = Some(List(detail)))
-          _ <- env.repository.createRefreshToken(refreshToken1, record)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record)
           found <- env.repository.findToken(refreshToken1)
         yield assertTrue(found.map(_.authorizationDetails) == Some(Some(List(detail))))
       },
@@ -124,7 +123,7 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
         for
           now <- Clock.instant
           record = tokenRecord1(now, shortTtl)
-          _ <- env.repository.createRefreshToken(refreshToken1, record)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record)
           foundBefore <- env.repository.findToken(refreshToken1)
           _ <- TestClock.adjust(3.minutes)
           foundAfter <- env.repository.findToken(refreshToken1)
@@ -137,12 +136,13 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
         for
           now <- Clock.instant
           record1 = tokenRecord1(now, refreshTtl)
-          record2 = record1.copy(previousRefreshToken = Some(refreshToken1))
-          _ <- env.repository.createRefreshToken(refreshToken1, record1)
-          _ <- env.repository.createRefreshToken(refreshToken2, record2)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1)
+          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2))
           oldTokenFound <- env.repository.findToken(refreshToken1)
           newTokenFound <- env.repository.findToken(refreshToken2)
         yield assertTrue(
+          // Retired rather than deleted: the row stays behind so a later replay of it still
+          // resolves to its family, but it is no longer usable.
           oldTokenFound.isEmpty,
           newTokenFound.isDefined,
         )
@@ -151,7 +151,7 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
         for
           now <- Clock.instant
           record1 = tokenRecord1(now, refreshTtl)
-          _ <- env.repository.createRefreshToken(refreshToken1, record1)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1)
 
           refreshTokens = List(
             refreshToken2,
@@ -161,8 +161,10 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
             refreshToken6,
             refreshToken7,
           )
-          results <- ZIO.foreachPar(refreshTokens)(token =>
-            env.repository.createRefreshToken(token, record1.copy(previousRefreshToken = Some(refreshToken1))).either,
+          results <- ZIO.foreachPar(refreshTokens.zipWithIndex)((token, i) =>
+            env.repository
+              .createRefreshToken(token, Some(refreshToken1), record1.copy(accessToken = AccessToken(Array.fill(16)((30 + i).toByte))))
+              .either,
           )
 
         yield assertTrue(
@@ -170,59 +172,115 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
           results.count(_.left.toOption.contains(())) == 5
         )
       },
-      test("markChainReplayed finds and expires the successor of an already-rotated token") {
+      test("revokeFamily revokes the whole family when a token retired generations ago is replayed") {
         for
           now <- Clock.instant
           record1 = tokenRecord1(now, refreshTtl)
-          record2 = record1.copy(previousRefreshToken = Some(refreshToken1), accessToken = accessToken2)
-          _ <- env.repository.createRefreshToken(refreshToken1, record1)
-          _ <- env.repository.createRefreshToken(refreshToken2, record2)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1)
+          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2))
+          _ <- env.repository.createRefreshToken(refreshToken3, Some(refreshToken2), record1.copy(accessToken = accessToken3))
 
-          replayed <- env.repository.markChainReplayed(refreshToken1, clientId1)
-          successorAfter <- env.repository.findToken(refreshToken2)
+          // The replayed token was retired two rotations ago, so a lookup that only knew the
+          // immediately following generation would have missed it and left the tip live.
+          revoked <- env.repository.revokeFamily(refreshToken1, clientId1, now.minusSeconds(300))
+          tipAfter <- env.repository.findToken(refreshToken3)
         yield assertTrue(
+          revoked.exists(_.userId == userId1),
           // Array-backed AccessToken has reference equality under `==`, hence `===`.
-          replayed.exists(r => r._1 == userId1 && r._2 === accessToken2),
-          // Expired, not deleted: the cleanup manager's expires_at sweep removes it later,
-          // rather than this call issuing its own DELETE inline.
-          successorAfter.isEmpty,
+          revoked.exists(_.accessTokens.exists(_ === accessToken3)),
+          // Expired, not deleted: the cleanup manager's expires_at sweep collects the family
+          // later, rather than this call issuing its own DELETE inline.
+          tipAfter.isEmpty,
         )
       },
-      test("markChainReplayed ignores a token with no successor") {
+      test("revokeFamily ignores a token that was never issued") {
         for
           now <- Clock.instant
-          record1 = tokenRecord1(now, refreshTtl)
-          _ <- env.repository.createRefreshToken(refreshToken1, record1)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, tokenRecord1(now, refreshTtl))
 
-          replayed <- env.repository.markChainReplayed(refreshToken2, clientId1)
-        yield assertTrue(replayed.isEmpty)
+          revoked <- env.repository.revokeFamily(refreshToken2, clientId1, now.minusSeconds(300))
+        yield assertTrue(revoked.isEmpty)
       },
-      test("markChainReplayed does not act on a chain owned by a different client") {
+      test("revokeFamily ignores a token that is still live") {
         for
           now <- Clock.instant
-          record1 = tokenRecord1(now, refreshTtl)
-          record2 = record1.copy(previousRefreshToken = Some(refreshToken1))
-          _ <- env.repository.createRefreshToken(refreshToken1, record1)
-          _ <- env.repository.createRefreshToken(refreshToken2, record2)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, tokenRecord1(now, refreshTtl))
 
-          replayed <- env.repository.markChainReplayed(refreshToken1, clientId2)
-          successorAfter <- env.repository.findToken(refreshToken2)
+          // Presenting a token that was never rotated away is not a replay, whatever else is
+          // wrong with the request.
+          revoked <- env.repository.revokeFamily(refreshToken1, clientId1, now.minusSeconds(300))
+          stillLive <- env.repository.findToken(refreshToken1)
         yield assertTrue(
-          replayed.isEmpty,
-          successorAfter.isDefined,
+          revoked.isEmpty,
+          stillLive.isDefined,
         )
       },
-      test("markChainReplayed is idempotent: a second replay of the same token finds nothing left to expire") {
+      test("revokeFamily does not act on a family owned by a different client") {
         for
           now <- Clock.instant
           record1 = tokenRecord1(now, refreshTtl)
-          record2 = record1.copy(previousRefreshToken = Some(refreshToken1))
-          _ <- env.repository.createRefreshToken(refreshToken1, record1)
-          _ <- env.repository.createRefreshToken(refreshToken2, record2)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1)
+          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2))
 
-          _ <- env.repository.markChainReplayed(refreshToken1, clientId1)
-          second <- env.repository.markChainReplayed(refreshToken1, clientId1)
-        yield assertTrue(second.isEmpty)
+          revoked <- env.repository.revokeFamily(refreshToken1, clientId2, now.minusSeconds(300))
+          tipAfter <- env.repository.findToken(refreshToken2)
+        yield assertTrue(
+          revoked.isEmpty,
+          tipAfter.isDefined,
+        )
+      },
+      test("revokeFamily leaves out access tokens already past their TTL") {
+        for
+          now <- Clock.instant
+          record1 = tokenRecord1(now, refreshTtl)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1)
+          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2))
+
+          revoked <- env.repository.revokeFamily(refreshToken1, clientId1, now.plusSeconds(60))
+          tipAfter <- env.repository.findToken(refreshToken2)
+        yield assertTrue(
+          // The family still dies; there is just nothing left worth pushing to the client.
+          revoked.exists(_.accessTokens.isEmpty),
+          tipAfter.isEmpty,
+        )
+      },
+      test("rotation of a family that was already revoked fails") {
+        for
+          now <- Clock.instant
+          record1 = tokenRecord1(now, refreshTtl)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1)
+          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2))
+          _ <- env.repository.revokeFamily(refreshToken1, clientId1, now.minusSeconds(300))
+
+          rotated <- env.repository.createRefreshToken(refreshToken3, Some(refreshToken2), record1.copy(accessToken = accessToken3)).either
+        yield assertTrue(rotated.isLeft)
+      },
+      test("a rotation racing a revocation never leaves a live successor behind") {
+        for
+          now <- Clock.instant
+          record1 = tokenRecord1(now, refreshTtl)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1)
+          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2))
+
+          // Whichever wins the family lock, the invariant holds: either the rotation commits
+          // first and its successor is expired by the revocation, or it finds the token it
+          // meant to rotate already dead.
+          _ <- env.repository.createRefreshToken(refreshToken3, Some(refreshToken2), record1.copy(accessToken = accessToken3)).either
+            .zipPar(env.repository.revokeFamily(refreshToken1, clientId1, now.minusSeconds(300)))
+
+          live <- ZIO.foreach(List(refreshToken1, refreshToken2, refreshToken3))(env.repository.findToken)
+        yield assertTrue(live.forall(_.isEmpty))
+      },
+      test("revokeFamily is idempotent: a second replay finds the family already dead") {
+        for
+          now <- Clock.instant
+          record1 = tokenRecord1(now, refreshTtl)
+          _ <- env.repository.createRefreshToken(refreshToken1, None, record1)
+          _ <- env.repository.createRefreshToken(refreshToken2, Some(refreshToken1), record1.copy(accessToken = accessToken2))
+
+          _ <- env.repository.revokeFamily(refreshToken1, clientId1, now.minusSeconds(300))
+          second <- env.repository.revokeFamily(refreshToken1, clientId1, now.minusSeconds(300))
+        yield assertTrue(second.exists(_.accessTokens.isEmpty))
       },
     )
 

--- a/auth/src/test/scala/versola/oauth/session/SessionRepositorySpec.scala
+++ b/auth/src/test/scala/versola/oauth/session/SessionRepositorySpec.scala
@@ -208,13 +208,12 @@ trait SessionRepositorySpec extends DatabaseSpecBase[SessionRepositorySpec.Env]:
             requestedClaims      = None,
             uiLocales            = None,
             nonce                = None,
-            previousRefreshToken = None,
             amr                  = Set(AuthMethodRef.pwd),
             authTime             = now,
             acr                  = None,
           )
           _            <- env.repository.create(atomicSessionId, session1, 5.minutes, None, None)
-          _            <- env.repository.createRefreshToken(atomicTokenId, record)
+          _            <- env.repository.createRefreshToken(atomicTokenId, None, record)
           _            <- env.repository.invalidateByUserId(userId1)
           sessionAfter <- env.repository.findSession(atomicSessionId)
           tokenAfter   <- env.repository.findToken(atomicTokenId)
@@ -255,13 +254,12 @@ trait SessionRepositorySpec extends DatabaseSpecBase[SessionRepositorySpec.Env]:
             requestedClaims      = None,
             uiLocales            = None,
             nonce                = None,
-            previousRefreshToken = None,
             amr                  = Set(AuthMethodRef.pwd),
             authTime             = now,
             acr                  = None,
           )
           _          <- env.repository.create(atomicSessionId, session1, 5.minutes, None, None)
-          _          <- env.repository.createRefreshToken(atomicTokenId, record)
+          _          <- env.repository.createRefreshToken(atomicTokenId, None, record)
           _          <- env.repository.invalidate(atomicSessionId)
           tokenAfter <- env.repository.findToken(atomicTokenId)
         yield assertTrue(tokenAfter.isEmpty)
@@ -318,13 +316,12 @@ trait SessionRepositorySpec extends DatabaseSpecBase[SessionRepositorySpec.Env]:
             requestedClaims      = None,
             uiLocales            = None,
             nonce                = None,
-            previousRefreshToken = None,
             amr                  = Set(AuthMethodRef.pwd),
             authTime             = now,
             acr                  = None,
           )
           _          <- env.repository.create(atomicSessionId, session1.copy(publicId = atomicPublicId), 5.minutes, None, None)
-          _          <- env.repository.createRefreshToken(atomicTokenId, record)
+          _          <- env.repository.createRefreshToken(atomicTokenId, None, record)
           _          <- env.repository.invalidateByPublicId(atomicPublicId)
           tokenAfter <- env.repository.findToken(atomicTokenId)
         yield assertTrue(tokenAfter.isEmpty)

--- a/auth/src/test/scala/versola/oauth/session/SessionRepositorySpec.scala
+++ b/auth/src/test/scala/versola/oauth/session/SessionRepositorySpec.scala
@@ -213,7 +213,7 @@ trait SessionRepositorySpec extends DatabaseSpecBase[SessionRepositorySpec.Env]:
             acr                  = None,
           )
           _            <- env.repository.create(atomicSessionId, session1, 5.minutes, None, None)
-          _            <- env.repository.createRefreshToken(atomicTokenId, None, record)
+          _            <- env.repository.createRefreshToken(atomicTokenId, None, record, None)
           _            <- env.repository.invalidateByUserId(userId1)
           sessionAfter <- env.repository.findSession(atomicSessionId)
           tokenAfter   <- env.repository.findToken(atomicTokenId)
@@ -259,7 +259,7 @@ trait SessionRepositorySpec extends DatabaseSpecBase[SessionRepositorySpec.Env]:
             acr                  = None,
           )
           _          <- env.repository.create(atomicSessionId, session1, 5.minutes, None, None)
-          _          <- env.repository.createRefreshToken(atomicTokenId, None, record)
+          _          <- env.repository.createRefreshToken(atomicTokenId, None, record, None)
           _          <- env.repository.invalidate(atomicSessionId)
           tokenAfter <- env.repository.findToken(atomicTokenId)
         yield assertTrue(tokenAfter.isEmpty)
@@ -321,7 +321,7 @@ trait SessionRepositorySpec extends DatabaseSpecBase[SessionRepositorySpec.Env]:
             acr                  = None,
           )
           _          <- env.repository.create(atomicSessionId, session1.copy(publicId = atomicPublicId), 5.minutes, None, None)
-          _          <- env.repository.createRefreshToken(atomicTokenId, None, record)
+          _          <- env.repository.createRefreshToken(atomicTokenId, None, record, None)
           _          <- env.repository.invalidateByPublicId(atomicPublicId)
           tokenAfter <- env.repository.findToken(atomicTokenId)
         yield assertTrue(tokenAfter.isEmpty)

--- a/auth/src/test/scala/versola/oauth/token/OAuthTokenServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/token/OAuthTokenServiceSpec.scala
@@ -51,6 +51,8 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
   val accessToken2 = AccessToken(Array.fill(32)(4.toByte))
   val refreshToken1 = RefreshToken(Array.fill(32)(4.toByte))
   val refreshTokenMac1 = MAC(Array.fill(32)(5.toByte))
+  val refreshToken2 = RefreshToken(Array.fill(32)(9.toByte))
+  val refreshTokenMac2 = MAC(Array.fill(32)(10.toByte))
 
   val clientSecret1 = Secret(Array.fill(32)(6.toByte))
 
@@ -181,6 +183,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
       result <- env.service.refreshAccessToken(
         RefreshTokenRequest(refreshToken1, None, None, requested),
         ClientIdWithSecret(clientId1, Some(clientSecret1)),
+        None,
       ).either
     yield result
 
@@ -587,7 +590,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           )
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.refreshAccessToken(request, credentials)
+          result <- env.service.refreshAccessToken(request, credentials, None)
 
           createCalls = env.tokenRepo.createRefreshToken.calls
         yield assertTrue(
@@ -643,7 +646,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = RefreshTokenRequest(refreshToken1, Some(reducedScope), None, None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.refreshAccessToken(request, credentials)
+          result <- env.service.refreshAccessToken(request, credentials, None)
 
           createCalls = env.tokenRepo.createRefreshToken.calls
         yield assertTrue(
@@ -659,7 +662,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = RefreshTokenRequest(refreshToken1, None, None, None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.refreshAccessToken(request, credentials).either
+          result <- env.service.refreshAccessToken(request, credentials, None).either
         yield assertTrue(
           result == Left(TokenEndpointError.InvalidClient),
         )
@@ -675,7 +678,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = RefreshTokenRequest(refreshToken1, None, None, None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.refreshAccessToken(request, credentials).either
+          result <- env.service.refreshAccessToken(request, credentials, None).either
         yield assertTrue(
           result == Left(TokenEndpointError.InvalidGrant.RefreshTokenNotFound),
           env.accessTokenRevocationService.revoke.calls.isEmpty,
@@ -694,7 +697,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = RefreshTokenRequest(refreshToken1, None, None, None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.refreshAccessToken(request, credentials).either
+          result <- env.service.refreshAccessToken(request, credentials, None).either
         yield assertTrue(
           result == Left(TokenEndpointError.InvalidGrant.RefreshTokenReplayed),
           // Generations older than the access-token TTL are not worth pushing to the client,
@@ -707,6 +710,138 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
             (testClient, accessToken1, userId1.toString, now.plus(testClient.accessTokenTtl)),
             (testClient, accessToken2, userId1.toString, now.plus(testClient.accessTokenTtl)),
           ),
+        )
+      },
+      test("continue the chain from the tip when a rotated-away token is retried under its key") {
+        val env = new Env
+        for
+          now <- Clock.instant
+
+          tipRecord = RefreshTokenRecord(
+            sessionId = sessionId1,
+            publicSessionId = publicSessionId1,
+            accessToken = accessToken1,
+            userId = userId1,
+            clientId = clientId1,
+            audience = List.empty,
+            authorizationDetails = None,
+            scope = scope1,
+            issuedAt = now.minusSeconds(60),
+            expiresAt = now.plusSeconds(testClient.refreshTokenTtl.toSeconds),
+            requestedClaims = Some(requestedClaims1),
+            uiLocales = Some(uiLocales1),
+            nonce = None,
+            amr = amr1,
+            authTime = authTime1,
+            acr = None,
+          )
+
+          _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
+          _ <- env.securityService.mac.succeedsWith(refreshTokenMac1)
+          _ <- env.tokenRepo.findToken.succeedsWith(None)
+          _ <- env.tokenRepo.findIdempotentRetry.succeedsWith(Some((refreshTokenMac2, tipRecord)))
+          _ <- env.propertyGenerator.nextAccessToken.succeedsWith(accessToken2)
+          _ <- env.propertyGenerator.nextRefreshToken.succeedsWith(refreshToken2)
+          _ <- env.tokenRepo.createRefreshToken.succeedsWith(())
+          _ <- env.userRepo.findRolesByUserAndTenant.succeedsWith(List.empty)
+
+          request = RefreshTokenRequest(refreshToken1, None, None, None)
+          credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
+
+          result <- env.service.refreshAccessToken(request, credentials, Some("key-1")).either
+
+          createCalls = env.tokenRepo.createRefreshToken.calls
+        yield assertTrue(
+          result.isRight,
+          // A fresh token, not the one the client missed: that was never stored, so the
+          // rotation continues from the tip rather than from what was presented.
+          createCalls.head._2.exists(mac => java.util.Arrays.equals(mac, refreshTokenMac2)),
+          // Nothing here looks like a leak, so the family stands.
+          env.tokenRepo.revokeFamily.calls.isEmpty,
+          env.accessTokenRevocationService.revoke.calls.isEmpty,
+        )
+      },
+      test("revoke the family when a rotated-away token is presented without a key") {
+        val env = new Env
+        for
+          _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
+          _ <- env.securityService.mac.succeedsWith(refreshTokenMac1)
+          _ <- env.tokenRepo.findToken.succeedsWith(None)
+          _ <- env.tokenRepo.revokeFamily.succeedsWith(Some(RevokedFamily(userId1, List(accessToken1))))
+          _ <- env.accessTokenRevocationService.revoke.succeedsWith(())
+
+          request = RefreshTokenRequest(refreshToken1, None, None, None)
+          credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
+
+          result <- env.service.refreshAccessToken(request, credentials, None).either
+
+          retries = env.tokenRepo.findIdempotentRetry.calls
+        yield assertTrue(
+          // Reuse detection is untouched for everyone who does not present a key.
+          result == Left(TokenEndpointError.InvalidGrant.RefreshTokenReplayed),
+          retries.isEmpty,
+        )
+      },
+      test("revoke the family when the key no longer names the family's last exchange") {
+        val env = new Env
+        for
+          _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
+          _ <- env.securityService.mac.succeedsWith(refreshTokenMac1)
+          _ <- env.tokenRepo.findToken.succeedsWith(None)
+          // The chain moved on under a different key, so this is reuse of a retired token.
+          _ <- env.tokenRepo.findIdempotentRetry.succeedsWith(None)
+          _ <- env.tokenRepo.revokeFamily.succeedsWith(Some(RevokedFamily(userId1, List(accessToken1))))
+          _ <- env.accessTokenRevocationService.revoke.succeedsWith(())
+
+          request = RefreshTokenRequest(refreshToken1, None, None, None)
+          credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
+
+          result <- env.service.refreshAccessToken(request, credentials, Some("key-1")).either
+        yield assertTrue(result == Left(TokenEndpointError.InvalidGrant.RefreshTokenReplayed))
+      },
+      test("do not revoke when two retries of the same request race each other") {
+        val env = new Env
+        for
+          now <- Clock.instant
+
+          tipRecord = RefreshTokenRecord(
+            sessionId = sessionId1,
+            publicSessionId = publicSessionId1,
+            accessToken = accessToken1,
+            userId = userId1,
+            clientId = clientId1,
+            audience = List.empty,
+            authorizationDetails = None,
+            scope = scope1,
+            issuedAt = now.minusSeconds(60),
+            expiresAt = now.plusSeconds(testClient.refreshTokenTtl.toSeconds),
+            requestedClaims = Some(requestedClaims1),
+            uiLocales = Some(uiLocales1),
+            nonce = None,
+            amr = amr1,
+            authTime = authTime1,
+            acr = None,
+          )
+
+          _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
+          _ <- env.securityService.mac.succeedsWith(refreshTokenMac1)
+          _ <- env.tokenRepo.findToken.succeedsWith(None)
+          _ <- env.tokenRepo.findIdempotentRetry.succeedsWith(Some((refreshTokenMac2, tipRecord)))
+          _ <- env.propertyGenerator.nextAccessToken.succeedsWith(accessToken2)
+          _ <- env.propertyGenerator.nextRefreshToken.succeedsWith(refreshToken2)
+          _ <- env.tokenRepo.createRefreshToken.failsWith(RefreshAlreadyExchanged())
+          _ <- env.userRepo.findRolesByUserAndTenant.succeedsWith(List.empty)
+
+          request = RefreshTokenRequest(refreshToken1, None, None, None)
+          credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
+
+          result <- env.service.refreshAccessToken(request, credentials, Some("key-1")).either
+        yield assertTrue(
+          // Whoever got there first is another attempt at the very same exchange, which the
+          // key already established, so nothing was leaked and the family must survive.
+          result == Left(TokenEndpointError.InvalidGrant.RefreshChainAlreadyExchanged),
+          env.tokenRepo.revokeFamily.calls.isEmpty,
+          env.accessTokenRevocationService.revoke.calls.isEmpty,
         )
       },
       test("fail with InvalidScope when requested scope exceeds client scope") {
@@ -741,7 +876,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = RefreshTokenRequest(refreshToken1, Some(invalidScope), None, None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.refreshAccessToken(request, credentials).either
+          result <- env.service.refreshAccessToken(request, credentials, None).either
         yield assertTrue(
           result == Left(TokenEndpointError.InvalidScope),
         )
@@ -784,7 +919,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = RefreshTokenRequest(refreshToken1, None, None, None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.refreshAccessToken(request, credentials).either
+          result <- env.service.refreshAccessToken(request, credentials, None).either
         yield assertTrue(
           // Losing the race means the same token was presented twice at once: the winner's
           // successor is live, and the leak is as proven as a sequential replay.
@@ -832,7 +967,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = RefreshTokenRequest(refreshToken1, None, None, None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.refreshAccessToken(request, credentials).either
+          result <- env.service.refreshAccessToken(request, credentials, None).either
         yield assertTrue(
           result == Left(TokenEndpointError.InvalidGrant.RefreshChainAlreadyExchanged),
           env.accessTokenRevocationService.revoke.calls.isEmpty,

--- a/auth/src/test/scala/versola/oauth/token/OAuthTokenServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/token/OAuthTokenServiceSpec.scala
@@ -335,7 +335,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
 
           result <- env.service.exchangeAuthorizationCode(request, credentials).either
         yield assertTrue(
-          result == Left(TokenEndpointError.InvalidGrant),
+          result == Left(TokenEndpointError.InvalidGrant.CodeNotFound),
         )
       },
       test("fail with InvalidGrant when redirect_uri doesn't match") {
@@ -371,7 +371,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
 
           result <- env.service.exchangeAuthorizationCode(request, credentials).either
         yield assertTrue(
-          result == Left(TokenEndpointError.InvalidGrant),
+          result == Left(TokenEndpointError.InvalidGrant.RedirectUriMismatch),
         )
       },
       test("fail with InvalidGrant and revoke the previously issued token when code is reused (double-spend)") {
@@ -410,7 +410,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           now <- Clock.instant
           result <- env.service.exchangeAuthorizationCode(request, credentials).either
         yield assertTrue(
-          result == Left(TokenEndpointError.InvalidGrant),
+          result == Left(TokenEndpointError.InvalidGrant.CodeReplayed),
           // The replayed code's token is not in hand, so its lifetime is bounded by the
           // client's access token TTL rather than read from the token itself.
           env.accessTokenRevocationService.revoke.calls ==
@@ -679,7 +679,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
 
           result <- env.service.refreshAccessToken(request, credentials).either
         yield assertTrue(
-          result == Left(TokenEndpointError.InvalidGrant),
+          result == Left(TokenEndpointError.InvalidGrant.RefreshTokenNotFound),
           env.accessTokenRevocationService.revoke.calls.isEmpty,
         )
       },
@@ -698,7 +698,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
 
           result <- env.service.refreshAccessToken(request, credentials).either
         yield assertTrue(
-          result == Left(TokenEndpointError.InvalidGrant),
+          result == Left(TokenEndpointError.InvalidGrant.RefreshTokenReplayed),
           env.tokenRepo.markChainReplayed.calls == List((refreshTokenMac1, clientId1)),
           // The replayed token's own access token is not in hand, only its id, so its
           // lifetime is bounded by the client's access token TTL rather than read from it.
@@ -785,7 +785,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
 
           result <- env.service.refreshAccessToken(request, credentials).either
         yield assertTrue(
-          result == Left(TokenEndpointError.InvalidGrant),
+          result == Left(TokenEndpointError.InvalidGrant.RefreshChainAlreadyExchanged),
         )
       },
     ),

--- a/auth/src/test/scala/versola/oauth/token/OAuthTokenServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/token/OAuthTokenServiceSpec.scala
@@ -672,6 +672,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
           _ <- env.securityService.mac.succeedsWith(refreshTokenMac1)
           _ <- env.tokenRepo.findToken.succeedsWith(None)
+          _ <- env.tokenRepo.markChainReplayed.succeedsWith(None)
 
           request = RefreshTokenRequest(refreshToken1, None, None, None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
@@ -679,6 +680,30 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           result <- env.service.refreshAccessToken(request, credentials).either
         yield assertTrue(
           result == Left(TokenEndpointError.InvalidGrant),
+          env.accessTokenRevocationService.revoke.calls.isEmpty,
+        )
+      },
+      test("fail with InvalidGrant and revoke the chain's access token when a rotated-away refresh token is replayed") {
+        val env = new Env
+        for
+          now <- Clock.instant
+          _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
+          _ <- env.securityService.mac.succeedsWith(refreshTokenMac1)
+          _ <- env.tokenRepo.findToken.succeedsWith(None)
+          _ <- env.tokenRepo.markChainReplayed.succeedsWith(Some((userId1, accessToken1)))
+          _ <- env.accessTokenRevocationService.revoke.succeedsWith(())
+
+          request = RefreshTokenRequest(refreshToken1, None, None, None)
+          credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
+
+          result <- env.service.refreshAccessToken(request, credentials).either
+        yield assertTrue(
+          result == Left(TokenEndpointError.InvalidGrant),
+          env.tokenRepo.markChainReplayed.calls == List((refreshTokenMac1, clientId1)),
+          // The replayed token's own access token is not in hand, only its id, so its
+          // lifetime is bounded by the client's access token TTL rather than read from it.
+          env.accessTokenRevocationService.revoke.calls ==
+            List((testClient, accessToken1, userId1.toString, now.plus(testClient.accessTokenTtl))),
         )
       },
       test("fail with InvalidScope when requested scope exceeds client scope") {

--- a/auth/src/test/scala/versola/oauth/token/OAuthTokenServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/token/OAuthTokenServiceSpec.scala
@@ -7,7 +7,7 @@ import versola.oauth.client.model.{AuthMethodRef, AuthorizationDetail, Authoriza
 import versola.oauth.model.{AccessToken, AuthorizationCode, AuthorizationCodeRecord, CodeChallenge, CodeChallengeMethod, CodeVerifier, RefreshToken}
 import versola.oauth.revoke.AccessTokenRevocationService
 import versola.oauth.session.SessionRepository
-import versola.oauth.session.model.{PublicSessionId, RefreshAlreadyExchanged, RefreshTokenRecord, SessionId}
+import versola.oauth.session.model.{PublicSessionId, RefreshAlreadyExchanged, RefreshTokenRecord, RevokedFamily, SessionId}
 import versola.oauth.token.model.{ClientCredentialsRequest, CodeExchangeRequest, IssuedTokens, RefreshTokenRequest, TokenEndpointError}
 import versola.oauth.client.model.Claim
 import versola.oauth.userinfo.model.{ClaimRequest, RequestedClaims}
@@ -48,6 +48,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
   val authCode1 = AuthorizationCode(Array.fill(16)(1.toByte))
   val codeMac1 = MAC(Array.fill(32)(2.toByte))
   val accessToken1 = AccessToken(Array.fill(32)(3.toByte))
+  val accessToken2 = AccessToken(Array.fill(32)(4.toByte))
   val refreshToken1 = RefreshToken(Array.fill(32)(4.toByte))
   val refreshTokenMac1 = MAC(Array.fill(32)(5.toByte))
 
@@ -164,7 +165,6 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
         requestedClaims = None,
         uiLocales = None,
         nonce = None,
-        previousRefreshToken = None,
         amr = amr1,
         authTime = authTime1,
         acr = None,
@@ -263,7 +263,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           result.audience == List(ResourceUri("https://api.example.com"), ResourceUri("resource://edge")),
           result.amr == amr1,
           result.authTime.contains(authTime1),
-          createCalls.head._2.audience == List(ResourceUri("https://api.example.com"), ResourceUri("resource://edge")),
+          createCalls.head._3.audience == List(ResourceUri("https://api.example.com"), ResourceUri("resource://edge")),
           env.clientService.getResourcesForClient.calls.isEmpty,
           env.clientService.findResource.calls.isEmpty,
           env.clientService.findResourceById.calls.isEmpty,
@@ -562,7 +562,6 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
             requestedClaims = Some(requestedClaims1),
             uiLocales = Some(uiLocales1),
             nonce = None,
-            previousRefreshToken = None,
             amr = amr1,
             authTime = authTime1,
             acr = None,
@@ -600,8 +599,8 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           result.amr == amr1,
           result.authTime.contains(authTime1),
           createCalls.length == 1,
-          createCalls.head._2.previousRefreshToken.exists(mac => java.util.Arrays.equals(mac, refreshTokenMac1)),
-          createCalls.head._2.audience == List(ResourceUri("resource://edge"), ResourceUri("https://api.example.com")),
+          createCalls.head._2.exists(mac => java.util.Arrays.equals(mac, refreshTokenMac1)),
+          createCalls.head._3.audience == List(ResourceUri("resource://edge"), ResourceUri("https://api.example.com")),
         )
       },
       test("successfully refresh with reduced scope") {
@@ -624,7 +623,6 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
             requestedClaims = None,
             uiLocales = None,
             nonce = None,
-            previousRefreshToken = None,
             amr = amr1,
             authTime = authTime1,
             acr = None,
@@ -650,7 +648,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           createCalls = env.tokenRepo.createRefreshToken.calls
         yield assertTrue(
           result.scope == reducedScope,
-          createCalls.head._2.scope == reducedScope,
+          createCalls.head._3.scope == reducedScope,
         )
       },
       test("fail with InvalidClient when client verification fails") {
@@ -672,7 +670,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
           _ <- env.securityService.mac.succeedsWith(refreshTokenMac1)
           _ <- env.tokenRepo.findToken.succeedsWith(None)
-          _ <- env.tokenRepo.markChainReplayed.succeedsWith(None)
+          _ <- env.tokenRepo.revokeFamily.succeedsWith(None)
 
           request = RefreshTokenRequest(refreshToken1, None, None, None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
@@ -683,14 +681,14 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           env.accessTokenRevocationService.revoke.calls.isEmpty,
         )
       },
-      test("fail with InvalidGrant and revoke the chain's access token when a rotated-away refresh token is replayed") {
+      test("fail with InvalidGrant and revoke the whole family when a rotated-away refresh token is replayed") {
         val env = new Env
         for
           now <- Clock.instant
           _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
           _ <- env.securityService.mac.succeedsWith(refreshTokenMac1)
           _ <- env.tokenRepo.findToken.succeedsWith(None)
-          _ <- env.tokenRepo.markChainReplayed.succeedsWith(Some((userId1, accessToken1)))
+          _ <- env.tokenRepo.revokeFamily.succeedsWith(Some(RevokedFamily(userId1, List(accessToken1, accessToken2))))
           _ <- env.accessTokenRevocationService.revoke.succeedsWith(())
 
           request = RefreshTokenRequest(refreshToken1, None, None, None)
@@ -699,11 +697,16 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           result <- env.service.refreshAccessToken(request, credentials).either
         yield assertTrue(
           result == Left(TokenEndpointError.InvalidGrant.RefreshTokenReplayed),
-          env.tokenRepo.markChainReplayed.calls == List((refreshTokenMac1, clientId1)),
-          // The replayed token's own access token is not in hand, only its id, so its
-          // lifetime is bounded by the client's access token TTL rather than read from it.
-          env.accessTokenRevocationService.revoke.calls ==
-            List((testClient, accessToken1, userId1.toString, now.plus(testClient.accessTokenTtl))),
+          // Generations older than the access-token TTL are not worth pushing to the client,
+          // so the repository is asked only for those issued since.
+          env.tokenRepo.revokeFamily.calls ==
+            List((refreshTokenMac1, clientId1, now.minus(testClient.accessTokenTtl))),
+          // Every access token the family issued goes, not just the tip's. None of them is in
+          // hand here, only their ids, so each lifetime is bounded by the client's TTL.
+          env.accessTokenRevocationService.revoke.calls == List(
+            (testClient, accessToken1, userId1.toString, now.plus(testClient.accessTokenTtl)),
+            (testClient, accessToken2, userId1.toString, now.plus(testClient.accessTokenTtl)),
+          ),
         )
       },
       test("fail with InvalidScope when requested scope exceeds client scope") {
@@ -726,7 +729,6 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
             requestedClaims = None,
             uiLocales = None,
             nonce = None,
-            previousRefreshToken = None,
             amr = amr1,
             authTime = authTime1,
             acr = None,
@@ -744,7 +746,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           result == Left(TokenEndpointError.InvalidScope),
         )
       },
-      test("fail with InvalidGrant when race condition occurs (create returns RefreshAlreadyExchanged)") {
+      test("fail with InvalidGrant and revoke the family when the rotation loses a concurrent race") {
         val env = new Env
         for
           now <- Clock.instant
@@ -763,22 +765,69 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
             requestedClaims = Some(requestedClaims1),
             uiLocales = Some(uiLocales1),
             nonce = None,
-            previousRefreshToken = None,
             amr = amr1,
             authTime = authTime1,
             acr = None,
           )
 
           newRefreshToken = RefreshToken(Array.fill(32)(7.toByte))
-          newRefreshTokenMac = MAC(Array.fill(32)(8.toByte))
 
           _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
           _ <- env.securityService.mac.succeedsWith(refreshTokenMac1)
-          _ <- env.securityService.mac.succeedsWith(newRefreshTokenMac)
           _ <- env.tokenRepo.findToken.succeedsWith(Some(tokenRecord))
           _ <- env.propertyGenerator.nextAccessToken.succeedsWith(accessToken1)
           _ <- env.propertyGenerator.nextRefreshToken.succeedsWith(newRefreshToken)
           _ <- env.tokenRepo.createRefreshToken.failsWith(RefreshAlreadyExchanged())
+          _ <- env.tokenRepo.revokeFamily.succeedsWith(Some(RevokedFamily(userId1, List(accessToken1))))
+          _ <- env.accessTokenRevocationService.revoke.succeedsWith(())
+
+          request = RefreshTokenRequest(refreshToken1, None, None, None)
+          credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
+
+          result <- env.service.refreshAccessToken(request, credentials).either
+        yield assertTrue(
+          // Losing the race means the same token was presented twice at once: the winner's
+          // successor is live, and the leak is as proven as a sequential replay.
+          result == Left(TokenEndpointError.InvalidGrant.RefreshTokenReplayed),
+          env.tokenRepo.revokeFamily.calls ==
+            List((refreshTokenMac1, clientId1, now.minus(testClient.accessTokenTtl))),
+          env.accessTokenRevocationService.revoke.calls ==
+            List((testClient, accessToken1, userId1.toString, now.plus(testClient.accessTokenTtl))),
+        )
+      },
+      test("fail with InvalidGrant when the rotation loses a race and the family is already gone") {
+        val env = new Env
+        for
+          now <- Clock.instant
+
+          tokenRecord = RefreshTokenRecord(
+            sessionId = sessionId1,
+            publicSessionId = publicSessionId1,
+            accessToken = accessToken1,
+            userId = userId1,
+            clientId = clientId1,
+            audience = List.empty,
+            authorizationDetails = None,
+            scope = scope1,
+            issuedAt = now.minusSeconds(3600),
+            expiresAt = now.plusSeconds(testClient.refreshTokenTtl.toSeconds),
+            requestedClaims = Some(requestedClaims1),
+            uiLocales = Some(uiLocales1),
+            nonce = None,
+            amr = amr1,
+            authTime = authTime1,
+            acr = None,
+          )
+
+          newRefreshToken = RefreshToken(Array.fill(32)(7.toByte))
+
+          _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
+          _ <- env.securityService.mac.succeedsWith(refreshTokenMac1)
+          _ <- env.tokenRepo.findToken.succeedsWith(Some(tokenRecord))
+          _ <- env.propertyGenerator.nextAccessToken.succeedsWith(accessToken1)
+          _ <- env.propertyGenerator.nextRefreshToken.succeedsWith(newRefreshToken)
+          _ <- env.tokenRepo.createRefreshToken.failsWith(RefreshAlreadyExchanged())
+          _ <- env.tokenRepo.revokeFamily.succeedsWith(None)
 
           request = RefreshTokenRequest(refreshToken1, None, None, None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
@@ -786,6 +835,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           result <- env.service.refreshAccessToken(request, credentials).either
         yield assertTrue(
           result == Left(TokenEndpointError.InvalidGrant.RefreshChainAlreadyExchanged),
+          env.accessTokenRevocationService.revoke.calls.isEmpty,
         )
       },
     ),

--- a/auth/src/test/scala/versola/oauth/token/TokenEndpointControllerSpec.scala
+++ b/auth/src/test/scala/versola/oauth/token/TokenEndpointControllerSpec.scala
@@ -164,7 +164,7 @@ object TokenEndpointControllerSpec extends UnitSpecBase:
         ).addHeader(authHeader(clientId1, Some(clientSecret1))),
         expectedStatus = Status.BadRequest,
         setup = services =>
-          services.oauthTokenService.exchangeAuthorizationCode.failsWith(TokenEndpointError.InvalidGrant),
+          services.oauthTokenService.exchangeAuthorizationCode.failsWith(TokenEndpointError.InvalidGrant.CodeNotFound),
         verify = response =>
           for
             body <- response.body.asString
@@ -233,7 +233,7 @@ object TokenEndpointControllerSpec extends UnitSpecBase:
         ).addHeader(authHeader(clientId1, Some(clientSecret1))),
         expectedStatus = Status.BadRequest,
         setup = services =>
-          services.oauthTokenService.refreshAccessToken.failsWith(TokenEndpointError.InvalidGrant),
+          services.oauthTokenService.refreshAccessToken.failsWith(TokenEndpointError.InvalidGrant.RefreshTokenNotFound),
         verify = response =>
           for
             body <- response.body.asString
@@ -276,7 +276,7 @@ object TokenEndpointControllerSpec extends UnitSpecBase:
         ).addHeader(authHeader(clientId1, Some(clientSecret1))),
         expectedStatus = Status.BadRequest,
         setup = services =>
-          services.oauthTokenService.refreshAccessToken.failsWith(TokenEndpointError.InvalidGrant),
+          services.oauthTokenService.refreshAccessToken.failsWith(TokenEndpointError.InvalidGrant.RefreshTokenReplayed),
         verify = response =>
           for
             body <- response.body.asString

--- a/auth/src/test/scala/versola/oauth/token/TokenEndpointControllerSpec.scala
+++ b/auth/src/test/scala/versola/oauth/token/TokenEndpointControllerSpec.scala
@@ -29,6 +29,7 @@ object TokenEndpointControllerSpec extends UnitSpecBase:
   val redirectUri = "https://example.com/callback"
   val accessToken1 = AccessToken(Array.fill(32)(2.toByte))
   val refreshToken1 = RefreshToken(Array.fill(32)(3.toByte))
+  val refreshToken2 = RefreshToken(Array.fill(32)(4.toByte))
   val scope1 = Set(ScopeToken("read"), ScopeToken("write"), ScopeToken.OfflineAccess)
   val clientSecret1 = Secret(Array.fill(32)(4.toByte))
 
@@ -62,6 +63,29 @@ object TokenEndpointControllerSpec extends UnitSpecBase:
       userInfoService: Stub[UserInfoService],
   )
 
+  /** Stands the endpoint up over stubbed services and hands back the client and the stubs, so
+    * a test can drive more than one request against the same server. */
+  def withTokenEndpoint[A](use: (Client, Services) => ZIO[Scope, Throwable, A]): ZIO[Client & TestClient & Scope, Throwable, A] =
+    for
+      client <- ZIO.service[Client]
+      tokenService = stub[OAuthTokenService]
+      clientService = stub[OAuthConfigurationService]
+      userInfoService = stub[UserInfoService]
+      config = TestEnvConfig.coreConfig
+      jwksService = TestEnvConfig.jwksService
+      tracing <- NoopTracing.layer.build
+
+      services = Services(tokenService, userInfoService)
+
+      _ <- TestClient.addRoutes(
+        Observability.handleErrors(
+          TokenEndpointController.routes
+            .provideEnvironment(ZEnvironment(tokenService) ++ ZEnvironment(clientService) ++ ZEnvironment(userInfoService) ++ ZEnvironment(jwksService) ++ ZEnvironment(config) ++ tracing)
+        )
+      )
+      result <- use(client, services)
+    yield result
+
   def tokenEndpointTestCase(
       description: String,
       request: Request,
@@ -70,28 +94,12 @@ object TokenEndpointControllerSpec extends UnitSpecBase:
       verify: Response => Task[TestResult] = _ => ZIO.succeed(assertTrue(true)),
   ) =
     test(description) {
-      for
-        client <- ZIO.service[Client]
-        tokenService = stub[OAuthTokenService]
-        clientService = stub[OAuthConfigurationService]
-        userInfoService = stub[UserInfoService]
-        config = TestEnvConfig.coreConfig
-        jwksService = TestEnvConfig.jwksService
-        tracing <- NoopTracing.layer.build
-
-        services = Services(tokenService, userInfoService)
-
-        _ <- TestClient.addRoutes(
-          Observability.handleErrors(
-            TokenEndpointController.routes
-              .provideEnvironment(ZEnvironment(tokenService) ++ ZEnvironment(clientService) ++ ZEnvironment(userInfoService) ++ ZEnvironment(jwksService) ++ ZEnvironment(config) ++ tracing)
-          )
-        )
-        _ <- setup(services)
-
-        response <- client.batched(request)
-        verifyResult <- verify(response)
-      yield assertTrue(response.status == expectedStatus) && verifyResult
+      withTokenEndpoint: (client, services) =>
+        for
+          _ <- setup(services)
+          response <- client.batched(request)
+          verifyResult <- verify(response)
+        yield assertTrue(response.status == expectedStatus) && verifyResult
     }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging
 
   val spec = suite("TokenEndpointController")(
@@ -284,6 +292,63 @@ object TokenEndpointControllerSpec extends UnitSpecBase:
             body.contains("invalid_grant"),
           ),
       ),
+    ),
+    suite("POST /token - Idempotency-Key")(
+      {
+        def refreshRequest(idempotencyKey: Option[String]) =
+          val request = Request.post(
+            url = URL.empty / "token",
+            body = Body.fromURLEncodedForm(
+              Form.fromStrings(
+                "grant_type" -> "refresh_token",
+                "refresh_token" -> Base64.urlEncode(refreshToken1),
+              )
+            ),
+          ).addHeader(authHeader(clientId1, Some(clientSecret1)))
+          idempotencyKey.fold(request)(request.addHeader("Idempotency-Key", _))
+
+        def headerTest(description: String)(
+            run: (Client, Services) => ZIO[Scope, Throwable, TestResult],
+        ) =
+          test(description) {
+            withTokenEndpoint(run)
+          }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging
+
+        List(
+          headerTest("the header reaches the service, which decides what it means") { (client, services) =>
+            for
+              _ <- services.oauthTokenService.refreshAccessToken.succeedsWith(issuedTokens)
+              response <- client.batched(refreshRequest(Some("key-1")))
+              keys = services.oauthTokenService.refreshAccessToken.calls.map(_._3)
+            yield assertTrue(response.status == Status.Ok, keys == List(Some("key-1")))
+          },
+          headerTest("no header means no key") { (client, services) =>
+            for
+              _ <- services.oauthTokenService.refreshAccessToken.succeedsWith(issuedTokens)
+              _ <- client.batched(refreshRequest(None))
+              keys = services.oauthTokenService.refreshAccessToken.calls.map(_._3)
+            yield assertTrue(keys == List(None))
+          },
+          headerTest("the header is ignored for grants other than refresh_token") { (client, services) =>
+            val codeRequest = Request.post(
+              url = URL.empty / "token",
+              body = Body.fromURLEncodedForm(
+                Form.fromStrings(
+                  "grant_type" -> "authorization_code",
+                  "code" -> Base64.urlEncode(authCode1),
+                  "redirect_uri" -> "https://client.example.com/callback",
+                  "code_verifier" -> codeVerifier1,
+                )
+              ),
+            ).addHeader(authHeader(clientId1, Some(clientSecret1))).addHeader("Idempotency-Key", "key-1")
+
+            for
+              _ <- services.oauthTokenService.exchangeAuthorizationCode.succeedsWith(issuedTokens)
+              response <- client.batched(codeRequest)
+            yield assertTrue(response.status == Status.Ok)
+          },
+        )
+      }*
     ),
     suite("POST /token - client_credentials grant")(
       tokenEndpointTestCase(

--- a/e2e/src/test/scala/versola/e2e/flows/basic/RefreshRetryFlowSpec.scala
+++ b/e2e/src/test/scala/versola/e2e/flows/basic/RefreshRetryFlowSpec.scala
@@ -1,0 +1,162 @@
+package versola.e2e.flows.basic
+
+import versola.e2e.support.{*, given}
+import zio.*
+import zio.http.Status
+import zio.test.*
+
+/** Rotation is single-use, so a client whose response never arrived is holding a token the
+  * server has already retired. Presenting it again is indistinguishable from a replay, and
+  * costs the user the whole session -- for a dropped connection rather than a leak.
+  *
+  * An `Idempotency-Key` is what tells the two apart. These exercise it against the real
+  * endpoint, since the interesting part is that reuse detection still bites for everyone who
+  * cannot produce the key.
+  */
+object RefreshRetryFlowSpec extends E2ESpec:
+
+  /** Logs in and exchanges the code for a first refresh token. */
+  private def login(s: Flows.Setup, auth: OAuthClient): Task[String] =
+    for
+      authorize <- auth.authorize(
+        clientId = Some(s.clientId),
+        redirectUri = Some(s.redirectUri),
+        scope = "openid email offline_access",
+      ).assertChallengeRedirect
+      cookie = authorize.conversationCookie.get
+      challenge <- auth.getChallenge(cookie).assertStep(ConversationStep.Credential)
+      code <- auth.submitLoginPassword(cookie, s.login.get, s.password, challenge.csrf).assertRedirect(auth, cookie)
+      token <- auth.token(
+        code,
+        authorize.verifier,
+        clientId = Some(s.clientId),
+        clientSecret = Some(s.clientSecret),
+        redirectUri = Some(s.redirectUri),
+      ).success
+      refreshToken <- ZIO.fromOption(token.refreshToken)
+        .orElseFail(RuntimeException("expected a refresh_token for the offline_access scope"))
+    yield refreshToken
+
+  def spec = suite("RefreshRetryFlowSpec")(
+    test("a retry under the same key is served instead of killing the session") {
+      for
+        (s, auth) <- setup(Flows.Id.LoginPassword)
+        refreshToken <- login(s, auth)
+
+        // The exchange whose response the client never sees.
+        first <- auth.refresh(
+          refreshToken,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+          idempotencyKey = Some("retry-key-1"),
+        ).success
+
+        // The client is still holding the token it started with, and tries again.
+        retry <- auth.refresh(
+          refreshToken,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+          idempotencyKey = Some("retry-key-1"),
+        ).success
+
+        // The token it is finally given has to work, which is the whole point.
+        continued <- auth.refresh(
+          retry.refreshToken.get,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+        ).success
+      yield assertTrue(
+        // A fresh token rather than the one that went missing: the original was never stored.
+        retry.refreshToken.isDefined,
+        retry.refreshToken != first.refreshToken,
+        continued.refreshToken.isDefined,
+      )
+    },
+    test("a client that retries repeatedly is still served") {
+      for
+        (s, auth) <- setup(Flows.Id.LoginPassword)
+        refreshToken <- login(s, auth)
+
+        // A backoff loop routinely gets this far, so honouring only the first retry would
+        // mean the feature never survives contact with a bad connection.
+        attempts <- ZIO.foreach(1 to 3): _ =>
+          auth.refresh(
+            refreshToken,
+            clientId = Some(s.clientId),
+            clientSecret = Some(s.clientSecret),
+            idempotencyKey = Some("retry-key-2"),
+          ).success
+
+        last = attempts.last
+        continued <- auth.refresh(
+          last.refreshToken.get,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+        ).success
+      yield assertTrue(
+        attempts.forall(_.refreshToken.isDefined),
+        attempts.map(_.refreshToken).distinct.size == 3,
+        continued.refreshToken.isDefined,
+      )
+    },
+    test("the same token without the key is still treated as a replay") {
+      for
+        (s, auth) <- setup(Flows.Id.LoginPassword)
+        refreshToken <- login(s, auth)
+
+        rotated <- auth.refresh(
+          refreshToken,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+          idempotencyKey = Some("retry-key-3"),
+        ).success
+
+        // Whoever presents the retired token without the key cannot be the client that made
+        // the request, so this is reuse and the chain goes.
+        replayed <- auth.refresh(
+          refreshToken,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+        )
+
+        // And the revocation is real: the successor the replay condemned is dead too.
+        successor <- auth.refresh(
+          rotated.refreshToken.get,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+        )
+      yield assertTrue(
+        replayed.response.status == Status.BadRequest,
+        successor.response.status == Status.BadRequest,
+      )
+    },
+    test("a key stops working once the client gets through and moves on") {
+      for
+        (s, auth) <- setup(Flows.Id.LoginPassword)
+        refreshToken <- login(s, auth)
+
+        rotated <- auth.refresh(
+          refreshToken,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+          idempotencyKey = Some("retry-key-4"),
+        ).success
+
+        // The client received this one and carried on under a new key, which settles the
+        // earlier attempt: the old key must not still be a way back into the chain.
+        _ <- auth.refresh(
+          rotated.refreshToken.get,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+          idempotencyKey = Some("retry-key-5"),
+        ).success
+
+        stale <- auth.refresh(
+          refreshToken,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+          idempotencyKey = Some("retry-key-4"),
+        )
+      yield assertTrue(stale.response.status == Status.BadRequest)
+    },
+  ) @@ TestAspect.sequential

--- a/e2e/src/test/scala/versola/e2e/support/OAuthClient.scala
+++ b/e2e/src/test/scala/versola/e2e/support/OAuthClient.scala
@@ -621,6 +621,7 @@ final class OAuthClient(client: Client, config: E2EConfig):
       clientId: Option[String] = None,
       clientSecret: Option[String] = None,
       scope: Option[String] = None,
+      idempotencyKey: Option[String] = None,
   ): Task[TokenResult] =
     val effectiveClientId = clientId.getOrElse(config.clientId)
     val effectiveClientSecret = clientSecret.getOrElse(throw IllegalArgumentException("clientSecret must be provided for token requests"))
@@ -631,7 +632,8 @@ final class OAuthClient(client: Client, config: E2EConfig):
     val req = Request.post(s"${config.authUrl}/token", body)
       .addHeader(Authorization.Basic(effectiveClientId, effectiveClientSecret))
       .addHeader(Header.ContentType(MediaType.application.`x-www-form-urlencoded`))
-    Client.batched(req).provide(ZLayer.succeed(client)).flatMap(TokenResult.parse)
+    val withKey = idempotencyKey.fold(req)(req.addHeader("Idempotency-Key", _))
+    Client.batched(withKey).provide(ZLayer.succeed(client)).flatMap(TokenResult.parse)
 
   /** POST /introspect — introspects a token (access or refresh) per RFC 7662. */
   def introspect(

--- a/util/src/main/scala/versola/util/http/Observability.scala
+++ b/util/src/main/scala/versola/util/http/Observability.scala
@@ -86,16 +86,6 @@ object Observability:
   def setError(code: String, description: Option[String] = None): UIO[Unit] =
     logContext.update(_.annotate(error, ErrorDetails(code, description)))
 
-  /** Like [[setError]], but a no-op if the error context was already filled in earlier in
-    * this request. Lets a service-layer detector record a more specific description than
-    * the generic default an endpoint's `catchAll` falls back to for the same error code,
-    * without that fallback clobbering it once the failure reaches the controller boundary. */
-  def setErrorIfAbsent(code: String, description: Option[String] = None): UIO[Unit] =
-    logContext.update: context =>
-      context.get(error) match
-        case Some(_) => context
-        case None    => context.annotate(error, ErrorDetails(code, description))
-
   val clientLogging: FiberRef[HttpObservabilityConfig.Client] = zio.Unsafe.unsafe { case given zio.Unsafe =>
     FiberRef.unsafe.make(HttpObservabilityConfig.Client.default)
   }

--- a/util/src/main/scala/versola/util/http/Observability.scala
+++ b/util/src/main/scala/versola/util/http/Observability.scala
@@ -86,6 +86,16 @@ object Observability:
   def setError(code: String, description: Option[String] = None): UIO[Unit] =
     logContext.update(_.annotate(error, ErrorDetails(code, description)))
 
+  /** Like [[setError]], but a no-op if the error context was already filled in earlier in
+    * this request. Lets a service-layer detector record a more specific description than
+    * the generic default an endpoint's `catchAll` falls back to for the same error code,
+    * without that fallback clobbering it once the failure reaches the controller boundary. */
+  def setErrorIfAbsent(code: String, description: Option[String] = None): UIO[Unit] =
+    logContext.update: context =>
+      context.get(error) match
+        case Some(_) => context
+        case None    => context.annotate(error, ErrorDetails(code, description))
+
   val clientLogging: FiberRef[HttpObservabilityConfig.Client] = zio.Unsafe.unsafe { case given zio.Unsafe =>
     FiberRef.unsafe.make(HttpObservabilityConfig.Client.default)
   }


### PR DESCRIPTION
Fixes #237.

## What

Presenting a refresh token that was already exchanged proves the chain leaked. It now revokes the entire rotation family instead of returning a bare `invalid_grant` and leaving the live tip working for its full TTL.

The first version of this PR reused `previous_id` to avoid a migration. Review found three holes in that (see the threads); all three are addressed here.

## Schema (`V0004` edited in place, pre-1.0)

- `+ family_id BYTEA NOT NULL` — the id of the chain's root; a fresh token is its own family.
- `+ rotated_at TIMESTAMPTZ` — rotation retires the predecessor in place rather than deleting it. The row is unusable (`findToken` requires `rotated_at IS NULL`) but still resolves to its family.
- `+ idempotency_key BYTEA` — see the retry section below.
- `- previous_id`

Deployed databases need a reset or a `flyway repair`.

## How the three holes close

**Depth.** Deleting the predecessor meant only one generation was ever visible: after `r1 -> r2 -> r3`, replaying `r1` matched nothing while `r3` stayed live. Retired rows now persist, so any generation resolves to its family and the whole family is expired at once, with every access token still inside its TTL (filtered by `issued_at`, since access-token expiry is not stored) pushed to the client's back channel.

**Concurrency.** The root row is the family's lock; rotation and revocation both take it before touching any member. Locking the presented token would not be enough — at READ COMMITTED, which this repository uses, a family-wide `UPDATE` cannot see a child inserted concurrently. Rotation extends the root's `expires_at` so the sweep cannot collect the anchor mid-family, and a missing root fails closed.

**Lost rotation race.** `RefreshAlreadyExchanged` routes into the same revocation: the same token presented twice concurrently is as proven a leak as the sequential case.

The single-child guarantee `UNIQUE(previous_id)` gave is now the root lock plus a conditional retire (zero rows means lost), which additionally covers the revocation race the index never did. Generation order remains recoverable from `issued_at`. `delete` and `deleteByAccessToken` become soft expiries, matching every other invalidate here, so a family cannot lose its anchor early.

## Retention of retired rows

Retiring a token sets its `expires_at` to a fixed **24h** window rather than the successor's expiry. `expires_at` on a retired row is not "when this token stops working" — `rotated_at` is — it is how long the row survives the cleanup sweep so a replay still resolves to its family. Tying that to `refresh_token_ttl` (90d by default) made retained rows outlive their usefulness by up to that TTL: steady-state size scaled with rotations-per-90-days instead of rotations-per-day, ~90x more rows at an hourly refresh cadence. A replay older than the window falls back to a plain `invalid_grant` with no revocation.

## Retrying a refresh whose response was lost

Family-wide revocation created a problem it is worth being explicit about: a client whose response is lost in flight still holds a token the server retired, and retrying it is indistinguishable from a replay. Before this PR that cost one failed request; after it, the user's session. At one refresh per access-token TTL that is routine on mobile, not a corner case.

Clients may now send an `Idempotency-Key`. It is MAC'd onto the row being retired; a retired token presented again under the same key continues the chain from the family's live tip rather than being read as reuse. The response is **not** reproduced — the token inside it was never stored — so a fresh one is minted, which also avoids replaying an access token that has since expired.

The key is a second secret alongside the token, which is what keeps this from weakening detection: anyone holding the token *without* it still trips reuse detection and still loses the family. Only one row per family carries a key at a time, each retry moving it onto the exchange it performs, so matching the key is the same question as "has the chain moved on". That is what lets a client retry repeatedly — a backoff loop routinely needs more than one attempt — while a refresh under a different key, the client having got through, strands the old key and restores detection. Nothing expires or is swept to make that hold.

An earlier draft cached the encrypted response instead and replayed it verbatim. It was dropped: it stored bearer credentials at rest, needed its own table and sweep, and handed back an access token that was often already expired by the time the retry arrived.

## Testing

Postgres integration (`PostgresRefreshTokenRepositorySpec`, live PG 15, 20 tests): replay two generations back kills the tip; live and unknown tokens are ignored; cross-client lookup is a no-op; access tokens past their TTL are left out; rotation after revocation fails; a rotation run in parallel with a revocation never leaves a live successor; repeat revocation is idempotent. For retries: the tip is returned when the key names the family's last exchange; unknown keys, other clients' keys and revoked families are refused; **repeated** retries keep working; a key stops being honoured once the chain moves on.

Unit (`OAuthTokenServiceSpec`, `TokenEndpointControllerSpec`): sequential replay revokes every access token the family issued; the lost race revokes when the family is found; a retry under a matching key continues from the tip and revokes nothing; the same token without a key still revokes; two retries racing each other do not revoke; the header reaches the service and is ignored for other grants.

Full suite green: util 72, util-postgres 36, auth 849, auth-postgres 144, edge 195, central 365.

`RefreshRetryFlowSpec` covers the flow end-to-end against the real endpoint. It compiles and is wired for CI, but I could not execute it locally — the e2e suite needs central+auth+edge staged, and `scala-cli` for the env configs is not available in my environment.

## Not done

A client that acts on a response arriving *after* a retry already succeeded is holding a superseded token, and presenting it is a genuine replay. True idempotency (replaying identical bytes) would be immune; this design is not. It needs a client to honour a request it had already timed out on, and the outcome is the re-login it would have had anyway. Documented on the endpoint rather than engineered around.

Authorization-code exchange has the same lost-response problem and is not covered here.