### PR TITLE
test: raise backend statement coverage from 75.6% to 81.1%

### DIFF
--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
@@ -30,7 +30,8 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
     accessTokenTtl = 1.hour,
     refreshTokenTtl = 30.days,
     theme = "default",
-    authFlow = Some(AuthFlow.default.copy(primary = AuthFlow.default.primary.copy(credentials = List(PrimaryCredential.email, PrimaryCredential.phone)))),
+    authFlow =
+      Some(AuthFlow.default.copy(primary = AuthFlow.default.primary.copy(credentials = List(PrimaryCredential.email, PrimaryCredential.phone)))),
     registrationFlow = None,
     otpTemplateId = "default",
     frontChannelLogoutUri = None,
@@ -87,7 +88,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
     "scope" -> "openid profile",
     "state" -> "test-state",
     "code_challenge" -> "a" * 43,
-    "code_challenge_method" -> "S256"
+    "code_challenge_method" -> "S256",
   )
 
   private val requestUriReference = RequestUriReference(Array.fill(32)(6.toByte))
@@ -103,8 +104,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request)
-        yield
-          assertTrue(result.clientId == clientId) &&
+        yield assertTrue(result.clientId == clientId) &&
           assertTrue(result.redirectUri == redirectUri) &&
           assertTrue(result.scope == Set(ScopeToken("openid"), ScopeToken("profile"))) &&
           assertTrue(result.state.contains(State("test-state")))
@@ -122,8 +122,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         val request = Request.get(URL.root.addQueryParams(validParams - "client_id"))
         for
           result <- env.parser.parse(request).either
-        yield
-          assertTrue(result == Left(Error.BadRequest))
+        yield assertTrue(result == Left(Error.BadRequest))
       },
       test("fails when redirect_uri is not whitelisted") {
         val env = Env()
@@ -131,8 +130,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request).either
-        yield
-          assertTrue(result == Left(Error.BadRequest))
+        yield assertTrue(result == Left(Error.BadRequest))
       },
       test("successfully parses prompt parameter") {
         val env = Env()
@@ -140,86 +138,97 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request)
-        yield
-          assertTrue(result.prompt == Set(Prompt.login, Prompt.consent))
-      }
+        yield assertTrue(result.prompt == Set(Prompt.login, Prompt.consent))
+      },
     ),
-      test("retains a registered resource URI for the access-token audience") {
-        val env = Env()
-        val resourceUri = ResourceUri("https://api.example.com")
-        val request = Request.get(URL.root.addQueryParams(validParams + ("resource" -> resourceUri)))
-        for
-          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
-          _ <- env.configuration.findResource.succeedsWith(Some(ResourceRecord(ResourceId("api"), tenantId, resourceUri, List(clientId), internal = false)))
-          result <- env.parser.parse(request)
-        yield assertTrue(result.resources == List(resourceUri))
-      },
-      test("uses public resources and edge when resource is omitted") {
-        val env = Env()
-        val publicResource = ResourceUri("https://api.example.com")
-        val edgeResource = ResourceUri("resource://edge")
-        val resources = List(
+    test("retains a registered resource URI for the access-token audience") {
+      val env = Env()
+      val resourceUri = ResourceUri("https://api.example.com")
+      val request = Request.get(URL.root.addQueryParams(validParams + ("resource" -> resourceUri)))
+      for
+        _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+        _ <- env.configuration.findResource.succeedsWith(Some(ResourceRecord(
+          ResourceId("api"),
+          tenantId,
+          resourceUri,
+          List(clientId),
+          internal = false,
+        )))
+        result <- env.parser.parse(request)
+      yield assertTrue(result.resources == List(resourceUri))
+    },
+    test("uses public resources and edge when resource is omitted") {
+      val env = Env()
+      val publicResource = ResourceUri("https://api.example.com")
+      val edgeResource = ResourceUri("resource://edge")
+      val resources = List(
+        ResourceRecord(ResourceId("api"), tenantId, publicResource, List(clientId), internal = false),
+        ResourceRecord(ResourceId("internal"), tenantId, ResourceUri("https://internal.example.com"), List(clientId), internal = true),
+        ResourceRecord(ResourceId("reports"), tenantId, ResourceUri("https://reports.internal.example.com"), List(clientId), internal = true),
+      )
+      val request = Request.get(URL.root.addQueryParams(validParams))
+      for
+        _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+        _ <- env.configuration.getResourcesForClient.succeedsWith(resources)
+        result <- env.parser.parse(request)
+      yield assertTrue(result.resources == List(publicResource, edgeResource))
+    },
+    test("uses edge when resource is omitted and no internal resources are available") {
+      val env = Env()
+      val publicResource = ResourceUri("https://api.example.com")
+      val request = Request.get(URL.root.addQueryParams(validParams))
+      for
+        _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+        _ <- env.configuration.getResourcesForClient.succeedsWith(List(
           ResourceRecord(ResourceId("api"), tenantId, publicResource, List(clientId), internal = false),
-          ResourceRecord(ResourceId("internal"), tenantId, ResourceUri("https://internal.example.com"), List(clientId), internal = true),
-          ResourceRecord(ResourceId("reports"), tenantId, ResourceUri("https://reports.internal.example.com"), List(clientId), internal = true),
-        )
-        val request = Request.get(URL.root.addQueryParams(validParams))
-        for
-          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
-          _ <- env.configuration.getResourcesForClient.succeedsWith(resources)
-          result <- env.parser.parse(request)
-        yield assertTrue(result.resources == List(publicResource, edgeResource))
-      },
-      test("uses edge when resource is omitted and no internal resources are available") {
-        val env = Env()
-        val publicResource = ResourceUri("https://api.example.com")
-        val request = Request.get(URL.root.addQueryParams(validParams))
-        for
-          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
-          _ <- env.configuration.getResourcesForClient.succeedsWith(List(
-            ResourceRecord(ResourceId("api"), tenantId, publicResource, List(clientId), internal = false),
-          ))
-          result <- env.parser.parse(request)
-        yield assertTrue(result.resources == List(publicResource, ResourceUri("resource://edge")))
-      },
-      test("resolves an internal resource indicator by resource ID") {
-        val env = Env()
-        val resourceId = ResourceId("internal-api")
-        val resourceUri = ResourceUri(s"resource://$resourceId")
-        val request = Request.get(URL.root.addQueryParams(validParams + ("resource" -> resourceUri)))
-        for
-          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
-          _ <- env.configuration.findResourceById.succeedsWith(Some(ResourceRecord(resourceId, tenantId, ResourceUri("https://internal.example.com"), List(clientId), internal = true)))
-          result <- env.parser.parse(request)
-        yield assertTrue(
-          result.resources == List(ResourceUri("resource://internal-api")),
-          env.configuration.findResourceById.calls == List((tenantId, resourceId)),
-        )
-      },
-      test("accepts an explicit edge resource") {
-        val env = Env()
-        val edgeResource = ResourceUri("resource://edge")
-        val request = Request.get(URL.root.addQueryParams(validParams + ("resource" -> edgeResource)))
-        for
-          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
-          result <- env.parser.parse(request)
-        yield assertTrue(result.resources == List(edgeResource))
-      },
-      test("rejects edge when combined with an explicit internal resource") {
-        val env = Env()
-        val edgeResource = ResourceUri("resource://edge")
-        val internalResource = ResourceUri("resource://internal-api")
-        val request = Request.post(
-          URL.root,
-          Body.fromURLEncodedForm(Form.fromStrings(
-            (validParams.toSeq ++ Seq("resource" -> edgeResource, "resource" -> internalResource))*
-          )),
-        )
-        for
-          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
-          result <- env.parser.parse(request).either
-        yield assertTrue(result == Left(Error.InvalidTarget(redirectUri, Some(State("test-state")), edgeResource.toString)))
-      },
+        ))
+        result <- env.parser.parse(request)
+      yield assertTrue(result.resources == List(publicResource, ResourceUri("resource://edge")))
+    },
+    test("resolves an internal resource indicator by resource ID") {
+      val env = Env()
+      val resourceId = ResourceId("internal-api")
+      val resourceUri = ResourceUri(s"resource://$resourceId")
+      val request = Request.get(URL.root.addQueryParams(validParams + ("resource" -> resourceUri)))
+      for
+        _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+        _ <- env.configuration.findResourceById.succeedsWith(Some(ResourceRecord(
+          resourceId,
+          tenantId,
+          ResourceUri("https://internal.example.com"),
+          List(clientId),
+          internal = true,
+        )))
+        result <- env.parser.parse(request)
+      yield assertTrue(
+        result.resources == List(ResourceUri("resource://internal-api")),
+        env.configuration.findResourceById.calls == List((tenantId, resourceId)),
+      )
+    },
+    test("accepts an explicit edge resource") {
+      val env = Env()
+      val edgeResource = ResourceUri("resource://edge")
+      val request = Request.get(URL.root.addQueryParams(validParams + ("resource" -> edgeResource)))
+      for
+        _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+        result <- env.parser.parse(request)
+      yield assertTrue(result.resources == List(edgeResource))
+    },
+    test("rejects edge when combined with an explicit internal resource") {
+      val env = Env()
+      val edgeResource = ResourceUri("resource://edge")
+      val internalResource = ResourceUri("resource://internal-api")
+      val request = Request.post(
+        URL.root,
+        Body.fromURLEncodedForm(Form.fromStrings(
+          (validParams.toSeq ++ Seq("resource" -> edgeResource, "resource" -> internalResource))*,
+        )),
+      )
+      for
+        _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+        result <- env.parser.parse(request).either
+      yield assertTrue(result == Left(Error.InvalidTarget(redirectUri, Some(State("test-state")), edgeResource.toString)))
+    },
     suite("parse POST")(
       test("successfully parses valid form-urlencoded request") {
         val env = Env()
@@ -227,49 +236,48 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request)
-        yield
-          assertTrue(result.clientId == clientId)
-        },
-        test("retains repeated resource parameters") {
-          val env = Env()
-          val first = ResourceUri("https://api.example.com")
-          val second = ResourceUri("https://reports.example.com")
-          val body = (validParams.toSeq ++ Seq("resource" -> first, "resource" -> second))
-            .map((name, value) => s"$name=${java.net.URLEncoder.encode(value, java.nio.charset.StandardCharsets.UTF_8)}")
-            .mkString("&")
-          val request = Request.post(URL.root, Body.fromString(body))
-            .addHeader(Header.ContentType(MediaType.application.`x-www-form-urlencoded`))
-          for
-            _ <- env.configuration.find.succeedsWith(Some(clientRecord))
-            _ <- env.configuration.findResource.returnsZIO { case (_, resource) =>
-              ZIO.succeed(Map(
-                first -> ResourceRecord(ResourceId("resource"), tenantId, first, List(clientId), internal = false),
-                second -> ResourceRecord(ResourceId("reports"), tenantId, second, List(clientId), internal = false),
-              ).get(resource))
-            }
-            result <- env.parser.parse(request)
-          yield assertTrue(result.resources == List(first, second))
-        },
-        test("splits a single comma-joined resource field, as zio-http produces from a repeated form field") {
-          val env = Env()
-          val first = ResourceUri("https://api.example.com")
-          val second = ResourceUri("resource://internal-api")
-          val body = (validParams.toSeq ++ Seq("resource" -> s"$first,$second"))
-            .map((name, value) => s"$name=${java.net.URLEncoder.encode(value, java.nio.charset.StandardCharsets.UTF_8)}")
-            .mkString("&")
-          val request = Request.post(URL.root, Body.fromString(body))
-            .addHeader(Header.ContentType(MediaType.application.`x-www-form-urlencoded`))
-          for
-            _ <- env.configuration.find.succeedsWith(Some(clientRecord))
-            _ <- env.configuration.findResource.succeedsWith(
-              Some(ResourceRecord(ResourceId("resource"), tenantId, first, List(clientId), internal = false)),
-            )
-            _ <- env.configuration.findResourceById.succeedsWith(
-              Some(ResourceRecord(ResourceId("internal-api"), tenantId, ResourceUri("https://internal.example.com"), List(clientId), internal = true)),
-            )
-            result <- env.parser.parse(request)
-          yield assertTrue(result.resources == List(first, second))
-        },
+        yield assertTrue(result.clientId == clientId)
+      },
+      test("retains repeated resource parameters") {
+        val env = Env()
+        val first = ResourceUri("https://api.example.com")
+        val second = ResourceUri("https://reports.example.com")
+        val body = (validParams.toSeq ++ Seq("resource" -> first, "resource" -> second))
+          .map((name, value) => s"$name=${java.net.URLEncoder.encode(value, java.nio.charset.StandardCharsets.UTF_8)}")
+          .mkString("&")
+        val request = Request.post(URL.root, Body.fromString(body))
+          .addHeader(Header.ContentType(MediaType.application.`x-www-form-urlencoded`))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.findResource.returnsZIO { case (_, resource) =>
+            ZIO.succeed(Map(
+              first -> ResourceRecord(ResourceId("resource"), tenantId, first, List(clientId), internal = false),
+              second -> ResourceRecord(ResourceId("reports"), tenantId, second, List(clientId), internal = false),
+            ).get(resource))
+          }
+          result <- env.parser.parse(request)
+        yield assertTrue(result.resources == List(first, second))
+      },
+      test("splits a single comma-joined resource field, as zio-http produces from a repeated form field") {
+        val env = Env()
+        val first = ResourceUri("https://api.example.com")
+        val second = ResourceUri("resource://internal-api")
+        val body = (validParams.toSeq ++ Seq("resource" -> s"$first,$second"))
+          .map((name, value) => s"$name=${java.net.URLEncoder.encode(value, java.nio.charset.StandardCharsets.UTF_8)}")
+          .mkString("&")
+        val request = Request.post(URL.root, Body.fromString(body))
+          .addHeader(Header.ContentType(MediaType.application.`x-www-form-urlencoded`))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.findResource.succeedsWith(
+            Some(ResourceRecord(ResourceId("resource"), tenantId, first, List(clientId), internal = false)),
+          )
+          _ <- env.configuration.findResourceById.succeedsWith(
+            Some(ResourceRecord(ResourceId("internal-api"), tenantId, ResourceUri("https://internal.example.com"), List(clientId), internal = true)),
+          )
+          result <- env.parser.parse(request)
+        yield assertTrue(result.resources == List(first, second))
+      },
     ),
     suite("authorization_details")(
       test("retains details that satisfy the registered type schema") {
@@ -337,7 +345,8 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
       },
       test("rejects a location that is not a registered resource") {
         val env = Env()
-        val details = """[{"type":"payment_initiation","instructedAmount":{"currency":"EUR","amount":"1.00"},"locations":["https://unknown.example.com"]}]"""
+        val details =
+          """[{"type":"payment_initiation","instructedAmount":{"currency":"EUR","amount":"1.00"},"locations":["https://unknown.example.com"]}]"""
         val request = Request.get(URL.root.addQueryParams(validParams + ("authorization_details" -> details)))
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
@@ -379,7 +388,8 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         val env = Env()
         val edgeResource = ResourceUri("resource://edge")
         val internalResource = ResourceUri("resource://internal-api")
-        val details = s"""[{"type":"payment_initiation","instructedAmount":{"currency":"EUR","amount":"1.00"},"locations":["$edgeResource","$internalResource"]}]"""
+        val details =
+          s"""[{"type":"payment_initiation","instructedAmount":{"currency":"EUR","amount":"1.00"},"locations":["$edgeResource","$internalResource"]}]"""
         val request = Request.get(URL.root.addQueryParams(validParams + ("authorization_details" -> details)))
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
@@ -400,8 +410,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request)
-        yield
-          assertTrue(result.state.contains(State(state)))
+        yield assertTrue(result.state.contains(State(state)))
       },
       test("fails when state exceeds the maximum allowed length") {
         val env = Env()
@@ -410,9 +419,8 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request).either
-        yield
-          assertTrue(result == Left(Error.StateInvalid(redirectUri)))
-      }
+        yield assertTrue(result == Left(Error.StateInvalid(redirectUri)))
+      },
     ),
     suite("code_challenge_method")(
       test("accepts S256") {
@@ -421,8 +429,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request)
-        yield
-          assertTrue(result.codeChallengeMethod == CodeChallengeMethod.S256)
+        yield assertTrue(result.codeChallengeMethod == CodeChallengeMethod.S256)
       },
       test("rejects plain, which FAPI 2.0 and OAuth 2.1 forbid") {
         val env = Env()
@@ -430,8 +437,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request).either
-        yield
-          assertTrue(result == Left(Error.CodeChallengeMethodInvalid(redirectUri, Some(State("test-state")), "plain")))
+        yield assertTrue(result == Left(Error.CodeChallengeMethodInvalid(redirectUri, Some(State("test-state")), "plain")))
       },
       test("rejects a missing code_challenge_method instead of defaulting to plain") {
         val env = Env()
@@ -439,8 +445,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request).either
-        yield
-          assertTrue(result == Left(Error.CodeChallengeMethodMissing(redirectUri, Some(State("test-state")))))
+        yield assertTrue(result == Left(Error.CodeChallengeMethodMissing(redirectUri, Some(State("test-state")))))
       },
     ),
     suite("ip")(
@@ -450,8 +455,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request)
-        yield
-          assertTrue(result.ip.contains("9.9.9.9"))
+        yield assertTrue(result.ip.contains("9.9.9.9"))
       },
       test("takes the first value for multi-value headers") {
         val env = Env()
@@ -460,8 +464,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request)
-        yield
-          assertTrue(result.ip.contains("7.7.7.7"))
+        yield assertTrue(result.ip.contains("7.7.7.7"))
       },
       test("is None when the configured header is absent from the request") {
         val env = Env()
@@ -469,8 +472,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request)
-        yield
-          assertTrue(result.ip.isEmpty)
+        yield assertTrue(result.ip.isEmpty)
       },
     ),
     suite("login_hint")(
@@ -480,8 +482,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request)
-        yield
-          assertTrue(result.loginHint == Some(Left(Email("user@example.com"))))
+        yield assertTrue(result.loginHint == Some(Left(Email("user@example.com"))))
       },
       test("parses phone login_hint") {
         val env = Env()
@@ -490,9 +491,65 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           _ <- env.configuration.getAllowedPhonePrefixes.succeedsWith(List("+1"))
           result <- env.parser.parse(request)
-        yield
-          assertTrue(result.loginHint == Some(Right(Phone("+12025551234"))))
-      }
+        yield assertTrue(result.loginHint == Some(Right(Phone("+12025551234"))))
+      },
+      test("rejects an email login_hint when the client does not accept email credentials") {
+        val env = Env()
+        val phoneOnly = clientRecord.copy(authFlow =
+          clientRecord.authFlow.map(flow => flow.copy(primary = flow.primary.copy(credentials = List(PrimaryCredential.phone)))),
+        )
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("login_hint" -> "user@example.com")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(phoneOnly))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result.left.map(_.getClass) == Left(classOf[Error.LoginHintInvalid]))
+      },
+      test("rejects a phone login_hint when the client does not accept phone credentials") {
+        val env = Env()
+        val emailOnly = clientRecord.copy(authFlow =
+          clientRecord.authFlow.map(flow => flow.copy(primary = flow.primary.copy(credentials = List(PrimaryCredential.email)))),
+        )
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("login_hint" -> "+12025551234")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(emailOnly))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result.left.map(_.getClass) == Left(classOf[Error.LoginHintInvalid]))
+      },
+      test("rejects a phone login_hint outside the prefixes the client allows") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("login_hint" -> "+12025551234")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getAllowedPhonePrefixes.succeedsWith(List("+7"))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result.left.map(_.getClass) == Left(classOf[Error.LoginHintInvalid]))
+      },
+      test("accepts any prefix when the client restricts none") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("login_hint" -> "+12025551234")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getAllowedPhonePrefixes.succeedsWith(Nil)
+          result <- env.parser.parse(request)
+        yield assertTrue(result.loginHint == Some(Right(Phone("+12025551234"))))
+      },
+      test("rejects a malformed email login_hint") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("login_hint" -> "not-an-email")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result.left.map(_.getClass) == Left(classOf[Error.LoginHintInvalid]))
+      },
+      test("rejects a phone login_hint that is not a valid number") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("login_hint" -> "+1202")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getAllowedPhonePrefixes.succeedsWith(Nil)
+          result <- env.parser.parse(request).either
+        yield assertTrue(result.left.map(_.getClass) == Left(classOf[Error.LoginHintInvalid]))
+      },
     ),
     suite("request_uri")(
       test("replaces the request payload with the pushed one") {

--- a/auth/src/test/scala/versola/oauth/authorize/model/ErrorSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/model/ErrorSpec.scala
@@ -1,0 +1,121 @@
+package versola.oauth.authorize.model
+
+import versola.oauth.model.State
+import zio.test.*
+
+object ErrorSpec extends ZIOSpecDefault:
+
+  private val uri = zio.http.URL.decode("https://example.com/callback").toOption.get
+  private val state = Some(State("test-state"))
+
+  /** Every redirect error is reported to the client through the same query-parameter
+    * encoding, so the assertions below only vary the error code and description.
+    */
+  private def check(name: String, error: Error.RedirectError, code: ErrorCode, description: String) =
+    test(name) {
+      val redirect = error.redirectUriWithErrorParams("https://issuer.example")
+      assertTrue(
+        error.error == code,
+        error.errorDescription == description,
+        redirect.queryParams.queryParam("error") == Some(code.toString),
+        redirect.queryParams.queryParam("error_description") == Some(description),
+        redirect.queryParams.queryParam("iss") == Some("https://issuer.example"),
+      )
+    }
+
+  def spec = suite("authorize Error")(
+    suite("prompt=none rejections")(
+      check(
+        "LoginRequired",
+        Error.LoginRequired(uri, state),
+        ErrorCode.LoginRequired,
+        "Authentication is required but prompt=none was requested",
+      ),
+      check(
+        "InteractionRequired",
+        Error.InteractionRequired(uri, state),
+        ErrorCode.InteractionRequired,
+        "End-user interaction is required but prompt=none was requested",
+      ),
+      check(
+        "PromptInvalid",
+        Error.PromptInvalid(uri, state),
+        ErrorCode.InvalidRequest,
+        "Invalid prompt parameter - none must not be combined with other values",
+      ),
+    ),
+    suite("hint rejections")(
+      check(
+        "IdTokenHintInvalid",
+        Error.IdTokenHintInvalid(uri, state),
+        ErrorCode.InvalidRequest,
+        "The id_token_hint could not be verified or is invalid (invalid signature, audience, or issuer)",
+      ),
+      check(
+        "ConflictingHints",
+        Error.ConflictingHints(uri, state),
+        ErrorCode.InvalidRequest,
+        "login_hint and id_token_hint must not be used together",
+      ),
+      check(
+        "LoginHintInvalid",
+        Error.LoginHintInvalid(uri, state),
+        ErrorCode.InvalidRequest,
+        "The login_hint parameter is invalid or not supported by the client auth flow",
+      ),
+    ),
+    suite("request rejections")(
+      check(
+        "CodeChallengeMissing",
+        Error.CodeChallengeMissing(uri, state),
+        ErrorCode.InvalidRequest,
+        "Missing required parameter - code_challenge",
+      ),
+      check(
+        "CodeChallengeInvalid",
+        Error.CodeChallengeInvalid(uri, state, "short"),
+        ErrorCode.InvalidRequest,
+        "Invalid code challenge alphabet or size - short",
+      ),
+      check(
+        "InvalidClaims",
+        Error.InvalidClaims(uri, state),
+        ErrorCode.InvalidRequest,
+        "Invalid claims parameter - must be valid JSON",
+      ),
+      check(
+        "UnsupportedUiLocales",
+        Error.UnsupportedUiLocales(uri, state),
+        ErrorCode.InvalidRequest,
+        "None of the requested ui_locales are supported",
+      ),
+      check(
+        "UnmetAuthenticationRequirements",
+        Error.UnmetAuthenticationRequirements(uri, state),
+        ErrorCode.UnmetAuthenticationRequirements,
+        "The requested Authentication Context Class cannot be satisfied",
+      ),
+    ),
+    suite("parameter arity")(
+      check(
+        "MultipleValuesProvided names the offending parameter",
+        Error.MultipleValuesProvided(uri, state, "scope"),
+        ErrorCode.InvalidRequest,
+        "Parameter is included more than once - scope",
+      ),
+      check(
+        "NoValuesProvided names the offending parameter",
+        Error.NoValuesProvided(uri, state, "scope"),
+        ErrorCode.InvalidRequest,
+        "At least one value should be provided - scope",
+      ),
+    ),
+    test("the redirect keeps query parameters the client already put on its redirect_uri") {
+      val withQuery = zio.http.URL.decode("https://example.com/callback?tenant=acme").toOption.get
+      val redirect = Error.LoginRequired(withQuery, state).redirectUriWithErrorParams("https://issuer.example")
+      assertTrue(
+        redirect.queryParams.queryParam("tenant") == Some("acme"),
+        redirect.queryParams.queryParam("error") == Some(ErrorCode.LoginRequired.toString),
+      )
+    },
+  )

--- a/auth/src/test/scala/versola/oauth/challenge/passkey/WebAuthnServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/challenge/passkey/WebAuthnServiceSpec.scala
@@ -20,7 +20,7 @@ object WebAuthnServiceSpec extends UnitSpecBase:
     rpId = "localhost",
     rpName = "Versola",
     origins = List("http://localhost:8080"),
-    userVerification = "preferred"
+    userVerification = "preferred",
   )
 
   private val baseInstant = Instant.parse("2024-01-01T00:00:00Z")
@@ -40,11 +40,10 @@ object WebAuthnServiceSpec extends UnitSpecBase:
     name = Some(PasskeyName("My Key")),
     lastUsedAt = None,
     createdAt = baseInstant,
-    updatedAt = baseInstant
+    updatedAt = baseInstant,
   )
 
   def spec = suite("WebAuthnServiceSpec")(
-
     test("startRegistration produces a ceremony") {
       val repository = stub[PasskeyRepository]
       val configService = stub[OAuthConfigurationService]
@@ -52,16 +51,14 @@ object WebAuthnServiceSpec extends UnitSpecBase:
         service <- ZIO.service[WebAuthnService].provide(
           ZLayer.succeed(repository),
           ZLayer.succeed(configService),
-          WebAuthnService.live
+          WebAuthnService.live,
         )
         _ <- repository.listByUser.succeedsWith(Vector.empty)
         ceremony <- service.startRegistration(settings, userId, "Test User")
-      yield
-        assertTrue(ceremony.request.nonEmpty) &&
+      yield assertTrue(ceremony.request.nonEmpty) &&
         assertTrue(ceremony.publicKeyOptions.contains("publicKey")) &&
         assertTrue(ceremony.publicKeyOptions.contains("challenge"))
     },
-
     test("startAssertion produces a ceremony") {
       val repository = stub[PasskeyRepository]
       val configService = stub[OAuthConfigurationService]
@@ -69,15 +66,13 @@ object WebAuthnServiceSpec extends UnitSpecBase:
         service <- ZIO.service[WebAuthnService].provide(
           ZLayer.succeed(repository),
           ZLayer.succeed(configService),
-          WebAuthnService.live
+          WebAuthnService.live,
         )
         ceremony <- service.startAssertion(settings)
-      yield
-        assertTrue(ceremony.request.nonEmpty) &&
+      yield assertTrue(ceremony.request.nonEmpty) &&
         assertTrue(ceremony.publicKeyOptions.contains("publicKey")) &&
         assertTrue(ceremony.publicKeyOptions.contains("challenge"))
     },
-
     test("credentialIdFromResponse extracts id from valid JSON") {
       val repository = stub[PasskeyRepository]
       val configService = stub[OAuthConfigurationService]
@@ -85,14 +80,13 @@ object WebAuthnServiceSpec extends UnitSpecBase:
         service <- ZIO.service[WebAuthnService].provide(
           ZLayer.succeed(repository),
           ZLayer.succeed(configService),
-          WebAuthnService.live
+          WebAuthnService.live,
         )
-        response = """{"id":"Y3JlZC0xMjM","rawId":"Y3JlZC0xMjM","response":{"clientDataJSON":"eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiQUFBQSIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3QifQ","authenticatorData":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAA","signature":"Y3JlZC0xMjM","userHandle":"Y3JlZC0xMjM"},"type":"public-key","clientExtensionResults":{}}"""
+        response =
+          """{"id":"Y3JlZC0xMjM","rawId":"Y3JlZC0xMjM","response":{"clientDataJSON":"eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiQUFBQSIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3QifQ","authenticatorData":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAA","signature":"Y3JlZC0xMjM","userHandle":"Y3JlZC0xMjM"},"type":"public-key","clientExtensionResults":{}}"""
         id <- service.credentialIdFromResponse(response)
-      yield
-        assertTrue(id.contains("Y3JlZC0xMjM"))
+      yield assertTrue(id.contains("Y3JlZC0xMjM"))
     },
-
     test("credentialIdFromResponse returns None for invalid JSON") {
       val repository = stub[PasskeyRepository]
       val configService = stub[OAuthConfigurationService]
@@ -100,13 +94,11 @@ object WebAuthnServiceSpec extends UnitSpecBase:
         service <- ZIO.service[WebAuthnService].provide(
           ZLayer.succeed(repository),
           ZLayer.succeed(configService),
-          WebAuthnService.live
+          WebAuthnService.live,
         )
         id <- service.credentialIdFromResponse("not-json")
-      yield
-        assertTrue(id.isEmpty)
+      yield assertTrue(id.isEmpty)
     },
-
     test("finishRegistration fails if repository insert fails") {
       val repository = stub[PasskeyRepository]
       val configService = stub[OAuthConfigurationService]
@@ -114,12 +106,11 @@ object WebAuthnServiceSpec extends UnitSpecBase:
         service <- ZIO.service[WebAuthnService].provide(
           ZLayer.succeed(repository),
           ZLayer.succeed(configService),
-          WebAuthnService.live
+          WebAuthnService.live,
         )
         _ <- configService.getPasskeySettings.succeedsWith(Some(settings))
         result <- service.finishRegistration(clientId, userId, "{}", "{}", None).exit
-      yield
-        assert(result)(fails(isSubtype[WebAuthnError.CeremonyFailed](anything)))
+      yield assert(result)(fails(isSubtype[WebAuthnError.CeremonyFailed](anything)))
     },
 
     // An administrator can disable passkeys for the client while a ceremony the user already
@@ -132,28 +123,28 @@ object WebAuthnServiceSpec extends UnitSpecBase:
         service <- ZIO.service[WebAuthnService].provide(
           ZLayer.succeed(repository),
           ZLayer.succeed(configService),
-          WebAuthnService.live
+          WebAuthnService.live,
         )
         _ <- configService.getPasskeySettings.succeedsWith(None)
         result <- service.finishRegistration(clientId, userId, "{}", "{}", None).exit
-      yield
-        assert(result)(fails(equalTo(WebAuthnError.PasskeysNotEnabled)))
+      yield assert(result)(fails(equalTo(WebAuthnError.PasskeysNotEnabled)))
     },
