### PR TITLE
test: cover previously-untested sync clients/services/repos; fix coverage badge (Phase 1 of 91% push)

### DIFF
--- a/.github/scripts/coverage-badge.scala
+++ b/.github/scripts/coverage-badge.scala
@@ -8,14 +8,20 @@ import scala.xml.XML
 
 val Output = "coverage.json"
 
-/** Locate the aggregated scoverage report produced by `sbt coverageAggregate`. */
+/** Locate the aggregated scoverage report produced by `sbt coverageAggregate`.
+  *
+  * Per-module reports (e.g. `auth/target/.../scoverage-report/scoverage.xml`) live several
+  * segments below the repo root; `coverageAggregate` writes the whole-build report directly to
+  * `target/scala-.../scoverage-report/scoverage.xml`, i.e. with `target` as the first path
+  * segment. Matching on that instead of taking the alphabetically-first report avoids picking an
+  * arbitrary module (previously `auth/implementations/postgres`, whose name sorts first).
+  */
 def findReport(): os.Path =
   os.walk(os.pwd)
     .filter(p => p.last == "scoverage.xml" && p.segments.contains("scoverage-report"))
-    .sortBy(_.toString)
-    .headOption
+    .find(p => p.relativeTo(os.pwd).segments.headOption.contains("target"))
     .getOrElse {
-      System.err.println("No scoverage report found")
+      System.err.println("No aggregated scoverage report found")
       sys.exit(1)
     }
 

--- a/auth/src/test/scala/versola/auth/model/OtpCodeSpec.scala
+++ b/auth/src/test/scala/versola/auth/model/OtpCodeSpec.scala
@@ -1,0 +1,22 @@
+package versola.auth.model
+
+import zio.schema.Schema
+import zio.schema.codec.JsonCodec as SchemaJsonCodec
+import zio.test.*
+
+object OtpCodeSpec extends ZIOSpecDefault:
+  private val config = SchemaJsonCodec.Configuration.default
+
+  private def decode(json: String) = SchemaJsonCodec.JsonDecoder.decode(Schema[OtpCode], json, config)
+
+  def spec = suite("OtpCode")(
+    test("decodes a numeric string via its schema") {
+      assertTrue(decode("\"123456\"") == Right(OtpCode("123456")))
+    },
+    test("rejects an empty string via its schema") {
+      assertTrue(decode("\"\"").isLeft)
+    },
+    test("rejects a non-digit string via its schema") {
+      assertTrue(decode("\"12a456\"").isLeft)
+    },
+  )

--- a/auth/src/test/scala/versola/oauth/client/AuthorizationDetailTypeSyncClientSpec.scala
+++ b/auth/src/test/scala/versola/oauth/client/AuthorizationDetailTypeSyncClientSpec.scala
@@ -1,0 +1,36 @@
+package versola.oauth.client
+
+import versola.auth.TestEnvConfig
+import versola.oauth.client.model.{AuthorizationDetailType, AuthorizationDetailTypeRecord, TenantId}
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.json.ast.Json
+import zio.test.*
+
+object AuthorizationDetailTypeSyncClientSpec extends ZIOSpecDefault:
+  private def tokenService(client: Client): CentralSyncTokenService = new CentralSyncTokenService:
+    override def getToken: UIO[String] = ZIO.dieMessage("Unused in test")
+    override def syncRequest(request: Request): ZIO[Scope, Throwable, Response] = client.request(request)
+
+  def spec = suite("AuthorizationDetailTypeSyncClient")(
+    test("fetches authorization detail types from central") {
+      val record = AuthorizationDetailTypeRecord(TenantId.default, AuthorizationDetailType("payment"), Json.Obj())
+      for
+        seen <- Ref.make(Option.empty[Request])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { request =>
+            seen.set(Some(request)).as(Response.json(AuthorizationDetailTypeSyncClient.TypesResponse(Vector(record)).toJson))
+          }.toRoutes,
+        )
+        client <- ZIO.service[Client]
+        service = AuthorizationDetailTypeSyncClient.Impl(TestEnvConfig.coreConfig, tokenService(client))
+        types <- service.getAll
+        request <- seen.get.someOrFail(RuntimeException("no request captured"))
+      yield assertTrue(
+        request.method == Method.GET,
+        request.url.path.encode.contains("configuration/authorization-detail-types/sync"),
+        types == Vector(record),
+      )
+    },
+  ).provide(TestClient.layer) @@ TestAspect.silentLogging

--- a/auth/src/test/scala/versola/oauth/client/ChallengeSettingsSyncClientSpec.scala
+++ b/auth/src/test/scala/versola/oauth/client/ChallengeSettingsSyncClientSpec.scala
@@ -1,0 +1,51 @@
+package versola.oauth.client
+
+import versola.auth.TestEnvConfig
+import versola.oauth.client.model.{ChallengeSettingsRecord, PasskeySettings, SubmissionLimits, TenantId}
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+object ChallengeSettingsSyncClientSpec extends ZIOSpecDefault:
+  private def tokenService(client: Client): CentralSyncTokenService = new CentralSyncTokenService:
+    override def getToken: UIO[String] = ZIO.dieMessage("Unused in test")
+    override def syncRequest(request: Request): ZIO[Scope, Throwable, Response] = client.request(request)
+
+  def spec = suite("ChallengeSettingsSyncClient")(
+    test("fetches challenge settings from central") {
+      val record = ChallengeSettingsRecord(
+        tenantId = TenantId.default,
+        allowedPrefixes = List("+1"),
+        submissionLimits = SubmissionLimits.empty,
+        otpLength = 6,
+        otpResendAfter = 30,
+        passkeySettings = PasskeySettings("idp.example", "Versola", List("https://idp.example"), "preferred"),
+        authConversationTtlSeconds = 600,
+        sessionTtlSeconds = 3600,
+        sessionIdleTtlSeconds = None,
+        userAgentTtlSeconds = 3600,
+        ipHeader = "X-Forwarded-For",
+        acrVocabulary = None,
+        postLogoutRedirectUris = List.empty,
+      )
+      for
+        seen <- Ref.make(Option.empty[Request])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { request =>
+            seen.set(Some(request)).as(
+              Response.json(ChallengeSettingsSyncClient.ChallengeSettingsResponse(Vector(record)).toJson),
+            )
+          }.toRoutes,
+        )
+        client <- ZIO.service[Client]
+        service = ChallengeSettingsSyncClient.Impl(TestEnvConfig.coreConfig, tokenService(client))
+        settings <- service.getAll
+        request <- seen.get.someOrFail(RuntimeException("no request captured"))
+      yield assertTrue(
+        request.method == Method.GET,
+        request.url.path.encode.contains("configuration/challenges/challenge-settings/sync"),
+        settings == Vector(record),
+      )
+    },
+  ).provide(TestClient.layer) @@ TestAspect.silentLogging

--- a/auth/src/test/scala/versola/oauth/client/FormSyncClientSpec.scala
+++ b/auth/src/test/scala/versola/oauth/client/FormSyncClientSpec.scala
@@ -1,0 +1,44 @@
+package versola.oauth.client
+
+import versola.auth.TestEnvConfig
+import versola.oauth.client.model.{BooleanProperty, FormRecord}
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+object FormSyncClientSpec extends ZIOSpecDefault:
+  private def tokenService(client: Client): CentralSyncTokenService = new CentralSyncTokenService:
+    override def getToken: UIO[String] = ZIO.dieMessage("Unused in test")
+    override def syncRequest(request: Request): ZIO[Scope, Throwable, Response] = client.request(request)
+
+  def spec = suite("FormSyncClient")(
+    test("fetches forms from central") {
+      val form = FormRecord(
+        id = "signup",
+        version = 1,
+        active = true,
+        style = "default",
+        jsSource = None,
+        jsCompiled = None,
+        localizations = Map.empty,
+        properties = Vector(BooleanProperty("marketingOptIn")),
+      )
+      for
+        seen <- Ref.make(Option.empty[Request])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { request =>
+            seen.set(Some(request)).as(Response.json(FormSyncClient.FormsResponse(Vector(form)).toJson))
+          }.toRoutes,
+        )
+        client <- ZIO.service[Client]
+        service = FormSyncClient.Impl(TestEnvConfig.coreConfig, tokenService(client))
+        forms <- service.getAll
+        request <- seen.get.someOrFail(RuntimeException("no request captured"))
+      yield assertTrue(
+        request.method == Method.GET,
+        request.url.path.encode.contains("configuration/forms/sync"),
+        forms == Vector(form),
+      )
+    },
+  ).provide(TestClient.layer) @@ TestAspect.silentLogging

