### PR TITLE
test: cover AuthorizeRequestParser, OAuthConfigurationService, WebAuthnService, JWT (Phase 3 of 91% push)

### DIFF
--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
@@ -4,14 +4,30 @@ import versola.auth.TestEnvConfig
 import versola.oauth.authorize.model.*
 import versola.oauth.client.OAuthConfigurationService
 import versola.oauth.client.model.*
-import versola.oauth.model.{CodeChallenge, CodeChallengeMethod, RequestUri, RequestUriReference, State}
+import versola.oauth.model.{
+  CodeChallenge,
+  CodeChallengeMethod,
+  Nonce,
+  RequestUri,
+  RequestUriReference,
+  SessionCookie,
+  State,
+  UserAgentCookie,
+  UserAgentCookiePayload,
+  UserAgentData,
+}
+import versola.oauth.session.model.{SessionId, UserAgentDetails, UserAgentId}
+import versola.oauth.userinfo.model.RequestedClaims
+import versola.user.model.UserId
 import versola.util.*
 import zio.*
 import zio.http.*
 import zio.json.*
 import zio.json.ast.Json
-import zio.prelude.NonEmptySet
+import zio.prelude.{NonEmptyList, NonEmptySet}
 import zio.test.*
+
+import java.util.UUID
 
 object AuthorizeRequestParserSpec extends UnitSpecBase:
 
@@ -228,6 +244,14 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
         _ <- env.configuration.find.succeedsWith(Some(clientRecord))
         result <- env.parser.parse(request).either
       yield assertTrue(result == Left(Error.InvalidTarget(redirectUri, Some(State("test-state")), edgeResource.toString)))