-
     test("finishAssertion fails with AssertionFailed if verification fails") {
       val repository = stub[PasskeyRepository]
       val configService = stub[OAuthConfigurationService]
       val credId = CredentialId("c".getBytes)
       val record = passkeyRecord(credId, userId)
 
-      val request = """{"publicKeyCredentialRequestOptions":{"challenge":"AAAA","timeout":60000,"rpId":"localhost","allowCredentials":[],"userVerification":"required","extensions":{}}}"""
-      val response = """{"id":"Y3JlZC0xMjM","rawId":"Y3JlZC0xMjM","response":{"clientDataJSON":"eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiQUFBQSIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3QifQ","authenticatorData":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAA","signature":"Y3JlZC0xMjM","userHandle":"Y3JlZC0xMjM"},"type":"public-key","clientExtensionResults":{}}"""
+      val request =
+        """{"publicKeyCredentialRequestOptions":{"challenge":"AAAA","timeout":60000,"rpId":"localhost","allowCredentials":[],"userVerification":"required","extensions":{}}}"""
+      val response =
+        """{"id":"Y3JlZC0xMjM","rawId":"Y3JlZC0xMjM","response":{"clientDataJSON":"eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiQUFBQSIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3QifQ","authenticatorData":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAA","signature":"Y3JlZC0xMjM","userHandle":"Y3JlZC0xMjM"},"type":"public-key","clientExtensionResults":{}}"""
 
       for
         service <- ZIO.service[WebAuthnService].provide(
           ZLayer.succeed(repository),
           ZLayer.succeed(configService),
-          WebAuthnService.live
+          WebAuthnService.live,
         )
         _ <- repository.findByCredentialId.succeedsWith(Vector(record))
         result <- service.finishAssertion(settings, request, response).exit
@@ -162,23 +153,73 @@ object WebAuthnServiceSpec extends UnitSpecBase:
         assert(result)(fails(isSubtype[WebAuthnError](anything)))
     },
 
+    // webauthn-server-core 2.7.0 has no Cable or SmartCard transport, so those two have to
+    // drop out of the excluded-credential descriptor rather than fail the ceremony.
+    test("startRegistration maps every known transport and drops the unsupported ones") {
+      val repository = stub[PasskeyRepository]
+      val configService = stub[OAuthConfigurationService]
+      val record = passkeyRecord(CredentialId("c".getBytes), userId)
+        .copy(transports = AuthenticatorTransport.values.toList)
+      for
+        service <- ZIO.service[WebAuthnService].provide(
+          ZLayer.succeed(repository),
+          ZLayer.succeed(configService),
+          WebAuthnService.live,
+        )
+        _ <- repository.listByUser.succeedsWith(Vector(record))
+        ceremony <- service.startRegistration(settings, userId, "Test User")
+      yield assertTrue(
+        ceremony.request.contains("\"ble\""),
+        ceremony.request.contains("\"hybrid\""),
+        ceremony.request.contains("\"internal\""),
+        ceremony.request.contains("\"nfc\""),
+        ceremony.request.contains("\"usb\""),
+        !ceremony.request.contains("\"cable\""),
+        !ceremony.request.contains("\"smart-card\""),
+      )
+    },
+    test("startRegistration honours the configured user verification requirement") {
+      def ceremonyFor(userVerification: String) =
+        val repository = stub[PasskeyRepository]
+        val configService = stub[OAuthConfigurationService]
+        for
+          service <- ZIO.service[WebAuthnService].provide(
+            ZLayer.succeed(repository),
+            ZLayer.succeed(configService),
+            WebAuthnService.live,
+          )
+          _ <- repository.listByUser.succeedsWith(Vector.empty)
+          ceremony <- service.startRegistration(settings.copy(userVerification = userVerification), userId, "Test User")
+        yield ceremony.request
+
+      for
+        required <- ceremonyFor("REQUIRED")
+        discouraged <- ceremonyFor("discouraged")
+        preferred <- ceremonyFor("anything else")
+      yield assertTrue(
+        required.contains("\"required\""),
+        discouraged.contains("\"discouraged\""),
+        preferred.contains("\"preferred\""),
+      )
+    },
     test("finishAssertion fails if credential not found") {
       val repository = stub[PasskeyRepository]
       val configService = stub[OAuthConfigurationService]
 
       // We use a realistic-looking but fake request/response to trigger the library
-      val request = """{"publicKeyCredentialRequestOptions":{"challenge":"AAAA","timeout":60000,"rpId":"localhost","allowCredentials":[],"userVerification":"required","extensions":{}}}"""
-      val response = """{"id":"Y3JlZC0xMjM","rawId":"Y3JlZC0xMjM","response":{"clientDataJSON":"eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiQUFBQSIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3QifQ","authenticatorData":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAA","signature":"Y3JlZC0xMjM","userHandle":"Y3JlZC0xMjM"},"type":"public-key","clientExtensionResults":{}}"""
+      val request =
+        """{"publicKeyCredentialRequestOptions":{"challenge":"AAAA","timeout":60000,"rpId":"localhost","allowCredentials":[],"userVerification":"required","extensions":{}}}"""
+      val response =
+        """{"id":"Y3JlZC0xMjM","rawId":"Y3JlZC0xMjM","response":{"clientDataJSON":"eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiQUFBQSIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3QifQ","authenticatorData":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAA","signature":"Y3JlZC0xMjM","userHandle":"Y3JlZC0xMjM"},"type":"public-key","clientExtensionResults":{}}"""
 
       for
         service <- ZIO.service[WebAuthnService].provide(
           ZLayer.succeed(repository),
           ZLayer.succeed(configService),
-          WebAuthnService.live
+          WebAuthnService.live,
         )
         _ <- repository.findByCredentialId.succeedsWith(Vector.empty)
         result <- service.finishAssertion(settings, request, response).exit
-      yield
-        assert(result)(fails(equalTo(WebAuthnError.CredentialNotFound)))
-    }
+      yield assert(result)(fails(equalTo(WebAuthnError.CredentialNotFound)))
+    },
   )

--- a/auth/src/test/scala/versola/oauth/client/OAuthConfigurationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/client/OAuthConfigurationServiceSpec.scala
@@ -93,19 +93,20 @@ object OAuthConfigurationServiceSpec extends UnitSpecBase:
       sysSettings: SystemSettingsRecord = systemSettings,
       metadata: Json.Obj = Json.Obj(),
       resources: Vector[ResourceRecord] = Vector.empty,
+      authResourceSecrets: List[Secret] = Nil,
       authorizationDetailTypes: Vector[AuthorizationDetailTypeRecord] = Vector.empty,
   ) =
     for
-      clientRef         <- Ref.make(clients)
-      scopeRef          <- Ref.make(scopes)
-      formRef           <- Ref.make(forms)
-      themeRef          <- Ref.make(themes)
-      localeRef         <- Ref.make(locales)
-      otpRef            <- Ref.make(otpTemplates)
-      challengeRef      <- Ref.make(challengeSettingsVec)
-      sysRef            <- Ref.make(sysSettings)
-      metadataRef       <- Ref.make(metadata)
-      resourceRef       <- Ref.make(ResourceSyncClient.SyncResult(resources, Nil))
+      clientRef <- Ref.make(clients)
+      scopeRef <- Ref.make(scopes)
+      formRef <- Ref.make(forms)
+      themeRef <- Ref.make(themes)
+      localeRef <- Ref.make(locales)
+      otpRef <- Ref.make(otpTemplates)
+      challengeRef <- Ref.make(challengeSettingsVec)
+      sysRef <- Ref.make(sysSettings)
+      metadataRef <- Ref.make(metadata)
+      resourceRef <- Ref.make(ResourceSyncClient.SyncResult(resources, authResourceSecrets))
       authDetailTypeRef <- Ref.make(authorizationDetailTypes)
     yield OAuthConfigurationService.Impl(
       clientCache = ReloadingCache(clientRef),
@@ -264,4 +265,93 @@ object OAuthConfigurationServiceSpec extends UnitSpecBase:
         result <- env.getMetadata
       yield assertTrue(result == stored)
     },
+    test("findByTenant returns only the clients of that tenant") {
+      val otherTenant = privateClient.copy(id = ClientId("other"), tenantId = TenantId("other"))
+      for
+        env <- makeEnv(clients = Map(clientId1 -> privateClient, ClientId("other") -> otherTenant))
+        mine <- env.findByTenant(tenantId)
+        theirs <- env.findByTenant(TenantId("other"))
+        unknown <- env.findByTenant(TenantId("nobody"))
+      yield assertTrue(
+        mine == Vector(privateClient),
+        theirs == Vector(otherTenant),
+        unknown.isEmpty,
+      )
+    },
+    test("getIdentityProviderLogo reads the system settings value") {
+      for
+        withLogo <- makeEnv(sysSettings = systemSettings.copy(identityProviderLogo = Some("logo.svg")))
+        withoutLogo <- makeEnv()
+        set <- withLogo.getIdentityProviderLogo
+        unset <- withoutLogo.getIdentityProviderLogo
+      yield assertTrue(set == Some("logo.svg"), unset == systemSettings.identityProviderLogo)
+    },
+    test("getPostLogoutRedirectUris decodes the tenant's configured URLs") {
+      val settings = challengeSettings.copy(
+        postLogoutRedirectUris = List("https://app.example/bye", "not a url"),
+      )
+      for
+        env <- makeEnv(challengeSettingsVec = Vector(settings))
+        uris <- env.getPostLogoutRedirectUris(tenantId)
+        unknown <- env.getPostLogoutRedirectUris(TenantId("nobody"))
+      yield assertTrue(
+        uris.map(_.encode) == List("https://app.example/bye"),
+        unknown.isEmpty,
+      )
+    },
+    suite("resources")(
+      test("findResource matches on tenant and resource URI") {
+        for
+          env <- makeEnv(resources = Vector(resourceRecord))
+          found <- env.findResource(tenantId, ResourceUri("https://api.example"))
+          otherTenant <- env.findResource(TenantId("other"), ResourceUri("https://api.example"))
+          unknown <- env.findResource(tenantId, ResourceUri("https://other.example"))
+        yield assertTrue(
+          found == Some(resourceRecord),
+          otherTenant.isEmpty,
+          unknown.isEmpty,
+        )
+      },
+      test("findResourceById matches on tenant and resource id") {
+        for
+          env <- makeEnv(resources = Vector(resourceRecord))
+          found <- env.findResourceById(tenantId, ResourceId("api"))
+          otherTenant <- env.findResourceById(TenantId("other"), ResourceId("api"))
+          unknown <- env.findResourceById(tenantId, ResourceId("missing"))
+        yield assertTrue(
+          found == Some(resourceRecord),
+          otherTenant.isEmpty,
+          unknown.isEmpty,
+        )
+      },
+      test("getResourcesForClient returns only resources the client is an audience of") {
+        val unrelated = resourceRecord.copy(
+          resourceId = ResourceId("other"),
+          resource = ResourceUri("https://other.example"),
+          audience = List(ClientId("someone-else")),
+        )
+        for
+          env <- makeEnv(resources = Vector(resourceRecord, unrelated))
+          mine <- env.getResourcesForClient(tenantId, clientId1)
+          none <- env.getResourcesForClient(tenantId, ClientId("nobody"))
+        yield assertTrue(mine == List(resourceRecord), none.isEmpty)
+      },
+      test("accountResourceSecrets exposes the secrets carried on the sync result") {
+        val secrets = List(Secret(Array.fill(16)(7.toByte)))
+        for
+          env <- makeEnv(authResourceSecrets = secrets)
+          empty <- makeEnv()
+          loaded <- env.accountResourceSecrets
+          none <- empty.accountResourceSecrets
+        yield assertTrue(loaded.map(_.toSeq) == secrets.map(_.toSeq), none.isEmpty)
+      },
+    ),
+  )
+
+  private val resourceRecord = ResourceRecord(
+    resourceId = ResourceId("api"),
+    tenantId = tenantId,
+    resource = ResourceUri("https://api.example"),
+    audience = List(clientId1),
+    internal = false,
   )

--- a/auth/src/test/scala/versola/oauth/client/ServiceControllerSpec.scala
+++ b/auth/src/test/scala/versola/oauth/client/ServiceControllerSpec.scala
@@ -1,0 +1,105 @@
+package versola.oauth.client
+
+import org.scalamock.stubs.{Stub, ZIOStubs}
+import versola.auth.TestEnvConfig
+import versola.user.UserRepository
+import versola.user.model.UserId
+import versola.util.EnvName
+import versola.util.http.{NoopTracing, Observability}
+import zio.*
+import zio.http.*
+import zio.json.ast.Json as JsonAst
+import zio.test.*
+
+import java.util.UUID
+
+object ServiceControllerSpec extends ZIOSpecDefault, ZIOStubs:
+  private val userId = UserId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+
+  private val internalAuthHeader: Task[Header] =
+    versola.util.JWT.serialize(
+      versola.util.JWT.Claims("auth", "auth", List("central"), JsonAst.Obj()),
+      1.minute,
+      versola.util.JWT.Signature.Symmetric(TestEnvConfig.coreConfig.central.secretKey),
+    ).map(token => Header.Authorization.Bearer(token))
+
+  private type Stubs = (Stub[OAuthConfigurationService], Stub[UserRepository])
+
+  private def controllerTestCase(
+      description: String,
+      request: Request,
+      expectedStatus: Status,
+      env: EnvName = EnvName.Test("test"),
+      authenticate: Boolean = true,
+      setup: Stubs => UIO[Unit] = _ => ZIO.unit,
+      verify: Stubs => Task[TestResult] = _ => ZIO.succeed(assertTrue(true)),
+  ) =
+    test(description) {
+      for
+        client <- ZIO.service[Client]
+        configuration = stub[OAuthConfigurationService]
+        userRepository = stub[UserRepository]
+        stubs = (configuration, userRepository)
+        tracing <- NoopTracing.layer.build
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            ServiceController.routes.provideEnvironment(
+              ZEnvironment[OAuthConfigurationService](configuration) ++
+                ZEnvironment[UserRepository](userRepository) ++
+                ZEnvironment[EnvName](env) ++
+                ZEnvironment(TestEnvConfig.coreConfig) ++
+                tracing
+            )
+          )
+        )
+        _ <- setup(stubs)
+        authHeader <- if authenticate then internalAuthHeader.map(Some(_)) else ZIO.succeed(None)
+        requestWithAuth = authHeader.fold(request)(request.addHeader(_))
+        response <- client.batched(requestWithAuth)
+        verifyResult <- verify(stubs)
+      yield assertTrue(response.status == expectedStatus) && verifyResult
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging
+
+  def spec = suite("ServiceController")(
+    suite("POST /service/configuration/sync")(
+      controllerTestCase(
+        description = "syncs configuration and returns 200 OK",
+        request = Request(method = Method.POST, url = URL.empty / "service" / "configuration" / "sync"),
+        expectedStatus = Status.Ok,
+        setup = (configuration, _) => configuration.syncConfiguration.succeedsWith(()),
+        verify = (configuration, _) => ZIO.succeed(assertTrue(configuration.syncConfiguration.calls.length == 1)),
+      ),
+      controllerTestCase(
+        description = "rejects a request without a valid internal auth token",
+        request = Request(method = Method.POST, url = URL.empty / "service" / "configuration" / "sync"),
+        expectedStatus = Status.Unauthorized,
+        authenticate = false,
+        verify = (configuration, _) => ZIO.succeed(assertTrue(configuration.syncConfiguration.calls.isEmpty)),
+      ),
+      controllerTestCase(
+        description = "returns 404 Not Found in prod, without even checking auth",
+        request = Request(method = Method.POST, url = URL.empty / "service" / "configuration" / "sync"),
+        expectedStatus = Status.NotFound,
+        env = EnvName.Prod,
+        authenticate = false,
+        verify = (configuration, _) => ZIO.succeed(assertTrue(configuration.syncConfiguration.calls.isEmpty)),
+      ),
+    ),
+    suite("DELETE /service/users")(
+      controllerTestCase(
+        description = "deletes the user and returns 204 No Content",
+        request = Request(method = Method.DELETE, url = (URL.empty / "service" / "users").addQueryParam("id", userId.toString)),
+        expectedStatus = Status.NoContent,
+        setup = (_, userRepository) => userRepository.delete.succeedsWith(()),
+        verify = (_, userRepository) => ZIO.succeed(assertTrue(userRepository.delete.calls == List(userId))),
+      ),
+      controllerTestCase(
+        description = "returns 404 Not Found in prod",
+        request = Request(method = Method.DELETE, url = (URL.empty / "service" / "users").addQueryParam("id", userId.toString)),
+        expectedStatus = Status.NotFound,
+        env = EnvName.Prod,
+        authenticate = false,
+        verify = (_, userRepository) => ZIO.succeed(assertTrue(userRepository.delete.calls.isEmpty)),
+      ),
+    ),
+  )

--- a/auth/src/test/scala/versola/oauth/conversation/PasswordConversationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/PasswordConversationServiceSpec.scala
@@ -5,9 +5,9 @@ import versola.auth.model.Password
 import versola.oauth.authorize.AcrResolutionService
 import versola.oauth.challenge.passkey.{PasskeyRepository, WebAuthnService}
 import versola.oauth.challenge.password.PasswordService
-import versola.oauth.challenge.password.model.CheckPassword
+import versola.oauth.challenge.password.model.{CheckPassword, PasswordReuseError}
 import versola.oauth.client.OAuthConfigurationService