--- a/auth/src/test/scala/versola/oauth/client/LocaleSyncClientSpec.scala
+++ b/auth/src/test/scala/versola/oauth/client/LocaleSyncClientSpec.scala
@@ -1,0 +1,35 @@
+package versola.oauth.client
+
+import versola.auth.TestEnvConfig
+import versola.oauth.client.model.{LocaleRecord, Locales}
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+object LocaleSyncClientSpec extends ZIOSpecDefault:
+  private def tokenService(client: Client): CentralSyncTokenService = new CentralSyncTokenService:
+    override def getToken: UIO[String] = ZIO.dieMessage("Unused in test")
+    override def syncRequest(request: Request): ZIO[Scope, Throwable, Response] = client.request(request)
+
+  def spec = suite("LocaleSyncClient")(
+    test("fetches locales from central") {
+      val locales = Locales(Vector(LocaleRecord("en", "English")), default = "en")
+      for
+        seen <- Ref.make(Option.empty[Request])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { request =>
+            seen.set(Some(request)).as(Response.json(locales.toJson))
+          }.toRoutes,
+        )
+        client <- ZIO.service[Client]
+        service = LocaleSyncClient.Impl(TestEnvConfig.coreConfig, tokenService(client))
+        result <- service.getAll
+        request <- seen.get.someOrFail(RuntimeException("no request captured"))
+      yield assertTrue(
+        request.method == Method.GET,
+        request.url.path.encode.contains("configuration/locales/sync"),
+        result == locales,
+      )
+    },
+  ).provide(TestClient.layer) @@ TestAspect.silentLogging

--- a/auth/src/test/scala/versola/oauth/client/OtpTemplateSyncClientSpec.scala
+++ b/auth/src/test/scala/versola/oauth/client/OtpTemplateSyncClientSpec.scala
@@ -1,0 +1,41 @@
+package versola.oauth.client
+
+import versola.auth.TestEnvConfig
+import versola.oauth.client.model.{OtpTemplateChannel, OtpTemplatePurpose, OtpTemplateRecord, TenantId}
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+object OtpTemplateSyncClientSpec extends ZIOSpecDefault:
+  private def tokenService(client: Client): CentralSyncTokenService = new CentralSyncTokenService:
+    override def getToken: UIO[String] = ZIO.dieMessage("Unused in test")
+    override def syncRequest(request: Request): ZIO[Scope, Throwable, Response] = client.request(request)
+
+  def spec = suite("OtpTemplateSyncClient")(
+    test("fetches OTP templates from central") {
+      val record = OtpTemplateRecord(
+        id = "signup-otp",
+        tenantId = TenantId.default,
+        localizations = Map("en" -> "Your code is {code}"),
+        purpose = OtpTemplatePurpose.otp,
+        channel = OtpTemplateChannel.sms,
+      )
+      for
+        seen <- Ref.make(Option.empty[Request])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { request =>
+            seen.set(Some(request)).as(Response.json(OtpTemplateSyncClient.TemplatesResponse(Vector(record)).toJson))
+          }.toRoutes,
+        )
+        client <- ZIO.service[Client]
+        service = OtpTemplateSyncClient.Impl(TestEnvConfig.coreConfig, tokenService(client))
+        templates <- service.getAll
+        request <- seen.get.someOrFail(RuntimeException("no request captured"))
+      yield assertTrue(
+        request.method == Method.GET,
+        request.url.path.encode.contains("configuration/challenges/otp-templates/sync"),
+        templates == Vector(record),
+      )
+    },
+  ).provide(TestClient.layer) @@ TestAspect.silentLogging

--- a/auth/src/test/scala/versola/oauth/client/ResourceSyncClientSpec.scala
+++ b/auth/src/test/scala/versola/oauth/client/ResourceSyncClientSpec.scala
@@ -1,0 +1,95 @@
+package versola.oauth.client
+
+import versola.auth.TestEnvConfig
+import versola.oauth.client.model.{ClientId, ResourceId, ResourceUri, TenantId}
+import versola.util.{Base64, Secret, SecurityService}
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+object ResourceSyncClientSpec extends ZIOSpecDefault:
+  private val decryptedSecret = Array.fill(32)(4.toByte)
+
+  private def tokenService(client: Client): CentralSyncTokenService = new CentralSyncTokenService:
+    override def getToken: UIO[String] = ZIO.dieMessage("Unused in test")
+    override def syncRequest(request: Request): ZIO[Scope, Throwable, Response] = client.request(request)
+
+  private val fakeSecurityService = new SecurityService:
+    override def encryptAes256(data: Array[Byte], key: javax.crypto.SecretKey) = ZIO.dieMessage("Unused in test")
+    override def decryptAes256(data: Array[Byte], key: javax.crypto.SecretKey) = ZIO.succeed(decryptedSecret)
+    override def encryptRsa(data: Array[Byte], key: java.security.PublicKey) = ZIO.dieMessage("Unused in test")
+    override def decryptRsa(data: Array[Byte], key: java.security.PrivateKey) = ZIO.dieMessage("Unused in test")
+    override def mac(macInput: Secret, key: Array[Byte]) = ZIO.dieMessage("Unused in test")
+    override def hashPassword(pw: Secret, salt: versola.util.Salt, pepper: Secret.Bytes16) =
+      ZIO.dieMessage("Unused in test")
+    override def generateRsaKeyPair = ZIO.dieMessage("Unused in test")
+
+  private case class RegistryEntryMirror(
+      resourceId: ResourceId,
+      tenantId: TenantId,
+      resource: ResourceUri,
+      audience: List[ClientId],
+      internal: Boolean,
+  ) derives JsonCodec
+
+  private case class RegistryResponseMirror(
+      resources: Vector[RegistryEntryMirror],
+      authResourceSecret: Option[String],
+      authResourcePreviousSecret: Option[String],
+  ) derives JsonCodec
+
+  private val resource = RegistryEntryMirror(
+    ResourceId("central"),
+    TenantId.default,
+    ResourceUri("https://central.example"),
+    List(ClientId("web-app")),
+    internal = true,
+  )
+
+  def spec = suite("ResourceSyncClient")(
+    test("maps the resource registry and decrypts current + previous auth secrets") {
+      val body = RegistryResponseMirror(
+        resources = Vector(resource),
+        authResourceSecret = Some(Base64.urlEncode(Array.fill(32)(1.toByte))),
+        authResourcePreviousSecret = Some(Base64.urlEncode(Array.fill(32)(2.toByte))),
+      ).toJson
+      for
+        seen <- Ref.make(Option.empty[Request])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { request =>
+            seen.set(Some(request)).as(Response.json(body))
+          }.toRoutes,
+        )
+        client <- ZIO.service[Client]
+        service = ResourceSyncClient.Impl(TestEnvConfig.coreConfig, fakeSecurityService, tokenService(client))
+        result <- service.getAll
+        request <- seen.get.someOrFail(RuntimeException("no request captured"))
+      yield assertTrue(
+        request.method == Method.GET,
+        request.url.path.encode.contains("configuration/resources/registry"),
+        result.resources == Vector(
+          versola.oauth.client.model.ResourceRecord(
+            ResourceId("central"),
+            TenantId.default,
+            ResourceUri("https://central.example"),
+            List(ClientId("web-app")),
+            true,
+          ),
+        ),
+        result.authResourceSecrets.size == 2,
+        result.authResourceSecrets.forall(_.sameElements(decryptedSecret)),
+      )
+    },
+    test("returns no auth secrets when central sends none") {
+      val body = RegistryResponseMirror(Vector.empty, None, None).toJson
+      for
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { _ => ZIO.succeed(Response.json(body)) }.toRoutes,
+        )
+        client <- ZIO.service[Client]
+        service = ResourceSyncClient.Impl(TestEnvConfig.coreConfig, fakeSecurityService, tokenService(client))
+        result <- service.getAll
+      yield assertTrue(result.resources.isEmpty, result.authResourceSecrets.isEmpty)
+    },
+  ).provide(TestClient.layer) @@ TestAspect.silentLogging

--- a/auth/src/test/scala/versola/oauth/client/SystemSettingsSyncClientSpec.scala
+++ b/auth/src/test/scala/versola/oauth/client/SystemSettingsSyncClientSpec.scala
@@ -1,0 +1,35 @@
+package versola.oauth.client
+
+import versola.auth.TestEnvConfig
+import versola.oauth.client.model.SystemSettingsRecord
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+object SystemSettingsSyncClientSpec extends ZIOSpecDefault:
+  private def tokenService(client: Client): CentralSyncTokenService = new CentralSyncTokenService:
+    override def getToken: UIO[String] = ZIO.dieMessage("Unused in test")
+    override def syncRequest(request: Request): ZIO[Scope, Throwable, Response] = client.request(request)
+
+  def spec = suite("SystemSettingsSyncClient")(
+    test("fetches system settings from central") {
+      val settings = SystemSettingsRecord.default
+      for
+        seen <- Ref.make(Option.empty[Request])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { request =>
+            seen.set(Some(request)).as(Response.json(settings.toJson))
+          }.toRoutes,
+        )
+        client <- ZIO.service[Client]
+        service = SystemSettingsSyncClient.Impl(TestEnvConfig.coreConfig, tokenService(client))
+        result <- service.getAll
+        request <- seen.get.someOrFail(RuntimeException("no request captured"))
+      yield assertTrue(
+        request.method == Method.GET,
+        request.url.path.encode.contains("configuration/system-settings/sync"),
+        result == settings,
+      )
+    },
+  ).provide(TestClient.layer) @@ TestAspect.silentLogging