+    },
+    test("rejects a malformed resource value") {
+      val env = Env()
+      val request = Request.get(URL.root.addQueryParams(validParams + ("resource" -> "not-a-valid-resource")))
+      for
+        _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+        result <- env.parser.parse(request).either
+      yield assertTrue(result == Left(Error.InvalidTarget(redirectUri, Some(State("test-state")), "not-a-valid-resource")))
     },
     suite("parse POST")(
       test("successfully parses valid form-urlencoded request") {
@@ -665,6 +689,365 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
           _ <- env.pushedAuthorizationRepository.consume.succeedsWith(Some(pushedRecord))
           result <- env.parser.parse(request).either
         yield assertTrue(result == Left(Error.BadRequest))
+      },
+    ),
+    suite("paramsFromForm")(
+      test("splits the repeatable resource field but keeps other fields single-valued") {
+        val form = Form.fromStrings(
+          "client_id" -> "test-client",
+          "resource" -> "https://a.example,https://b.example",
+        )
+        val params = AuthorizeRequestParser.paramsFromForm(form)
+        assertTrue(
+          params("client_id") == Chunk("test-client"),
+          params("resource") == Chunk("https://a.example", "https://b.example"),
+        )
+      },
+    ),
+    suite("code_challenge")(
+      test("rejects a missing code_challenge") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams - "code_challenge"))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.CodeChallengeMissing(redirectUri, Some(State("test-state")))))
+      },
+      test("rejects an invalid code_challenge") {
+        val env = Env()
+        val invalid = "a" * 42
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("code_challenge" -> invalid)))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.CodeChallengeInvalid(redirectUri, Some(State("test-state")), invalid)))
+      },
+    ),
+    suite("response_type")(
+      test("accepts code id_token") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("response_type" -> "code id_token")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request)
+        yield assertTrue(result.responseType == NonEmptySet(ResponseTypeEntry.Code, ResponseTypeEntry.IdToken))
+      },
+      test("rejects an unsupported response_type") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("response_type" -> "token")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.UnsupportedResponseType(redirectUri, Some(State("test-state")), "token")))
+      },
+      test("rejects a missing response_type") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams - "response_type"))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.ResponseTypeMissing(redirectUri, Some(State("test-state")))))
+      },
+    ),
+    suite("claims")(
+      test("parses a valid claims JSON object") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("claims" -> """{"userinfo":{},"id_token":{}}""")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request)
+        yield assertTrue(result.requestedClaims == Some(RequestedClaims(Map.empty, Map.empty)))
+      },
+      test("rejects claims that are not valid JSON") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("claims" -> "not-json")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.InvalidClaims(redirectUri, Some(State("test-state")))))
+      },
+    ),
+    suite("ui_locales")(
+      test("splits ui_locales into a list") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("ui_locales" -> "en fr")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request)
+        yield assertTrue(result.uiLocales == Some(List("en", "fr")))
+      },
+    ),
+    suite("nonce")(
+      test("captures the nonce parameter") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("nonce" -> "abc123")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request)
+        yield assertTrue(result.nonce == Some(Nonce("abc123")))
+      },
+    ),
+    suite("prompt")(
+      test("accepts prompt=none alone") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("prompt" -> "none")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request)
+        yield assertTrue(result.prompt == Set(Prompt.none))
+      },
+      test("rejects prompt=none combined with other values") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("prompt" -> "none login")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.PromptInvalid(redirectUri, Some(State("test-state")))))
+      },
+      test("ignores unrecognized prompt tokens") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("prompt" -> "bogus")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request)
+        yield assertTrue(result.prompt == Set.empty)
+      },
+    ),
+    suite("max_age")(
+      test("parses a numeric max_age") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("max_age" -> "3600")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request)
+        yield assertTrue(result.maxAge == Some(3600L))
+      },
+      test("silently drops a non-numeric max_age") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("max_age" -> "not-a-number")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request)
+        yield assertTrue(result.maxAge == None)
+      },
+    ),
+    suite("acr_values")(
+      test("parses acr_values into a list of Acr") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("acr_values" -> "urn:mfa urn:pwd")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request)
+        yield assertTrue(result.acrValues == Some(NonEmptyList(Acr("urn:mfa"), Acr("urn:pwd"))))
+      },
+    ),
+    suite("id_token_hint")(
+      test("captures the id_token_hint parameter") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("id_token_hint" -> "raw-jwt-value")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request)
+        yield assertTrue(result.idTokenHint == Some("raw-jwt-value"))
+      },
+    ),
+    suite("user_agent")(
+      test("captures the User-Agent header") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams)).addHeader("User-Agent", "TestAgent/1.0")
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request)
+        yield assertTrue(result.userAgent == Some("TestAgent/1.0"))
+      },
+    ),
+    suite("cookies")(
+      test("parses a signed session cookie") {
+        val env = Env()
+        val sessionId = SessionId(Array.fill(32)(1.toByte))
+        val cookie = SessionCookie(sessionId, 1.hour, TestEnvConfig.coreConfig.security.sessionCookieSecret)
+        val request = Request.get(URL.root.addQueryParams(validParams))
+          .addCookie(Cookie.Request(SessionCookie.name, cookie.content))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request)
+        yield assertTrue(result.sessionId.map(_.toSeq) == Some(sessionId.toSeq))
+      },
+      test("parses a signed user agent cookie") {
+        val env = Env()
+        val userAgentId = UserAgentId(UUID.fromString("018f0f2a-1c7b-7000-8000-000000000001"))
+        val userAgentData = UserAgentData(
+          userAgent = Some("Mozilla/5.0"),
+          userId = UserId(UUID.fromString("00000000-0000-7000-8000-000000000001")),
+          details = UserAgentDetails(None, None, None, None),
+        )
+        val cookie = UserAgentCookie(userAgentId, userAgentData, 180.days, TestEnvConfig.coreConfig.security.userAgentCookieSecret)
+        val request = Request.get(URL.root.addQueryParams(validParams))
+          .addCookie(Cookie.Request(UserAgentCookie.name, cookie.content))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request)
+        yield assertTrue(result.userAgentCookie == Some(UserAgentCookiePayload(userAgentId, userAgentData)))
+      },
+    ),
+    suite("redirect_uri")(
+      test("rejects a relative redirect_uri") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("redirect_uri" -> "/callback")))
+        for result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.BadRequest))
+      },
+      test("rejects a redirect_uri containing a fragment") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("redirect_uri" -> "https://example.com/callback#section")))
+        for result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.BadRequest))
+      },
+      test("fails when redirect_uri is provided more than once") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams).addQueryParam("redirect_uri", "https://other.example"))
+        for result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.BadRequest))
+      },
+    ),
+    suite("client_id")(
+      test("fails when client_id is provided more than once") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams).addQueryParam("client_id", "other-client"))
+        for result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.BadRequest))
+      },
+    ),
+    suite("multiple values provided")(
+      test("fails when state is provided more than once") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams).addQueryParam("state", "another"))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.MultipleValuesProvided(redirectUri, None, "state")))
+      },
+      test("fails when response_type is provided more than once") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams).addQueryParam("response_type", "code"))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.MultipleValuesProvided(redirectUri, Some(State("test-state")), "response_type")))
+      },
+      test("fails when code_challenge is provided more than once") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams).addQueryParam("code_challenge", "a" * 43))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.MultipleValuesProvided(redirectUri, Some(State("test-state")), "code_challenge")))
+      },
+      test("fails when code_challenge_method is provided more than once") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams).addQueryParam("code_challenge_method", "S256"))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.MultipleValuesProvided(redirectUri, Some(State("test-state")), "code_challenge_method")))
+      },
+      test("fails when scope is provided more than once") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams).addQueryParam("scope", "openid"))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.MultipleValuesProvided(redirectUri, Some(State("test-state")), "scope")))
+      },
+      test("fails when ui_locales is provided more than once") {
+        val env = Env()
+        val request = Request.get(
+          URL.root.addQueryParams(validParams ++ Map("ui_locales" -> "en")).addQueryParam("ui_locales", "fr"),
+        )
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.MultipleValuesProvided(redirectUri, Some(State("test-state")), "ui_locales")))
+      },
+      test("fails when claims is provided more than once") {
+        val env = Env()
+        val request = Request.get(
+          URL.root.addQueryParams(validParams ++ Map("claims" -> "{}")).addQueryParam("claims", "{}"),
+        )
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.MultipleValuesProvided(redirectUri, Some(State("test-state")), "claims")))
+      },
+      test("fails when nonce is provided more than once") {
+        val env = Env()
+        val request = Request.get(
+          URL.root.addQueryParams(validParams ++ Map("nonce" -> "n1")).addQueryParam("nonce", "n2"),
+        )
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.MultipleValuesProvided(redirectUri, Some(State("test-state")), "nonce")))
+      },
+      test("fails when prompt is provided more than once") {
+        val env = Env()
+        val request = Request.get(
+          URL.root.addQueryParams(validParams ++ Map("prompt" -> "login")).addQueryParam("prompt", "consent"),
+        )
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.MultipleValuesProvided(redirectUri, Some(State("test-state")), "prompt")))
+      },
+      test("fails when max_age is provided more than once") {
+        val env = Env()
+        val request = Request.get(
+          URL.root.addQueryParams(validParams ++ Map("max_age" -> "60")).addQueryParam("max_age", "120"),
+        )
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.MultipleValuesProvided(redirectUri, Some(State("test-state")), "max_age")))
+      },
+      test("fails when acr_values is provided more than once") {
+        val env = Env()
+        val request = Request.get(
+          URL.root.addQueryParams(validParams ++ Map("acr_values" -> "urn:mfa")).addQueryParam("acr_values", "urn:pwd"),
+        )
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.MultipleValuesProvided(redirectUri, Some(State("test-state")), "acr_values")))
+      },
+      test("fails when login_hint is provided more than once") {
+        val env = Env()
+        val request = Request.get(
+          URL.root.addQueryParams(validParams ++ Map("login_hint" -> "user@example.com")).addQueryParam("login_hint", "user2@example.com"),
+        )
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.MultipleValuesProvided(redirectUri, Some(State("test-state")), "login_hint")))
+      },
+      test("fails when id_token_hint is provided more than once") {
+        val env = Env()
+        val request = Request.get(
+          URL.root.addQueryParams(validParams ++ Map("id_token_hint" -> "jwt-1")).addQueryParam("id_token_hint", "jwt-2"),
+        )
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.MultipleValuesProvided(redirectUri, Some(State("test-state")), "id_token_hint")))
+      },
+      test("fails when authorization_details is provided more than once") {
+        val env = Env()
+        val request = Request.get(
+          URL.root.addQueryParams(validParams ++ Map("authorization_details" -> "[]")).addQueryParam("authorization_details", "[]"),
+        )
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.MultipleValuesProvided(redirectUri, Some(State("test-state")), "authorization_details")))
       },
     ),
   )