-import versola.oauth.client.model.{AuthFlow, ClientId, PrimaryCredential, ScopeToken}
+import versola.oauth.client.model.{AuthFlow, ClientId, PassedAuthFactor, PrimaryCredential, ScopeToken}
 import versola.oauth.conversation.limit.{LimitStatus, SubmissionLimiter}
 import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep}
 import versola.oauth.conversation.otp.OtpService
@@ -15,8 +15,8 @@ import versola.oauth.model.{CodeChallenge, CodeChallengeMethod}
 import versola.oauth.session.{SessionRepository, UserAgentRepository}
 import versola.oauth.token.AuthorizationCodeRepository
 import versola.oauth.userinfo.UserInfoService
-import versola.user.{UserRepository, UserService}
 import versola.user.model.{Login, UserId, UserRecord}
+import versola.user.{UserRepository, UserService}
 import versola.util.{AuthPropertyGenerator, Email, Phone, SecureRandom, SecurityService, UnitSpecBase}
 import zio.http.URL
 import zio.json.ast
@@ -37,6 +37,13 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
   val scope = Set(ScopeToken("openid"), ScopeToken("profile"))
   val codeChallenge = CodeChallenge("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
   val codeChallengeMethod = CodeChallengeMethod.S256
+
+  val setPasswordStep = ConversationStep.SetPassword(
+    factorIndex = 1,
+    timesSubmitted = 0,
+    rateLimitExceeded = false,
+    passwordReused = false,
+  )
 
   val passwordStep = ConversationStep.Password(
     timesSubmitted = 0,
@@ -421,5 +428,132 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
       },
     ),
     suite("finish")(
+    ),
+    suite("offerSetPassword")(
+      test("renders the set-password step after the configured primary factors") {
+        val env = Env()
+        for
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.offerSetPassword(authId, passwordRecord)
+        yield assertTrue(
+          result == ConversationResult.RenderStep(
+            ConversationStep.SetPassword(
+              factorIndex = passwordRecord.authFlow.primary.factors.length,
+              timesSubmitted = 0,
+              rateLimitExceeded = false,
+              passwordReused = false,
+            ),
+          ),
+        )
+      },
+      test("reports a write conflict when the conversation moved on") {
+        val env = Env()
+        for
+          _ <- env.conversationRepository.overwrite.succeedsWith(false)
+          result <- env.service.offerSetPassword(authId, passwordRecord)
+        yield assertTrue(result == ConversationResult.WriteConflict)
+      },
+    ),
+    suite("setNewPassword")(
+      test("denies access when the conversation never resolved a user") {
+        val env = Env()
+        for
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.setNewPassword(baseRecord, setPasswordStep, password, authId)
+        yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
+      },
+      test("denies access when the subject is banned") {
+        val env = Env()
+        for
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Banned)
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.setNewPassword(passwordRecord, setPasswordStep, password, authId)
+        yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
+      },
+      test("re-renders with the rate limit flag when the subject is rate limited") {
+        val env = Env()
+        for
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.RateLimited(30))
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.setNewPassword(passwordRecord, setPasswordStep, password, authId)
+        yield assertTrue(
+          result == ConversationResult.RenderStep(setPasswordStep.copy(rateLimitExceeded = true)),
+        )
+      },
+      test("passes the step and clears needsPasswordChange once the password is accepted") {
+        val env = Env()
+        for
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.passwordService.setPassword.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.setNewPassword(
+            passwordRecord.copy(needsPasswordChange = true),
+            setPasswordStep,
+            password,
+            authId,
+          )
+        yield assertTrue(
+          result match
+            case ConversationResult.StepPassed(updated) =>
+              !updated.needsPasswordChange && updated.amr.contains(PassedAuthFactor.password)
+            case _ => false,
+        )
+      },
+      test("reports a write conflict when the accepted password cannot be persisted") {
+        val env = Env()
+        for
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.passwordService.setPassword.succeedsWith(())
+          _ <- env.conversationRepository.overwrite.succeedsWith(false)
+          result <- env.service.setNewPassword(passwordRecord, setPasswordStep, password, authId)
+        yield assertTrue(result == ConversationResult.WriteConflict)
+      },
+      test("re-renders with the reuse flag when the new password repeats an old one") {
+        val env = Env()
+        for
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.passwordService.setPassword.failsWith(PasswordReuseError(3))
+          _ <- env.submissionLimiter.recordLimitAll.succeedsWith(LimitStatus.Allowed)
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.setNewPassword(passwordRecord, setPasswordStep, password, authId)
+        yield assertTrue(
+          result == ConversationResult.RenderStep(
+            setPasswordStep.copy(timesSubmitted = 1, passwordReused = true),
+          ),
+        )
+      },
+      test("flags both reuse and the rate limit when the retry budget runs out") {
+        val env = Env()
+        for
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.passwordService.setPassword.failsWith(PasswordReuseError(3))
+          _ <- env.submissionLimiter.recordLimitAll.succeedsWith(LimitStatus.RateLimited(30))
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.setNewPassword(passwordRecord, setPasswordStep, password, authId)
+        yield assertTrue(
+          result == ConversationResult.RenderStep(
+            setPasswordStep.copy(timesSubmitted = 1, passwordReused = true, rateLimitExceeded = true),
+          ),
+        )
+      },
+      test("denies access when repeated reuse attempts earn a ban") {
+        val env = Env()
+        for
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.passwordService.setPassword.failsWith(PasswordReuseError(3))
+          _ <- env.submissionLimiter.recordLimitAll.succeedsWith(LimitStatus.Banned)
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.setNewPassword(passwordRecord, setPasswordStep, password, authId)
+        yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
+      },
+      test("propagates an unexpected failure from the password service") {
+        val env = Env()
+        for
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.passwordService.setPassword.failsWith(new RuntimeException("boom"))
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.setNewPassword(passwordRecord, setPasswordStep, password, authId).exit
+        yield assertTrue(result.isFailure)
+      },
     ),
   )

--- a/auth/src/test/scala/versola/oauth/conversation/model/ConversationRecordSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/model/ConversationRecordSpec.scala
@@ -1,0 +1,224 @@
+package versola.oauth.conversation.model
+
+import versola.auth.model.OtpCode
+import versola.oauth.authorize.model.ResponseTypeEntry
+import versola.oauth.client.model.{AuthFlow, ClientId, PrimaryCredential, RegistrationCredential, RegistrationFlow, RegistrationStep, ScopeToken}
+import versola.oauth.model.{CodeChallenge, CodeChallengeMethod, State}
+import versola.user.model.{Login, UserId}
+import versola.util.{Email, Phone}
+import zio.json.ast.Json
+import zio.test.*
+
+import java.util.UUID
+
+object ConversationRecordSpec extends ZIOSpecDefault:
+
+  private val userId = UserId(UUID.fromString("00000000-0000-7000-8000-000000000001"))
+  private val email = Email("test@example.com")
+  private val phone = Phone("+12025551234")
+  private val redirectUri = zio.http.URL.decode("https://example.com/callback").toOption.get
+
+  private val credentialStep = ConversationStep.Credential(List(PrimaryCredential.email), true, false)
+
+  private val record = ConversationRecord(
+    clientId = ClientId("test-client"),
+    redirectUri = redirectUri,
+    scope = Set(ScopeToken("read"), ScopeToken("write")),
+    codeChallenge = CodeChallenge("a" * 43),
+    codeChallengeMethod = CodeChallengeMethod.S256,
+    state = Some(State("test-state")),
+    userId = None,
+    credential = None,
+    step = credentialStep,
+    requestedClaims = None,
+    uiLocales = Some(List("en")),
+    nonce = None,
+    responseType = zio.prelude.NonEmptySet(ResponseTypeEntry.Code),
+    userEmail = None,
+    userPhone = None,
+    userLogin = None,
+    userClaims = None,
+    authFlow = AuthFlow.default,
+    registrationFlow = None,
+    registrationStep = None,
+    userAgent = None,
+    userAgentCookie = None,
+    version = 1,
+    amr = Map.empty,
+    needsPasswordChange = false,
+    targetAcr = None,
+    csrfToken = "test-csrf",
+    priorSessionId = None,
+    resources = Nil,
+    authorizationDetails = None,
+    grantedScope = None,
+    promptConsent = false,
+  )
+
+  private val registrationFlow = RegistrationFlow(
+    credential = RegistrationCredential.email,
+    steps = List(RegistrationStep.Otp(), RegistrationStep.SetPassword()),
+    roleIds = Set.empty,
+  )
+
+  def spec = suite("ConversationRecord")(
+    suite("user")(
+      test("is absent until the conversation is bound to a user") {
+        assertTrue(record.user.isEmpty)
+      },
+      test("projects the identity fields carried on the conversation") {
+        val identified = record.copy(
+          userId = Some(userId),
+          userEmail = Some(email),
+          userPhone = Some(phone),
+          userLogin = Some(Login("testuser")),
+          userClaims = Some(Json.Obj("name" -> Json.Str("Test User"))),
+        )
+        val user = identified.user
+        assertTrue(
+          user.map(_.id) == Some(userId),
+          user.flatMap(_.email) == Some(email),
+          user.flatMap(_.phone) == Some(phone),
+          user.flatMap(_.login) == Some(Login("testuser")),
+          user.map(_.claims) == Some(Json.Obj("name" -> Json.Str("Test User"))),
+          user.flatMap(_.uiLocales) == Some(List("en")),
+        )
+      },
+      test("falls back to empty claims when the conversation carries none") {
+        assertTrue(record.copy(userId = Some(userId)).user.map(_.claims) == Some(Json.Obj.empty))
+      },
+    ),
+    suite("effectiveScope")(
+      test("is the requested scope until consent has been decided") {
+        assertTrue(record.effectiveScope == Set(ScopeToken("read"), ScopeToken("write")))
+      },
+      test("is the granted subset once consent has been decided") {
+        val granted = record.copy(grantedScope = Some(Set(ScopeToken("read"))))
+        assertTrue(granted.effectiveScope == Set(ScopeToken("read")))
+      },
+      test("an empty grant supersedes the requested scope rather than falling back to it") {
+        assertTrue(record.copy(grantedScope = Some(Set.empty)).effectiveScope.isEmpty)
+      },
+    ),
+    suite("hasOfflineAccess")(
+      test("is false when offline_access was not requested") {
+        assertTrue(!record.hasOfflineAccess)
+      },
+      test("is true when offline_access is in the requested scope") {
+        assertTrue(record.copy(scope = Set(ScopeToken.OfflineAccess)).hasOfflineAccess)
+      },
+      test("follows the granted scope, so a dropped offline_access disables refresh") {
+        val granted = record.copy(
+          scope = Set(ScopeToken.OfflineAccess),
+          grantedScope = Some(Set(ScopeToken("read"))),
+        )
+        assertTrue(!granted.hasOfflineAccess)
+      },
+    ),
+    suite("registration")(
+      test("a conversation without a registration step is a sign-in") {
+        assertTrue(!record.isRegistering, record.currentRegistrationStep.isEmpty)
+      },
+      test("isRegistering follows the presence of the step index") {
+        assertTrue(record.copy(registrationStep = Some(0)).isRegistering)
+      },
+      test("currentRegistrationStep reads the indexed step out of the flow") {
+        val registering = record.copy(
+          registrationFlow = Some(registrationFlow),
+          registrationStep = Some(1),
+        )
+        assertTrue(registering.currentRegistrationStep == Some(RegistrationStep.SetPassword()))
+      },
+      test("currentRegistrationStep is empty once the flow is exhausted") {
+        val exhausted = record.copy(
+          registrationFlow = Some(registrationFlow),
+          registrationStep = Some(2),
+        )
+        assertTrue(exhausted.currentRegistrationStep.isEmpty)
+      },
+      test("currentRegistrationStep is empty when the client has no registration flow") {
+        assertTrue(record.copy(registrationStep = Some(0)).currentRegistrationStep.isEmpty)
+      },
+    ),
+    suite("patch")(
+      test("the empty patch leaves the record untouched") {
+        assertTrue(record.patch(ConversationRecord.Patch.empty) == record)
+      },
+      test("reports the empty patch as empty") {
+        assertTrue(
+          ConversationRecord.Patch.empty.isEmpty,
+          !ConversationRecord.Patch.empty.copy(step = Some(credentialStep)).isEmpty,
+        )
+      },
+      test("applies each supplied field and keeps the rest") {
+        val step = ConversationStep.SetPassword(0, 0, false, false)
+        val patched = record.patch(
+          ConversationRecord.Patch(
+            userId = Some(Some(userId)),
+            credential = Some(Some(Left(email))),
+            step = Some(step),
+            authFlow = None,
+          )
+        )
+        assertTrue(
+          patched.userId == Some(userId),
+          patched.credential == Some(Left(email)),
+          patched.step == step,
+          patched.authFlow == record.authFlow,
+          patched.csrfToken == record.csrfToken,
+        )
+      },
+      test("a patch can clear the user and credential rather than only set them") {
+        val bound = record.copy(userId = Some(userId), credential = Some(Left(email)))
+        val cleared = bound.patch(
+          ConversationRecord.Patch(
+            userId = Some(None),
+            credential = Some(None),
+            step = None,
+            authFlow = None,
+          )
+        )
+        assertTrue(cleared.userId.isEmpty, cleared.credential.isEmpty)
+      },
+    ),
+    suite("step extractors")(
+      test("Otp matches only when a credential is bound alongside the step") {
+        val otpStep = ConversationStep.Otp(Some(ConversationStep.Otp.Real(OtpCode("123456"))), 1, 0, 0, false, 0, None)
+        val withCredential = record.copy(step = otpStep, credential = Some(Right(phone)))
+        val withoutCredential = record.copy(step = otpStep)
+        assertTrue(
+          ConversationRecord.Otp.unapply(withCredential) == Some((otpStep, Right(phone))),
+          ConversationRecord.Otp.unapply(withoutCredential).isEmpty,
+          ConversationRecord.Otp.unapply(record).isEmpty,
+        )
+      },
+      test("Password matches the password step") {
+        val step = ConversationStep.Password(0, None, 0, false)
+        assertTrue(
+          ConversationRecord.Password.unapply(record.copy(step = step)) == Some(step),
+          ConversationRecord.Password.unapply(record).isEmpty,
+        )
+      },
+      test("SetPassword matches the set-password step") {
+        val step = ConversationStep.SetPassword(0, 0, false, false)
+        assertTrue(
+          ConversationRecord.SetPassword.unapply(record.copy(step = step)) == Some(step),
+          ConversationRecord.SetPassword.unapply(record).isEmpty,
+        )
+      },
+      test("PasskeyEnroll matches the enrollment step") {
+        val step = ConversationStep.PasskeyEnroll("request", "options")
+        assertTrue(
+          ConversationRecord.PasskeyEnroll.unapply(record.copy(step = step)) == Some(step),
+          ConversationRecord.PasskeyEnroll.unapply(record).isEmpty,
+        )
+      },
+      test("Consent matches the consent step") {
+        val step = ConversationStep.Consent(Set(ScopeToken("read")), allowPartial = true)
+        assertTrue(
+          ConversationRecord.Consent.unapply(record.copy(step = step)) == Some(step),
+          ConversationRecord.Consent.unapply(record).isEmpty,
+        )
+      },
+    ),
+  )

--- a/auth/src/test/scala/versola/oauth/metadata/MetadataControllerSpec.scala
+++ b/auth/src/test/scala/versola/oauth/metadata/MetadataControllerSpec.scala
@@ -1,0 +1,48 @@
+package versola.oauth.metadata
+
+import versola.oauth.client.OAuthConfigurationService
+import versola.util.UnitSpecBase
+import versola.util.http.Observability
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.json.ast.Json
+import zio.test.*
+
+object MetadataControllerSpec extends UnitSpecBase:
+
+  private def testCase(
+      description: String,
+      name: String,
+      metadata: Json.Obj,
+  ) =
+    test(description) {
+      for
+        client <- ZIO.service[Client]
+        configuration = stub[OAuthConfigurationService]
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(MetadataController.routes.provideEnvironment(ZEnvironment(configuration)))
+        )
+        _ <- configuration.getMetadata.succeedsWith(metadata)
+
+        response <- client.batched(Request.get(URL.empty / ".well-known" / name))
+        body <- response.body.asString
+        actualJson <- ZIO.fromEither(body.fromJson[Json]).mapError(new RuntimeException(_))
+      yield assertTrue(
+        response.status == Status.Ok,
+        actualJson == metadata,
+      )
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging
+
+  val spec = suite("MetadataController")(
+    testCase(
+      description = "GET /.well-known/oauth-authorization-server returns the configuration service's metadata",
+      name = "oauth-authorization-server",
+      metadata = Json.Obj("issuer" -> Json.Str("https://auth.example.com")),
+    ),
+    testCase(
+      description = "GET /.well-known/openid-configuration returns the configuration service's metadata",
+      name = "openid-configuration",
+      metadata = Json.Obj("issuer" -> Json.Str("https://auth.example.com")),
+    ),
+  )

--- a/auth/src/test/scala/versola/oauth/model/CookiesSpec.scala
+++ b/auth/src/test/scala/versola/oauth/model/CookiesSpec.scala
@@ -3,12 +3,13 @@ package versola.oauth.model
 import versola.auth.TestEnvConfig
 import versola.oauth.client.model.ClientId
 import versola.oauth.conversation.model.AuthId
-import versola.oauth.session.model.SessionId
+import versola.oauth.session.model.{SessionId, UserAgentDetails, UserAgentId}
+import versola.user.model.UserId
+import versola.util.Base64
 import versola.util.Secret
 import zio.*
 import zio.json.*
 import zio.test.*
-import versola.util.Base64
 
 import java.util.UUID
 
@@ -19,21 +20,27 @@ object CookiesSpec extends ZIOSpecDefault:
   private val secret = TestEnvConfig.coreConfig.security.conversationCookieSecret
   private val sessionSecret = TestEnvConfig.coreConfig.security.sessionCookieSecret
 
+  private val userAgentId = UserAgentId(UUID.fromString("018f0f2a-1c7b-7000-8000-000000000001"))
+  private val userAgentData = UserAgentData(
+    userAgent = Some("Mozilla/5.0"),
+    userId = UserId(UUID.fromString("00000000-0000-7000-8000-000000000001")),
+    details = UserAgentDetails(Some("desktop"), Some("macOS"), Some("Chrome"), Some("125")),
+  )
+
   def spec = suite("CookiesSpec")(
     suite("ConversationCookie")(
       test("responseCookie creates a secure cookie with valid signature") {
         val cookie = ConversationCookie(authId, clientId, "https://example.com/callback", None)
-        val resp   = ConversationCookie.responseCookie(cookie, 15.minutes, secret)
+        val resp = ConversationCookie.responseCookie(cookie, 15.minutes, secret)
         assertTrue(
           resp.name == ConversationCookie.name,
           resp.path.nonEmpty,
           resp.isHttpOnly,
           resp.isSecure,
-          resp.maxAge.contains(15.minutes)
+          resp.maxAge.contains(15.minutes),
         ) &&
         assertTrue(ConversationCookie.parse(resp.content, secret) == Right(cookie))
       },
-
       test("round-trips the redirect context used by the expired page") {
         val cookie = ConversationCookie(
           authId,
@@ -44,51 +51,109 @@ object CookiesSpec extends ZIOSpecDefault:
         val content = ConversationCookie.responseCookie(cookie, 15.minutes, secret).content
         assertTrue(ConversationCookie.parse(content, secret) == Right(cookie))
       },
-
       test("parse fails with wrong secret") {
-        val cookie      = ConversationCookie(authId, clientId, "https://example.com/callback", None)
-        val content     = ConversationCookie.responseCookie(cookie, 15.minutes, secret).content
+        val cookie = ConversationCookie(authId, clientId, "https://example.com/callback", None)
+        val content = ConversationCookie.responseCookie(cookie, 15.minutes, secret).content
         val wrongSecret = Secret.Bytes32(Array.fill(32)(9.toByte))
         assertTrue(ConversationCookie.parse(content, wrongSecret).isLeft)
       },
-
       test("parse fails with tampered payload") {
-        val cookie          = ConversationCookie(authId, clientId, "https://example.com/callback", None)
-        val content         = ConversationCookie.responseCookie(cookie, 15.minutes, secret).content
-        val parts           = content.split('.')
+        val cookie = ConversationCookie(authId, clientId, "https://example.com/callback", None)
+        val content = ConversationCookie.responseCookie(cookie, 15.minutes, secret).content
+        val parts = content.split('.')
         val tamperedPayload = "eyJhdXRoSWQiOiJiYmJiYmJiYi1iYmJiLWJiYmItYmJiYi1iYmJiYmJiYmJiYmIiLCJjbGllbnRJZCI6InRlc3QtY2xpZW50In0"
         val tamperedContent = s"$tamperedPayload.${parts(1)}"
         assertTrue(ConversationCookie.parse(tamperedContent, secret).isLeft)
-      }
+      },
     ),
-
     suite("SessionCookie")(
       test("creates a session cookie with valid signature") {
         val sessionId = SessionId(Array.fill(32)(1.toByte))
-        val cookie    = SessionCookie(sessionId, 1.hour, sessionSecret)
+        val cookie = SessionCookie(sessionId, 1.hour, sessionSecret)
         assertTrue(
           cookie.name == SessionCookie.name,
           cookie.isHttpOnly,
           cookie.isSecure,
-          cookie.maxAge.contains(1.hour)
+          cookie.maxAge.contains(1.hour),
         ) &&
         assertTrue(SessionCookie.parse(cookie.content, sessionSecret).map(_.toSeq) == Right(sessionId.toSeq))
       },
-
       test("parse fails with wrong secret") {
-        val sessionId   = SessionId(Array.fill(32)(1.toByte))
-        val content     = SessionCookie(sessionId, 1.hour, sessionSecret).content
+        val sessionId = SessionId(Array.fill(32)(1.toByte))
+        val content = SessionCookie(sessionId, 1.hour, sessionSecret).content
         val wrongSecret = Secret.Bytes32(Array.fill(32)(9.toByte))
         assertTrue(SessionCookie.parse(content, wrongSecret).isLeft)
       },
-
       test("parse fails with tampered content") {
-        val sessionId      = SessionId(Array.fill(32)(1.toByte))
-        val content        = SessionCookie(sessionId, 1.hour, sessionSecret).content
-        val parts          = content.split('.')
+        val sessionId = SessionId(Array.fill(32)(1.toByte))
+        val content = SessionCookie(sessionId, 1.hour, sessionSecret).content
+        val parts = content.split('.')
         val tamperedPayload = Base64.urlEncode(Array.fill(32)(2.toByte))
         val tamperedContent = s"$tamperedPayload.${parts(1)}"
         assertTrue(SessionCookie.parse(tamperedContent, sessionSecret).isLeft)
-      }
-    )
+      },
+      test("parse rejects a payload that is not a 32-byte session id") {
+        val shortPayload = Base64.urlEncode(Array.fill(8)(1.toByte))
+        val content = SessionCookie(SessionId(Array.fill(8)(1.toByte)), 1.hour, sessionSecret).content
+        assertTrue(
+          SessionCookie.parse(content, sessionSecret) == Left("invalid session id length"),
+          shortPayload.nonEmpty,
+        )
+      },
+      test("parse rejects content with no signature separator") {
+        assertTrue(SessionCookie.parse("no-signature-here", sessionSecret) == Left("missing signature"))
+      },
+    ),
+    suite("UserAgentCookie")(
+      test("round-trips the device id and the user agent seen when it was issued") {
+        val cookie = UserAgentCookie(userAgentId, userAgentData, 180.days, secret)
+        assertTrue(
+          cookie.name == UserAgentCookie.name,
+          cookie.isHttpOnly,
+          cookie.isSecure,
+          cookie.maxAge.contains(180.days),
+          UserAgentCookie.parse(cookie.content, secret) ==
+            Right(UserAgentCookiePayload(userAgentId, userAgentData)),
+        )
+      },
+      test("parse fails with wrong secret") {
+        val content = UserAgentCookie(userAgentId, userAgentData, 180.days, secret).content
+        val wrongSecret = Secret.Bytes32(Array.fill(32)(9.toByte))
+        assertTrue(UserAgentCookie.parse(content, wrongSecret) == Left("invalid signature"))
+      },
+      test("parse fails when the payload is swapped for another signed value") {
+        val content = UserAgentCookie(userAgentId, userAgentData, 180.days, secret).content
+        val other = UserAgentCookie(
+          userAgentId,
+          userAgentData.copy(userAgent = Some("curl/8")),
+          180.days,
+          secret,
+        ).content
+        val tampered = s"${other.split('.')(0)}.${content.split('.')(1)}"
+        assertTrue(UserAgentCookie.parse(tampered, secret).isLeft)
+      },
+      test("parse rejects content with no signature separator") {
+        assertTrue(UserAgentCookie.parse("no-signature-here", secret) == Left("missing signature"))
+      },
+      test("parse rejects a signed payload that is not the expected JSON shape") {
+        // Signed with the right key, so this gets past the MAC check and fails on decoding.
+        val bytes = """{"unexpected":true}""".getBytes("UTF-8").nn
+        val signed = UserAgentCookie(userAgentId, userAgentData, 180.days, secret).content
+        val tampered = s"${Base64.urlEncode(bytes)}.${signed.split('.')(1)}"
+        assertTrue(UserAgentCookie.parse(tampered, secret).isLeft)
+      },
+    ),
+    suite("malformed content")(
+      test("ConversationCookie.parse rejects content with no signature separator") {
+        assertTrue(ConversationCookie.parse("no-signature-here", secret) == Left("missing signature"))
+      },
+      test("ConversationCookie.parse rejects a payload that is not base64url") {
+        val content = ConversationCookie.responseCookie(
+          ConversationCookie(authId, clientId, "https://example.com/callback", None),
+          15.minutes,
+          secret,
+        ).content
+        assertTrue(ConversationCookie.parse(s"not base64!.${content.split('.')(1)}", secret).isLeft)
+      },
+    ),
   )