--- a/auth/src/test/scala/versola/oauth/client/ThemeSyncClientSpec.scala
+++ b/auth/src/test/scala/versola/oauth/client/ThemeSyncClientSpec.scala
@@ -1,0 +1,35 @@
+package versola.oauth.client
+
+import versola.auth.TestEnvConfig
+import versola.oauth.client.model.ThemeRecord
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+object ThemeSyncClientSpec extends ZIOSpecDefault:
+  private def tokenService(client: Client): CentralSyncTokenService = new CentralSyncTokenService:
+    override def getToken: UIO[String] = ZIO.dieMessage("Unused in test")
+    override def syncRequest(request: Request): ZIO[Scope, Throwable, Response] = client.request(request)
+
+  def spec = suite("ThemeSyncClient")(
+    test("fetches themes from central") {
+      val theme = ThemeRecord("default", "body { color: black; }", tenantId = None)
+      for
+        seen <- Ref.make(Option.empty[Request])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { request =>
+            seen.set(Some(request)).as(Response.json(ThemeSyncClient.ThemesResponse(Vector(theme)).toJson))
+          }.toRoutes,
+        )
+        client <- ZIO.service[Client]
+        service = ThemeSyncClient.Impl(TestEnvConfig.coreConfig, tokenService(client))
+        themes <- service.getAll
+        request <- seen.get.someOrFail(RuntimeException("no request captured"))
+      yield assertTrue(
+        request.method == Method.GET,
+        request.url.path.encode.contains("configuration/themes/sync"),
+        themes == Vector(theme),
+      )
+    },
+  ).provide(TestClient.layer) @@ TestAspect.silentLogging

--- a/auth/src/test/scala/versola/oauth/jwks/JwksServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/jwks/JwksServiceSpec.scala
@@ -1,0 +1,35 @@
+package versola.oauth.jwks
+
+import versola.util.{JWT, ReloadingCache}
+import zio.*
+import zio.test.*
+
+object JwksServiceSpec extends ZIOSpecDefault:
+
+  private def publicKeys(keyId: String): JWT.PublicKeys =
+    val generator = java.security.KeyPairGenerator.getInstance("RSA").nn
+    generator.initialize(2048)
+    val keyPair = generator.generateKeyPair().nn
+    val jwk = com.nimbusds.jose.jwk.RSAKey
+      .Builder(keyPair.getPublic.asInstanceOf[java.security.interfaces.RSAPublicKey])
+      .keyID(keyId)
+      .build()
+    JWT.PublicKeys(com.nimbusds.jose.jwk.JWKSet(jwk))
+
+  def spec = suite("JwksService")(
+    test("getPublicKeys reads through to the underlying cache") {
+      for
+        cache <- Ref.make(publicKeys("key-1"))
+        service = JwksService.Impl(ReloadingCache(cache))
+        result <- service.getPublicKeys
+      yield assertTrue(result.active.id == "key-1")
+    },
+    test("getPublicKeys reflects a cache update") {
+      for
+        cache <- Ref.make(publicKeys("key-1"))
+        service = JwksService.Impl(ReloadingCache(cache))
+        _ <- cache.set(publicKeys("key-2"))
+        result <- service.getPublicKeys
+      yield assertTrue(result.active.id == "key-2")
+    },
+  )

--- a/auth/src/test/scala/versola/oauth/logout/BackChannelDispatcherSpec.scala
+++ b/auth/src/test/scala/versola/oauth/logout/BackChannelDispatcherSpec.scala
@@ -1,0 +1,72 @@
+package versola.oauth.logout
+
+import versola.auth.TestEnvConfig
+import versola.oauth.client.model.ClientId
+import versola.util.JWT
+import zio.*
+import zio.http.*
+import zio.json.ast.Json
+import zio.test.*
+
+object BackChannelDispatcherSpec extends ZIOSpecDefault:
+
+  private val audience = NonEmptyChunk(ClientId("client-a"), ClientId("client-b"))
+  private val uri = URL.decode("https://rp.example/back-channel-logout").toOption.get
+  private val customClaims = Json.Obj("events" -> Json.Obj("logout" -> Json.Obj()))
+
+  private def dispatcher(client: Client): BackChannelDispatcher.Impl =
+    BackChannelDispatcher.Impl(TestEnvConfig.coreConfig, TestEnvConfig.jwksService, client)
+
+  def spec = suite("BackChannelDispatcher")(
+    test("signs and posts a logout token form-encoded to the given URI") {
+      for
+        seen <- Ref.make(Option.empty[Request])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { request =>
+            seen.set(Some(request)).as(Response.ok)
+          }.toRoutes,
+        )
+        client <- ZIO.service[Client]
+        _ <- dispatcher(client).dispatch(audience, uri, "user-42", customClaims)
+        request <- seen.get.someOrFail(RuntimeException("no request captured"))
+        body <- request.body.asString
+        token = body.stripPrefix("logout_token=")
+        claims <- JWT.deserialize[Json.Obj](token, TestEnvConfig.publicKeys, JWT.Type.JWT)
+      yield assertTrue(
+        request.method == Method.POST,
+        request.url.path.encode == uri.path.encode,
+        request.body.mediaType.contains(MediaType.application.`x-www-form-urlencoded`),
+        claims.get("iss").contains(Json.Str(TestEnvConfig.coreConfig.jwt.issuer)),
+        claims.get("sub").contains(Json.Str("user-42")),
+        claims.get("aud").contains(Json.Arr(Json.Str("client-a"), Json.Str("client-b"))),
+        claims.get("events") == customClaims.get("events"),
+      )
+    },
+    test("fails with the status and body when the endpoint rejects the event") {
+      for
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { _ =>
+            ZIO.succeed(Response.text("client is disabled").status(Status.BadRequest))
+          }.toRoutes,
+        )
+        client <- ZIO.service[Client]
+        exit <- dispatcher(client).dispatch(audience, uri, "user-42", customClaims).exit
+      yield assertTrue(
+        exit.isFailure,
+        exit.causeOption.exists(_.squashTrace.getMessage.contains("400")),
+        exit.causeOption.exists(_.squashTrace.getMessage.contains("client is disabled")),
+      )
+    },
+    test("times out a delivery that never responds") {
+      for
+        _ <- TestClient.addRoutes(Handler.fromFunctionZIO[Request](_ => ZIO.never).toRoutes)
+        client <- ZIO.service[Client]
+        fiber <- dispatcher(client).dispatch(audience, uri, "user-42", customClaims).exit.fork
+        _ <- TestClock.adjust(5.seconds)
+        exit <- fiber.join
+      yield assertTrue(
+        exit.isFailure,
+        exit.causeOption.exists(_.squashTrace.getMessage.contains("timed out")),
+      )
+    },
+  ).provide(TestClient.layer) @@ TestAspect.silentLogging @@ TestAspect.sequential

--- a/auth/src/test/scala/versola/oauth/metadata/MetadataSyncClientSpec.scala
+++ b/auth/src/test/scala/versola/oauth/metadata/MetadataSyncClientSpec.scala
@@ -1,0 +1,36 @@
+package versola.oauth.metadata
+
+import versola.auth.TestEnvConfig
+import versola.oauth.client.CentralSyncTokenService
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.json.ast.Json
+import zio.test.*
+
+object MetadataSyncClientSpec extends ZIOSpecDefault:
+  private def tokenService(client: Client): CentralSyncTokenService = new CentralSyncTokenService:
+    override def getToken: UIO[String] = ZIO.dieMessage("Unused in test")
+    override def syncRequest(request: Request): ZIO[Scope, Throwable, Response] = client.request(request)
+
+  def spec = suite("MetadataSyncClient")(
+    test("fetches server metadata overrides from central") {
+      val overrides = Json.Obj("service_documentation" -> Json.Str("https://docs.example"))
+      for
+        seen <- Ref.make(Option.empty[Request])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { request =>
+            seen.set(Some(request)).as(Response.json(overrides.toJson))
+          }.toRoutes,
+        )
+        client <- ZIO.service[Client]
+        service = MetadataSyncClient.Impl(TestEnvConfig.coreConfig, tokenService(client))
+        result <- service.getAll
+        request <- seen.get.someOrFail(RuntimeException("no request captured"))
+      yield assertTrue(
+        request.method == Method.GET,
+        request.url.path.encode.contains("configuration/server-metadata/sync"),
+        result == overrides,
+      )
+    },
+  ).provide(TestClient.layer) @@ TestAspect.silentLogging