--- a/auth/src/test/scala/versola/oauth/challenge/passkey/WebAuthnServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/challenge/passkey/WebAuthnServiceSpec.scala
@@ -1,5 +1,6 @@
 package versola.oauth.challenge.passkey
 
+import com.fasterxml.jackson.dataformat.cbor.CBORFactory
 import versola.auth.model.{AuthenticatorTransport, CredentialDeviceType, CredentialId, PasskeyName, PasskeyRecord}
 import versola.oauth.client.OAuthConfigurationService
 import versola.oauth.client.model.{ClientId, PasskeySettings}
@@ -9,8 +10,134 @@ import zio.*
 import zio.test.*
 import zio.test.Assertion.*
 
+import java.io.ByteArrayOutputStream
+import java.security.interfaces.{ECPrivateKey, ECPublicKey}
+import java.security.spec.ECGenParameterSpec
+import java.security.{KeyPairGenerator, MessageDigest, Signature}
 import java.time.Instant
-import java.util.UUID
+import java.util.{Base64, UUID}
+
+/** Hand-rolled "virtual authenticator": the java-webauthn-server library ships no public
+  * test-jar with one (unlike its own test suite, which has an internal `TestAuthenticator`),
+  * so a successful registration/assertion ceremony has to be constructed by hand here --
+  * a real ES256 key pair, CBOR-encoded `attestationObject`/COSE key, and a real ECDSA
+  * signature over `authenticatorData || sha256(clientDataJSON)` -- to reach any of
+  * [[WebAuthnService]]'s success-path branches at all.
+  */
+object VirtualAuthenticator:
+  private val cbor = CBORFactory()
+
+  def keyPair() =
+    val kpg = KeyPairGenerator.getInstance("EC")
+    kpg.initialize(ECGenParameterSpec("secp256r1"))
+    kpg.generateKeyPair()
+
+  /** The 16-byte `userHandle` [[WebAuthnService.Impl.userIdToHandle]] derives from a UUID --
+    * duplicated here (rather than made accessible) since it's a one-line private encoding. */
+  def userHandle(userId: UUID): Array[Byte] =
+    val bb = java.nio.ByteBuffer.allocate(16)
+    bb.putLong(userId.getMostSignificantBits)
+    bb.putLong(userId.getLeastSignificantBits)
+    bb.array()
+
+  /** The raw COSE_Key bytes for `pub`, as would be stored in [[PasskeyRecord.publicKey]]. */
+  def publicKeyCose(pub: ECPublicKey): Array[Byte] = coseKey(pub)
+
+  private def sha256(bytes: Array[Byte]): Array[Byte] = MessageDigest.getInstance("SHA-256").digest(bytes)
+
+  private def b64Url(bytes: Array[Byte]): String = Base64.getUrlEncoder.withoutPadding.encodeToString(bytes)
+
+  private def fixed32(bi: java.math.BigInteger): Array[Byte] =
+    val raw = bi.toByteArray
+    val trimmed = if raw.length > 32 then raw.takeRight(32) else raw
+    Array.fill[Byte](32 - trimmed.length)(0) ++ trimmed
+
+  /** COSE_Key (RFC 9053) EC2/ES256 encoding of a public key, using integer field ids --
+    * this is why the encoding is done with the low-level `CBORGenerator` rather than
+    * Jackson's `ObjectMapper`, which only knows how to write String field names.
+    */
+  private def coseKey(pub: ECPublicKey): Array[Byte] =
+    val out = ByteArrayOutputStream()
+    val gen = cbor.createGenerator(out)
+    gen.writeStartObject()
+    gen.writeFieldId(1); gen.writeNumber(2)  // kty: EC2
+    gen.writeFieldId(3); gen.writeNumber(-7) // alg: ES256
+    gen.writeFieldId(-1); gen.writeNumber(1) // crv: P-256
+    gen.writeFieldId(-2); gen.writeBinary(fixed32(pub.getW.getAffineX))
+    gen.writeFieldId(-3); gen.writeBinary(fixed32(pub.getW.getAffineY))
+    gen.writeEndObject()
+    gen.close()
+    out.toByteArray
+
+  private def authenticatorData(rpId: String, credentialId: Array[Byte], pub: ECPublicKey, attested: Boolean): Array[Byte] =
+    val rpIdHash = sha256(rpId.getBytes("UTF-8"))
+    val flags: Byte = if attested then 0x45.toByte else 0x05.toByte // UP|UV(|AT)
+    val signCount = Array[Byte](0, 0, 0, 1)
+    val attestedData =
+      if !attested then Array.emptyByteArray
+      else
+        val aaguid = Array.fill[Byte](16)(0)
+        val credIdLen = Array[Byte]((credentialId.length >> 8).toByte, credentialId.length.toByte)
+        aaguid ++ credIdLen ++ credentialId ++ coseKey(pub)
+    rpIdHash ++ Array(flags) ++ signCount ++ attestedData
+
+  private def attestationObject(authData: Array[Byte]): Array[Byte] =
+    val out = ByteArrayOutputStream()
+    val gen = cbor.createGenerator(out)
+    gen.writeStartObject()
+    gen.writeFieldName("fmt"); gen.writeString("none")
+    gen.writeFieldName("attStmt"); gen.writeStartObject(); gen.writeEndObject()
+    gen.writeFieldName("authData"); gen.writeBinary(authData)
+    gen.writeEndObject()
+    gen.close()
+    out.toByteArray
+
+  /** Extracts `"challenge":"..."` from a library-serialized creation/request options JSON,
+    * so the fabricated response's clientDataJSON can echo the real, ceremony-specific value.
+    */
+  def extractChallenge(optionsJson: String): String =
+    "\"challenge\":\"([^\"]+)\"".r.findFirstMatchIn(optionsJson).get.group(1)
+
+  /** Builds a `response` JSON accepted by `PublicKeyCredential.parseRegistrationResponseJson`,
+    * simulating a fresh authenticator enrolling `credentialId` under the given key pair.
+    */
+  def registrationResponse(
+      rpId: String,
+      origin: String,
+      challenge: String,
+      credentialId: Array[Byte],
+      pub: ECPublicKey,
+  ): String =
+    val clientData = s"""{"type":"webauthn.create","challenge":"$challenge","origin":"$origin"}"""
+    val authData = authenticatorData(rpId, credentialId, pub, attested = true)
+    s"""{"id":"${b64Url(credentialId)}","rawId":"${b64Url(credentialId)}","response":{"clientDataJSON":"${b64Url(
+        clientData.getBytes("UTF-8"),
+      )}","attestationObject":"${b64Url(attestationObject(authData))}"},"type":"public-key","clientExtensionResults":{}}"""
+
+  /** Builds a `response` JSON accepted by `PublicKeyCredential.parseAssertionResponseJson`,
+    * simulating an authenticator asserting `credentialId`, signed with its private key.
+    */
+  def assertionResponse(
+      rpId: String,
+      origin: String,
+      challenge: String,
+      credentialId: Array[Byte],
+      userHandle: Array[Byte],
+      pub: ECPublicKey,
+      priv: ECPrivateKey,
+  ): String =
+    val clientData = s"""{"type":"webauthn.get","challenge":"$challenge","origin":"$origin"}"""
+    val clientDataBytes = clientData.getBytes("UTF-8")
+    val authData = authenticatorData(rpId, credentialId, pub, attested = false)
+    val signer = Signature.getInstance("SHA256withECDSA")
+    signer.initSign(priv)
+    signer.update(authData ++ sha256(clientDataBytes))
+    val signature = signer.sign()
+    s"""{"id":"${b64Url(credentialId)}","rawId":"${b64Url(credentialId)}","response":{"clientDataJSON":"${b64Url(
+        clientDataBytes,
+      )}","authenticatorData":"${b64Url(authData)}","signature":"${b64Url(signature)}","userHandle":"${b64Url(
+        userHandle,
+      )}"},"type":"public-key","clientExtensionResults":{}}"""
 
 object WebAuthnServiceSpec extends UnitSpecBase:
 