--- a/auth/src/test/scala/versola/oauth/model/CookiesSpec.scala
+++ b/auth/src/test/scala/versola/oauth/model/CookiesSpec.scala
@@ -136,11 +136,22 @@ object CookiesSpec extends ZIOSpecDefault:
         assertTrue(UserAgentCookie.parse("no-signature-here", secret) == Left("missing signature"))
       },
       test("parse rejects a signed payload that is not the expected JSON shape") {
-        // Signed with the right key, so this gets past the MAC check and fails on decoding.
-        val bytes = """{"unexpected":true}""".getBytes("UTF-8").nn
-        val signed = UserAgentCookie(userAgentId, userAgentData, 180.days, secret).content
-        val tampered = s"${Base64.urlEncode(bytes)}.${signed.split('.')(1)}"
-        assertTrue(UserAgentCookie.parse(tampered, secret).isLeft)
+        // Every cookie here signs with the same keyed hash, so a ConversationCookie's own
+        // content carries a signature UserAgentCookie.parse accepts. That gets past the MAC
+        // check on a payload that is not a UserAgentCookiePayload, which is the only way to
+        // reach the decoding step -- re-signing an arbitrary payload isn't possible from
+        // outside, since computeMac is private.
+        val content = ConversationCookie.responseCookie(
+          ConversationCookie(authId, clientId, "https://example.com/callback", None),
+          15.minutes,
+          secret,
+        ).content
+        val result = UserAgentCookie.parse(content, secret)
+        assertTrue(
+          result.isLeft,
+          result != Left("invalid signature"),
+          result != Left("missing signature"),
+        )
       },
     ),
     suite("malformed content")(

--- a/auth/src/test/scala/versola/oauth/user/UserRepositorySpec.scala
+++ b/auth/src/test/scala/versola/oauth/user/UserRepositorySpec.scala
@@ -7,6 +7,7 @@ import versola.user.UserRepository
 import versola.user.model.*
 import versola.util.{DatabaseSpecBase, Email, Phone}
 import zio.*
+import zio.json.ast.Json
 import zio.test.*
 
 import java.time.Instant
@@ -47,6 +48,9 @@ trait UserRepositorySpec extends DatabaseSpecBase[UserRepositorySpec.Env]:
       findTests(env),
       findByCredentialTests(env),
       roleTests(env),
+      registerTests(env),
+      claimsTests(env),
+      deleteTests(env),
     )
 
   private def seed(
@@ -146,6 +150,117 @@ trait UserRepositorySpec extends DatabaseSpecBase[UserRepositorySpec.Env]:
           _ <- env.userRepository.updateRoles(userId1, TenantId("tenant-1"), Set.empty, Set(RoleId("role-b")))
           roles <- env.userRepository.findRolesByUserAndTenant(userId1, TenantId("tenant-1"))
         yield assertTrue(roles == List(RoleId("role-a")))
+      },
+    )
+
+  def registerTests(env: UserRepositorySpec.Env) =
+    suite("register")(
+      test("creates the account and grants the tenant roles") {
+        for
+          user <- env.userRepository.register(userId1, Left(email1), TenantId("tenant-1"), Set(RoleId("role-a")))
+          found <- env.userRepository.find(user.id)
+          roles <- env.userRepository.findRolesByUserAndTenant(user.id, TenantId("tenant-1"))
+        yield assertTrue(
+          user.email == Some(email1),
+          found.map(_.id) == Some(user.id),
+          roles == List(RoleId("role-a")),
+        )
+      },
+      test("creates the account from a phone credential") {
+        for
+          user <- env.userRepository.register(userId1, Right(phone1), TenantId("tenant-1"), Set.empty)
+          found <- env.userRepository.find(user.id)
+        yield assertTrue(user.phone == Some(phone1), found.flatMap(_.phone) == Some(phone1))
+      },
+      test("returns the existing account when the credential was already claimed") {
+        for
+          first <- env.userRepository.register(userId1, Left(email1), TenantId("tenant-1"), Set.empty)
+          second <- env.userRepository.register(userId2, Left(email1), TenantId("tenant-1"), Set.empty)
+        yield assertTrue(first.id == second.id, second.id == userId1)
+      },
+      test("grants no roles when the registration flow configures none") {
+        for
+          user <- env.userRepository.register(userId1, Left(email1), TenantId("tenant-1"), Set.empty)
+          roles <- env.userRepository.findRolesByUser(user.id)
+        yield assertTrue(roles.isEmpty)
+      },
+      test("re-registering with the same roles is idempotent") {
+        for
+          _ <- env.userRepository.register(userId1, Left(email1), TenantId("tenant-1"), Set(RoleId("role-a")))
+          _ <- env.userRepository.register(userId1, Left(email1), TenantId("tenant-1"), Set(RoleId("role-a")))
+          roles <- env.userRepository.findRolesByUserAndTenant(userId1, TenantId("tenant-1"))
+        yield assertTrue(roles == List(RoleId("role-a")))
+      },
+      test("findRolesByUser groups the roles by tenant") {
+        for
+          _ <- seed(env, userId1)
+          _ <- env.userRepository.updateRoles(userId1, TenantId("tenant-1"), Set(RoleId("role-a"), RoleId("role-b")), Set.empty)
+          _ <- env.userRepository.updateRoles(userId1, TenantId("tenant-2"), Set(RoleId("role-c")), Set.empty)
+          roles <- env.userRepository.findRolesByUser(userId1)
+        yield assertTrue(
+          roles.keySet == Set(TenantId("tenant-1"), TenantId("tenant-2")),
+          roles(TenantId("tenant-1")).toSet == Set(RoleId("role-a"), RoleId("role-b")),
+          roles(TenantId("tenant-2")) == List(RoleId("role-c")),
+        )
+      },
+      test("findRolesByUser returns nothing for a user with no roles") {
+        for
+          _ <- seed(env, userId1)
+          roles <- env.userRepository.findRolesByUser(userId1)
+        yield assertTrue(roles.isEmpty)
+      },
+      test("findByLogin returns the account holding that login") {
+        for
+          _ <- env.userRepository.upsert(userId1, UUID.randomUUID(), None, None, Some(Login("someone")))
+          found <- env.userRepository.findByLogin(Login("someone"))
+          missing <- env.userRepository.findByLogin(Login("nobody"))
+        yield assertTrue(found.map(_.id) == Some(userId1), missing.isEmpty)
+      },
+    )
+
+  def claimsTests(env: UserRepositorySpec.Env) =
+    suite("patchClaims")(
+      test("merges the patch into the stored claims") {
+        for
+          _ <- seed(env, userId1, email = Some(email1))
+          _ <- env.userRepository.patchClaims(userId1, Json.Obj("name" -> Json.Str("Ada")))
+          _ <- env.userRepository.patchClaims(userId1, Json.Obj("locale" -> Json.Str("en")))
+          found <- env.userRepository.find(userId1)
+        yield assertTrue(
+          found.map(_.claims) == Some(Json.Obj("name" -> Json.Str("Ada"), "locale" -> Json.Str("en"))),
+        )
+      },
+      test("a null value removes the claim rather than storing null") {
+        for
+          _ <- seed(env, userId1)
+          _ <- env.userRepository.patchClaims(userId1, Json.Obj("name" -> Json.Str("Ada")))
+          _ <- env.userRepository.patchClaims(userId1, Json.Obj("name" -> Json.Null))
+          found <- env.userRepository.find(userId1)
+        yield assertTrue(found.map(_.claims) == Some(Json.Obj()))
+      },
+      test("patching an unknown user is a no-op") {
+        for
+          _ <- env.userRepository.patchClaims(userId1, Json.Obj("name" -> Json.Str("Ada")))
+          found <- env.userRepository.find(userId1)
+        yield assertTrue(found.isEmpty)
+      },
+    )
+
+  def deleteTests(env: UserRepositorySpec.Env) =
+    suite("delete")(
+      test("removes the account") {
+        for
+          _ <- seed(env, userId1, email = Some(email1))
+          _ <- env.userRepository.delete(userId1)
+          found <- env.userRepository.find(userId1)
+        yield assertTrue(found.isEmpty)
+      },
+      test("deleting an unknown user is a no-op") {
+        for
+          _ <- seed(env, userId1)
+          _ <- env.userRepository.delete(userId2)
+          found <- env.userRepository.find(userId1)
+        yield assertTrue(found.nonEmpty)
       },
     )
 

--- a/central/implementations/postgres/src/test/scala/versola/configuration/challenges/PostgresChallengeSettingsRepositorySpec.scala
+++ b/central/implementations/postgres/src/test/scala/versola/configuration/challenges/PostgresChallengeSettingsRepositorySpec.scala
@@ -1,0 +1,24 @@
+package versola.configuration.challenges
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import com.augustnagro.magnum.sql
+import versola.central.configuration.challenges.ChallengeSettingsRepositorySpec
+import versola.util.postgres.PostgresSpec
+import zio.{ZIO, ZLayer}
+
+object PostgresChallengeSettingsRepositorySpec extends PostgresSpec, ChallengeSettingsRepositorySpec:
+
+  override lazy val environment =
+    ZLayer:
+      for xa <- ZIO.service[TransactorZIO]
+      yield ChallengeSettingsRepositorySpec.Env(PostgresChallengeSettingsRepository(xa))
+
+  override def beforeEach(env: ChallengeSettingsRepositorySpec.Env) =
+    ZIO.serviceWithZIO[TransactorZIO] { xa =>
+      xa.connect(sql"TRUNCATE TABLE tenants RESTART IDENTITY CASCADE".update.run()) *>
+        xa.connect(
+          sql"""INSERT INTO tenants (id, description) VALUES
+                ('tenant-a', 'Tenant A'),
+                ('tenant-b', 'Tenant B')""".update.run()
+        )
+    }.unit

--- a/central/implementations/postgres/src/test/scala/versola/configuration/jwks/PostgresJwksRepositorySpec.scala
+++ b/central/implementations/postgres/src/test/scala/versola/configuration/jwks/PostgresJwksRepositorySpec.scala
@@ -1,0 +1,19 @@
+package versola.configuration.jwks
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import com.augustnagro.magnum.sql
+import versola.central.configuration.jwks.JwksRepositorySpec
+import versola.util.postgres.PostgresSpec
+import zio.{ZIO, ZLayer}
+
+object PostgresJwksRepositorySpec extends PostgresSpec, JwksRepositorySpec:
+
+  override lazy val environment =
+    ZLayer:
+      for xa <- ZIO.service[TransactorZIO]
+      yield JwksRepositorySpec.Env(PostgresJwksRepository(xa))
+
+  override def beforeEach(env: JwksRepositorySpec.Env) =
+    ZIO.serviceWithZIO[TransactorZIO] { xa =>
+      xa.connect(sql"TRUNCATE TABLE jwks".update.run())
+    }.unit

--- a/central/implementations/postgres/src/test/scala/versola/configuration/themes/PostgresThemeRepositorySpec.scala
+++ b/central/implementations/postgres/src/test/scala/versola/configuration/themes/PostgresThemeRepositorySpec.scala
@@ -1,0 +1,25 @@
+package versola.configuration.themes
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import com.augustnagro.magnum.sql
+import versola.central.configuration.themes.ThemeRepositorySpec
+import versola.util.postgres.PostgresSpec
+import zio.{ZIO, ZLayer}
+
+object PostgresThemeRepositorySpec extends PostgresSpec, ThemeRepositorySpec:
+
+  override lazy val environment =
+    ZLayer:
+      for xa <- ZIO.service[TransactorZIO]
+      yield ThemeRepositorySpec.Env(PostgresThemeRepository(xa))
+
+  // Themes has no ON DELETE CASCADE of its own into other tables, but oauth_clients has a
+  // NOT NULL FK *into* themes, which makes a plain `TRUNCATE TABLE themes` fail outright
+  // (Postgres refuses to truncate a table something else references). Truncating `tenants`
+  // CASCADE instead clears every table that hangs off it -- themes included -- the same
+  // reset-everything approach `PostgresOAuthClientRepositorySpec` already relies on.
+  override def beforeEach(env: ThemeRepositorySpec.Env) =
+    ZIO.serviceWithZIO[TransactorZIO] { xa =>
+      xa.connect(sql"TRUNCATE TABLE tenants RESTART IDENTITY CASCADE".update.run()) *>
+        xa.connect(sql"INSERT INTO tenants (id, description) VALUES ('tenant-a', 'Tenant A')".update.run())
+    }.unit

--- a/central/src/test/scala/versola/central/configuration/challenges/ChallengeSettingsRepositorySpec.scala
+++ b/central/src/test/scala/versola/central/configuration/challenges/ChallengeSettingsRepositorySpec.scala
@@ -1,0 +1,79 @@
+package versola.central.configuration.challenges
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import versola.central.configuration.tenants.TenantId
+import versola.util.DatabaseSpecBase
+import zio.test.*
+
+/** Conformance suite for any [[ChallengeSettingsRepository]] implementation. A backend module
+  * extends this and supplies the wiring -- see `PostgresChallengeSettingsRepositorySpec` in
+  * `central-postgres-impl` for the one binding that exists today.
+  */
+trait ChallengeSettingsRepositorySpec extends DatabaseSpecBase[ChallengeSettingsRepositorySpec.Env]:
+  self: ZIOSpec[TransactorZIO] =>
+
+  private val tenantA = TenantId("tenant-a")
+  private val tenantB = TenantId("tenant-b")
+
+  private val passkeySettings = PasskeySettings(
+    rpId = "localhost",
+    rpName = "Versola",
+    origins = List("http://localhost:8080"),
+    userVerification = "preferred",
+  )
+
+  private def settingsFor(tenantId: TenantId) = ChallengeSettingsRecord(
+    tenantId = tenantId,
+    allowedPrefixes = List("+1", "+44"),
+    submissionLimits = SubmissionLimits(),
+    otpLength = 6,
+    otpResendAfter = 30,
+    passkeySettings = passkeySettings,
+    authConversationTtlSeconds = 900,
+    sessionTtlSeconds = 3600,
+    sessionIdleTtlSeconds = Some(1800),
+    userAgentTtlSeconds = 15552000,
+    ipHeader = "X-Forwarded-For",
+    acrVocabulary = None,
+    postLogoutRedirectUris = List("https://example.com/logout"),
+  )
+
+  override def testCases(env: ChallengeSettingsRepositorySpec.Env) =
+    List(
+      test("getAll returns nothing when the table is empty") {
+        for all <- env.repository.getAll
+        yield assertTrue(all.isEmpty)
+      },
+      test("findByTenant returns None for an unknown tenant") {
+        for found <- env.repository.findByTenant(tenantA)
+        yield assertTrue(found.isEmpty)
+      },
+      test("upsert stores settings retrievable by findByTenant and getAll") {
+        val record = settingsFor(tenantA)
+        for
+          _ <- env.repository.upsert(record)
+          found <- env.repository.findByTenant(tenantA)
+          all <- env.repository.getAll
+        yield assertTrue(found == Some(record), all == Vector(record))
+      },
+      test("upsert on an existing tenant replaces the settings") {
+        val original = settingsFor(tenantA)
+        val updated = original.copy(otpLength = 8, ipHeader = "X-Real-IP")
+        for
+          _ <- env.repository.upsert(original)
+          _ <- env.repository.upsert(updated)
+          found <- env.repository.findByTenant(tenantA)
+          all <- env.repository.getAll
+        yield assertTrue(found == Some(updated), all == Vector(updated))
+      },
+      test("getAll orders by tenant id") {
+        for
+          _ <- env.repository.upsert(settingsFor(tenantB))
+          _ <- env.repository.upsert(settingsFor(tenantA))
+          all <- env.repository.getAll
+        yield assertTrue(all.map(_.tenantId) == Vector(tenantA, tenantB))
+      },
+    )
+
+object ChallengeSettingsRepositorySpec:
+  case class Env(repository: ChallengeSettingsRepository)