--- a/auth/src/test/scala/versola/oauth/model/GrantTypeSpec.scala
+++ b/auth/src/test/scala/versola/oauth/model/GrantTypeSpec.scala
@@ -1,0 +1,17 @@
+package versola.oauth.model
+
+import zio.test.*
+
+object GrantTypeSpec extends ZIOSpecDefault:
+  def spec = suite("GrantType")(
+    test("from parses each known grant type") {
+      assertTrue(
+        GrantType.from("authorization_code") == Right(GrantType.AuthorizationCode),
+        GrantType.from("client_credentials") == Right(GrantType.ClientCredentials),
+        GrantType.from("refresh_token") == Right(GrantType.RefreshToken),
+      )
+    },
+    test("from rejects an unknown grant type") {
+      assertTrue(GrantType.from("implicit") == Left("Unsupported grant type: implicit"))
+    },
+  )

--- a/auth/src/test/scala/versola/user/UserRegistrationSyncClientSpec.scala
+++ b/auth/src/test/scala/versola/user/UserRegistrationSyncClientSpec.scala
@@ -1,0 +1,54 @@
+package versola.user
+
+import versola.auth.TestEnvConfig
+import versola.oauth.client.CentralSyncTokenService
+import versola.user.model.{Login, UserId}
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+import java.util.UUID
+
+object UserRegistrationSyncClientSpec extends ZIOSpecDefault:
+  private val userId = UserId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+  private val event = UserRegisteredEvent(email = None, phone = None, login = Some(Login("new-user")))
+
+  private def tokenService(client: Client): CentralSyncTokenService = new CentralSyncTokenService:
+    override def getToken: UIO[String] = ZIO.dieMessage("Unused in test")
+    override def syncRequest(request: Request): ZIO[Scope, Throwable, Response] = client.request(request)
+
+  def spec = suite("UserRegistrationSyncClient")(
+    test("claims a registration and returns the canonical user id") {
+      for
+        seen <- Ref.make(Option.empty[Request])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { request =>
+            seen.set(Some(request)).as(Response.json(RegistrationClaimResponse(userId).toJson))
+          }.toRoutes,
+        )
+        client <- ZIO.service[Client]
+        service = UserRegistrationSyncClient.Impl(TestEnvConfig.coreConfig, tokenService(client))
+        result <- service.claimRegistration(event)
+        request <- seen.get.someOrFail(RuntimeException("no request captured"))
+        body <- request.body.asString
+      yield assertTrue(
+        result == userId,
+        request.method == Method.POST,
+        request.url.path.encode.contains("users/registrations"),
+        body == event.toJson,
+      )
+    },
+    test("fails when central rejects the claim") {
+      for
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { _ =>
+            ZIO.succeed(Response.status(Status.Conflict))
+          }.toRoutes,
+        )
+        client <- ZIO.service[Client]
+        service = UserRegistrationSyncClient.Impl(TestEnvConfig.coreConfig, tokenService(client))
+        exit <- service.claimRegistration(event).exit
+      yield assertTrue(exit.isFailure)
+    },
+  ).provide(TestClient.layer) @@ TestAspect.silentLogging

--- a/auth/src/test/scala/versola/util/AuthPropertyGeneratorSpec.scala
+++ b/auth/src/test/scala/versola/util/AuthPropertyGeneratorSpec.scala
@@ -1,0 +1,69 @@
+package versola.util
+
+import zio.*
+import zio.test.*
+
+import java.security.SecureRandom as JSecureRandom
+
+object AuthPropertyGeneratorSpec extends ZIOSpecDefault:
+
+  /** Records the length requested of each call and returns a deterministic, distinct
+    * fixed-length byte array (the byte value equals the requested length) so a test can
+    * confirm both the length asked for and that the returned value actually wraps it.
+    */
+  private def fakeRandom(requestedLengths: Ref[List[Int]]): SecureRandom =
+    new SecureRandom:
+      override def nextBytes(length: Int): UIO[Array[Byte]] =
+        requestedLengths.update(_ :+ length).as(Array.fill(length)(length.toByte))
+      override def nextHex(length: Int): UIO[String] = ZIO.dieMessage("Unused in test")
+      override def nextNumeric(length: Int): UIO[String] = ZIO.dieMessage("Unused in test")
+      override def nextAlphanumeric(length: Int): UIO[String] = ZIO.dieMessage("Unused in test")
+      override def nextUUIDv7: UIO[java.util.UUID] = ZIO.dieMessage("Unused in test")
+      override def setSeed(seed: Long): UIO[Unit] = ZIO.dieMessage("Unused in test")
+      override def execute[A](fn: JSecureRandom => A): UIO[A] = ZIO.dieMessage("Unused in test")
+
+  def spec = suite("AuthPropertyGenerator")(
+    test("nextAuthorizationCode draws 16 bytes") {
+      for
+        lengths <- Ref.make(List.empty[Int])
+        generator = AuthPropertyGenerator.Impl(fakeRandom(lengths))
+        code <- generator.nextAuthorizationCode
+        seen <- lengths.get
+      yield assertTrue(seen == List(16), code.sameElements(Array.fill(16)(16.toByte)))
+    },
+    test("nextSessionId draws 32 bytes") {
+      for
+        lengths <- Ref.make(List.empty[Int])
+        generator = AuthPropertyGenerator.Impl(fakeRandom(lengths))
+        id <- generator.nextSessionId
+        seen <- lengths.get
+      yield assertTrue(seen == List(32), id.sameElements(Array.fill(32)(32.toByte)))
+    },
+    test("nextPublicSessionId draws 16 bytes and base64url-encodes them") {
+      for
+        lengths <- Ref.make(List.empty[Int])
+        generator = AuthPropertyGenerator.Impl(fakeRandom(lengths))
+        id <- generator.nextPublicSessionId
+        seen <- lengths.get
+      yield assertTrue(
+        seen == List(16),
+        (id: String) == versola.util.Base64.urlEncode(Array.fill(16)(16.toByte)),
+      )
+    },
+    test("nextAccessToken draws 16 bytes") {
+      for
+        lengths <- Ref.make(List.empty[Int])
+        generator = AuthPropertyGenerator.Impl(fakeRandom(lengths))
+        token <- generator.nextAccessToken
+        seen <- lengths.get
+      yield assertTrue(seen == List(16), token.sameElements(Array.fill(16)(16.toByte)))
+    },
+    test("nextRefreshToken draws 32 bytes") {
+      for
+        lengths <- Ref.make(List.empty[Int])
+        generator = AuthPropertyGenerator.Impl(fakeRandom(lengths))
+        token <- generator.nextRefreshToken
+        seen <- lengths.get
+      yield assertTrue(seen == List(32), token.sameElements(Array.fill(32)(32.toByte)))
+    },
+  )

--- a/central/implementations/postgres/src/test/scala/versola/configuration/metadata/PostgresServerMetadataRepositorySpec.scala
+++ b/central/implementations/postgres/src/test/scala/versola/configuration/metadata/PostgresServerMetadataRepositorySpec.scala
@@ -1,0 +1,19 @@
+package versola.configuration.metadata
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import com.augustnagro.magnum.sql
+import versola.central.configuration.metadata.ServerMetadataRepositorySpec
+import versola.util.postgres.PostgresSpec
+import zio.{ZIO, ZLayer}
+
+object PostgresServerMetadataRepositorySpec extends PostgresSpec, ServerMetadataRepositorySpec:
+
+  override lazy val environment =
+    ZLayer:
+      for xa <- ZIO.service[TransactorZIO]
+      yield ServerMetadataRepositorySpec.Env(PostgresServerMetadataRepository(xa))
+
+  override def beforeEach(env: ServerMetadataRepositorySpec.Env) =
+    ZIO.serviceWithZIO[TransactorZIO] { xa =>
+      xa.connect(sql"TRUNCATE TABLE server_metadata".update.run())
+    }.unit

--- a/central/implementations/postgres/src/test/scala/versola/configuration/system/PostgresSystemSettingsRepositorySpec.scala
+++ b/central/implementations/postgres/src/test/scala/versola/configuration/system/PostgresSystemSettingsRepositorySpec.scala
@@ -1,0 +1,19 @@
+package versola.configuration.system
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import com.augustnagro.magnum.sql
+import versola.central.configuration.system.SystemSettingsRepositorySpec
+import versola.util.postgres.PostgresSpec
+import zio.{ZIO, ZLayer}
+
+object PostgresSystemSettingsRepositorySpec extends PostgresSpec, SystemSettingsRepositorySpec:
+
+  override lazy val environment =
+    ZLayer:
+      for xa <- ZIO.service[TransactorZIO]
+      yield SystemSettingsRepositorySpec.Env(PostgresSystemSettingsRepository(xa))
+
+  override def beforeEach(env: SystemSettingsRepositorySpec.Env) =
+    ZIO.serviceWithZIO[TransactorZIO] { xa =>
+      xa.connect(sql"TRUNCATE TABLE system_settings".update.run())
+    }.unit