@@ -221,5 +348,118 @@ object WebAuthnServiceSpec extends UnitSpecBase:
         _ <- repository.findByCredentialId.succeedsWith(Vector.empty)
         result <- service.finishAssertion(settings, request, response).exit
       yield assert(result)(fails(equalTo(WebAuthnError.CredentialNotFound)))
+    },
+    test("finishRegistration verifies a real ceremony and persists a single-device passkey") {
+      val repository = stub[PasskeyRepository]
+      val configService = stub[OAuthConfigurationService]
+      val credentialId = "test-credential-1".getBytes("UTF-8")
+      val keyPair = VirtualAuthenticator.keyPair()
+
+      for
+        service <- ZIO.service[WebAuthnService].provide(
+          ZLayer.succeed(repository),
+          ZLayer.succeed(configService),
+          WebAuthnService.live,
+        )
+        _ <- repository.listByUser.succeedsWith(Vector.empty)
+        ceremony <- service.startRegistration(settings, userId, "Test User")
+        challenge = VirtualAuthenticator.extractChallenge(ceremony.publicKeyOptions)
+        response = VirtualAuthenticator.registrationResponse(
+          rpId = settings.rpId,
+          origin = settings.origins.head,
+          challenge = challenge,
+          credentialId = credentialId,
+          pub = keyPair.getPublic.asInstanceOf[java.security.interfaces.ECPublicKey],
+        )
+        _ <- configService.getPasskeySettings.succeedsWith(Some(settings))
+        // RelyingParty.finishRegistration rejects a credential id already known to the RP, so
+        // it checks `credentialRepository.lookupAll` (-> repository.findByCredentialId) too.
+        _ <- repository.findByCredentialId.succeedsWith(Vector.empty)
+        _ <- repository.insert.succeedsWith(())
+        record <- service.finishRegistration(clientId, userId, ceremony.request, response, Some(PasskeyName("My Key")))
+      yield assertTrue(
+        record.id.sameElements(credentialId),
+        record.userId == userId,
+        record.publicKey.nonEmpty,
+        record.deviceType == CredentialDeviceType.SingleDevice,
+        !record.backedUp,
+        !record.backupEligible,
+        record.attestationObject.isDefined,
+        record.clientDataJson.isDefined,
+        record.aaguid.exists(_.length == 16),
+        record.name.contains(PasskeyName("My Key")),
+      )
+    },
+    test("finishAssertion verifies a real ceremony, resolves the user and bumps usage") {
+      val repository = stub[PasskeyRepository]
+      val configService = stub[OAuthConfigurationService]
+      val keyPair = VirtualAuthenticator.keyPair()
+      val pub = keyPair.getPublic.asInstanceOf[java.security.interfaces.ECPublicKey]
+      val priv = keyPair.getPrivate.asInstanceOf[java.security.interfaces.ECPrivateKey]
+      val credId = CredentialId("test-credential-2".getBytes("UTF-8"))
+      val record = passkeyRecord(credId, userId).copy(publicKey = VirtualAuthenticator.publicKeyCose(pub))
+
+      for
+        service <- ZIO.service[WebAuthnService].provide(
+          ZLayer.succeed(repository),
+          ZLayer.succeed(configService),
+          WebAuthnService.live,
+        )
+        ceremony <- service.startAssertion(settings)
+        challenge = VirtualAuthenticator.extractChallenge(ceremony.publicKeyOptions)
+        response = VirtualAuthenticator.assertionResponse(
+          rpId = settings.rpId,
+          origin = settings.origins.head,
+          challenge = challenge,
+          credentialId = credId,
+          userHandle = VirtualAuthenticator.userHandle(userId),
+          pub = pub,
+          priv = priv,
+        )
+        _ <- repository.findByCredentialId.succeedsWith(Vector(record))
+        _ <- repository.findByCredentialIdAndUser.succeedsWith(Some(record))
+        _ <- repository.updateUsage.succeedsWith(true)
+        outcome <- service.finishAssertion(settings, ceremony.request, response)
+      yield assertTrue(
+        outcome.userId == userId,
+        outcome.credentialId.sameElements(credId),
+        outcome.signatureCount >= 0L,
+      )
+    },
+    // repository.findByCredentialIdAndUser also backs the RP's own signature-verification
+    // lookup (it needs the stored public key to succeed at all), so it has to keep answering
+    // Some(record) throughout -- the only way to reach the `updated == false` branch below
+    // with a stub that returns one canned answer per call is to have the record still exist.
+    test("finishAssertion fails with AssertionFailed when repository.updateUsage reports no row despite the record existing") {
+      val repository = stub[PasskeyRepository]
+      val configService = stub[OAuthConfigurationService]
+      val keyPair = VirtualAuthenticator.keyPair()
+      val pub = keyPair.getPublic.asInstanceOf[java.security.interfaces.ECPublicKey]
+      val priv = keyPair.getPrivate.asInstanceOf[java.security.interfaces.ECPrivateKey]
+      val credId = CredentialId("test-credential-3".getBytes("UTF-8"))
+      val record = passkeyRecord(credId, userId).copy(publicKey = VirtualAuthenticator.publicKeyCose(pub))
+
+      for
+        service <- ZIO.service[WebAuthnService].provide(
+          ZLayer.succeed(repository),
+          ZLayer.succeed(configService),
+          WebAuthnService.live,
+        )
+        ceremony <- service.startAssertion(settings)
+        challenge = VirtualAuthenticator.extractChallenge(ceremony.publicKeyOptions)
+        response = VirtualAuthenticator.assertionResponse(
+          rpId = settings.rpId,
+          origin = settings.origins.head,
+          challenge = challenge,
+          credentialId = credId,
+          userHandle = VirtualAuthenticator.userHandle(userId),
+          pub = pub,
+          priv = priv,
+        )
+        _ <- repository.findByCredentialId.succeedsWith(Vector(record))
+        _ <- repository.findByCredentialIdAndUser.succeedsWith(Some(record))
+        _ <- repository.updateUsage.succeedsWith(false)
+        result <- service.finishAssertion(settings, ceremony.request, response).exit
+      yield assert(result)(fails(equalTo(WebAuthnError.AssertionFailed)))
     },
   )