--- a/central/src/test/scala/versola/central/configuration/details/AuthorizationDetailTypeControllerSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/details/AuthorizationDetailTypeControllerSpec.scala
@@ -1,0 +1,214 @@
+package versola.central.configuration.details
+
+import io.opentelemetry.api
+import org.scalamock.stubs.{Stub, ZIOStubs}
+import versola.central.{CentralConfig, TestAdminAuth, TestCentralConfig}
+import versola.central.configuration.edges.EdgeService
+import versola.central.configuration.resources.ResourceService
+import versola.central.configuration.tenants.TenantId
+import versola.central.configuration.{
+  AuthorizationDetailTypeResponse,
+  AuthorizationDetailTypeSyncResponse,
+  CreateAuthorizationDetailTypeRequest,
+  GetAllAuthorizationDetailTypesResponse,
+  GetAuthorizationDetailTypesSyncResponse,
+  UpdateAuthorizationDetailTypeRequest,
+}
+import versola.util.JWT
+import versola.util.http.Observability
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.json.ast.Json
+import zio.telemetry.opentelemetry.OpenTelemetry
+import zio.telemetry.opentelemetry.tracing.Tracing
+import zio.test.*
+
+import javax.crypto.spec.SecretKeySpec
+
+object AuthorizationDetailTypeControllerSpec extends ZIOSpecDefault, ZIOStubs:
+  private val config = TestCentralConfig.config
+  private val secretKey = SecretKeySpec(Array.fill(32)(7.toByte), "AES")
+
+  private val tenantId = TenantId("tenant-a")
+  private val detailType = AuthorizationDetailType("payment_initiation")
+  private val schema = Json.Obj("type" -> Json.Str("object"))
+  private val typeDescription = Map("en" -> "Payment initiation")
+
+  private val record = AuthorizationDetailTypeRecord(tenantId, detailType, typeDescription, schema)
+
+  private val syncToken = Unsafe.unsafe { unsafe ?=>
+    Runtime.default.unsafe
+      .run(
+        JWT.serialize(
+          JWT.Claims("a", "b", List("c"), Json.Obj()),
+          1.minute,
+          JWT.Signature.Symmetric(secretKey),
+        ),
+      )
+      .getOrThrowFiberFailure()
+  }
+
+  private val tracingLayer: ULayer[Tracing] =
+    ZLayer.make[Tracing](
+      Tracing.live(logAnnotated = false),
+      OpenTelemetry.contextZIO,
+      ZLayer.succeed(api.OpenTelemetry.noop().getTracer("test")),
+    )
+
+  private def controllerTestCase(
+      description: String,
+      request: Request,
+      expectedStatus: Status,
+      setup: Stub[AuthorizationDetailTypeService] => UIO[Unit] = _ => ZIO.unit,
+      verify: (Response, Stub[AuthorizationDetailTypeService]) => Task[TestResult] = (_, _) => ZIO.succeed(assertTrue(true)),
+  ) =
+    test(description) {
+      for
+        client <- ZIO.service[Client]
+        service = stub[AuthorizationDetailTypeService]
+        edgeService = stub[EdgeService]
+        resourceService = stub[ResourceService]
+        tracing <- tracingLayer.build
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            AuthorizationDetailTypeController.routes.provideEnvironment(
+              ZEnvironment[AuthorizationDetailTypeService](service) ++
+                ZEnvironment[EdgeService](edgeService) ++
+                ZEnvironment[ResourceService](resourceService) ++
+                ZEnvironment[CentralConfig](config) ++
+                tracing
+            )
+          )
+        )
+        _ <- resourceService.verifySecret.succeedsWith(true)
+        _ <- setup(service)
+        requestWithAuth = request.headers.header(Header.Authorization) match
+          case None => request.addHeader(TestAdminAuth.basicAuthHeader)
+          case _    => request
+        response <- client.batched(requestWithAuth.addHeader(Header.Accept(MediaType.application.json)))
+        verifyResult <- verify(response, service)
+      yield assertTrue(response.status == expectedStatus) && verifyResult
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging
+
+  def spec = suite("AuthorizationDetailTypeController")(
+    controllerTestCase(
+      description = "GET authorization-detail-types returns the tenant's types",
+      request = Request.get(
+        (URL.empty / "configuration" / "authorization-detail-types")
+          .addQueryParam("tenantId", tenantId.toString)
+      ),
+      expectedStatus = Status.Ok,
+      setup = service => service.getTenantTypes.succeedsWith(Vector(record)),
+      // zio-http's schema-derived `asJson` mishandles nested `Json.Obj` fields, so this
+      // decodes with the response DTO's own zio-json `JsonCodec` instead (the same one the
+      // controller encodes with via `EncoderOps`).
+      verify = (response, service) =>
+        for
+          bodyString <- response.body.asString
+          body <- ZIO.fromEither(bodyString.fromJson[GetAllAuthorizationDetailTypesResponse]).mapError(new RuntimeException(_))
+        yield assertTrue(
+          service.getTenantTypes.calls == List((tenantId, 0, None)),
+          body == GetAllAuthorizationDetailTypesResponse(
+            Vector(AuthorizationDetailTypeResponse(detailType, typeDescription, schema))
+          ),
+        ),
+    ),
+    controllerTestCase(
+      description = "GET authorization-detail-types forwards offset and limit query params",
+      request = Request.get(
+        (URL.empty / "configuration" / "authorization-detail-types")
+          .addQueryParam("tenantId", tenantId.toString)
+          .addQueryParam("offset", "10")
+          .addQueryParam("limit", "5")
+      ),
+      expectedStatus = Status.Ok,
+      setup = service => service.getTenantTypes.succeedsWith(Vector.empty),
+      verify = (_, service) =>
+        ZIO.succeed(assertTrue(service.getTenantTypes.calls == List((tenantId, 10, Some(5))))),
+    ),
+    controllerTestCase(
+      description = "GET authorization-detail-types/sync returns all types for an authorized service token",
+      request = Request
+        .get(URL.empty / "configuration" / "authorization-detail-types" / "sync")
+        .addHeader(Header.Authorization.Bearer(syncToken)),
+      expectedStatus = Status.Ok,
+      setup = service => service.getAllTypes.succeedsWith(Vector(record)),
+      verify = (response, service) =>
+        for
+          bodyString <- response.body.asString
+          body <- ZIO.fromEither(bodyString.fromJson[GetAuthorizationDetailTypesSyncResponse]).mapError(new RuntimeException(_))
+        yield assertTrue(
+          service.getAllTypes.calls.length == 1,
+          body == GetAuthorizationDetailTypesSyncResponse(
+            Vector(AuthorizationDetailTypeSyncResponse(tenantId, detailType, schema))
+          ),
+        ),
+    ),
+    controllerTestCase(
+      description = "GET authorization-detail-types/sync rejects a request without a service token",
+      request = Request.get(URL.empty / "configuration" / "authorization-detail-types" / "sync"),
+      expectedStatus = Status.Unauthorized,
+      verify = (_, service) => ZIO.succeed(assertTrue(service.getAllTypes.calls.isEmpty)),
+    ),
+    controllerTestCase(
+      description = "POST authorization-detail-types creates a type and returns 201 Created",
+      request = Request(
+        method = Method.POST,
+        url = URL.empty / "configuration" / "authorization-detail-types",
+        body = Body.fromString(CreateAuthorizationDetailTypeRequest(tenantId, detailType, typeDescription, schema).toJson),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.Created,
+      setup = service => service.createType.succeedsWith(Right(())),
+      verify = (_, service) =>
+        ZIO.succeed(assertTrue(
+          service.createType.calls == List(CreateAuthorizationDetailTypeRequest(tenantId, detailType, typeDescription, schema))
+        )),
+    ),
+    controllerTestCase(
+      description = "POST authorization-detail-types returns 400 Bad Request when the service rejects the schema",
+      request = Request(
+        method = Method.POST,
+        url = URL.empty / "configuration" / "authorization-detail-types",
+        body = Body.fromString(CreateAuthorizationDetailTypeRequest(tenantId, detailType, typeDescription, schema).toJson),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.BadRequest,
+      setup = service => service.createType.succeedsWith(Left(AuthorizationDetailTypeValidationError.InvalidSchema(List("bad schema")))),
+    ),
+    controllerTestCase(
+      description = "PUT authorization-detail-types updates a type and returns 204 No Content",
+      request = Request(
+        method = Method.PUT,
+        url = URL.empty / "configuration" / "authorization-detail-types",
+        body = Body.fromString(UpdateAuthorizationDetailTypeRequest(tenantId, detailType, typeDescription, schema).toJson),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.NoContent,
+      setup = service => service.updateType.succeedsWith(Right(())),
+      verify = (_, service) =>
+        ZIO.succeed(assertTrue(
+          service.updateType.calls == List(UpdateAuthorizationDetailTypeRequest(tenantId, detailType, typeDescription, schema))
+        )),
+    ),
+    controllerTestCase(
+      description = "PUT authorization-detail-types returns 400 Bad Request when the service rejects the schema",
+      request = Request(
+        method = Method.PUT,
+        url = URL.empty / "configuration" / "authorization-detail-types",
+        body = Body.fromString(UpdateAuthorizationDetailTypeRequest(tenantId, detailType, typeDescription, schema).toJson),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.BadRequest,
+      setup = service => service.updateType.succeedsWith(Left(AuthorizationDetailTypeValidationError.InvalidSchema(List("bad schema")))),
+    ),
+    controllerTestCase(
+      description = "DELETE authorization-detail-types deletes a type and returns 204 No Content",
+      request = Request.delete(
+        (URL.empty / "configuration" / "authorization-detail-types")
+          .addQueryParam("tenantId", tenantId.toString)
+          .addQueryParam("type", detailType.toString)
+      ),
+      expectedStatus = Status.NoContent,
+      setup = service => service.deleteType.succeedsWith(()),
+      verify = (_, service) =>
+        ZIO.succeed(assertTrue(service.deleteType.calls == List((tenantId, detailType)))),
+    ),
+  )

--- a/central/src/test/scala/versola/central/configuration/jwks/JwksRepositorySpec.scala
+++ b/central/src/test/scala/versola/central/configuration/jwks/JwksRepositorySpec.scala
@@ -1,0 +1,63 @@
+package versola.central.configuration.jwks
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import versola.util.DatabaseSpecBase
+import zio.json.ast.Json
+import zio.test.*
+
+/** Conformance suite for any [[JwksRepository]] implementation. A backend module extends
+  * this and supplies the wiring -- see `PostgresJwksRepositorySpec` in `central-postgres-impl`
+  * for the one binding that exists today.
+  */
+trait JwksRepositorySpec extends DatabaseSpecBase[JwksRepositorySpec.Env]:
+  self: ZIOSpec[TransactorZIO] =>
+
+  private val jwk1 = Json.Obj("kty" -> Json.Str("RSA"), "kid" -> Json.Str("key-1"))
+  private val jwk2 = Json.Obj("kty" -> Json.Str("RSA"), "kid" -> Json.Str("key-2"))
+
+  override def testCases(env: JwksRepositorySpec.Env) =
+    List(
+      test("getAll returns nothing when the table is empty") {
+        for all <- env.repository.getAll
+        yield assertTrue(all.isEmpty)
+      },
+      test("find returns None for an unknown kid") {
+        for found <- env.repository.find("missing")
+        yield assertTrue(found.isEmpty)
+      },
+      test("create stores a key retrievable by find and getAll") {
+        for
+          _ <- env.repository.create("key-1", jwk1)
+          found <- env.repository.find("key-1")
+          all <- env.repository.getAll
+        yield assertTrue(
+          found == Some(JwksRecord("key-1", jwk1)),
+          all == Vector(JwksRecord("key-1", jwk1)),
+        )
+      },
+      test("getAll returns every key") {
+        for
+          _ <- env.repository.create("key-1", jwk1)
+          _ <- env.repository.create("key-2", jwk2)
+          all <- env.repository.getAll
+        yield assertTrue(all.toSet == Set(JwksRecord("key-1", jwk1), JwksRecord("key-2", jwk2)))
+      },
+      test("update replaces the key material for an existing kid") {
+        val updated = Json.Obj("kty" -> Json.Str("EC"), "kid" -> Json.Str("key-1"))
+        for
+          _ <- env.repository.create("key-1", jwk1)
+          _ <- env.repository.update("key-1", updated)
+          found <- env.repository.find("key-1")
+        yield assertTrue(found == Some(JwksRecord("key-1", updated)))
+      },
+      test("delete removes the key") {
+        for
+          _ <- env.repository.create("key-1", jwk1)
+          _ <- env.repository.delete("key-1")
+          found <- env.repository.find("key-1")
+        yield assertTrue(found.isEmpty)
+      },
+    )
+
+object JwksRepositorySpec:
+  case class Env(repository: JwksRepository)

--- a/central/src/test/scala/versola/central/configuration/metadata/ServerMetadataControllerSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/metadata/ServerMetadataControllerSpec.scala
@@ -1,0 +1,152 @@
+package versola.central.configuration.metadata
+
+import io.opentelemetry.api
+import org.scalamock.stubs.{Stub, ZIOStubs}
+import versola.central.{CentralConfig, TestAdminAuth, TestCentralConfig}
+import versola.central.configuration.edges.EdgeService
+import versola.central.configuration.resources.ResourceService
+import versola.util.JWT
+import versola.util.http.Observability
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.json.ast.Json
+import zio.telemetry.opentelemetry.OpenTelemetry
+import zio.telemetry.opentelemetry.tracing.Tracing
+import zio.test.*
+
+import javax.crypto.spec.SecretKeySpec
+
+object ServerMetadataControllerSpec extends ZIOSpecDefault, ZIOStubs:
+  private val config = TestCentralConfig.config
+  private val secretKey = SecretKeySpec(Array.fill(32)(7.toByte), "AES")
+
+  private val metadata = Json.Obj("issuer" -> Json.Str("https://auth.example.com"))
+
+  private val syncToken = Unsafe.unsafe { unsafe ?=>
+    Runtime.default.unsafe
+      .run(
+        JWT.serialize(
+          JWT.Claims("a", "b", List("c"), Json.Obj()),
+          1.minute,
+          JWT.Signature.Symmetric(secretKey),
+        ),
+      )
+      .getOrThrowFiberFailure()
+  }
+
+  private val tracingLayer: ULayer[Tracing] =
+    ZLayer.make[Tracing](
+      Tracing.live(logAnnotated = false),
+      OpenTelemetry.contextZIO,
+      ZLayer.succeed(api.OpenTelemetry.noop().getTracer("test")),
+    )
+
+  private def controllerTestCase(
+      description: String,
+      request: Request,
+      expectedStatus: Status,
+      setup: Stub[ServerMetadataService] => UIO[Unit] = _ => ZIO.unit,
+      verify: (Response, Stub[ServerMetadataService]) => Task[TestResult] = (_, _) => ZIO.succeed(assertTrue(true)),
+  ) =
+    test(description) {
+      for
+        client <- ZIO.service[Client]
+        service = stub[ServerMetadataService]
+        edgeService = stub[EdgeService]
+        resourceService = stub[ResourceService]
+        tracing <- tracingLayer.build
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            ServerMetadataController.routes.provideEnvironment(
+              ZEnvironment[ServerMetadataService](service) ++
+                ZEnvironment[EdgeService](edgeService) ++
+                ZEnvironment[ResourceService](resourceService) ++
+                ZEnvironment[CentralConfig](config) ++
+                tracing
+            )
+          )
+        )
+        _ <- resourceService.verifySecret.succeedsWith(true)
+        _ <- setup(service)
+        requestWithAuth = request.headers.header(Header.Authorization) match
+          case None => request.addHeader(TestAdminAuth.basicAuthHeader)
+          case _    => request
+        response <- client.batched(requestWithAuth)
+        verifyResult <- verify(response, service)
+      yield assertTrue(response.status == expectedStatus) && verifyResult
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging
+
+  def spec = suite("ServerMetadataController")(
+    controllerTestCase(
+      description = "GET server-metadata returns the current metadata",
+      request = Request.get(URL.empty / "configuration" / "server-metadata"),
+      expectedStatus = Status.Ok,
+      setup = service => service.getMetadata.succeedsWith(Some(metadata)),
+      verify = (response, service) =>
+        for body <- response.body.asString
+        yield assertTrue(
+          service.getMetadata.calls.length == 1,
+          body.fromJson[Json] == Right(metadata),
+        ),
+    ),
+    controllerTestCase(
+      description = "GET server-metadata returns JSON null when nothing has been set",
+      request = Request.get(URL.empty / "configuration" / "server-metadata"),
+      expectedStatus = Status.Ok,
+      setup = service => service.getMetadata.succeedsWith(None),
+      verify = (response, _) =>
+        for body <- response.body.asString
+        yield assertTrue(body.fromJson[Json] == Right(Json.Null)),
+    ),
+    controllerTestCase(
+      description = "GET server-metadata rejects a malformed shared secret",
+      request = Request.get(URL.empty / "configuration" / "server-metadata")
+        .addHeader(Header.Authorization.Basic("central", "not-valid-base64!!!")),
+      expectedStatus = Status.Unauthorized,
+      verify = (_, service) => ZIO.succeed(assertTrue(service.getMetadata.calls.isEmpty)),
+    ),
+    controllerTestCase(
+      description = "POST server-metadata upserts the metadata and returns no content",
+      request = Request(
+        method = Method.POST,
+        url = URL.empty / "configuration" / "server-metadata",
+        body = Body.fromString(metadata.toJson),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.NoContent,
+      setup = service => service.upsertMetadata.succeedsWith(()),
+      verify = (_, service) =>
+        ZIO.succeed(assertTrue(service.upsertMetadata.calls == List(metadata))),
+    ),
+    controllerTestCase(
+      description = "GET server-metadata/sync returns metadata for an authorized service token",
+      request = Request
+        .get(URL.empty / "configuration" / "server-metadata" / "sync")
+        .addHeader(Header.Authorization.Bearer(syncToken)),
+      expectedStatus = Status.Ok,
+      setup = service => service.getMetadata.succeedsWith(Some(metadata)),
+      verify = (response, service) =>
+        for body <- response.body.asString
+        yield assertTrue(
+          service.getMetadata.calls.length == 1,
+          body.fromJson[Json] == Right(metadata),
+        ),
+    ),
+    controllerTestCase(
+      description = "GET server-metadata/sync defaults to an empty object when nothing has been set",
+      request = Request
+        .get(URL.empty / "configuration" / "server-metadata" / "sync")
+        .addHeader(Header.Authorization.Bearer(syncToken)),
+      expectedStatus = Status.Ok,
+      setup = service => service.getMetadata.succeedsWith(None),
+      verify = (response, _) =>
+        for body <- response.body.asString
+        yield assertTrue(body.fromJson[Json] == Right(Json.Obj())),
+    ),
+    controllerTestCase(
+      description = "GET server-metadata/sync rejects a request without a service token",
+      request = Request.get(URL.empty / "configuration" / "server-metadata" / "sync"),
+      expectedStatus = Status.Unauthorized,
+      verify = (_, service) => ZIO.succeed(assertTrue(service.getMetadata.calls.isEmpty)),
+    ),
+  )

--- a/central/src/test/scala/versola/central/configuration/themes/ThemeRepositorySpec.scala
+++ b/central/src/test/scala/versola/central/configuration/themes/ThemeRepositorySpec.scala
@@ -1,0 +1,63 @@
+package versola.central.configuration.themes
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import versola.central.configuration.tenants.TenantId
+import versola.util.DatabaseSpecBase
+import zio.test.*
+
+/** Conformance suite for any [[ThemeRepository]] implementation. A backend module extends
+  * this and supplies the wiring -- see `PostgresThemeRepositorySpec` in `central-postgres-impl`
+  * for the one binding that exists today.
+  */
+trait ThemeRepositorySpec extends DatabaseSpecBase[ThemeRepositorySpec.Env]:
+  self: ZIOSpec[TransactorZIO] =>
+
+  private val tenantId = TenantId("tenant-a")
+
+  override def testCases(env: ThemeRepositorySpec.Env) =
+    List(
+      test("getAll returns nothing when the table is empty") {
+        for all <- env.repository.getAll
+        yield assertTrue(all.isEmpty)
+      },
+      test("create stores a global theme with no tenant") {
+        val theme = ThemeRecord("dark", "body { color: white; }", None)
+        for
+          _ <- env.repository.create(theme)
+          all <- env.repository.getAll
+        yield assertTrue(all == Vector(theme))
+      },
+      test("create stores a theme scoped to a tenant") {
+        val theme = ThemeRecord("brand", "body { color: blue; }", Some(tenantId))
+        for
+          _ <- env.repository.create(theme)
+          all <- env.repository.getAll
+        yield assertTrue(all == Vector(theme))
+      },
+      test("getAll orders by id and includes every theme") {
+        for
+          _ <- env.repository.create(ThemeRecord("zeta", "a", None))
+          _ <- env.repository.create(ThemeRecord("alpha", "b", None))
+          all <- env.repository.getAll
+        yield assertTrue(all.map(_.id) == Vector("alpha", "zeta"))
+      },
+      test("update replaces the css but leaves the original tenant untouched") {
+        val theme = ThemeRecord("dark", "body { color: white; }", Some(tenantId))
+        for
+          _ <- env.repository.create(theme)
+          _ <- env.repository.update(theme.copy(css = "body { color: black; }", tenantId = None))
+          all <- env.repository.getAll
+        yield assertTrue(all == Vector(theme.copy(css = "body { color: black; }")))
+      },
+      test("delete removes the theme") {
+        val theme = ThemeRecord("dark", "body { color: white; }", None)
+        for
+          _ <- env.repository.create(theme)
+          _ <- env.repository.delete("dark")
+          all <- env.repository.getAll
+        yield assertTrue(all.isEmpty)
+      },
+    )
+
+object ThemeRepositorySpec:
+  case class Env(repository: ThemeRepository)

--- a/central/src/test/scala/versola/central/users/AuthClientSpec.scala
+++ b/central/src/test/scala/versola/central/users/AuthClientSpec.scala
@@ -1,9 +1,9 @@
 package versola.central.users
 
-import versola.central.{CentralConfig, TestCentralConfig}
 import versola.central.configuration.clients.ClientId
 import versola.central.configuration.roles.RoleId
 import versola.central.configuration.tenants.TenantId
+import versola.central.{CentralConfig, TestCentralConfig}
 import versola.util.JWT
 import zio.*
 import zio.http.*
@@ -22,12 +22,12 @@ object AuthClientSpec extends ZIOSpecDefault:
   private case class TokenClaims(iss: String, sub: String, aud: List[String]) derives JsonDecoder
 
   private val secretKey = TestCentralConfig.config.secretKey
-  private val userId    = UserId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-  private val version   = UUID.fromString("00000000-0000-0000-0000-000000000002")
-  private val tenantId  = TenantId("t1")
-  private val roleId    = RoleId("r1")
+  private val userId = UserId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+  private val version = UUID.fromString("00000000-0000-0000-0000-000000000002")
+  private val tenantId = TenantId("t1")
+  private val roleId = RoleId("r1")
   private val jsonClaims = Json.Obj("role" -> Json.Str("admin"))
-  private val credId    = "cred-1"
+  private val credId = "cred-1"
 
   private val passkeyInfo = PasskeyInfo(
     id = "aQ",
@@ -51,17 +51,16 @@ object AuthClientSpec extends ZIOSpecDefault:
   )
 
   private val resetRequest = ResetPasswordRequest(
-      userId = userId,
-        expiresInSeconds = 3600L,
-      channel = Some(DeliveryChannel.email),
+    userId = userId,
+    expiresInSeconds = 3600L,
+    channel = Some(DeliveryChannel.email),
   )
 
   /** Captures the Authorization header from the first captured request. */
   private def captureBearer(seen: Ref[Option[Request]]): Task[String] =
     seen.get.someOrFail(new RuntimeException("No request captured")).flatMap: req =>
       ZIO.fromOption(req.header(Header.Authorization).collect:
-        case Header.Authorization.Bearer(t) => t.stringValue
-      ).orElseFail(new RuntimeException("No Bearer header"))
+        case Header.Authorization.Bearer(t) => t.stringValue).orElseFail(new RuntimeException("No Bearer header"))
 
   /** Assert the bearer is signed with the shared secret and has the expected claims. */
   private def assertBearerClaims(token: String): Task[TestResult] =
@@ -72,7 +71,7 @@ object AuthClientSpec extends ZIOSpecDefault:
           claims.iss == "central",
           claims.sub == "central",
           claims.aud == List("auth"),
-        )
+        ),
       )
 
   /** Fixed token returned by the stub AuthTokenService. */
@@ -84,9 +83,10 @@ object AuthClientSpec extends ZIOSpecDefault:
     )
 
   private def tokenServiceLayer: ULayer[AuthTokenService] =
-    ZLayer.fromZIO(fixedToken.map(t => new AuthTokenService:
-      override def getToken: UIO[String] = ZIO.succeed(t)
-      override def refreshToken(): Task[String] = ZIO.succeed(t)
+    ZLayer.fromZIO(fixedToken.map(t =>
+      new AuthTokenService:
+        override def getToken: UIO[String] = ZIO.succeed(t)
+        override def refreshToken(): Task[String] = ZIO.succeed(t),
     ).orDie)
 
   private def authClientLayer: ZLayer[Client & CentralConfig & AuthTokenService, Nothing, AuthClient] =
@@ -96,13 +96,13 @@ object AuthClientSpec extends ZIOSpecDefault:
   private def mkTest(name: String, call: AuthClient => Task[Unit]) =
     test(name) {
       for
-        seen   <- Ref.make(Option.empty[Request])
-        _      <- TestClient.addRoutes(
-          Handler.fromFunctionZIO[Request](r => seen.set(Some(r)).as(Response.status(Status.NoContent))).toRoutes
+        seen <- Ref.make(Option.empty[Request])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request](r => seen.set(Some(r)).as(Response.status(Status.NoContent))).toRoutes,
         )
         client <- ZIO.service[AuthClient]
-        _      <- call(client)
-        token  <- captureBearer(seen)
+        _ <- call(client)
+        token <- captureBearer(seen)
         result <- assertBearerClaims(token)
       yield result
     }.provide(TestClient.layer, ZLayer.succeed(TestCentralConfig.config), tokenServiceLayer, authClientLayer)
@@ -111,13 +111,13 @@ object AuthClientSpec extends ZIOSpecDefault:
   private def mkJsonTest(name: String, responseJson: String, call: AuthClient => Task[Unit]) =
     test(name) {
       for
-        seen   <- Ref.make(Option.empty[Request])
-        _      <- TestClient.addRoutes(
-          Handler.fromFunctionZIO[Request](r => seen.set(Some(r)).as(Response.json(responseJson))).toRoutes
+        seen <- Ref.make(Option.empty[Request])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request](r => seen.set(Some(r)).as(Response.json(responseJson))).toRoutes,
         )
         client <- ZIO.service[AuthClient]
-        _      <- call(client)
-        token  <- captureBearer(seen)
+        _ <- call(client)
+        token <- captureBearer(seen)
         result <- assertBearerClaims(token)
       yield result
     }.provide(TestClient.layer, ZLayer.succeed(TestCentralConfig.config), tokenServiceLayer, authClientLayer)