--- a/central/src/test/scala/versola/central/configuration/metadata/ServerMetadataRepositorySpec.scala
+++ b/central/src/test/scala/versola/central/configuration/metadata/ServerMetadataRepositorySpec.scala
@@ -1,0 +1,40 @@
+package versola.central.configuration.metadata
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import versola.util.DatabaseSpecBase
+import zio.json.ast.Json
+import zio.test.*
+
+/** Conformance suite for any [[ServerMetadataRepository]] implementation. A backend module
+  * extends this and supplies the wiring -- see `PostgresServerMetadataRepositorySpec` in
+  * `central-postgres-impl` for the one binding that exists today.
+  */
+trait ServerMetadataRepositorySpec extends DatabaseSpecBase[ServerMetadataRepositorySpec.Env]:
+  self: ZIOSpec[TransactorZIO] =>
+
+  override def testCases(env: ServerMetadataRepositorySpec.Env) =
+    List(
+      test("get returns nothing when no metadata has been stored") {
+        for result <- env.repository.get
+        yield assertTrue(result.isEmpty)
+      },
+      test("upsert then get returns the stored metadata") {
+        val metadata = Json.Obj("service_documentation" -> Json.Str("https://docs.example"))
+        for
+          _ <- env.repository.upsert(metadata)
+          result <- env.repository.get
+        yield assertTrue(result == Some(ServerMetadataRecord("default", metadata)))
+      },
+      test("upsert overwrites the previously stored metadata") {
+        val first = Json.Obj("a" -> Json.Str("1"))
+        val second = Json.Obj("b" -> Json.Str("2"))
+        for
+          _ <- env.repository.upsert(first)
+          _ <- env.repository.upsert(second)
+          result <- env.repository.get
+        yield assertTrue(result == Some(ServerMetadataRecord("default", second)))
+      },
+    )
+
+object ServerMetadataRepositorySpec:
+  case class Env(repository: ServerMetadataRepository)

--- a/central/src/test/scala/versola/central/configuration/sync/CacheSyncRepositorySpec.scala
+++ b/central/src/test/scala/versola/central/configuration/sync/CacheSyncRepositorySpec.scala
@@ -1,0 +1,14 @@
+package versola.central.configuration.sync
+
+import zio.*
+import zio.test.*
+
+object CacheSyncRepositorySpec extends ZIOSpecDefault:
+  def spec = suite("CacheSyncRepository")(
+    test("noop never emits a notification") {
+      for
+        repository <- ZIO.service[CacheSyncRepository]
+        notifications <- repository.getNotifications.runCollect
+      yield assertTrue(notifications.isEmpty)
+    },
+  ).provide(CacheSyncRepository.noop)

--- a/central/src/test/scala/versola/central/configuration/system/SystemSettingsRepositorySpec.scala
+++ b/central/src/test/scala/versola/central/configuration/system/SystemSettingsRepositorySpec.scala
@@ -1,0 +1,44 @@
+package versola.central.configuration.system
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import versola.util.DatabaseSpecBase
+import zio.test.*
+
+/** Conformance suite for any [[SystemSettingsRepository]] implementation. A backend module
+  * extends this and supplies the wiring -- see `PostgresSystemSettingsRepositorySpec` in
+  * `central-postgres-impl` for the one binding that exists today.
+  */
+trait SystemSettingsRepositorySpec extends DatabaseSpecBase[SystemSettingsRepositorySpec.Env]:
+  self: ZIOSpec[TransactorZIO] =>
+
+  private val record = SystemSettingsRecord(
+    passwordRegex = "^.{8,}$",
+    passwordHistorySize = 3,
+    passwordNumDifferent = 1,
+    identityProviderLogo = Some("https://idp.example/logo.png"),
+  )
+
+  override def testCases(env: SystemSettingsRepositorySpec.Env) =
+    List(
+      test("getAll throws when no settings row has been stored") {
+        for exit <- env.repository.getAll.exit
+        yield assertTrue(exit.isFailure)
+      },
+      test("upsert then getAll returns the stored settings") {
+        for
+          _ <- env.repository.upsert(record)
+          result <- env.repository.getAll
+        yield assertTrue(result == record)
+      },
+      test("upsert overwrites the previously stored settings") {
+        val updated = record.copy(passwordHistorySize = 5, identityProviderLogo = None)
+        for
+          _ <- env.repository.upsert(record)
+          _ <- env.repository.upsert(updated)
+          result <- env.repository.getAll
+        yield assertTrue(result == updated)
+      },
+    )
+
+object SystemSettingsRepositorySpec:
+  case class Env(repository: SystemSettingsRepository)

--- a/edge/src/test/scala/versola/edge/AuthorizationPresetsSyncClientSpec.scala
+++ b/edge/src/test/scala/versola/edge/AuthorizationPresetsSyncClientSpec.scala
@@ -1,0 +1,72 @@
+package versola.edge
+
+import versola.edge.model.{AuthorizationPreset, ClientId, PresetId}
+import versola.util.RedirectUri
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+object AuthorizationPresetsSyncClientSpec extends ZIOSpecDefault:
+  private val syncToken = "sync-token"
+
+  private val keyPair =
+    val generator = java.security.KeyPairGenerator.getInstance("RSA").nn
+    generator.initialize(2048)
+    generator.generateKeyPair().nn
+
+  private val config = EdgeConfig(
+    versola.edge.model.EdgeId("edge-1"),
+    "edge-key",
+    keyPair.getPrivate.nn,
+    EdgeConfig.Security(
+      EdgeConfig.Security.TokenEncryption(versola.util.Secret.Bytes32(Array.fill(32)(1.toByte))),
+      EdgeConfig.Security.EdgeSessions(versola.util.Secret.Bytes32(Array.fill(32)(2.toByte)), 1.hour),
+    ),
+    EdgeConfig.CentralConfig(URL.decode("https://central.example").toOption.get),
+    URL.decode("https://idp.example").toOption.get,
+    configurationCacheRefreshInterval = 5.minutes,
+  )
+
+  private val centralSyncTokenService = new CentralSyncTokenService:
+    override def getToken: UIO[String] = ZIO.succeed(syncToken)
+
+  private val preset = AuthorizationPreset(
+    id = PresetId("preset-1"),
+    clientId = ClientId("web-app"),
+    description = "Default preset",
+    redirectUri = RedirectUri("https://app.example/complete"),
+    postLoginRedirectUri = RedirectUri("https://app.example/home"),
+    postLogoutRedirectUri = None,
+    scope = Set("openid"),
+    responseType = "code",
+    uiLocales = None,
+    customParameters = Map.empty,
+    cookieDomain = None,
+    cookiePath = None,
+  )
+
+  private case class ResponseMirror(presets: Vector[AuthorizationPreset]) derives JsonCodec
+
+  def spec = suite("AuthorizationPresetsSyncClient")(
+    test("maps presets by id") {
+      val body = ResponseMirror(Vector(preset)).toJson
+      for
+        seen <- Ref.make(Option.empty[Request])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { request =>
+            seen.set(Some(request)).as(Response.json(body))
+          }.toRoutes,
+        )
+        client <- ZIO.service[Client]
+        service = AuthorizationPresetsSyncClient.Impl(client, config, centralSyncTokenService)
+        presets <- service.getAll
+        request <- seen.get.someOrFail(RuntimeException("no request captured"))
+      yield assertTrue(
+        request.method == Method.GET,
+        request.url.path.encode.contains("configuration/auth-request-presets/sync"),
+        request.header(Header.Authorization).contains(Header.Authorization.Bearer(syncToken)),
+        presets == Map(PresetId("preset-1") -> preset),
+      )
+    },
+  ).provide(TestClient.layer) @@ TestAspect.silentLogging

--- a/edge/src/test/scala/versola/edge/JwksServiceSpec.scala
+++ b/edge/src/test/scala/versola/edge/JwksServiceSpec.scala
@@ -1,0 +1,36 @@
+package versola.edge
+
+import versola.util.{JWT, ReloadingCache}
+import zio.*
+import zio.test.*
+
+object JwksServiceSpec extends ZIOSpecDefault:
+
+  private def publicKeys(keyId: String): JWT.PublicKeys =
+    val generator = java.security.KeyPairGenerator.getInstance("RSA").nn
+    generator.initialize(2048)
+    val keyPair = generator.generateKeyPair().nn
+    val jwk = com.nimbusds.jose.jwk.RSAKey
+      .Builder(keyPair.getPublic.asInstanceOf[java.security.interfaces.RSAPublicKey])
+      .keyID(keyId)
+      .build()
+    JWT.PublicKeys(com.nimbusds.jose.jwk.JWKSet(jwk))
+
+  def spec = suite("JwksService")(
+    test("getPublicKeys reads through to the underlying cache") {
+      for
+        keys <- ZIO.succeed(publicKeys("key-1"))
+        cache <- Ref.make(keys)
+        service = JwksService.Impl(ReloadingCache(cache))
+        result <- service.getPublicKeys
+      yield assertTrue(result.active.id == "key-1")
+    },
+    test("getPublicKeys reflects a cache update") {
+      for
+        cache <- Ref.make(publicKeys("key-1"))
+        service = JwksService.Impl(ReloadingCache(cache))
+        _ <- cache.set(publicKeys("key-2"))
+        result <- service.getPublicKeys
+      yield assertTrue(result.active.id == "key-2")
+    },
+  )