--- a/auth/src/test/scala/versola/oauth/client/OAuthConfigurationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/client/OAuthConfigurationServiceSpec.scala
@@ -1,12 +1,13 @@
 package versola.oauth.client
 
 import versola.oauth.client.model.*
+import versola.oauth.conversation.otp.model.OtpTemplate
 import versola.oauth.metadata.MetadataSyncClient
 import versola.util.*
 import zio.*
 import zio.durationInt
 import zio.json.ast.Json
-import zio.prelude.NonEmptySet
+import zio.prelude.{NonEmptyList, NonEmptySet}
 import zio.test.*
 
 object OAuthConfigurationServiceSpec extends UnitSpecBase:
@@ -220,10 +221,59 @@ object OAuthConfigurationServiceSpec extends UnitSpecBase:
         result <- env.getOtpSettings(clientId1)
       yield assertTrue(result.length == 6, result.resendAfter == 60)
     },
+    test("getOtpSettings returns default settings for unknown client") {
+      for
+        env <- makeEnv()
+        result <- env.getOtpSettings(ClientId("missing"))
+      yield assertTrue(result == OtpSettings.default)
+    },
+    test("getSubmissionLimits returns limits from challenge settings for known client") {
+      val limits = SubmissionLimits(banDurationSeconds = 30)
+      for
+        env <- makeEnv(challengeSettingsVec = Vector(challengeSettings.copy(submissionLimits = limits)))
+        result <- env.getSubmissionLimits(clientId1)
+      yield assertTrue(result == limits)
+    },
+    test("getSubmissionLimits returns empty for unknown client") {
+      for
+        env <- makeEnv()
+        result <- env.getSubmissionLimits(ClientId("missing"))
+      yield assertTrue(result == SubmissionLimits.empty)
+    },
+    test("getIpHeader returns header from challenge settings for known client") {
+      for
+        env <- makeEnv(challengeSettingsVec = Vector(challengeSettings.copy(ipHeader = "X-Custom-IP")))
+        result <- env.getIpHeader(clientId1)
+      yield assertTrue(result == "X-Custom-IP")
+    },
+    test("getIpHeader returns default header for unknown client") {
+      for
+        env <- makeEnv()
+        result <- env.getIpHeader(ClientId("missing"))
+      yield assertTrue(result == "X-Real-IP")
+    },
+    test("getPasskeySettings returns settings for known client") {
+      for
+        env <- makeEnv()
+        result <- env.getPasskeySettings(clientId1)
+      yield assertTrue(result.contains(challengeSettings.passkeySettings))
+    },
+    test("getPasskeySettings returns None for unknown client") {
+      for
+        env <- makeEnv()
+        result <- env.getPasskeySettings(ClientId("missing"))
+      yield assertTrue(result.isEmpty)
+    },
     test("getAuthConversationTtl returns duration from challenge settings") {
       for
         env <- makeEnv()
         result <- env.getAuthConversationTtl(clientId1)
+      yield assertTrue(result == Duration.fromSeconds(900))
+    },
+    test("getAuthConversationTtl returns default when client not found") {
+      for
+        env <- makeEnv()
+        result <- env.getAuthConversationTtl(ClientId("missing"))
       yield assertTrue(result == Duration.fromSeconds(900))
     },
     test("getSessionTtl returns duration from challenge settings") {
@@ -232,11 +282,23 @@ object OAuthConfigurationServiceSpec extends UnitSpecBase:
         result <- env.getSessionTtl(clientId1)
       yield assertTrue(result == Duration.fromSeconds(86400))
     },
+    test("getSessionTtl returns default when client not found") {
+      for
+        env <- makeEnv()
+        result <- env.getSessionTtl(ClientId("missing"))
+      yield assertTrue(result == Duration.fromSeconds(86400))
+    },
     test("getSessionIdleTtl returns Some when set") {
       for
         env <- makeEnv()
         result <- env.getSessionIdleTtl(clientId1)
       yield assertTrue(result.contains(Duration.fromSeconds(3600)))
+    },
+    test("getSessionIdleTtl returns None when client not found") {
+      for
+        env <- makeEnv()
+        result <- env.getSessionIdleTtl(ClientId("missing"))
+      yield assertTrue(result.isEmpty)
     },
     test("getUserAgentTtl returns duration from challenge settings") {
       for
@@ -299,6 +361,61 @@ object OAuthConfigurationServiceSpec extends UnitSpecBase:
         unknown.isEmpty,
       )
     },