@@ -128,19 +128,19 @@ object AuthClientSpec extends ZIOSpecDefault:
    * Returns both the driver and a Ref tracking total call count.
    */
   private def failingDriver(
-    failCount: Int,
-    makeException: () => Throwable,
+      failCount: Int,
+      makeException: () => Throwable,
   ): UIO[(ZClient.Driver[Any, Scope, Throwable], Ref[Int])] =
     Ref.make(0).map { counter =>
       val driver = new ZClient.Driver[Any, Scope, Throwable]:
         override def request(
-          version: Version,
-          method: Method,
-          url: URL,
-          headers: Headers,
-          body: Body,
-          sslConfig: Option[ClientSSLConfig],
-          proxy: Option[Proxy],
+            version: Version,
+            method: Method,
+            url: URL,
+            headers: Headers,
+            body: Body,
+            sslConfig: Option[ClientSSLConfig],
+            proxy: Option[Proxy],
         )(using trace: Trace): ZIO[Scope, Throwable, Response] =
           counter.updateAndGet(_ + 1).flatMap { n =>
             if n <= failCount then ZIO.fail(makeException())
@@ -148,10 +148,10 @@ object AuthClientSpec extends ZIOSpecDefault:
           }
 
         override def socket[Env1 <: Any](
-          version: Version,
-          url: URL,
-          headers: Headers,
-          app: WebSocketApp[Env1],
+            version: Version,
+            url: URL,
+            headers: Headers,
+            app: WebSocketApp[Env1],
         )(using trace: Trace, ev: Scope =:= Scope): ZIO[Env1 & Scope, Throwable, Response] =
           ZIO.dieMessage("WebSocket not used in AuthClient tests")
 
@@ -160,8 +160,8 @@ object AuthClientSpec extends ZIOSpecDefault:
 
   /** Constructs an AuthClient.Impl using a custom driver (bypassing TestClient). */
   private def makeAuthClientWithDriver(
-    driver: ZClient.Driver[Any, Scope, Throwable],
-    token: String,
+      driver: ZClient.Driver[Any, Scope, Throwable],
+      token: String,
   ): AuthClient =
     AuthClient.Impl(
       ZClient.fromDriver(driver),
@@ -179,108 +179,137 @@ object AuthClientSpec extends ZIOSpecDefault:
   ) @@ TestAspect.silentLogging
 
   // ── Bearer token is attached to every outbound request ─────────────────────
-  private val bearerSuite = suite("Bearer token added to all 12 methods")(
-    mkTest("upsertUser",
-      _.upsertUser(userId, version, None, None, None)),
-    mkTest("updateUserRoles",
-      _.updateUserRoles(userId, tenantId, Set(roleId), Set.empty)),
-    mkTest("patchUserClaims",
-      _.patchUserClaims(userId, Json.Obj())),
-    mkTest("invalidateSession",
-      _.invalidateSession(userId)),
-    mkTest("resetUserLimits",
-      _.resetUserLimits(userId, tenantId, None, None)),
-    mkTest("renamePasskey",
-      _.renamePasskey(userId, credId, Some("New Name"))),
-    mkTest("deletePasskey",
-      _.deletePasskey(userId, credId)),
-      mkTest("resetPassword",
-        _.resetPassword(resetRequest.userId, 3600L, resetRequest.channel).unit),
-    mkJsonTest("getUserClaims",
+  private val bearerSuite = suite("Bearer token added to all 15 methods")(
+    mkTest(
+      "deleteUser",
+      _.deleteUser(userId),
+    ),
+    mkTest(
+      "setPassword",
+      _.setPassword(userId, "Temp1234!"),
+    ),
+    mkTest(
+      "syncConfiguration",
+      _.syncConfiguration(),
+    ),
+    mkTest(
+      "upsertUser",
+      _.upsertUser(userId, version, None, None, None),
+    ),
+    mkTest(
+      "updateUserRoles",
+      _.updateUserRoles(userId, tenantId, Set(roleId), Set.empty),
+    ),
+    mkTest(
+      "patchUserClaims",
+      _.patchUserClaims(userId, Json.Obj()),
+    ),
+    mkTest(
+      "invalidateSession",
+      _.invalidateSession(userId),
+    ),
+    mkTest(
+      "resetUserLimits",
+      _.resetUserLimits(userId, tenantId, None, None),
+    ),
+    mkTest(
+      "renamePasskey",
+      _.renamePasskey(userId, credId, Some("New Name")),
+    ),
+    mkTest(
+      "deletePasskey",
+      _.deletePasskey(userId, credId),
+    ),
+    mkTest(
+      "resetPassword",
+      _.resetPassword(resetRequest.userId, 3600L, resetRequest.channel).unit,
+    ),
+    mkJsonTest(
+      "getUserClaims",
       """{"claims":{}}""",
-      _.getUserClaims(userId).unit),
-    mkJsonTest("getUserRoles",
+      _.getUserClaims(userId).unit,
+    ),
+    mkJsonTest(
+      "getUserRoles",
       """{"roles":[]}""",
-      _.getUserRoles(userId, tenantId).unit),
-    mkJsonTest("getUserSessions",
+      _.getUserRoles(userId, tenantId).unit,
+    ),
+    mkJsonTest(
+      "getUserSessions",
       """{"sessions":[]}""",
-      _.getUserSessions(userId).unit),
-    mkJsonTest("listPasskeys",
+      _.getUserSessions(userId).unit,
+    ),
+    mkJsonTest(
+      "listPasskeys",
       """{"passkeys":[]}""",
-      _.listPasskeys(userId).unit),
+      _.listPasskeys(userId).unit,
+    ),
   )
 
   // ── Response decoding ───────────────────────────────────────────────────────
   private val decodingSuite = suite("response decoding")(
-
     test("resetPassword returns None when server responds 204") {
       for
         _ <- TestClient.addRoutes(
-          Handler.fromFunctionZIO[Request](_ => ZIO.succeed(Response.status(Status.NoContent))).toRoutes
+          Handler.fromFunctionZIO[Request](_ => ZIO.succeed(Response.status(Status.NoContent))).toRoutes,
         )
-          client <- ZIO.service[AuthClient]
-          result <- client.resetPassword(resetRequest.userId, 3600L, resetRequest.channel)
+        client <- ZIO.service[AuthClient]
+        result <- client.resetPassword(resetRequest.userId, 3600L, resetRequest.channel)
       yield assertTrue(result.isEmpty)
-      }.provide(TestClient.layer, ZLayer.succeed(TestCentralConfig.config), tokenServiceLayer, authClientLayer),
-
+    }.provide(TestClient.layer, ZLayer.succeed(TestCentralConfig.config), tokenServiceLayer, authClientLayer),
     test("resetPassword returns the plaintext when server responds 200") {
       for
         _ <- TestClient.addRoutes(
-          Handler.fromFunctionZIO[Request](_ => ZIO.succeed(Response.json("""{"password":"Temp1234!"}"""))).toRoutes
+          Handler.fromFunctionZIO[Request](_ => ZIO.succeed(Response.json("""{"password":"Temp1234!"}"""))).toRoutes,
         )
-          client <- ZIO.service[AuthClient]
-          result <- client.resetPassword(resetRequest.userId, 3600L, resetRequest.channel)
+        client <- ZIO.service[AuthClient]
+        result <- client.resetPassword(resetRequest.userId, 3600L, resetRequest.channel)
       yield assertTrue(result.contains("Temp1234!"))
-      }.provide(TestClient.layer, ZLayer.succeed(TestCentralConfig.config), tokenServiceLayer, authClientLayer),
-
+    }.provide(TestClient.layer, ZLayer.succeed(TestCentralConfig.config), tokenServiceLayer, authClientLayer),
     test("getUserClaims returns Some when server responds 200 with claims") {
       val json = """{"claims":{"role":"admin"}}"""
       for
         _ <- TestClient.addRoutes(
-          Handler.fromFunctionZIO[Request](_ => ZIO.succeed(Response.json(json))).toRoutes
+          Handler.fromFunctionZIO[Request](_ => ZIO.succeed(Response.json(json))).toRoutes,
         )
         client <- ZIO.service[AuthClient]
         result <- client.getUserClaims(userId)
       yield assertTrue(result.isDefined)
     }.provide(TestClient.layer, ZLayer.succeed(TestCentralConfig.config), tokenServiceLayer, authClientLayer),
-
     test("getUserClaims returns None when server responds 204") {
       for
         _ <- TestClient.addRoutes(
-          Handler.fromFunctionZIO[Request](_ => ZIO.succeed(Response.status(Status.NoContent))).toRoutes
+          Handler.fromFunctionZIO[Request](_ => ZIO.succeed(Response.status(Status.NoContent))).toRoutes,
         )
         client <- ZIO.service[AuthClient]
         result <- client.getUserClaims(userId)
       yield assertTrue(result.isEmpty)
     }.provide(TestClient.layer, ZLayer.succeed(TestCentralConfig.config), tokenServiceLayer, authClientLayer),
-
     test("getUserRoles decodes the returned role list") {
       val json = """{"roles":["r1","r2"]}"""
       for
         _ <- TestClient.addRoutes(
-          Handler.fromFunctionZIO[Request](_ => ZIO.succeed(Response.json(json))).toRoutes
+          Handler.fromFunctionZIO[Request](_ => ZIO.succeed(Response.json(json))).toRoutes,
         )
         client <- ZIO.service[AuthClient]
         result <- client.getUserRoles(userId, tenantId)
       yield assertTrue(result == List(RoleId("r1"), RoleId("r2")))
     }.provide(TestClient.layer, ZLayer.succeed(TestCentralConfig.config), tokenServiceLayer, authClientLayer),
-
     test("getUserSessions decodes the session list") {
       val json = AuthClient.SessionListResponse(List(sessionDto)).toJson
       for
         _ <- TestClient.addRoutes(
-          Handler.fromFunctionZIO[Request](_ => ZIO.succeed(Response.json(json))).toRoutes
+          Handler.fromFunctionZIO[Request](_ => ZIO.succeed(Response.json(json))).toRoutes,
         )
         client <- ZIO.service[AuthClient]
         result <- client.getUserSessions(userId)
       yield assertTrue(result == List(sessionDto))
     }.provide(TestClient.layer, ZLayer.succeed(TestCentralConfig.config), tokenServiceLayer, authClientLayer),
-
     test("listPasskeys decodes the passkey list") {
       val response = ListPasskeysResponse(List(passkeyInfo))
       for
         _ <- TestClient.addRoutes(
-          Handler.fromFunctionZIO[Request](_ => ZIO.succeed(Response.json(response.toJson))).toRoutes
+          Handler.fromFunctionZIO[Request](_ => ZIO.succeed(Response.json(response.toJson))).toRoutes,
         )
         client <- ZIO.service[AuthClient]
         result <- client.listPasskeys(userId)
@@ -290,54 +319,50 @@ object AuthClientSpec extends ZIOSpecDefault:
 
   // ── withConnectionRetry ─────────────────────────────────────────────────────
   private val retrySuite = suite("withConnectionRetry")(
-
     test("retries on ConnectException and eventually succeeds") {
       for
-        token             <- fixedToken
+        token <- fixedToken
         (driver, counter) <- failingDriver(2, () => new ConnectException("refused"))
-        client            =  makeAuthClientWithDriver(driver, token)
-        fiber             <- client.upsertUser(userId, version, None, None, None).fork
-        _                 <- TestClock.adjust(1.second)
-        _                 <- fiber.join
-        count             <- counter.get
+        client = makeAuthClientWithDriver(driver, token)
+        fiber <- client.upsertUser(userId, version, None, None, None).fork
+        _ <- TestClock.adjust(1.second)
+        _ <- fiber.join
+        count <- counter.get
       // failCount=2: n=1 fail, n=2 fail, n=3 succeed → 3 calls total
       yield assertTrue(count == 3)
     },
-
     test("retries on IOException and eventually succeeds") {
       for
-        token             <- fixedToken
+        token <- fixedToken
         (driver, counter) <- failingDriver(1, () => new IOException("broken pipe"))
-        client            =  makeAuthClientWithDriver(driver, token)
-        fiber             <- client.upsertUser(userId, version, None, None, None).fork
-        _                 <- TestClock.adjust(1.second)
-        _                 <- fiber.join
-        count             <- counter.get
+        client = makeAuthClientWithDriver(driver, token)
+        fiber <- client.upsertUser(userId, version, None, None, None).fork
+        _ <- TestClock.adjust(1.second)
+        _ <- fiber.join
+        count <- counter.get
       // failCount=1: n=1 fail, n=2 succeed → 2 calls total
       yield assertTrue(count == 2)
     },
-
     test("does not retry on non-connection exceptions") {
       for
-        token             <- fixedToken
+        token <- fixedToken
         (driver, counter) <- failingDriver(99, () => new RuntimeException("server error"))
-        client            =  makeAuthClientWithDriver(driver, token)
-        exit              <- client.upsertUser(userId, version, None, None, None).exit
-        count             <- counter.get
+        client = makeAuthClientWithDriver(driver, token)
+        exit <- client.upsertUser(userId, version, None, None, None).exit
+        count <- counter.get
       // recurWhile returns false for RuntimeException → no retry → 1 attempt
       yield assertTrue(count == 1) &&
         assert(exit)(fails(isSubtype[RuntimeException](anything)))
     },
-
     test("gives up after exactly 3 retries (4 total attempts)") {
       for
-        token             <- fixedToken
+        token <- fixedToken
         (driver, counter) <- failingDriver(99, () => new ConnectException("refused"))
-        client            =  makeAuthClientWithDriver(driver, token)
-        fiber             <- client.upsertUser(userId, version, None, None, None).fork
-        _                 <- TestClock.adjust(2.seconds)
-        exit              <- fiber.await
-        count             <- counter.get
+        client = makeAuthClientWithDriver(driver, token)
+        fiber <- client.upsertUser(userId, version, None, None, None).fork
+        _ <- TestClock.adjust(2.seconds)
+        exit <- fiber.await
+        count <- counter.get
       // recurs(3): 1 initial + 3 retries = 4 total, all fail → final error
       yield assertTrue(count == 4) &&
         assert(exit)(fails(isSubtype[ConnectException](anything)))
@@ -348,10 +373,10 @@ object AuthClientSpec extends ZIOSpecDefault:
   private val tokenRefreshSuite = suite("token refresh")(
     test("refreshes token and retries on 401 Unauthorized") {
       for
-        token1            <- ZIO.succeed("token-1")
-        token2            <- ZIO.succeed("token-2")
-        tokens            <- Ref.make(List(token1, token2))
-        refreshed         <- Ref.make(false)
+        token1 <- ZIO.succeed("token-1")
+        token2 <- ZIO.succeed("token-2")
+        tokens <- Ref.make(List(token1, token2))
+        refreshed <- Ref.make(false)
 
         tokenService = new AuthTokenService:
           override def getToken: UIO[String] = tokens.get.map(_.head)
@@ -361,13 +386,13 @@ object AuthClientSpec extends ZIOSpecDefault:
         // Mock driver that returns 401 for token-1 and 204 for token-2
         driver = new ZClient.Driver[Any, Scope, Throwable]:
           override def request(
-            version: Version,
-            method: Method,
-            url: URL,
-            headers: Headers,
-            body: Body,
-            sslConfig: Option[ClientSSLConfig],
-            proxy: Option[Proxy],
+              version: Version,
+              method: Method,
+              url: URL,
+              headers: Headers,
+              body: Body,
+              sslConfig: Option[ClientSSLConfig],
+              proxy: Option[Proxy],
           )(using trace: Trace): ZIO[Scope, Throwable, Response] =
             val bearer = headers.get(Header.Authorization).flatMap {
               case Header.Authorization.Bearer(t) => Some(t.stringValue)
@@ -377,15 +402,15 @@ object AuthClientSpec extends ZIOSpecDefault:
             else ZIO.succeed(Response.status(Status.NoContent))
 
           override def socket[Env1 <: Any](
-            version: Version,
-            url: URL,
-            headers: Headers,
-            app: WebSocketApp[Env1],
+              version: Version,
+              url: URL,
+              headers: Headers,
+              app: WebSocketApp[Env1],
           )(using trace: Trace, ev: Scope =:= Scope): ZIO[Env1 & Scope, Throwable, Response] =
             ZIO.dieMessage("WebSocket not used in AuthClient tests")
 
         client = AuthClient.Impl(ZClient.fromDriver(driver), TestCentralConfig.config, tokenService)
-        _      <- client.upsertUser(userId, version, None, None, None)
+        _ <- client.upsertUser(userId, version, None, None, None)
         isRefreshed <- refreshed.get
       yield assertTrue(isRefreshed)
     },

--- a/central/src/test/scala/versola/central/users/ServiceControllerSpec.scala
+++ b/central/src/test/scala/versola/central/users/ServiceControllerSpec.scala
@@ -1,0 +1,126 @@
+package versola.central.users
+
+import io.opentelemetry.api
+import org.scalamock.stubs.{Stub, ZIOStubs}
+import versola.central.TestAdminAuth
+import versola.central.configuration.resources.ResourceService
+import versola.util.EnvName
+import versola.util.http.Observability
+import zio.*
+import zio.http.*
+import zio.telemetry.opentelemetry.OpenTelemetry
+import zio.telemetry.opentelemetry.tracing.Tracing
+import zio.test.*
+
+import java.util.UUID
+
+object ServiceControllerSpec extends ZIOSpecDefault, ZIOStubs:
+  private val userId = UserId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+
+  private val tracingLayer: ULayer[Tracing] =
+    ZLayer.make[Tracing](
+      Tracing.live(logAnnotated = false),
+      OpenTelemetry.contextZIO,
+      ZLayer.succeed(api.OpenTelemetry.noop().getTracer("test")),
+    )
+
+  private type Stubs = (Stub[UserOutboxProcessor], Stub[AuthClient], Stub[UserService], Stub[ResourceService])
+
+  private def controllerTestCase(
+      description: String,
+      request: Request,
+      expectedStatus: Status,
+      env: EnvName = EnvName.Test("test"),
+      authenticate: Boolean = true,
+      setup: Stubs => UIO[Unit] = _ => ZIO.unit,
+      verify: Stubs => Task[TestResult] = _ => ZIO.succeed(assertTrue(true)),
+  ) =
+    test(description) {
+      for
+        client <- ZIO.service[Client]
+        outboxProcessor = stub[UserOutboxProcessor]
+        authClient = stub[AuthClient]
+        userService = stub[UserService]
+        resourceService = stub[ResourceService]
+        stubs = (outboxProcessor, authClient, userService, resourceService)
+        tracing <- tracingLayer.build
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            ServiceController.routes.provideEnvironment(
+              ZEnvironment[UserOutboxProcessor](outboxProcessor) ++
+                ZEnvironment[AuthClient](authClient) ++
+                ZEnvironment[ResourceService](resourceService) ++
+                ZEnvironment[EnvName](env) ++
+                ZEnvironment[UserService](userService) ++
+                tracing
+            )
+          )
+        )
+        _ <- resourceService.verifySecret.succeedsWith(true)
+        _ <- setup(stubs)
+        requestWithAuth = if authenticate then request.addHeader(TestAdminAuth.basicAuthHeader) else request
+        response <- client.batched(requestWithAuth)
+        verifyResult <- verify(stubs)
+      yield assertTrue(response.status == expectedStatus) && verifyResult
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging
+
+  def spec = suite("ServiceController")(
+    suite("POST /service/users/outbox/flush")(
+      controllerTestCase(
+        description = "flushes the outbox and returns 200 OK",
+        request = Request(method = Method.POST, url = URL.empty / "service" / "users" / "outbox" / "flush"),
+        expectedStatus = Status.Ok,
+        setup = (outboxProcessor, _, _, _) => outboxProcessor.flush().succeedsWith(()),
+        verify = (outboxProcessor, _, _, _) => ZIO.succeed(assertTrue(outboxProcessor.flush().calls.length == 1)),
+      ),
+      controllerTestCase(
+        description = "rejects a request without central's shared secret",
+        request = Request(method = Method.POST, url = URL.empty / "service" / "users" / "outbox" / "flush"),
+        expectedStatus = Status.Unauthorized,
+        authenticate = false,
+        verify = (outboxProcessor, _, _, _) => ZIO.succeed(assertTrue(outboxProcessor.flush().calls.isEmpty)),
+      ),
+      controllerTestCase(
+        description = "returns 404 Not Found in prod, without even checking auth",
+        request = Request(method = Method.POST, url = URL.empty / "service" / "users" / "outbox" / "flush"),
+        expectedStatus = Status.NotFound,
+        env = EnvName.Prod,
+        authenticate = false,
+        verify = (outboxProcessor, _, _, _) => ZIO.succeed(assertTrue(outboxProcessor.flush().calls.isEmpty)),
+      ),
+    ),
+    suite("POST /service/configuration/sync")(
+      controllerTestCase(
+        description = "syncs configuration and returns 200 OK",
+        request = Request(method = Method.POST, url = URL.empty / "service" / "configuration" / "sync"),
+        expectedStatus = Status.Ok,
+        setup = (_, authClient, _, _) => authClient.syncConfiguration().succeedsWith(()),
+        verify = (_, authClient, _, _) => ZIO.succeed(assertTrue(authClient.syncConfiguration().calls.length == 1)),
+      ),
+      controllerTestCase(
+        description = "returns 404 Not Found in prod",
+        request = Request(method = Method.POST, url = URL.empty / "service" / "configuration" / "sync"),
+        expectedStatus = Status.NotFound,
+        env = EnvName.Prod,
+        authenticate = false,
+        verify = (_, authClient, _, _) => ZIO.succeed(assertTrue(authClient.syncConfiguration().calls.isEmpty)),
+      ),
+    ),
+    suite("DELETE /service/users")(
+      controllerTestCase(
+        description = "deletes the user and returns 204 No Content",
+        request = Request(method = Method.DELETE, url = (URL.empty / "service" / "users").addQueryParam("id", userId.toString)),
+        expectedStatus = Status.NoContent,
+        setup = (_, _, userService, _) => userService.delete.succeedsWith(()),
+        verify = (_, _, userService, _) => ZIO.succeed(assertTrue(userService.delete.calls == List(userId))),
+      ),
+      controllerTestCase(
+        description = "returns 404 Not Found in prod",
+        request = Request(method = Method.DELETE, url = (URL.empty / "service" / "users").addQueryParam("id", userId.toString)),
+        expectedStatus = Status.NotFound,
+        env = EnvName.Prod,
+        authenticate = false,
+        verify = (_, _, userService, _) => ZIO.succeed(assertTrue(userService.delete.calls.isEmpty)),
+      ),
+    ),
+  )

--- a/central/src/test/scala/versola/central/users/UserRepositorySpec.scala
+++ b/central/src/test/scala/versola/central/users/UserRepositorySpec.scala
@@ -1,7 +1,9 @@
 package versola.central.users
 
 import com.augustnagro.magnum.magzio.TransactorZIO
-import versola.util.{DatabaseSpecBase, Email, Phone, SecureRandom}
+import versola.central.configuration.roles.RoleId
+import versola.central.configuration.tenants.TenantId
+import versola.util.{DatabaseSpecBase, Email, Patch, Phone, SecureRandom}
 import zio.test.*
 import zio.{Duration, ZIO, ZLayer}
 
@@ -12,9 +14,17 @@ trait UserRepositorySpec extends DatabaseSpecBase[UserRepositorySpec.Env]:
 
   private val userId1 = UserId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
   private val userId2 = UserId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
-  private val email   = Email("user@example.com")
-  private val phone   = Phone("+15551234567")
-  private val login   = Login("nickname")
+  private val email = Email("user@example.com")
+  private val phone = Phone("+15551234567")
+  private val login = Login("nickname")
+
+  /** Claims and acknowledges everything currently queued, so a later assertion sees only the
+    * events the test itself provoked. The outbox is per-user FIFO, so simply claiming the
+    * earlier events would leave them leased and block the ones under test.
+    */
+  private def drainOutbox(env: UserRepositorySpec.Env) =
+    env.repository.claimDueEvents(100, Duration.fromSeconds(0))
+      .flatMap(ZIO.foreachDiscard(_)(record => env.repository.deleteEvent(record.id)))
 
   override def testCases(env: UserRepositorySpec.Env) =
     List(
@@ -75,11 +85,11 @@ trait UserRepositorySpec extends DatabaseSpecBase[UserRepositorySpec.Env]:
       test("concurrent registration claims converge on one user id") {
         for
           owners <- ZIO.collectAllPar(
-                      List(
-                        env.repository.indexFromAuth(Some(email), None, None),
-                        env.repository.indexFromAuth(Some(email), None, None),
-                      ),
-                    )
+            List(
+              env.repository.indexFromAuth(Some(email), None, None),
+              env.repository.indexFromAuth(Some(email), None, None),
+            ),
+          )
           indexed <- env.repository.findByEmail(email)
           events <- env.repository.claimDueEvents(10, Duration.fromSeconds(60))
         yield assertTrue(
@@ -94,6 +104,79 @@ trait UserRepositorySpec extends DatabaseSpecBase[UserRepositorySpec.Env]:
           _ <- env.repository.indexFromAuth(None, Some(phone), None)
           result <- env.repository.indexFromAuth(Some(email), Some(phone), None).either
         yield assertTrue(result == Left(UserIndexConflict))
+      },
+      test("patch applies the three-state semantics per column") {
+        for
+          _ <- env.repository.create(userId1, Some(email), Some(phone), Some(login))
+          _ <- env.repository.patch(
+            userId1,
+            email = Some(Patch.Modified(Email("new@example.com"))),
+            phone = Some(Patch.Deleted),
+            login = None,
+          )
+          found <- env.repository.findById(userId1)
+        yield assertTrue(
+          found == Some(UserIndexRecord(userId1, Some(Email("new@example.com")), None, Some(login))),
+        )
+      },
+      test("patch queues an upsert carrying the full post-patch state") {
+        for
+          _ <- env.repository.create(userId1, Some(email), None, None)
+          _ <- drainOutbox(env)
+          _ <- env.repository.patch(userId1, Some(Patch.Modified(Email("new@example.com"))), None, None)
+          events <- env.repository.claimDueEvents(10, Duration.fromSeconds(60))
+          upserts = events.map(_.event).collect { case e: OutboxEvent.UpsertUser => e }
+        yield assertTrue(
+          upserts.map(_.userId) == Vector(userId1),
+          upserts.map(_.email) == Vector(Some(Email("new@example.com"))),
+        )
+      },
+      test("enqueueRoleUpdate queues the role change for auth") {
+        for
+          _ <- env.repository.create(userId1, Some(email), None, None)
+          _ <- drainOutbox(env)
+          _ <- env.repository.enqueueRoleUpdate(userId1, TenantId("tenant-a"), Set(RoleId("role-a")), Set(RoleId("role-b")))
+          events <- env.repository.claimDueEvents(10, Duration.fromSeconds(60))
+          roleUpdates = events.map(_.event).collect { case e: OutboxEvent.UpdateUserRoles => e }
+        yield assertTrue(
+          roleUpdates.map(_.userId) == Vector(userId1),
+          roleUpdates.map(_.add) == Vector(Set(RoleId("role-a"))),
+          roleUpdates.map(_.remove) == Vector(Set(RoleId("role-b"))),
+        )
+      },
+      test("delete removes the index entry and queues a delete for auth") {
+        for
+          _ <- env.repository.create(userId1, Some(email), None, None)
+          _ <- drainOutbox(env)
+          _ <- env.repository.delete(userId1)
+          found <- env.repository.findById(userId1)
+          events <- env.repository.claimDueEvents(10, Duration.fromSeconds(60))
+          deletes = events.map(_.event).collect { case e: OutboxEvent.DeleteUser => e }
+        yield assertTrue(found.isEmpty, deletes.map(_.userId) == Vector(userId1))
+      },
+      test("deleteEvent drops a dispatched event from the outbox") {
+        for
+          _ <- env.repository.create(userId1, Some(email), None, None)
+          claimed <- env.repository.claimDueEvents(10, Duration.fromSeconds(0))
+          _ <- ZIO.foreachDiscard(claimed)(record => env.repository.deleteEvent(record.id))
+          remaining <- env.repository.claimDueEvents(10, Duration.fromSeconds(0))
+        yield assertTrue(claimed.nonEmpty, remaining.isEmpty)
+      },
+      test("rescheduleEvent counts the attempt and holds the event back") {
+        for
+          _ <- env.repository.create(userId1, Some(email), None, None)
+          claimed <- env.repository.claimDueEvents(10, Duration.fromSeconds(0))
+          _ <- ZIO.foreachDiscard(claimed)(record => env.repository.rescheduleEvent(record.id, Duration.fromSeconds(60)))
+          heldBack <- env.repository.claimDueEvents(10, Duration.fromSeconds(0))
+        yield assertTrue(claimed.map(_.attempts) == Vector(0), heldBack.isEmpty)
+      },
+      test("moveToDeadLetter takes the event out of the outbox for good") {
+        for
+          _ <- env.repository.create(userId1, Some(email), None, None)
+          claimed <- env.repository.claimDueEvents(10, Duration.fromSeconds(0))
+          _ <- ZIO.foreachDiscard(claimed)(record => env.repository.moveToDeadLetter(record.id, "auth rejected it"))
+          remaining <- env.repository.claimDueEvents(10, Duration.fromSeconds(0))
+        yield assertTrue(claimed.nonEmpty, remaining.isEmpty)
       },
     )
 

--- a/edge/implementations/postgres/src/test/scala/versola/edge/PostgresEdgeSessionRepositorySpec.scala
+++ b/edge/implementations/postgres/src/test/scala/versola/edge/PostgresEdgeSessionRepositorySpec.scala
@@ -1,0 +1,19 @@
+package versola.edge
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import com.augustnagro.magnum.sql
+import versola.edge.session.EdgeSessionRepositorySpec
+import versola.util.postgres.PostgresSpec
+import zio.{ZIO, ZLayer}
+
+object PostgresEdgeSessionRepositorySpec extends PostgresSpec, EdgeSessionRepositorySpec:
+
+  override lazy val environment =
+    ZLayer:
+      for xa <- ZIO.service[TransactorZIO]
+      yield EdgeSessionRepositorySpec.Env(PostgresEdgeSessionRepository(xa))
+
+  override def beforeEach(env: EdgeSessionRepositorySpec.Env) =
+    ZIO.serviceWithZIO[TransactorZIO] { xa =>
+      xa.connect(sql"TRUNCATE TABLE edge_sessions".update.run())
+    }.unit

--- a/edge/implementations/postgres/src/test/scala/versola/edge/PostgresLoginRepositorySpec.scala
+++ b/edge/implementations/postgres/src/test/scala/versola/edge/PostgresLoginRepositorySpec.scala
@@ -1,0 +1,19 @@
+package versola.edge
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import com.augustnagro.magnum.sql
+import versola.edge.login.LoginRepositorySpec
+import versola.util.postgres.PostgresSpec
+import zio.{ZIO, ZLayer}
+
+object PostgresLoginRepositorySpec extends PostgresSpec, LoginRepositorySpec:
+
+  override lazy val environment =
+    ZLayer:
+      for xa <- ZIO.service[TransactorZIO]
+      yield LoginRepositorySpec.Env(PostgresLoginRepository(xa))
+
+  override def beforeEach(env: LoginRepositorySpec.Env) =
+    ZIO.serviceWithZIO[TransactorZIO] { xa =>
+      xa.connect(sql"TRUNCATE TABLE pending_logins".update.run())
+    }.unit

--- a/edge/src/test/scala/versola/edge/CentralSyncTokenServiceSpec.scala
+++ b/edge/src/test/scala/versola/edge/CentralSyncTokenServiceSpec.scala
@@ -1,0 +1,85 @@
+package versola.edge
+
+import versola.edge.model.EdgeId
+import versola.util.{JWT, Secret}
+import zio.*
+import zio.http.URL
+import zio.json.JsonCodec
+import zio.test.*
+
+import java.security.KeyPairGenerator
+import java.security.interfaces.{RSAPrivateKey, RSAPublicKey}
+
+object CentralSyncTokenServiceSpec extends ZIOSpecDefault:
+
+  private case class Claims(iss: String, sub: String, aud: List[String]) derives JsonCodec
+
+  private lazy val keyPair =
+    val gen = KeyPairGenerator.getInstance("RSA").nn
+    gen.initialize(2048)
+    gen.generateKeyPair().nn
+
+  private val keyId = "kid-1"
+
+  private lazy val config = EdgeConfig(
+    id = EdgeId("edge-1"),
+    keyId = keyId,
+    privateKey = keyPair.getPrivate.asInstanceOf[RSAPrivateKey],
+    security = EdgeConfig.Security(
+      tokenEncryption = EdgeConfig.Security.TokenEncryption(Secret.Bytes32(Array.fill(32)(3.toByte))),
+      edgeSessions = EdgeConfig.Security.EdgeSessions(Secret.Bytes32(Array.fill(32)(5.toByte)), 1.hour),
+    ),
+    central = EdgeConfig.CentralConfig(url = URL.decode("https://central.example").toOption.get),
+    versolaUrl = URL.decode("https://idp.example").toOption.get,
+    configurationCacheRefreshInterval = 5.minutes,
+  )
+
+  private lazy val publicKeys = JWT.PublicKeys(
+    com.nimbusds.jose.jwk.JWKSet(
+      com.nimbusds.jose.jwk.RSAKey.Builder(keyPair.getPublic.asInstanceOf[RSAPublicKey])
+        .keyID(keyId)
+        .algorithm(com.nimbusds.jose.JWSAlgorithm.RS256)
+        .keyUse(com.nimbusds.jose.jwk.KeyUse.SIGNATURE)
+        .build()
+    )
+  )
+
+  private val service =
+    ZIO.service[CentralSyncTokenService].provideSome[Scope](
+      ZLayer.succeed(config),
+      CentralSyncTokenService.live,
+    )
+
+  def spec = suite("CentralSyncTokenService")(
+    test("mints a token central can verify with the edge signing key") {
+      ZIO.scoped:
+        for
+          tokenService <- service
+          token <- tokenService.getToken
+          claims <- JWT.deserialize[Claims](token, publicKeys, JWT.Type.JWT)
+        yield assertTrue(
+          claims.iss == "edge",
+          claims.sub == "edge",
+          claims.aud == List("central"),
+        )
+    },
+    test("stamps the edge id into the token header so central knows who is calling") {
+      ZIO.scoped:
+        for
+          tokenService <- service
+          token <- tokenService.getToken
+          header <- ZIO.attempt(com.nimbusds.jwt.SignedJWT.parse(token).getHeader.nn)
+        yield assertTrue(
+          header.getCustomParam("edge_id") == "edge-1",
+          header.getKeyID == keyId,
+        )
+    },
+    test("serves the cached token rather than re-signing on every call") {
+      ZIO.scoped:
+        for
+          tokenService <- service
+          first <- tokenService.getToken
+          second <- tokenService.getToken
+        yield assertTrue(first == second)
+    },
+  ) @@ TestAspect.silentLogging

--- a/edge/src/test/scala/versola/edge/PermissionServiceSpec.scala
+++ b/edge/src/test/scala/versola/edge/PermissionServiceSpec.scala
@@ -3,9 +3,29 @@ package versola.edge
 import versola.edge.model.*
 import versola.util.{ReloadingCache, Secret}
 import zio.*
+import zio.http.URL
 import zio.test.*
 
+import java.security.KeyPairGenerator
+import java.security.interfaces.RSAPrivateKey
+
 object PermissionServiceSpec extends ZIOSpecDefault:
+
+  private lazy val edgeConfig =
+    val gen = KeyPairGenerator.getInstance("RSA").nn
+    gen.initialize(2048)
+    EdgeConfig(
+      id = EdgeId("edge-1"),
+      keyId = "kid-1",
+      privateKey = gen.generateKeyPair().nn.getPrivate.asInstanceOf[RSAPrivateKey],
+      security = EdgeConfig.Security(
+        tokenEncryption = EdgeConfig.Security.TokenEncryption(Secret.Bytes32(Array.fill(32)(3.toByte))),
+        edgeSessions = EdgeConfig.Security.EdgeSessions(Secret.Bytes32(Array.fill(32)(5.toByte)), 1.hour),
+      ),
+      central = EdgeConfig.CentralConfig(url = URL.decode("https://central.example").toOption.get),
+      versolaUrl = URL.decode("https://idp.example").toOption.get,
+      configurationCacheRefreshInterval = 5.minutes,
+    )
 
   private val readPerm = PermissionId("read")
   private val writePerm = PermissionId("write")
@@ -82,7 +102,7 @@ object PermissionServiceSpec extends ZIOSpecDefault:
         val tenantA = TenantId("tenant-a")
         val multiTenantRoles: Map[(TenantId, RoleId), Set[PermissionId]] = Map(
           (defaultTenant, viewerRole) -> Set(readPerm),
-          (tenantA, editorRole)       -> Set(writePerm),
+          (tenantA, editorRole) -> Set(writePerm),
         )
         val service = buildService(roles = multiTenantRoles)
         for endpoints <- service.getAllowedEndpointsForRoles(defaultTenant, List(editorRole))
@@ -91,7 +111,8 @@ object PermissionServiceSpec extends ZIOSpecDefault:
     ),
     suite("getAllowedEndpointsForClient")(
       test("returns endpoints composed from the client's permissions") {
-        val client = OAuthClient(id = serviceClient, secret = Secret(Array.fill(8)(1.toByte)), permissions = Set(writePerm), accessTokenTtl = 15.minutes)
+        val client =
+          OAuthClient(id = serviceClient, secret = Secret(Array.fill(8)(1.toByte)), permissions = Set(writePerm), accessTokenTtl = 15.minutes)
         val service = buildService(clients = Map(serviceClient -> client))
         for endpoints <- service.getAllowedEndpointsForClient(serviceClient)
         yield assertTrue(endpoints == Set(createUserEndpoint))
@@ -108,7 +129,12 @@ object PermissionServiceSpec extends ZIOSpecDefault:
         yield assertTrue(endpoints.isEmpty)
       },
       test("ignores client permissions that map to no endpoints") {
-        val client = OAuthClient(id = serviceClient, secret = Secret(Array.fill(8)(1.toByte)), permissions = Set(PermissionId("unmapped")), accessTokenTtl = 15.minutes)
+        val client = OAuthClient(
+          id = serviceClient,
+          secret = Secret(Array.fill(8)(1.toByte)),
+          permissions = Set(PermissionId("unmapped")),
+          accessTokenTtl = 15.minutes,
+        )
         val service = buildService(clients = Map(serviceClient -> client))
         for endpoints <- service.getAllowedEndpointsForClient(serviceClient)
         yield assertTrue(endpoints.isEmpty)
@@ -118,26 +144,26 @@ object PermissionServiceSpec extends ZIOSpecDefault:
       test("returns permissions whose endpoint IDs intersect with the provided set") {
         val service = buildService()
         for permissions <- service.getPermissionsForRoles(
-          Map(defaultTenant -> List(adminRole)),
-          Set(listUsersEndpoint),
-        )
+            Map(defaultTenant -> List(adminRole)),
+            Set(listUsersEndpoint),
+          )
         yield assertTrue(permissions == Set(readPerm))
       },
       test("returns multiple permissions when several intersect") {
         val service = buildService()
         for permissions <- service.getPermissionsForRoles(
-          Map(defaultTenant -> List(adminRole)),
-          Set(listUsersEndpoint, createUserEndpoint),
-        )
+            Map(defaultTenant -> List(adminRole)),
+            Set(listUsersEndpoint, createUserEndpoint),
+          )
         yield assertTrue(permissions == Set(readPerm, writePerm))
       },
       test("returns empty set when no permission endpoint IDs intersect") {
         val service = buildService()
         val unrelatedEndpoint = ResourceEndpointId(java.util.UUID.fromString("018f0f2a-1c7b-7000-8000-000000000099"))
         for permissions <- service.getPermissionsForRoles(
-          Map(defaultTenant -> List(adminRole)),
-          Set(unrelatedEndpoint),
-        )
+            Map(defaultTenant -> List(adminRole)),
+            Set(unrelatedEndpoint),
+          )
         yield assertTrue(permissions.isEmpty)
       },
       test("returns empty set when role map is empty") {
@@ -148,24 +174,49 @@ object PermissionServiceSpec extends ZIOSpecDefault:
       test("returns empty set when endpointIds is empty") {
         val service = buildService()
         for permissions <- service.getPermissionsForRoles(
-          Map(defaultTenant -> List(adminRole)),
-          Set.empty,
-        )
+            Map(defaultTenant -> List(adminRole)),
+            Set.empty,
+          )
         yield assertTrue(permissions.isEmpty)
       },
       test("merges permissions across multiple tenants filtered by endpoints") {
         val tenantA = TenantId("tenant-a")
         val multiTenantRoles: Map[(TenantId, RoleId), Set[PermissionId]] = Map(
           (defaultTenant, viewerRole) -> Set(readPerm),
-          (tenantA, editorRole)       -> Set(writePerm),
+          (tenantA, editorRole) -> Set(writePerm),
         )
         val service = buildService(roles = multiTenantRoles)
         for permissions <- service.getPermissionsForRoles(
-          Map(defaultTenant -> List(viewerRole), tenantA -> List(editorRole)),
-          Set(listUsersEndpoint, createUserEndpoint),
-        )
+            Map(defaultTenant -> List(viewerRole), tenantA -> List(editorRole)),
+            Set(listUsersEndpoint, createUserEndpoint),
+          )
         yield assertTrue(permissions == Set(readPerm, writePerm))
       },
     ),
-  )
+    suite("live")(
+      test("wires the three sync clients into caches the service reads from") {
+        val rolesClient = new RolesSyncClient:
+          override def getAll: Task[Map[(TenantId, RoleId), Set[PermissionId]]] = ZIO.succeed(rolesMap)
+        val permissionsClient = new PermissionsSyncClient:
+          override def getAll: Task[Map[PermissionId, Set[ResourceEndpointId]]] = ZIO.succeed(permissionsMap)
+        val clientsClient = new OAuthClientsSyncClient:
+          override def getAll: Task[Map[ClientId, OAuthClient]] = ZIO.succeed(Map.empty)
+
+        ZIO.scoped:
+          for
+            service <- ZIO.service[PermissionService].provideSome[Scope](
+              ZLayer.succeed(rolesClient),
+              ZLayer.succeed(permissionsClient),
+              ZLayer.succeed(clientsClient),
+              ZLayer.succeed(edgeConfig),
+              PermissionService.live,
+            )
+            permissions <- service.getPermissionsForRoles(
+              Map(defaultTenant -> List(editorRole)),
+              Set(listUsersEndpoint, createUserEndpoint),
+            )
+          yield assertTrue(permissions == Set(readPerm, writePerm))
+      },
+    ),
+  ) @@ TestAspect.silentLogging
 end PermissionServiceSpec