--- a/edge/src/test/scala/versola/edge/JwksSyncClientSpec.scala
+++ b/edge/src/test/scala/versola/edge/JwksSyncClientSpec.scala
@@ -1,0 +1,69 @@
+package versola.edge
+
+import versola.util.JWT
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+object JwksSyncClientSpec extends ZIOSpecDefault:
+  private val syncToken = "sync-token"
+
+  private val keyPair =
+    val generator = java.security.KeyPairGenerator.getInstance("RSA").nn
+    generator.initialize(2048)
+    generator.generateKeyPair().nn
+
+  private val rsaJwk =
+    com.nimbusds.jose.jwk.RSAKey.Builder(keyPair.getPublic.asInstanceOf[java.security.interfaces.RSAPublicKey])
+      .keyID("central-key")
+      .build()
+
+  private val jwksJson = zio.json.ast.Json.Obj(
+    "keys" -> zio.json.ast.Json.Arr(
+      zio.json.ast.Json.Obj(
+        "kid" -> zio.json.ast.Json.Str("central-key"),
+        "kty" -> zio.json.ast.Json.Str("RSA"),
+        "n" -> zio.json.ast.Json.Str(rsaJwk.getModulus.toString),
+        "e" -> zio.json.ast.Json.Str(rsaJwk.getPublicExponent.toString),
+      ),
+    ),
+  )
+
+  private val config = EdgeConfig(
+    versola.edge.model.EdgeId("edge-1"),
+    "edge-key",
+    keyPair.getPrivate.nn,
+    EdgeConfig.Security(
+      EdgeConfig.Security.TokenEncryption(versola.util.Secret.Bytes32(Array.fill(32)(1.toByte))),
+      EdgeConfig.Security.EdgeSessions(versola.util.Secret.Bytes32(Array.fill(32)(2.toByte)), 1.hour),
+    ),
+    EdgeConfig.CentralConfig(URL.decode("https://central.example").toOption.get),
+    URL.decode("https://idp.example").toOption.get,
+    configurationCacheRefreshInterval = 5.minutes,
+  )
+
+  private val centralSyncTokenService = new CentralSyncTokenService:
+    override def getToken: UIO[String] = ZIO.succeed(syncToken)
+
+  def spec = suite("JwksSyncClient")(
+    test("fetches JWKS from central with a bearer token") {
+      for
+        seen <- Ref.make(Option.empty[Request])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { request =>
+            seen.set(Some(request)).as(Response.json(jwksJson.toJson))
+          }.toRoutes,
+        )
+        client <- ZIO.service[Client]
+        service = JwksSyncClient.Impl(client, config, centralSyncTokenService)
+        keys <- service.getAll
+        request <- seen.get.someOrFail(RuntimeException("no request captured"))
+      yield assertTrue(
+        request.method == Method.GET,
+        request.url.path.encode.contains("configuration/jwks/sync"),
+        request.header(Header.Authorization).contains(Header.Authorization.Bearer(syncToken)),
+        keys.active.id == "central-key",
+      )
+    },
+  ).provide(TestClient.layer) @@ TestAspect.silentLogging

--- a/edge/src/test/scala/versola/edge/OAuthClientsSyncClientSpec.scala
+++ b/edge/src/test/scala/versola/edge/OAuthClientsSyncClientSpec.scala
@@ -1,0 +1,93 @@
+package versola.edge
+
+import versola.edge.model.{ClientId, EdgeId, PermissionId}
+import versola.util.{Base64, Secret, SecurityService}
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+import java.security.KeyPairGenerator
+
+object OAuthClientsSyncClientSpec extends ZIOSpecDefault:
+  private val decryptedSecretA = Array.fill(32)(3.toByte)
+  private val syncToken = "sync-token"
+
+  private val keyPair =
+    val generator = KeyPairGenerator.getInstance("RSA")
+    generator.initialize(2048)
+    generator.generateKeyPair()
+
+  private val config = EdgeConfig(
+    EdgeId("edge-1"),
+    "edge-key",
+    keyPair.getPrivate.nn,
+    EdgeConfig.Security(
+      EdgeConfig.Security.TokenEncryption(Secret.Bytes32(Array.fill(32)(1.toByte))),
+      EdgeConfig.Security.EdgeSessions(Secret.Bytes32(Array.fill(32)(2.toByte)), 1.hour),
+    ),
+    EdgeConfig.CentralConfig(URL.decode("https://central.example").toOption.get),
+    URL.decode("https://idp.example").toOption.get,
+    configurationCacheRefreshInterval = 5.minutes,
+  )
+
+  private def fakeSecurityService(decryptedByCiphertext: Map[String, Array[Byte]]): SecurityService =
+    new SecurityService:
+      override def encryptAes256(data: Array[Byte], key: javax.crypto.SecretKey) = ZIO.dieMessage("Unused in test")
+      override def decryptAes256(data: Array[Byte], key: javax.crypto.SecretKey) = ZIO.dieMessage("Unused in test")
+      override def encryptRsa(data: Array[Byte], key: java.security.PublicKey) = ZIO.dieMessage("Unused in test")
+      override def decryptRsa(data: Array[Byte], key: java.security.PrivateKey) =
+        ZIO.succeed(decryptedByCiphertext(Base64.urlEncode(data)))
+      override def mac(macInput: Secret, key: Array[Byte]) = ZIO.dieMessage("Unused in test")
+      override def hashPassword(pw: Secret, salt: versola.util.Salt, pepper: Secret.Bytes16) =
+        ZIO.dieMessage("Unused in test")
+      override def generateRsaKeyPair = ZIO.dieMessage("Unused in test")
+
+  private val centralSyncTokenService = new CentralSyncTokenService:
+    override def getToken: UIO[String] = ZIO.succeed(syncToken)
+
+  private case class SyncClientRecordMirror(
+      id: ClientId,
+      secret: Option[String],
+      accessTokenTtl: Duration,
+      permissions: Set[String] = Set.empty,
+  ) derives JsonCodec
+
+  private case class SyncResponseMirror(clients: Vector[SyncClientRecordMirror]) derives JsonCodec
+
+  def spec = suite("OAuthClientsSyncClient")(
+    test("decrypts every client with a secret and drops clients missing one") {
+      val secretACiphertext = Base64.urlEncode(Array.fill(32)(30.toByte))
+      val body = SyncResponseMirror(
+        Vector(
+          SyncClientRecordMirror(ClientId("with-secret"), Some(secretACiphertext), 15.minutes, Set("oauth:read")),
+          SyncClientRecordMirror(ClientId("no-secret"), None, 30.minutes),
+        ),
+      ).toJson
+      for
+        seen <- Ref.make(Option.empty[Request])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { request =>
+            seen.set(Some(request)).as(Response.json(body))
+          }.toRoutes,
+        )
+        client <- ZIO.service[Client]
+        service = OAuthClientsSyncClient.Impl(
+          client,
+          config,
+          fakeSecurityService(Map(secretACiphertext -> decryptedSecretA)),
+          centralSyncTokenService,
+        )
+        clients <- service.getAll
+        request <- seen.get.someOrFail(RuntimeException("no request captured"))
+      yield assertTrue(
+        request.method == Method.GET,
+        request.url.path.encode.contains("configuration/clients/sync"),
+        request.header(Header.Authorization).contains(Header.Authorization.Bearer(syncToken)),
+        clients.keySet == Set(ClientId("with-secret")),
+        clients(ClientId("with-secret")).secret.sameElements(decryptedSecretA),
+        clients(ClientId("with-secret")).permissions == Set(PermissionId("oauth:read")),
+        clients(ClientId("with-secret")).accessTokenTtl == 15.minutes,
+      )
+    },
+  ).provide(TestClient.layer) @@ TestAspect.silentLogging