+    suite("getAcrVocabulary")(
+      test("returns empty map for unknown client") {
+        for
+          env <- makeEnv()
+          result <- env.getAcrVocabulary(ClientId("missing"))
+        yield assertTrue(result.isEmpty)
+      },
+      test("returns empty map when challenge settings carry no vocabulary") {
+        for
+          env <- makeEnv()
+          result <- env.getAcrVocabulary(clientId1)
+        yield assertTrue(result.isEmpty)
+      },
+      test("converts the configured vocabulary to non-empty factor lists") {
+        val vocabulary = Map("urn:mfa" -> List(PassedAuthFactor.otp, PassedAuthFactor.password))
+        for
+          env <- makeEnv(challengeSettingsVec = Vector(challengeSettings.copy(acrVocabulary = Some(vocabulary))))
+          result <- env.getAcrVocabulary(clientId1)
+        yield assertTrue(result == Map(Acr("urn:mfa") -> NonEmptyList(PassedAuthFactor.otp, PassedAuthFactor.password)))
+      },
+    ),
+    suite("getPasswordTemplate")(
+      test("fails when no global template matches the purpose and channel") {
+        for
+          env <- makeEnv()
+          result <- env.getPasswordTemplate(OtpTemplateChannel.email, None).either
+        yield assertTrue(result.left.map(_.getMessage) == Left("No global password template configured"))
+      },
+      test("falls back to any localization when uiLocales and default locale don't match") {
+        val template = OtpTemplateRecord(
+          id = "password-template",
+          tenantId = tenantId,
+          localizations = Map("fr" -> "Corps FR"),
+          purpose = OtpTemplatePurpose.password,
+          channel = OtpTemplateChannel.email,
+        )
+        for
+          env <- makeEnv(otpTemplates = Vector(template))
+          result <- env.getPasswordTemplate(OtpTemplateChannel.email, Some(List("de")))
+        yield assertTrue(result == OtpTemplate("Corps FR"))
+      },
+      test("fails when the matching template has no localizations") {
+        val template = OtpTemplateRecord(
+          id = "password-template",
+          tenantId = tenantId,
+          localizations = Map.empty,
+          purpose = OtpTemplatePurpose.password,
+          channel = OtpTemplateChannel.sms,
+        )
+        for
+          env <- makeEnv(otpTemplates = Vector(template))
+          result <- env.getPasswordTemplate(OtpTemplateChannel.sms, None).either
+        yield assertTrue(result.left.map(_.getMessage) == Left("Password template has no localizations"))
+      },
+    ),
     suite("resources")(
       test("findResource matches on tenant and resource URI") {
         for
@@ -344,6 +461,114 @@ object OAuthConfigurationServiceSpec extends UnitSpecBase:
           loaded <- env.accountResourceSecrets
           none <- empty.accountResourceSecrets
         yield assertTrue(loaded.map(_.toSeq) == secrets.map(_.toSeq), none.isEmpty)
+      },
+    ),
+    suite("syncConfiguration")(
+      test("refreshes every cache from its repository") {
+        val newClients = Map(clientId1 -> privateClient)
+        val newScopes = Vector(ScopeRecord(ScopeToken("write"), Map("en" -> "Write access"), Vector.empty))
+        val newForms = Vector(testForm.copy(id = "form-2"))
+        val newThemes = Vector(testTheme.copy(id = "dark"))
+        val newLocales = Locales(Vector(LocaleRecord("fr", "Français")), "fr")
+        val newOtpTemplates = Vector(
+          OtpTemplateRecord("tmpl-2", tenantId, Map("en" -> "code"), OtpTemplatePurpose.otp, OtpTemplateChannel.sms),
+        )
+        val newChallengeSettings = Vector(challengeSettings.copy(ipHeader = "X-Forwarded-For"))
+        val newSystemSettings = systemSettings.copy(identityProviderLogo = Some("new-logo.svg"))
+        val newMetadata = Json.Obj("issuer" -> Json.Str("https://idp.example"))
+        val newResources = Vector(resourceRecord)
+        val newSecrets = List(Secret(Array.fill(16)(3.toByte)))
+        val newAuthorizationDetailTypes = Vector(
+          AuthorizationDetailTypeRecord(tenantId, AuthorizationDetailType("payment"), Json.Obj()),
+        )
+
+        // `makeEnv` builds its stubs inline as constructor args, typed away to their trait
+        // (Impl's field types), so `.succeedsWith` isn't reachable through `env.xRepository`
+        // -- keep typed handles to the stubs here instead and build Impl directly.
+        val clientRepository = stub[OAuthClientSyncClient]
+        val scopeRepository = stub[OAuthScopeSyncClient]
+        val formRepository = stub[FormSyncClient]
+        val themeRepository = stub[ThemeSyncClient]
+        val localeRepository = stub[LocaleSyncClient]
+        val otpTemplateRepository = stub[OtpTemplateSyncClient]
+        val challengeSettingsRepository = stub[ChallengeSettingsSyncClient]
+        val systemSettingsRepository = stub[SystemSettingsSyncClient]
+        val metadataRepository = stub[MetadataSyncClient]
+        val resourceRepository = stub[ResourceSyncClient]
+        val authorizationDetailTypeRepository = stub[AuthorizationDetailTypeSyncClient]
+
+        for
+          clientRef <- Ref.make(Map(clientId1 -> privateClient, publicClientId -> publicClient))
+          scopeRef <- Ref.make(testScopes)
+          formRef <- Ref.make(Vector(testForm))
+          themeRef <- Ref.make(Vector(testTheme))
+          localeRef <- Ref.make(testLocales)
+          otpRef <- Ref.make(Vector.empty[OtpTemplateRecord])
+          challengeRef <- Ref.make(Vector(challengeSettings))
+          sysRef <- Ref.make(systemSettings)
+          metadataRef <- Ref.make(Json.Obj())
+          resourceRef <- Ref.make(ResourceSyncClient.SyncResult(Vector.empty, Nil))
+          authDetailTypeRef <- Ref.make(Vector.empty[AuthorizationDetailTypeRecord])
+          env = OAuthConfigurationService.Impl(
+            clientCache = ReloadingCache(clientRef),
+            clientRepository = clientRepository,
+            scopeCache = ReloadingCache(scopeRef),
+            scopeRepository = scopeRepository,
+            formCache = ReloadingCache(formRef),
+            formRepository = formRepository,
+            themeCache = ReloadingCache(themeRef),
+            themeRepository = themeRepository,
+            localeCache = ReloadingCache(localeRef),
+            localeRepository = localeRepository,
+            otpTemplateCache = ReloadingCache(otpRef),
+            otpTemplateRepository = otpTemplateRepository,
+            challengeSettingsCache = ReloadingCache(challengeRef),
+            challengeSettingsRepository = challengeSettingsRepository,
+            systemSettingsCache = ReloadingCache(sysRef),
+            systemSettingsRepository = systemSettingsRepository,
+            metadataCache = ReloadingCache(metadataRef),
+            metadataRepository = metadataRepository,
+            resourceCache = ReloadingCache(resourceRef),
+            resourceRepository = resourceRepository,
+            authorizationDetailTypeCache = ReloadingCache(authDetailTypeRef),
+            authorizationDetailTypeRepository = authorizationDetailTypeRepository,
+          )
+          _ <- clientRepository.getAll.succeedsWith(newClients)
+          _ <- scopeRepository.getAll.succeedsWith(newScopes)
+          _ <- formRepository.getAll.succeedsWith(newForms)
+          _ <- themeRepository.getAll.succeedsWith(newThemes)
+          _ <- localeRepository.getAll.succeedsWith(newLocales)
+          _ <- otpTemplateRepository.getAll.succeedsWith(newOtpTemplates)
+          _ <- challengeSettingsRepository.getAll.succeedsWith(newChallengeSettings)
+          _ <- systemSettingsRepository.getAll.succeedsWith(newSystemSettings)
+          _ <- metadataRepository.getAll.succeedsWith(newMetadata)
+          _ <- resourceRepository.getAll.succeedsWith(ResourceSyncClient.SyncResult(newResources, newSecrets))
+          _ <- authorizationDetailTypeRepository.getAll.succeedsWith(newAuthorizationDetailTypes)
+          _ <- env.syncConfiguration
+          clients <- env.clientCache.get
+          scopes <- env.scopeCache.get
+          forms <- env.formCache.get
+          themes <- env.themeCache.get
+          locales <- env.localeCache.get
+          otpTemplates <- env.otpTemplateCache.get
+          challengeSettingsResult <- env.challengeSettingsCache.get
+          sysSettings <- env.systemSettingsCache.get
+          metadata <- env.metadataCache.get
+          resources <- env.resourceCache.get
+          authorizationDetailTypes <- env.authorizationDetailTypeCache.get
+        yield assertTrue(
+          clients == newClients,
+          scopes == newScopes,
+          forms == newForms,
+          themes == newThemes,
+          locales == newLocales,
+          otpTemplates == newOtpTemplates,
+          challengeSettingsResult == newChallengeSettings,
+          sysSettings == newSystemSettings,
+          metadata == newMetadata,
+          resources == ResourceSyncClient.SyncResult(newResources, newSecrets),
+          authorizationDetailTypes == newAuthorizationDetailTypes,
+        )
       },
     ),
   )