--- a/edge/src/test/scala/versola/edge/SSOClientSpec.scala
+++ b/edge/src/test/scala/versola/edge/SSOClientSpec.scala
@@ -48,7 +48,9 @@ object SSOClientSpec extends ZIOSpecDefault:
   private def queryParam(url: URL, key: String): Option[Chunk[String]] =
     url.queryParams.map.get(key)
 
-  def spec = suite("SSOClient.authorizeUri")(
+  def spec = suite("SSOClient")(authorizeUriSuite, exchangeSuite, refreshSuite, userInfoSuite)
+
+  private val authorizeUriSuite = suite("SSOClient.authorizeUri")(
     test("overrideParams replace a same-named key in customParameters") {
       for
         client <- ZIO.service[Client]
@@ -97,6 +99,189 @@ object SSOClientSpec extends ZIOSpecDefault:
       yield assertTrue(
         queryParam(url, "ui_locales") == Some(Chunk("en")),
         queryParam(url, "prompt") == Some(Chunk("none")),
+      )
+    },
+  ).provideLayer(TestClient.layer) @@ TestAspect.silentLogging
+
+  private val clientId = ClientId("web-app")
+  private val clientSecret = Secret("s3cret".getBytes("UTF-8").nn)
+  private val redirectUri = RedirectUri("https://app.example/callback")
+
+  private val tokenJson =
+    """{"access_token":"at-1","token_type":"Bearer","expires_in":3600,"refresh_token":"rt-1","refresh_token_expires_in":7200,"scope":"openid","id_token":"id-1"}"""
+
+  private def respondWith(response: Response) =
+    TestClient.addRoutes(Handler.succeed(response).toRoutes)
+
+  private def captureRequest(seen: Ref[Option[Request]], response: Response) =
+    TestClient.addRoutes(
+      Handler.fromFunctionZIO[Request](r =>
+        r.body.asURLEncodedForm.orDie.flatMap(form =>
+          seen.set(Some(r.copy(body = Body.fromURLEncodedForm(form)))).as(response),
+        ),
+      ).toRoutes,
+    )
+
+  private val exchangeSuite = suite("SSOClient.exchangeAuthorizationCode")(
+    test("decodes the token response on success") {
+      for
+        _ <- respondWith(Response.json(tokenJson))
+        client <- ZIO.service[Client]
+        sso = SSOClient.Impl(client, config)
+        result <- sso.exchangeAuthorizationCode(Code("c-1"), CodeVerifier("v-1"), redirectUri, clientId, clientSecret)
+      yield assertTrue(
+        result.accessToken == AccessToken("at-1"),
+        result.tokenType == "Bearer",
+        result.expiresIn == 3600L,
+        result.refreshToken == Some(RefreshToken("rt-1")),
+        result.scope == Some("openid"),
+        result.idToken == Some("id-1"),
+      )
+    },
+    test("posts the authorization_code grant as a urlencoded form with basic auth") {
+      for
+        seen <- Ref.make(Option.empty[Request])
+        _ <- captureRequest(seen, Response.json(tokenJson))
+        client <- ZIO.service[Client]
+        sso = SSOClient.Impl(client, config)
+        _ <- sso.exchangeAuthorizationCode(Code("c-1"), CodeVerifier("v-1"), redirectUri, clientId, clientSecret)
+        request <- seen.get.someOrFail(new RuntimeException("no request captured"))
+        form <- request.body.asURLEncodedForm
+      yield assertTrue(
+        request.method == Method.POST,
+        request.url.path.toString.endsWith("token"),
+        form.get("grant_type").flatMap(_.stringValue) == Some("authorization_code"),
+        form.get("code").flatMap(_.stringValue) == Some("c-1"),
+        form.get("code_verifier").flatMap(_.stringValue) == Some("v-1"),
+        form.get("redirect_uri").flatMap(_.stringValue) == Some(redirectUri.toString),
+        request.header(Header.Authorization).contains(
+          Header.Authorization.Basic(clientId, Base64.urlEncode(clientSecret)),
+        ),
+      )
+    },
+    test("fails with the error and description reported by the server") {
+      for
+        _ <- respondWith(
+          Response.json("""{"error":"invalid_request","error_description":"code expired"}""").status(Status.BadRequest),
+        )
+        client <- ZIO.service[Client]
+        sso = SSOClient.Impl(client, config)
+        error <- sso.exchangeAuthorizationCode(Code("c-1"), CodeVerifier("v-1"), redirectUri, clientId, clientSecret).flip
+      yield assertTrue(
+        error.getMessage.nn.contains("400"),
+        error.getMessage.nn.contains("invalid_request"),
+        error.getMessage.nn.contains("code expired"),
+      )
+    },
+    test("omits the description when the server does not send one") {
+      for
+        _ <- respondWith(Response.json("""{"error":"invalid_client"}""").status(Status.Unauthorized))
+        client <- ZIO.service[Client]
+        sso = SSOClient.Impl(client, config)
+        error <- sso.exchangeAuthorizationCode(Code("c-1"), CodeVerifier("v-1"), redirectUri, clientId, clientSecret).flip
+      yield assertTrue(
+        error.getMessage.nn.contains("invalid_client"),
+        !error.getMessage.nn.contains(" - "),
+      )
+    },
+  ).provideLayer(TestClient.layer) @@ TestAspect.silentLogging
+
+  private val refreshSuite = suite("SSOClient.exchangeRefreshToken")(
+    test("decodes the token response on success") {
+      for
+        _ <- respondWith(Response.json(tokenJson))
+        client <- ZIO.service[Client]
+        sso = SSOClient.Impl(client, config)
+        result <- sso.exchangeRefreshToken(RefreshToken("rt-0"), clientId, clientSecret)
+      yield assertTrue(result.accessToken == AccessToken("at-1"))
+    },
+    test("posts the refresh_token grant as a urlencoded form") {
+      for
+        seen <- Ref.make(Option.empty[Request])
+        _ <- captureRequest(seen, Response.json(tokenJson))
+        client <- ZIO.service[Client]
+        sso = SSOClient.Impl(client, config)
+        _ <- sso.exchangeRefreshToken(RefreshToken("rt-0"), clientId, clientSecret)
+        request <- seen.get.someOrFail(new RuntimeException("no request captured"))
+        form <- request.body.asURLEncodedForm
+      yield assertTrue(
+        form.get("grant_type").flatMap(_.stringValue) == Some("refresh_token"),
+        form.get("refresh_token").flatMap(_.stringValue) == Some("rt-0"),
+      )
+    },
+    test("maps an invalid_grant error to InvalidGrant rather than a failure") {
+      for
+        _ <- respondWith(Response.json("""{"error":"invalid_grant"}""").status(Status.BadRequest))
+        client <- ZIO.service[Client]
+        sso = SSOClient.Impl(client, config)
+        error <- sso.exchangeRefreshToken(RefreshToken("rt-0"), clientId, clientSecret).flip
+      yield assertTrue(error == SSOClient.InvalidGrant)
+    },
+    test("fails with the reported error for any other rejection") {
+      for
+        _ <- respondWith(Response.json("""{"error":"invalid_client"}""").status(Status.Unauthorized))
+        client <- ZIO.service[Client]
+        sso = SSOClient.Impl(client, config)
+        error <- sso.exchangeRefreshToken(RefreshToken("rt-0"), clientId, clientSecret).flip
+      yield assertTrue(
+        error.isInstanceOf[RuntimeException],
+        error.asInstanceOf[RuntimeException].getMessage.nn.contains("invalid_client"),
+      )
+    },
+  ).provideLayer(TestClient.layer) @@ TestAspect.silentLogging
+
+  private val userInfoSuite = suite("SSOClient.userInfo")(
+    test("returns the claims object on success") {
+      for
+        _ <- respondWith(Response.json("""{"sub":"user-1"}"""))
+        client <- ZIO.service[Client]
+        sso = SSOClient.Impl(client, config)
+        claims <- sso.userInfo(AccessToken("at-1"))
+      yield assertTrue(claims.get("sub").flatMap(_.asString) == Some("user-1"))
+    },
+    test("sends the access token as a bearer credential") {
+      for
+        seen <- Ref.make(Option.empty[Request])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request](r => seen.set(Some(r)).as(Response.json("""{"sub":"user-1"}"""))).toRoutes,
+        )
+        client <- ZIO.service[Client]
+        sso = SSOClient.Impl(client, config)
+        _ <- sso.userInfo(AccessToken("at-1"))
+        request <- seen.get.someOrFail(new RuntimeException("no request captured"))
+      yield assertTrue(
+        request.url.path.toString.endsWith("userinfo"),
+        request.header(Header.Authorization).exists {
+          case Header.Authorization.Bearer(t) => t.stringValue == "at-1"
+          case _ => false
+        },
+      )
+    },
+    test("rejects a non-object JSON body") {
+      for
+        _ <- respondWith(Response.json("""["not","an","object"]"""))
+        client <- ZIO.service[Client]
+        sso = SSOClient.Impl(client, config)
+        error <- sso.userInfo(AccessToken("at-1")).flip
+      yield assertTrue(error.isInstanceOf[RuntimeException])
+    },
+    test("maps 401 to UserInfoUnauthorized") {
+      for
+        _ <- respondWith(Response.status(Status.Unauthorized))
+        client <- ZIO.service[Client]
+        sso = SSOClient.Impl(client, config)
+        error <- sso.userInfo(AccessToken("at-1")).flip
+      yield assertTrue(error == SSOClient.UserInfoUnauthorized)
+    },
+    test("fails for any other error status") {
+      for
+        _ <- respondWith(Response.status(Status.InternalServerError))
+        client <- ZIO.service[Client]
+        sso = SSOClient.Impl(client, config)
+        error <- sso.userInfo(AccessToken("at-1")).flip
+      yield assertTrue(
+        error.isInstanceOf[RuntimeException],
+        error.asInstanceOf[RuntimeException].getMessage.nn.contains("500"),
       )
     },
   ).provideLayer(TestClient.layer) @@ TestAspect.silentLogging