--- a/edge/src/test/scala/versola/edge/PermissionsSyncClientSpec.scala
+++ b/edge/src/test/scala/versola/edge/PermissionsSyncClientSpec.scala
@@ -1,0 +1,65 @@
+package versola.edge
+
+import versola.edge.model.{PermissionId, ResourceEndpointId}
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+import java.util.UUID
+
+object PermissionsSyncClientSpec extends ZIOSpecDefault:
+  private val syncToken = "sync-token"
+
+  private val keyPair =
+    val generator = java.security.KeyPairGenerator.getInstance("RSA").nn
+    generator.initialize(2048)
+    generator.generateKeyPair().nn
+
+  private val config = EdgeConfig(
+    versola.edge.model.EdgeId("edge-1"),
+    "edge-key",
+    keyPair.getPrivate.nn,
+    EdgeConfig.Security(
+      EdgeConfig.Security.TokenEncryption(versola.util.Secret.Bytes32(Array.fill(32)(1.toByte))),
+      EdgeConfig.Security.EdgeSessions(versola.util.Secret.Bytes32(Array.fill(32)(2.toByte)), 1.hour),
+    ),
+    EdgeConfig.CentralConfig(URL.decode("https://central.example").toOption.get),
+    URL.decode("https://idp.example").toOption.get,
+    configurationCacheRefreshInterval = 5.minutes,
+  )
+
+  private val centralSyncTokenService = new CentralSyncTokenService:
+    override def getToken: UIO[String] = ZIO.succeed(syncToken)
+
+  private case class PermissionRecordMirror(id: String, endpointIds: Set[UUID]) derives JsonCodec
+  private case class ResponseMirror(permissions: Vector[PermissionRecordMirror]) derives JsonCodec
+
+  def spec = suite("PermissionsSyncClient")(
+    test("maps permission ids to their endpoint ids") {
+      val endpointA = UUID.randomUUID()
+      val endpointB = UUID.randomUUID()
+      val body = ResponseMirror(
+        Vector(PermissionRecordMirror("oauth:read", Set(endpointA, endpointB))),
+      ).toJson
+      for
+        seen <- Ref.make(Option.empty[Request])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { request =>
+            seen.set(Some(request)).as(Response.json(body))
+          }.toRoutes,
+        )
+        client <- ZIO.service[Client]
+        service = PermissionsSyncClient.Impl(client, config, centralSyncTokenService)
+        permissions <- service.getAll
+        request <- seen.get.someOrFail(RuntimeException("no request captured"))
+      yield assertTrue(
+        request.method == Method.GET,
+        request.url.path.encode.contains("configuration/permissions/sync"),
+        request.header(Header.Authorization).contains(Header.Authorization.Bearer(syncToken)),
+        permissions == Map(
+          PermissionId("oauth:read") -> Set(ResourceEndpointId(endpointA), ResourceEndpointId(endpointB)),
+        ),
+      )
+    },
+  ).provide(TestClient.layer) @@ TestAspect.silentLogging

--- a/edge/src/test/scala/versola/edge/RolesSyncClientSpec.scala
+++ b/edge/src/test/scala/versola/edge/RolesSyncClientSpec.scala
@@ -1,0 +1,69 @@
+package versola.edge
+
+import versola.edge.model.{PermissionId, RoleId, TenantId}
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.test.*
+
+object RolesSyncClientSpec extends ZIOSpecDefault:
+  private val syncToken = "sync-token"
+
+  private val keyPair =
+    val generator = java.security.KeyPairGenerator.getInstance("RSA").nn
+    generator.initialize(2048)
+    generator.generateKeyPair().nn
+
+  private val config = EdgeConfig(
+    versola.edge.model.EdgeId("edge-1"),
+    "edge-key",
+    keyPair.getPrivate.nn,
+    EdgeConfig.Security(
+      EdgeConfig.Security.TokenEncryption(versola.util.Secret.Bytes32(Array.fill(32)(1.toByte))),
+      EdgeConfig.Security.EdgeSessions(versola.util.Secret.Bytes32(Array.fill(32)(2.toByte)), 1.hour),
+    ),
+    EdgeConfig.CentralConfig(URL.decode("https://central.example").toOption.get),
+    URL.decode("https://idp.example").toOption.get,
+    configurationCacheRefreshInterval = 5.minutes,
+  )
+
+  private val centralSyncTokenService = new CentralSyncTokenService:
+    override def getToken: UIO[String] = ZIO.succeed(syncToken)
+
+  private case class RoleRecordMirror(
+      tenantId: String,
+      id: String,
+      permissions: Set[String],
+      active: Boolean,
+  ) derives JsonCodec
+  private case class ResponseMirror(roles: Vector[RoleRecordMirror]) derives JsonCodec
+
+  def spec = suite("RolesSyncClient")(
+    test("maps (tenant, role) to permission ids, dropping inactive roles") {
+      val body = ResponseMirror(
+        Vector(
+          RoleRecordMirror("tenant-a", "admin", Set("oauth:read", "oauth:write"), active = true),
+          RoleRecordMirror("tenant-a", "disabled-role", Set("oauth:read"), active = false),
+        ),
+      ).toJson
+      for
+        seen <- Ref.make(Option.empty[Request])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { request =>
+            seen.set(Some(request)).as(Response.json(body))
+          }.toRoutes,
+        )
+        client <- ZIO.service[Client]
+        service = RolesSyncClient.Impl(client, config, centralSyncTokenService)
+        roles <- service.getAll
+        request <- seen.get.someOrFail(RuntimeException("no request captured"))
+      yield assertTrue(
+        request.method == Method.GET,
+        request.url.path.encode.contains("configuration/roles/sync"),
+        request.header(Header.Authorization).contains(Header.Authorization.Bearer(syncToken)),
+        roles == Map(
+          (TenantId("tenant-a"), RoleId("admin")) -> Set(PermissionId("oauth:read"), PermissionId("oauth:write")),
+        ),
+      )
+    },
+  ).provide(TestClient.layer) @@ TestAspect.silentLogging

--- a/edge/src/test/scala/versola/edge/ServiceControllerSpec.scala
+++ b/edge/src/test/scala/versola/edge/ServiceControllerSpec.scala
@@ -1,0 +1,121 @@
+package versola.edge
+
+import org.scalamock.stubs.{Stub, ZIOStubs}
+import versola.edge.model.EdgeId
+import versola.util.{Base64Url, EnvName, Secret}
+import versola.util.http.Observability
+import zio.*
+import zio.http.*
+import zio.telemetry.opentelemetry.OpenTelemetry
+import zio.telemetry.opentelemetry.tracing.Tracing
+import zio.test.*
+import io.opentelemetry.api
+
+import java.security.KeyPairGenerator
+
+object ServiceControllerSpec extends ZIOSpecDefault, ZIOStubs:
+
+  private val keyPair =
+    val gen = KeyPairGenerator.getInstance("RSA").nn
+    gen.initialize(2048)
+    gen.generateKeyPair().nn
+
+  private val internalSecret = Secret(Array.fill(32)(4.toByte))
+
+  // Positional args through `privateKey` avoid a named `privateKey = ...` argument.
+  private def edgeConfig(secret: Option[Secret]): EdgeConfig = EdgeConfig(
+    EdgeId("edge-1"),
+    "edge-key",
+    keyPair.getPrivate.nn,
+    EdgeConfig.Security(
+      EdgeConfig.Security.TokenEncryption(Secret.Bytes32(Array.fill(32)(1.toByte))),
+      EdgeConfig.Security.EdgeSessions(Secret.Bytes32(Array.fill(32)(2.toByte)), 1.hour),
+      internalSecret = secret,
+    ),
+    EdgeConfig.CentralConfig(URL.decode("https://central.example").toOption.get),
+    URL.decode("https://idp.example").toOption.get,
+    configurationCacheRefreshInterval = 5.minutes,
+  )
+
+  private val tracingLayer: ULayer[Tracing] =
+    ZLayer.make[Tracing](
+      Tracing.live(logAnnotated = false),
+      OpenTelemetry.contextZIO,
+      ZLayer.succeed(api.OpenTelemetry.noop().getTracer("test")),
+    )
+
+  private def run(
+      request: Request,
+      config: EdgeConfig = edgeConfig(Some(internalSecret)),
+      env: EnvName = EnvName.Test("test"),
+      setup: Stub[OAuthClientService] => UIO[Unit] = _ => ZIO.unit,
+  ): ZIO[TestClient & Client & Scope, Throwable, (Response, Stub[OAuthClientService])] =
+    for
+      client  <- ZIO.service[Client]
+      service =  stub[OAuthClientService]
+      tracing <- tracingLayer.build
+      _ <- TestClient.addRoutes(
+        Observability.handleErrors(
+          ServiceController.routes.provideEnvironment(
+            ZEnvironment[OAuthClientService](service) ++
+              ZEnvironment[EdgeConfig](config) ++
+              ZEnvironment[EnvName](env) ++
+              tracing,
+          ),
+        ),
+      )
+      _        <- setup(service)
+      response <- client.batched(request)
+    yield (response, service)
+
+  private def syncRequest(auth: Option[Header.Authorization]): Request =
+    val base = Request.post(URL.empty / "service" / "configuration" / "sync", Body.empty)
+    auth.fold(base)(base.addHeader(_))
+
+  private val validAuth = Header.Authorization.Basic("edge", Base64Url.encode(internalSecret))
+
+  def spec = suite("ServiceController")(
+    suite("POST /service/configuration/sync")(
+      test("syncs configuration and returns 200 OK when the internal secret matches") {
+        for
+          (response, service) <- run(syncRequest(Some(validAuth)), setup = _.refreshNow.succeedsWith(()))
+        yield assertTrue(response.status == Status.Ok, service.refreshNow.calls.length == 1)
+      },
+      test("rejects a request with no Authorization header") {
+        for
+          (response, service) <- run(syncRequest(None))
+        yield assertTrue(response.status == Status.Unauthorized, service.refreshNow.calls.isEmpty)
+      },
+      test("rejects a request with the wrong username") {
+        val wrongAuth = Header.Authorization.Basic("central", Base64Url.encode(internalSecret))
+        for
+          (response, service) <- run(syncRequest(Some(wrongAuth)))
+        yield assertTrue(response.status == Status.Unauthorized, service.refreshNow.calls.isEmpty)
+      },
+      test("rejects a request whose secret does not match") {
+        val wrongAuth = Header.Authorization.Basic("edge", Base64Url.encode(Secret(Array.fill(32)(9.toByte))))
+        for
+          (response, service) <- run(syncRequest(Some(wrongAuth)))
+        yield assertTrue(response.status == Status.Unauthorized, service.refreshNow.calls.isEmpty)
+      },
+      test("rejects a request whose secret is not valid base64url") {
+        val malformedAuth = Header.Authorization.Basic("edge", "not-valid-base64!!!")
+        for
+          (response, service) <- run(syncRequest(Some(malformedAuth)))
+        yield assertTrue(response.status == Status.Unauthorized, service.refreshNow.calls.isEmpty)
+      },
+      test("rejects every request when the config has no internal secret configured") {
+        for
+          (response, service) <- run(
+            syncRequest(Some(validAuth)),
+            config = edgeConfig(secret = None),
+          )
+        yield assertTrue(response.status == Status.Unauthorized, service.refreshNow.calls.isEmpty)
+      },
+      test("returns 404 Not Found in prod, without even checking auth") {
+        for
+          (response, service) <- run(syncRequest(None), env = EnvName.Prod)
+        yield assertTrue(response.status == Status.NotFound, service.refreshNow.calls.isEmpty)
+      },
+    ),
+  ).provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging

--- a/edge/src/test/scala/versola/edge/model/ScopeTokenSpec.scala
+++ b/edge/src/test/scala/versola/edge/model/ScopeTokenSpec.scala
@@ -1,0 +1,16 @@
+package versola.edge.model
+
+import zio.test.*
+
+object ScopeTokenSpec extends ZIOSpecDefault:
+  def spec = suite("ScopeToken")(
+    test("parseTokens splits a space-separated scope string") {
+      assertTrue(
+        ScopeToken.parseTokens("openid offline_access custom:scope") ==
+          Set(ScopeToken.OpenId, ScopeToken.OfflineAccess, ScopeToken("custom:scope")),
+      )
+    },
+    test("parseTokens on a single token returns a singleton set") {
+      assertTrue(ScopeToken.parseTokens("openid") == Set(ScopeToken.OpenId))
+    },
+  )

--- a/util/src/test/scala/versola/util/http/ReadinessServiceSpec.scala
+++ b/util/src/test/scala/versola/util/http/ReadinessServiceSpec.scala
@@ -1,0 +1,24 @@
+package versola.util.http
+
+import zio.*
+import zio.test.*
+
+object ReadinessServiceSpec extends ZIOSpecDefault:
+
+  def spec = suite("ReadinessService")(
+    test("starts out not ready") {
+      for
+        service <- ReadinessService.make
+        ready <- service.isReady
+      yield assertTrue(!ready)
+    },
+    test("becomes ready after setReady and stays ready") {
+      for
+        service <- ReadinessService.make
+        _ <- service.setReady
+        ready <- service.isReady
+        _ <- service.setReady
+        stillReady <- service.isReady
+      yield assertTrue(ready, stillReady)
+    },
+  )


### PR DESCRIPTION
## Context

Follow-up to #241. The published coverage badge (84%) turned out to be wrong -- see below -- and the real aggregate was 80.87%, not 84%. This PR is Phase 1 of a 4-phase plan to close the gap to 91%: the 47 files scoverage reported at *0%* coverage (378 statements), which mostly share one shape (a thin HTTP sync client that GETs a central endpoint and unwraps the response).

**Aggregate: 80.87% → 82.82% statements (12610 → 12920 of 15596), verified via a from-clean `sbt coverage test coverageReport coverageAggregate`. All 8 modules green, 0 test failures.**

| module | before | after |
|---|---|---|
| auth | 80.63% | 82.89% |
| auth-postgres | 84.04% | 84.04% |
| central | 79.74% | 79.85% |
| central-postgres | 80.26% | 82.24% |
| edge | 80.99% | 89.02% |
| edge-postgres | 91.30% | 91.30% |
| util | 81.71% | 82.53% |
| util-postgres | 84.38% | 84.38% |

## Coverage badge bug

`.github/scripts/coverage-badge.scala` picked the alphabetically-first `scoverage.xml` anywhere under the repo root, which happens to be `auth/implementations/postgres`'s own module report, not the whole-build report `sbt coverageAggregate` writes to `target/scala-.../scoverage-report/`. The published badge (and gist) has been silently reporting one module's number (84%) instead of the aggregate (81% at the time). Fixed to match on the aggregate report's path specifically.

## What's covered now (328 of the 378 zero-coverage statements)

- All 8 `auth` `oauth/client` `*SyncClient` thin wrappers (Theme, Form, Locale, ChallengeSettings, SystemSettings, AuthorizationDetailType, OtpTemplate) plus `metadata.MetadataSyncClient` -- via `TestClient`, asserting method/URL/response mapping.
- Edge's equivalent sync clients: `OAuthClientsSyncClient` (incl. RSA secret decryption and dropping clients with no secret), `RolesSyncClient`, `PermissionsSyncClient`, `AuthorizationPresetsSyncClient`, `JwksSyncClient`, and both modules' `JwksService` cache passthroughs.
- `UserRegistrationSyncClient` and `ResourceSyncClient` (auth), including the latter's current+previous AES secret decryption.
- Edge's `ServiceController` (internal HTTP Basic auth: wrong username, wrong/malformed secret, absent config secret, prod 404 without checking auth).
- `BackChannelDispatcher`: JWT signing, form-encoded POST, non-2xx failure surfacing status+body, and the 5s delivery timeout (via `TestClock`).
- `AuthPropertyGenerator` and `ReadinessService` (util).
- Two previously-untested Postgres repositories (`PostgresServerMetadataRepository`, `PostgresSystemSettingsRepository`), following the existing shared-trait + `PostgresSpec` conformance-suite pattern used elsewhere in the repo.
- `GrantType.from`, `OtpCode`'s schema validation (via `zio.schema.codec.JsonCodec` directly, since the bug is in a `transformOrFail` closure nothing else reaches), `ScopeToken.parseTokens`, `CacheSyncRepository.noop`.

## Deliberately skipped

- `OAuthProvider.scala` (a Google/GitHub OAuth model: `OAuthTokenRequest`, `OAuthUserInfo`, `GoogleUserInfo`, `GitHubUserInfo`, etc.) has **zero references anywhere else in the repository** -- it's dead code, not just undertested. Worth a follow-up to delete it rather than write tests that only exist to exercise otherwise-unreachable case classes.
- A handful of 1-3 statement opaque-type/newtype files (`Acr`, `PresetId`, `Code`, `RoleId`, `Permission`, `Login`, etc.) were left for a later, lower-priority pass -- diminishing returns for file-count added.
- `Observability.scala` and `EdgeService.scala`'s tracing/instrumentation branches (84 and 37 missing statements respectively) are still out of scope per the original PR's reasoning: tests there would mostly assert a span was named what it was told to be named.

## Next phases (not in this PR)

- Phase 2: conversation subsystem (`ConversationService` 210, `ConversationRouter` 153, `ConversationRenderService` 127, `ConversationController` 79 missing statements) → ~87%
- Phase 3: auth core (`AuthorizeEndpointService`, `WebAuthnService`, `AuthorizeRequestParser`, `OAuthConfigurationService`, `JWT`) → ~89%
- Phase 4: central controllers/services (`UserController`, `OAuthClientService`, `UserOutboxProcessor`, etc.) → ~91-92%

## Testing

Fresh sandbox (no cached JDK/sbt/Postgres) -- installed JDK 17, sbt 1.12.5, Postgres 15 to verify. Ran `sbt clean coverage util/test util-postgres/test auth/test auth-postgres-impl/test edge/test edge-postgres-impl/test central/test central-postgres-impl/test coverageReport coverageAggregate` against local Postgres (`POSTGRES_HOST=localhost:5432`) end to end: 0 failures, 82.82% aggregate. One `AuthMetricsSpec` flake was observed during an earlier *non-clean, non-final* run -- confirmed pre-existing and unrelated (passes standalone and on the final clean rerun); it asserts deltas on process-global ZIO metrics and is sensitive to what else is running concurrently in the same JVM.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M1R187HGTGCA8J95BYK714XK&panel=chat)