--- a/util/src/test/scala/versola/util/JWTSpec.scala
+++ b/util/src/test/scala/versola/util/JWTSpec.scala
@@ -33,14 +33,59 @@ object JWTSpec extends ZIOSpecDefault:
   keyGenerator.init(256)
   private val symmetricKey = keyGenerator.generateKey()
 
+  // Test EC key pair, registered under its own kid so `verifySignature`'s ECKey branch
+  // (as opposed to the RSAKey branch every other asymmetric test exercises) gets hit.
+  private val ecKeyPairGenerator = KeyPairGenerator.getInstance("EC")
+  ecKeyPairGenerator.initialize(com.nimbusds.jose.jwk.Curve.P_256.toECParameterSpec)
+  private val ecKeyPair = ecKeyPairGenerator.generateKeyPair()
+  private val ecPublicKeys = JWT.PublicKeys(
+    com.nimbusds.jose.jwk.JWKSet(
+      new com.nimbusds.jose.jwk.ECKey.Builder(
+        com.nimbusds.jose.jwk.Curve.P_256,
+        ecKeyPair.getPublic.asInstanceOf[java.security.interfaces.ECPublicKey],
+      ).keyID("ec-key-1").build(),
+    ),
+  )
+
+  // Test HMAC key registered as an octet-sequence JWK (rather than passed directly), so
+  // `verifySignature`'s OctetSequenceKey branch gets hit via the [[JWT.PublicKeys]] path.
+  private val octetPublicKeys = JWT.PublicKeys(
+    com.nimbusds.jose.jwk.JWKSet(
+      new com.nimbusds.jose.jwk.OctetSequenceKey.Builder(symmetricKey.getEncoded)
+        .keyID("hmac-key-1").build(),
+    ),
+  )
+
   // Test claims
   case class TestClaims(sub: String, name: String, admin: Boolean) derives JsonCodec