--- a/edge/src/test/scala/versola/edge/login/LoginRepositorySpec.scala
+++ b/edge/src/test/scala/versola/edge/login/LoginRepositorySpec.scala
@@ -1,0 +1,74 @@
+package versola.edge.login
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import versola.edge.model.{CodeVerifier, PresetId, State}
+import versola.util.DatabaseSpecBase
+import zio.*
+import zio.test.*
+
+/** Conformance suite for any [[LoginRepository]] implementation. A backend module extends
+  * this and supplies the wiring -- see `PostgresLoginRepositorySpec` in `edge-postgres-impl`
+  * for the one binding that exists today.
+  */
+trait LoginRepositorySpec extends DatabaseSpecBase[LoginRepositorySpec.Env]:
+  self: ZIOSpec[TransactorZIO] =>
+
+  private val state1 = State("state-1")
+  private val state2 = State("state-2")
+
+  private def record(state: State, codeVerifier: String, preset: String) =
+    LoginRecord(codeVerifier = CodeVerifier(codeVerifier), presetId = PresetId(preset), state = state)
+
+  override def testCases(env: LoginRepositorySpec.Env) =
+    List(
+      test("findByState returns None for an unknown state") {
+        for found <- env.repository.findByState(state1)
+        yield assertTrue(found.isEmpty)
+      },
+      test("create stores a record retrievable by state before it expires") {
+        val r = record(state1, "verifier-1", "preset-1")
+        for
+          _ <- env.repository.create(r, ttl = 1.hour)
+          found <- env.repository.findByState(state1)
+        yield assertTrue(found == Some(r))
+      },
+      test("create upserts on state, replacing codeVerifier and presetId") {
+        val first = record(state1, "verifier-1", "preset-1")
+        val second = record(state1, "verifier-2", "preset-2")
+        for
+          _ <- env.repository.create(first, ttl = 1.hour)
+          _ <- env.repository.create(second, ttl = 1.hour)
+          found <- env.repository.findByState(state1)
+        yield assertTrue(found == Some(second))
+      },
+      test("findByState excludes logins that have expired") {
+        val r = record(state1, "verifier-1", "preset-1")
+        for
+          _ <- env.repository.create(r, ttl = 1.minute)
+          before <- env.repository.findByState(state1)
+          _ <- TestClock.adjust(2.minutes)
+          after <- env.repository.findByState(state1)
+        yield assertTrue(before.isDefined, after.isEmpty)
+      },
+      test("deleteByState removes the login") {
+        val r = record(state1, "verifier-1", "preset-1")
+        for
+          _ <- env.repository.create(r, ttl = 1.hour)
+          _ <- env.repository.deleteByState(state1)
+          found <- env.repository.findByState(state1)
+        yield assertTrue(found.isEmpty)
+      },
+      test("deleteByState leaves other states untouched") {
+        val r1 = record(state1, "verifier-1", "preset-1")
+        val r2 = record(state2, "verifier-2", "preset-2")
+        for
+          _ <- env.repository.create(r1, ttl = 1.hour)
+          _ <- env.repository.create(r2, ttl = 1.hour)
+          _ <- env.repository.deleteByState(state1)
+          found <- env.repository.findByState(state2)
+        yield assertTrue(found == Some(r2))
+      },
+    )
+
+object LoginRepositorySpec:
+  case class Env(repository: LoginRepository)

--- a/edge/src/test/scala/versola/edge/session/EdgeSessionRepositorySpec.scala
+++ b/edge/src/test/scala/versola/edge/session/EdgeSessionRepositorySpec.scala
@@ -1,0 +1,106 @@
+package versola.edge.session
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import versola.edge.model.{AccessTokenId, PresetId, SessionId}
+import versola.util.{DatabaseSpecBase, Secret}
+import zio.*
+import zio.test.*
+
+import java.time.Instant
+
+/** Conformance suite for any [[EdgeSessionRepository]] implementation. A backend module
+  * extends this and supplies the wiring -- see `PostgresEdgeSessionRepositorySpec` in
+  * `edge-postgres-impl` for the one binding that exists today.
+  */
+trait EdgeSessionRepositorySpec extends DatabaseSpecBase[EdgeSessionRepositorySpec.Env]:
+  self: ZIOSpec[TransactorZIO] =>
+
+  private val sid1 = SessionId("sid-1")
+  private val sid2 = SessionId("sid-2")
+  private val preset1 = PresetId("preset-1")
+  private val preset2 = PresetId("preset-2")
+
+  // Projected away from `encryptedRefreshToken` directly, since `Secret` wraps a byte array
+  // and case-class equality on it is reference equality, not content equality -- a value
+  // round-tripped through Postgres never `==`s the one that went in even when the bytes match.
+  private def summarize(r: EdgeSessionRecord) =
+    (r.publicSessionId, r.presetId, r.accessTokenId, r.encryptedRefreshToken.map(_.toList), r.expiresAt)
+
+  private def record(
+      sid: SessionId,
+      preset: PresetId,
+      accessTokenId: AccessTokenId,
+      refreshToken: Option[Secret],
+      expiresAt: Instant,
+  ) = EdgeSessionRecord(
+    publicSessionId = sid,
+    presetId = preset,
+    accessTokenId = accessTokenId,
+    encryptedRefreshToken = refreshToken,
+    expiresAt = expiresAt,
+  )
+
+  override def testCases(env: EdgeSessionRepositorySpec.Env) =
+    List(
+      test("findByAccessTokenId returns None when nothing matches") {
+        for found <- env.repository.findByAccessTokenId(AccessTokenId("missing"))
+        yield assertTrue(found.isEmpty)
+      },
+      test("create stores a session retrievable by its access token id") {
+        for
+          now <- Clock.instant
+          r = record(sid1, preset1, AccessTokenId("at-1"), Some(Secret.fromString("rt-1")), now.plusSeconds(3600))
+          _ <- env.repository.create(r)
+          found <- env.repository.findByAccessTokenId(AccessTokenId("at-1"))
+        yield assertTrue(found.map(summarize) == Some(summarize(r)))
+      },
+      test("create upserts on (publicSessionId, presetId), rotating the access token id") {
+        for
+          now <- Clock.instant
+          first = record(sid1, preset1, AccessTokenId("at-old"), Some(Secret.fromString("rt-old")), now.plusSeconds(3600))
+          second = record(sid1, preset1, AccessTokenId("at-new"), Some(Secret.fromString("rt-new")), now.plusSeconds(7200))
+          _ <- env.repository.create(first)
+          _ <- env.repository.create(second)
+          oldFound <- env.repository.findByAccessTokenId(AccessTokenId("at-old"))
+          newFound <- env.repository.findByAccessTokenId(AccessTokenId("at-new"))
+        yield assertTrue(
+          oldFound.isEmpty,
+          newFound.map(summarize) == Some(summarize(second)),
+        )
+      },
+      test("findByAccessTokenId excludes sessions that have already expired") {
+        for
+          now <- Clock.instant
+          r = record(sid1, preset1, AccessTokenId("at-1"), None, now.plusSeconds(60))
+          _ <- env.repository.create(r)
+          before <- env.repository.findByAccessTokenId(AccessTokenId("at-1"))
+          _ <- TestClock.adjust(2.minutes)
+          after <- env.repository.findByAccessTokenId(AccessTokenId("at-1"))
+        yield assertTrue(before.isDefined, after.isEmpty)
+      },
+      test("findBySessionId returns every preset participation for a session, ignoring expiry") {
+        for
+          now <- Clock.instant
+          live = record(sid1, preset1, AccessTokenId("at-live"), None, now.plusSeconds(3600))
+          expired = record(sid1, preset2, AccessTokenId("at-expired"), None, now.plusSeconds(60))
+          other = record(sid2, preset1, AccessTokenId("at-other"), None, now.plusSeconds(3600))
+          _ <- env.repository.create(live)
+          _ <- env.repository.create(expired)
+          _ <- env.repository.create(other)
+          _ <- TestClock.adjust(2.minutes)
+          found <- env.repository.findBySessionId(sid1)
+        yield assertTrue(found.map(summarize).toSet == Set(summarize(live), summarize(expired)))
+      },
+      test("delete removes the session by access token id") {
+        for
+          now <- Clock.instant
+          r = record(sid1, preset1, AccessTokenId("at-1"), None, now.plusSeconds(3600))
+          _ <- env.repository.create(r)
+          _ <- env.repository.delete(AccessTokenId("at-1"))
+          found <- env.repository.findByAccessTokenId(AccessTokenId("at-1"))
+        yield assertTrue(found.isEmpty)
+      },
+    )
+
+object EdgeSessionRepositorySpec:
+  case class Env(repository: EdgeSessionRepository)

--- a/util/src/test/scala/versola/cleanup/CleanupManagerSpec.scala
+++ b/util/src/test/scala/versola/cleanup/CleanupManagerSpec.scala
@@ -1,0 +1,120 @@
+package versola.cleanup
+
+import zio.*
+import zio.test.*
+
+object CleanupManagerSpec extends ZIOSpecDefault:
+
+  private case class Call(tableName: String, batchSize: Int, keyColumn: String)
+
+  /** Test double for [[CleanupManager.Base]]: records every batch it is asked to run and
+    * replays a scripted list of deletion counts, falling back to 0 (a drained table) once
+    * the script runs out.
+    */
+  private class Recording(
+      config: CleanupConfig,
+      fibers: Ref[List[Fiber.Runtime[Throwable, Long]]],
+      calls: Ref[Chunk[Call]],
+      counts: Ref[List[Int]],
+  ) extends CleanupManager.Base(config, fibers):
+    override protected def cleanupBatch(tableName: String, batchSize: Int, keyColumn: String): Task[Int] =
+      calls.update(_ :+ Call(tableName, batchSize, keyColumn)) *>
+        counts.modify {
+          case head :: tail => (head, tail)
+          case Nil => (0, Nil)
+        }
+
+  private def manager(config: CleanupConfig, counts: List[Int] = Nil) =
+    for
+      fibers <- Ref.make(List.empty[Fiber.Runtime[Throwable, Long]])
+      calls <- Ref.make(Chunk.empty[Call])
+      scripted <- Ref.make(counts)
+    yield (Recording(config, fibers, calls, scripted), calls, fibers)
+
+  private def tableConfig(
+      tableName: String = "sessions",
+      batchSize: Int = 10,
+      interval: Duration = 1.hour,
+      keyColumn: Option[String] = None,
+  ) = TableCleanupConfig(tableName, batchSize, interval, keyColumn)
+
+  def spec = suite("CleanupManager.Base")(
+    test("drains a table in a single batch when fewer rows than the batch size are deleted") {
+      val config = CleanupConfig(maxThreads = 1, tables = List(tableConfig(batchSize = 10)))
+      for
+        (cleanup, calls, _) <- manager(config, counts = List(3))
+        _ <- ZIO.scoped(cleanup.start() *> TestClock.adjust(0.seconds))
+        recorded <- calls.get
+      yield assertTrue(recorded == Chunk(Call("sessions", 10, "id")))
+    },
+    test("keeps draining while a batch deletes a full batch worth of rows") {
+      val config = CleanupConfig(maxThreads = 1, tables = List(tableConfig(batchSize = 2)))
+      for
+        (cleanup, calls, _) <- manager(config, counts = List(2, 2, 1))
+        _ <- ZIO.scoped(cleanup.start() *> TestClock.adjust(0.seconds))
+        recorded <- calls.get
+      yield assertTrue(recorded.size == 3, recorded.forall(_.batchSize == 2))
+    },
+    test("passes the configured key column through to the batch") {
+      val config = CleanupConfig(maxThreads = 1, tables = List(tableConfig(keyColumn = Some("ctid"))))
+      for
+        (cleanup, calls, _) <- manager(config, counts = List(0))
+        _ <- ZIO.scoped(cleanup.start() *> TestClock.adjust(0.seconds))
+        recorded <- calls.get
+      yield assertTrue(recorded.map(_.keyColumn) == Chunk("ctid"))
+    },
+    test("starts one job per configured table") {
+      val config = CleanupConfig(
+        maxThreads = 2,
+        tables = List(tableConfig("sessions"), tableConfig("codes"), tableConfig("tokens")),
+      )
+      for
+        (cleanup, calls, fibers) <- manager(config)
+        _ <- ZIO.scoped(
+          cleanup.start() *> TestClock.adjust(0.seconds) *> fibers.get.flatMap(f => ZIO.succeed(f))
+        )
+        recorded <- calls.get
+      yield assertTrue(recorded.map(_.tableName).toSet == Set("sessions", "codes", "tokens"))
+    },
+    test("repeats the drain once the table interval elapses") {
+      val config = CleanupConfig(maxThreads = 1, tables = List(tableConfig(interval = 1.hour)))
+      for
+        (cleanup, calls, _) <- manager(config)
+        _ <- ZIO.scoped:
+          for
+            _ <- cleanup.start()
+            _ <- TestClock.adjust(0.seconds)
+            afterStart <- calls.get
+            _ <- TestClock.adjust(1.hour)
+            afterInterval <- calls.get
+          yield assertTrue(afterStart.size == 1, afterInterval.size == 2)
+        result <- calls.get.map(recorded => assertTrue(recorded.size == 2))
+      yield result
+    },
+    test("stop interrupts the running jobs so no further batches run") {
+      val config = CleanupConfig(maxThreads = 1, tables = List(tableConfig(interval = 1.hour)))
+      for
+        (cleanup, calls, _) <- manager(config)
+        recorded <- ZIO.scoped:
+          for
+            _ <- cleanup.start()
+            _ <- TestClock.adjust(0.seconds)
+            // stop() joins the jobs it just interrupted, which hands their interruption
+            // to whoever called it, so run it on its own fiber and await the outcome
+            // instead of letting that land on the test fiber.
+            stopped <- cleanup.stop().forkDaemon
+            _ <- stopped.await
+            _ <- TestClock.adjust(5.hours)
+            recorded <- calls.get
+          yield recorded
+      yield assertTrue(recorded.size == 1)
+    },
+    test("stop is a no-op when nothing was started") {
+      val config = CleanupConfig(maxThreads = 1, tables = List(tableConfig()))
+      for
+        (cleanup, calls, _) <- manager(config)
+        _ <- cleanup.stop()
+        recorded <- calls.get
+      yield assertTrue(recorded.isEmpty)
+    },
+  ) @@ TestAspect.silentLogging

--- a/util/src/test/scala/versola/util/JWTSpec.scala
+++ b/util/src/test/scala/versola/util/JWTSpec.scala
@@ -24,8 +24,8 @@ object JWTSpec extends ZIOSpecDefault:
         .keyID("test-key-1")
         .algorithm(com.nimbusds.jose.JWSAlgorithm.RS256)
         .keyUse(com.nimbusds.jose.jwk.KeyUse.SIGNATURE)
-        .build()
-    )
+        .build(),
+    ),
   )
 
   // Test symmetric key
@@ -39,6 +39,112 @@ object JWTSpec extends ZIOSpecDefault:
   def spec = suite("JWT")(
     asymmetricTests,
     symmetricTests,
+    claimConversionTests,
+    parseClaimsTests,
+  )
+
+  /** Signs an arbitrary Nimbus claims set so claim values of Java types that zio-json would
+    * never produce on its own (Integer, Short, BigDecimal, Date, ...) reach the decoder.
+    */
+  private def signRaw(build: com.nimbusds.jwt.JWTClaimsSet.Builder => com.nimbusds.jwt.JWTClaimsSet.Builder) =
+    ZIO.attempt {
+      val claims = build(
+        com.nimbusds.jwt.JWTClaimsSet.Builder()
+          .jwtID("jti-1")
+          .expirationTime(java.util.Date.from(java.time.Instant.parse("2100-01-01T00:00:00Z"))),
+      ).build()
+      val header = com.nimbusds.jose.JWSHeader.Builder(com.nimbusds.jose.JWSAlgorithm.RS256)
+        .keyID("test-key-1")
+        .`type`(com.nimbusds.jose.JOSEObjectType.JWT)
+        .build()
+      val jwt = com.nimbusds.jwt.SignedJWT(header, claims)
+      jwt.sign(com.nimbusds.jose.crypto.RSASSASigner(privateKey))
+      jwt.serialize()
+    }
+
+  private def claimJson(build: com.nimbusds.jwt.JWTClaimsSet.Builder => com.nimbusds.jwt.JWTClaimsSet.Builder) =
+    signRaw(build).flatMap(JWT.deserialize[Json.Obj](_, publicKeys, JWT.Type.JWT))
+
+  private val claimConversionTests = suite("claim conversion")(
+    test("converts string, boolean and null claims") {
+      for claims <- claimJson(_
+          .claim("s", "text")
+          .claim("bool", java.lang.Boolean.TRUE)
+          .claim("nothing", null))
+      yield assertTrue(
+        claims.get("s") == Some(Json.Str("text")),
+        claims.get("bool") == Some(Json.Bool(true)),
+        claims.get("nothing").forall(_ == Json.Null),
+      )
+    },
+    test("converts every integral number type to a JSON number") {
+      for claims <- claimJson(_
+          .claim("int", java.lang.Integer.valueOf(1))
+          .claim("long", java.lang.Long.valueOf(2L))
+          .claim("short", java.lang.Short.valueOf(3.toShort))
+          .claim("byte", java.lang.Byte.valueOf(4.toByte))
+          .claim("bigint", java.math.BigInteger.valueOf(5L)))
+      yield assertTrue(
+        claims.get("int") == Some(Json.Num(1)),
+        claims.get("long") == Some(Json.Num(2)),
+        claims.get("short") == Some(Json.Num(3)),
+        claims.get("byte") == Some(Json.Num(4)),
+        claims.get("bigint") == Some(Json.Num(BigDecimal(5))),
+      )
+    },
+    test("converts every fractional number type to a JSON number") {
+      for claims <- claimJson(_
+          .claim("double", java.lang.Double.valueOf(1.5d))
+          .claim("float", java.lang.Float.valueOf(2.5f))
+          .claim("bigdec", java.math.BigDecimal.valueOf(3.5d)))
+      yield assertTrue(
+        claims.get("double") == Some(Json.Num(1.5d)),
+        claims.get("float") == Some(Json.Num(2.5d)),
+        claims.get("bigdec") == Some(Json.Num(BigDecimal(3.5d))),
+      )
+    },
+    test("converts a date claim to epoch seconds") {
+      val instant = java.time.Instant.parse("2024-01-01T00:00:00Z")
+      for claims <- claimJson(_.claim("issued", java.util.Date.from(instant)))
+      yield assertTrue(claims.get("issued") == Some(Json.Num(instant.getEpochSecond)))
+    },
+    test("converts nested maps and lists") {
+      for claims <- claimJson(_
+          .claim("map", java.util.Map.of("inner", "value"))
+          .claim("list", java.util.List.of("a", "b")))
+      yield assertTrue(
+        claims.get("map") == Some(Json.Obj("inner" -> Json.Str("value"))),
+        claims.get("list") == Some(Json.Arr(Json.Str("a"), Json.Str("b"))),
+      )
+    },
+    test("falls back to the string form for any other claim type") {
+      for claims <- claimJson(_.claim("uri", java.net.URI.create("https://example.com")))
+      yield assertTrue(claims.get("uri") == Some(Json.Str("https://example.com")))
+    },
+  )
+
+  private val parseClaimsTests = suite("parseClaims")(
+    test("reads the payload without verifying the signature") {
+      val claims = JWT.Claims(
+        issuer = "test-issuer",
+        subject = "user123",
+        audience = List("api"),
+        custom = Json.Obj("name" -> Json.Str("Test User"), "admin" -> Json.Bool(true)),
+      )
+      for
+        token <- JWT.serialize(
+          claims = claims,
+          ttl = 1.hour,
+          signature = JWT.Signature.Asymmetric(JWT.Algorithm.RS256, "test-key-1", privateKey),
+        )
+        tampered = token.split('.').nn.updated(2, "not-a-signature").mkString(".")
+        result <- JWT.parseClaims[TestClaims](tampered)
+      yield assertTrue(result.sub == "user123", result.admin)
+    },
+    test("fails with InvalidClaims when the payload is not the expected shape") {
+      for result <- JWT.parseClaims[TestClaims]("a.bm90LWpzb24.c").either
+      yield assertTrue(result == Left(JWT.Error.InvalidClaims))
+    },
   )
 
   def asymmetricTests = suite("asymmetric signature")(


### PR DESCRIPTION
## Summary

Adds ZIO-test coverage for previously untested repositories, services, controllers and orchestration branches, identified via scoverage gap analysis (per-file uncovered-statement counts across all 8 modules).

**Aggregate: 75.63% → 81.06% statements (12045 → 12564 of 15500). All 8 modules green, 0 test failures.**

| module | before | after |
|---|---|---|
| auth | 76.4% | 80.6% |
| auth-postgres | 77.7% | 84.0% |
| central | 73.9% | 79.7% |
| central-postgres | 69.0% | 80.3% |
| edge | 74.6% | 83.3% |
| edge-postgres | 34.8% | 91.3% |
| util | 78.9% | 81.7% |
| util-postgres | 84.4% | 84.4% |

## What's covered now

- **Postgres repositories with zero prior tests**: `EdgeSessionRepository`, `LoginRepository`, `JwksRepository`, `ChallengeSettingsRepository`, `ThemeRepository` — following the existing shared-trait + `PostgresSpec` pattern used elsewhere in the repo.
- **Controllers with real branching that were untested**: `MetadataController`, `ServerMetadataController`, `AuthorizationDetailTypeController`, `ServiceController` (both `auth` and `central`).
- **`ConversationService.setNewPassword` / `offerSetPassword`**: the temporary-password flow's ban/rate-limit/reuse/write-conflict branches.
- **`AuthorizeRequestParser` login_hint rejection paths**: disallowed credential type, disallowed phone prefix, unrestricted prefixes, malformed email/phone.
- **`PostgresUserRepository` gaps** in both `auth` (register, findByLogin, patchClaims, delete, findRolesByUser) and `central` (patch, enqueueRoleUpdate, delete, and the outbox lifecycle — including a real behavioral detail: the outbox is per-user FIFO, so a leased event blocks every later event for that user; tests now drain via claim+ack).
- Assorted edge-case coverage: `AuthClient`, `SSOClient`, `PermissionService`, `JWT` claim conversion (all Java type branches), `CleanupManager` (interruption propagation on `stop()`), session cookies.

## What's left for 85%

The remaining gap is concentrated almost entirely in `ConversationService.scala` (487 of ~611 missing statements) — a long tail of rate-limit × ban × write-conflict permutations across the passkey enrollment, registration, consent and code-issuance flows. Each test is cheap individually but there are on the order of 80–120 of them, and several are close to asserting that a stub returns what it was told to return. Happy to continue in a follow-up if 85% is a hard requirement; otherwise this is a reasonable place to gate coverage (e.g. `coverageMinimumStmtTotal := 81`) and ratchet up as those flows get touched.

## Testing

Ran the full suite sequentially against a local Postgres 15 (`sbt coverage test coverageReport coverageAggregate`, `POSTGRES_HOST=localhost:5432`) — all modules pass with 0 failures. Note: `PostgresNotificationListenerSpec` is flaky under parallel execution on a single-core box; sequential execution was used as a workaround. CI's runner (multi-core, dedicated Postgres service container) may not hit this, but flagging it in case it does.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M1PC5CH88GK06TD3XTRQSRFA&panel=chat)