+
+  private def signRawWithHeader(
+      keyId: String,
+      algorithm: com.nimbusds.jose.JWSAlgorithm,
+      signer: com.nimbusds.jose.JWSSigner,
+  )(build: com.nimbusds.jwt.JWTClaimsSet.Builder => com.nimbusds.jwt.JWTClaimsSet.Builder) =
+    ZIO.attempt {
+      val claims = build(
+        com.nimbusds.jwt.JWTClaimsSet.Builder()
+          .jwtID("jti-1")
+          .expirationTime(java.util.Date.from(java.time.Instant.parse("2100-01-01T00:00:00Z"))),
+      ).build()
+      val header = com.nimbusds.jose.JWSHeader.Builder(algorithm)
+        .keyID(keyId)
+        .`type`(com.nimbusds.jose.JOSEObjectType.JWT)
+        .build()
+      val jwt = com.nimbusds.jwt.SignedJWT(header, claims)
+      jwt.sign(signer)
+      jwt.serialize()
+    }
 
   def spec = suite("JWT")(
     asymmetricTests,
     symmetricTests,
     claimConversionTests,
     parseClaimsTests,
+    signatureAlgorithmTests,
+    headerTests,
   )
 
   /** Signs an arbitrary Nimbus claims set so claim values of Java types that zio-json would
@@ -186,6 +231,71 @@ object JWTSpec extends ZIOSpecDefault:
         _ <- TestClock.adjust(2.hours)
         result <- JWT.deserialize[TestClaims](token, publicKeys, JWT.Type.JWT).either
       yield assertTrue(result.left.exists { case _: JWT.Error.Expired => true; case _ => false })
+    },
+    test("serializes nested-object and null custom claims") {
+      val claims = JWT.Claims(
+        issuer = "test-issuer",
+        subject = "user123",
+        audience = List("api"),
+        custom = Json.Obj("meta" -> Json.Obj("k" -> Json.Str("v")), "nothing" -> Json.Null),
+      )
+
+      for
+        token <- JWT.serialize(
+          claims = claims,
+          ttl = 1.hour,
+          signature = JWT.Signature.Asymmetric(JWT.Algorithm.RS256, "test-key-1", privateKey),
+        )
+        result <- JWT.deserialize[Json.Obj](token, publicKeys, JWT.Type.JWT)
+      yield assertTrue(
+        result.get("meta") == Some(Json.Obj("k" -> Json.Str("v"))),
+        result.get("nothing").forall(_ == Json.Null),
+      )
+    },
+    test("verifies against an EC key served from the JWKS (not just RSA)") {
+      for
+        token <- signRawWithHeader(
+          "ec-key-1",
+          com.nimbusds.jose.JWSAlgorithm.ES256,
+          com.nimbusds.jose.crypto.ECDSASigner(ecKeyPair.getPrivate.asInstanceOf[java.security.interfaces.ECPrivateKey]),
+        )(_.subject("user123"))
+        result <- JWT.deserialize[Json.Obj](token, ecPublicKeys, JWT.Type.JWT)
+      yield assertTrue(result.get("sub") == Some(Json.Str("user123")))
+    },
+    test("verifies against an octet-sequence key served from the JWKS (not passed directly)") {
+      for
+        token <- signRawWithHeader(
+          "hmac-key-1",
+          com.nimbusds.jose.JWSAlgorithm.HS256,
+          com.nimbusds.jose.crypto.MACSigner(symmetricKey),
+        )(_.subject("user123"))
+        result <- JWT.deserialize[Json.Obj](token, octetPublicKeys, JWT.Type.JWT)
+      yield assertTrue(result.get("sub") == Some(Json.Str("user123")))
+    },
+  )
+
+  private val signatureAlgorithmTests = suite("signature/algorithm mismatch")(
+    test("fails to serialize when an asymmetric signature declares a non-RS256 algorithm") {
+      val claims = JWT.Claims("test-issuer", "user123", List("api"), Json.Obj())
+      for result <- JWT.serialize(
+          claims = claims,
+          ttl = 1.hour,
+          signature = JWT.Signature.Asymmetric(JWT.Algorithm.HS256, "test-key-1", privateKey),
+        ).exit
+      yield assertTrue(result.isFailure)
+    },
+  )
+
+  private val headerTests = suite("Header")(
+    test("get returns the custom param when present and None otherwise") {
+      val header = com.nimbusds.jose.JWSHeader.Builder(com.nimbusds.jose.JWSAlgorithm.RS256)
+        .customParam("eid", "edge-1")
+        .build()
+      val jwtHeader = JWT.Header(header)
+      assertTrue(
+        jwtHeader.get("eid") == Some("edge-1"),
+        jwtHeader.get("missing") == None,
+      )
     },
   )
 


### PR DESCRIPTION
## Context

Phase 3 of the coverage push tracked in #243 (Phase 1: sync clients/thin wrappers, ~80.87% -> 82.82%). This PR targets the auth-core validation/crypto layer called out in that PR's roadmap: `AuthorizeRequestParser`, `OAuthConfigurationService`, `WebAuthnService`, `JWT`. (Skipped `AuthorizeEndpointService` -- its only 3 uncovered statements are its `live` ZLayer wiring, a 14-arg constructor call not worth an integration test.)

Note: branched from current `main` (this PR does not depend on #243 landing first), so the baseline here is 80.87%, not 82.82%.

**Aggregate: 80.87% -> 81.72% statements, verified via a from-clean `sbt coverage test coverageReport coverageAggregate`. All 8 modules green, 0 test failures.** auth module 930 -> 989 tests (80.63% -> 82.14%), util module 89 -> 96 tests (81.71% -> 83.33%).

## What's covered

- **AuthorizeRequestParser** -- the bulk of its OAuth2/OIDC authorize-request validation branches (response_type, PKCE code_challenge, claims, ui_locales, nonce, malformed resource, `paramsFromForm`, and more) that had no direct coverage despite the file's size.
- **OAuthConfigurationService** -- `syncConfiguration` (exercising every repository -> cache pair it wires), plus `getAcrVocabulary`/`getPasswordTemplate` and other previously-untested accessors. Left the object's own `live` ZLayer wiring (a 22-arg constructor call) uncovered, matching this codebase's established convention for pure DI glue.
- **WebAuthnService** -- this needed a real virtual WebAuthn authenticator: an ES256 key pair, a hand-built CBOR `attestationObject`/COSE key, and a real ECDSA signature over `authenticatorData || sha256(clientDataJSON)`, since `java-webauthn-server` ships no public test-jar with one (unlike its own internal test suite). The existing spec only exercised failure paths with fabricated responses, so none of the actual registration/assertion *verification success* path was reachable before. Added successful `finishRegistration` and `finishAssertion` ceremonies, plus the `updateUsage`-returns-false-but-record-still-exists edge case (-> `AssertionFailed`).
  - Left one branch uncovered: `updateUsage`-false **and** record vanished (-> `CredentialNotFound`) needs the same stubbed repository call to answer differently on its first (verification) and second (post-`updateUsage`) invocation within a single ceremony -- not expressible with this codebase's one-canned-answer-per-method stub framework.
- **JWT** -- nested-object/null custom claims, the asymmetric-signature/algorithm-mismatch fallback (throws when an `Asymmetric` signature declares a non-RS256 algorithm), `Header.get`, and `verifySignature`'s EC-key and octet-sequence-key JWKS branches (previously only ever exercised via RSA).

## Testing

Same sandbox as the Phase 1 PR (JDK 17, sbt 1.12.5, local Postgres 15). Ran `sbt clean coverage util/test util-postgres/test auth/test auth-postgres-impl/test edge/test edge-postgres-impl/test central/test central-postgres-impl/test coverageReport coverageAggregate` end to end: 0 failures, 81.72% aggregate.

## Next

Phase 4: central controllers/services (`UserController`, `OAuthClientService`, `UserOutboxProcessor`, etc.) -> targeting ~91-92% aggregate, tracked as a follow-up PR.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M1R187HGTGCA8J95BYK714XK&panel=chat)