### PR TITLE
test: cover UserController, AuthClient, OAuthClientService, UserOutboxProcessor (Phase 4 of 91% push)

### DIFF
--- a/central/src/test/scala/versola/central/configuration/clients/OAuthClientServiceSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/clients/OAuthClientServiceSpec.scala
@@ -1,18 +1,25 @@
 package versola.central.configuration.clients
 
 import org.scalamock.stubs.{Stub, ZIOStubs}
-import versola.central.{CentralConfig, TestCentralConfig}
 import versola.central.configuration.edges.EdgeId
 import versola.central.configuration.permissions.Permission
 import versola.central.configuration.roles.{RoleRecord, RoleRepository}
 import versola.central.configuration.scopes.ScopeToken
 import versola.central.configuration.sync.SyncEvent
 import versola.central.configuration.tenants.{TenantId, TenantRecord, TenantRepository}
-import versola.central.configuration.{ConsentFlowDto, CreateClientRequest, PatchClientRedirectUris, PatchClientScope, PatchPermissions, UpdateClientRequest}
+import versola.central.configuration.{
+  ConsentFlowDto,
+  CreateClientRequest,
+  PatchClientRedirectUris,
+  PatchClientScope,
+  PatchPermissions,
+  UpdateClientRequest,
+}
+import versola.central.{CentralConfig, TestCentralConfig}
 import versola.util.{Patch, RedirectUri, ReloadingCache, Secret, SecureRandom, SecurityService}
-import zio.prelude.EqualOps
 import zio.*
 import zio.http.URL
+import zio.prelude.EqualOps
 import zio.test.*
 
 import javax.crypto.spec.SecretKeySpec
@@ -207,7 +214,7 @@ object OAuthClientServiceSpec extends ZIOSpecDefault, ZIOStubs:
       for
         _ <- env.repository.updateClient.succeedsWith(())
         _ <- env.service.updateClient(
-          updateRequest.copy(consentFlow = Some(Patch.Modified(consentFlow)))
+          updateRequest.copy(consentFlow = Some(Patch.Modified(consentFlow))),
         )
       yield assertTrue(
         env.repository.updateClient.calls == List(
@@ -230,8 +237,71 @@ object OAuthClientServiceSpec extends ZIOSpecDefault, ZIOStubs:
             None,
             None,
             Some(Patch.Modified(ConsentFlow(allowPartial = false, rememberDuration = Some(30.days)))),
-          )
-        )
+          ),
+        ),
+      )
+    },
+    test("getAllClients returns everything in the cache") {
+      val env = new Env(Vector(cachedClient, otherTenantClient))
+      for result <- env.service.getAllClients
+      yield assertTrue(result == Vector(cachedClient, otherTenantClient))
+    },
+    test("registerClient accepts a valid https logoUri, policyUri and tosUri") {
+      val env = new Env()
+
+      for
+        _ <- env.secureRandom.nextBytes.succeedsWith(Array.fill(32)(11.toByte))
+        _ <- env.securityService.encryptAes256.succeedsWith(Array.fill(48)(17.toByte))
+        _ <- env.repository.createClient.succeedsWith(())
+        _ <- env.service.registerClient(createRequest.copy(
+          logoUri = Some("https://example.com/logo.png"),
+          policyUri = Some("https://example.com/policy"),
+          tosUri = Some("https://example.com/tos"),
+        ))
+        created = env.repository.createClient.calls.head
+      yield assertTrue(
+        created.logoUri == Some("https://example.com/logo.png"),
+        created.policyUri == Some("https://example.com/policy"),
+        created.tosUri == Some("https://example.com/tos"),
+      )
+    },
+    test("registerClient rejects a non-HTTPS logoUri instead of silently dropping it") {
+      val env = new Env()
+
+      for
+        result <- env.service.registerClient(createRequest.copy(logoUri = Some("http://example.com/logo.png"))).either
+        createCalls = env.repository.createClient.times
+      yield assertTrue(
+        result.left.toOption.exists:
+          case error: InvalidConsentUri => error.field == "logoUri"
+          case _ => false,
+        createCalls == 0,
+      )
+    },
+    test("registerClient rejects a malformed policyUri instead of silently dropping it") {
+      val env = new Env()
+
+      for
+        result <- env.service.registerClient(createRequest.copy(policyUri = Some("not a url"))).either
+        createCalls = env.repository.createClient.times
+      yield assertTrue(
+        result.left.toOption.exists:
+          case error: InvalidConsentUri => error.field == "policyUri"
+          case _ => false,
+        createCalls == 0,
+      )
+    },
+    test("updateClient rejects a non-HTTPS tosUri patch instead of silently dropping it") {
+      val env = new Env()
+
+      for
+        result <- env.service.updateClient(updateRequest.copy(tosUri = Some(Patch.Modified("http://example.com/tos")))).either
+        updateCalls = env.repository.updateClient.times
+      yield assertTrue(
+        result.left.toOption.exists:
+          case error: InvalidConsentUri => error.field == "tosUri"
+          case _ => false,
+        updateCalls == 0,
       )
     },
     test("registerClient accepts an https frontChannelLogoutUri") {
@@ -267,7 +337,7 @@ object OAuthClientServiceSpec extends ZIOSpecDefault, ZIOStubs:
       yield assertTrue(
         result.left.toOption.exists:
           case error: InvalidConsentUri => error.field == "frontChannelLogoutUri"
-          case _                        => false,
+          case _ => false,
         createCalls == 0,
       )
     },
@@ -282,7 +352,7 @@ object OAuthClientServiceSpec extends ZIOSpecDefault, ZIOStubs:
       yield assertTrue(
         result.left.toOption.exists:
           case error: InvalidConsentUri => error.field == "backChannelLogoutUri"
-          case _                        => false,
+          case _ => false,
         createCalls == 0,
       )
     },
@@ -297,9 +367,36 @@ object OAuthClientServiceSpec extends ZIOSpecDefault, ZIOStubs:
       yield assertTrue(
         result.left.toOption.exists:
           case error: InvalidConsentUri => error.field == "frontChannelLogoutUri"
-          case _                        => false,
+          case _ => false,
         updateCalls == 0,
       )
+    },
+    test("registerClient rejects a relative frontChannelLogoutUri instead of silently dropping it") {
+      val env = new Env()
+
+      for
+        result <- env.service.registerClient(createRequest.copy(frontChannelLogoutUri = Some("/relative/front-logout"))).either
+        createCalls = env.repository.createClient.times
+      yield assertTrue(
+        result.left.toOption.exists:
+          case error: InvalidConsentUri => error.field == "frontChannelLogoutUri"
+          case _ => false,
+        createCalls == 0,
+      )
+    },
+    test("updateClient clears frontChannelLogoutUri and consentFlow when the patch is an explicit deletion") {
+      val env = new Env()
+
+      for
+        _ <- env.repository.updateClient.succeedsWith(())
+        _ <- env.service.updateClient(
+          updateRequest.copy(
+            frontChannelLogoutUri = Some(Patch.Deleted),
+            consentFlow = Some(Patch.Deleted),
+          ),
+        )
+        (_, _, _, _, _, _, _, _, _, _, _, frontChannelLogoutUri, _, _, _, _, _, consentFlow) = env.repository.updateClient.calls.head
+      yield assertTrue(frontChannelLogoutUri == Some(Patch.Deleted), consentFlow == Some(Patch.Deleted))
     },
     test("updateClient stores a frontChannelLogoutUri with surrounding whitespace instead of clearing it") {
       val env = new Env()
@@ -307,7 +404,7 @@ object OAuthClientServiceSpec extends ZIOSpecDefault, ZIOStubs:
       for
         _ <- env.repository.updateClient.succeedsWith(())
         _ <- env.service.updateClient(
-          updateRequest.copy(frontChannelLogoutUri = Some(Patch.Modified(" https://rp.example.com/front-logout ")))
+          updateRequest.copy(frontChannelLogoutUri = Some(Patch.Modified(" https://rp.example.com/front-logout "))),
         )
         patched = env.repository.updateClient.calls.head._12
       yield assertTrue(patched == Some(Patch.Modified(URL.decode("https://rp.example.com/front-logout").toOption.get)))
@@ -324,7 +421,7 @@ object OAuthClientServiceSpec extends ZIOSpecDefault, ZIOStubs:
       yield assertTrue(
         result.left.toOption.exists:
           case error: InvalidRegistrationConfiguration => error.reason.contains("does not exist")
-          case _                                       => false,
+          case _ => false,
         createCalls == 0,
       )
     },
@@ -361,7 +458,7 @@ object OAuthClientServiceSpec extends ZIOSpecDefault, ZIOStubs:
       yield assertTrue(
         result.left.toOption.exists:
           case error: InvalidRegistrationConfiguration => error.reason.contains("login+password")
-          case _                                       => false,
+          case _ => false,
         createCalls == 0,
       )
     },
@@ -382,7 +479,7 @@ object OAuthClientServiceSpec extends ZIOSpecDefault, ZIOStubs:
       yield assertTrue(
         result.left.toOption.exists:
           case error: InvalidRegistrationConfiguration => error.reason.contains("password inline")
-          case _                                       => false,
+          case _ => false,
         createCalls == 0,
       )
     },
@@ -402,7 +499,7 @@ object OAuthClientServiceSpec extends ZIOSpecDefault, ZIOStubs:
       yield assertTrue(
         result.left.toOption.exists:
           case error: InvalidRegistrationConfiguration => error.reason.contains("exactly one primary credential")
-          case _                                       => false,
+          case _ => false,
         createCalls == 0,
       )
     },
@@ -421,7 +518,7 @@ object OAuthClientServiceSpec extends ZIOSpecDefault, ZIOStubs:
       yield assertTrue(
         result.left.toOption.exists:
           case error: InvalidRegistrationConfiguration => error.reason.contains("login+password")
-          case _                                       => false,
+          case _ => false,
         updateCalls == 0,
       )
     },
@@ -496,7 +593,7 @@ object OAuthClientServiceSpec extends ZIOSpecDefault, ZIOStubs:
         cached <- env.cache.get
       yield assertTrue(
         env.repository.find.calls === List(clientId),
-        cached === Vector(otherTenantClient, decryptedClient),  // sorted by ID: mobile-app, web-app
+        cached === Vector(otherTenantClient, decryptedClient), // sorted by ID: mobile-app, web-app
       )
     },
     test("sync removes cached client when record is missing on non-delete event") {
@@ -510,5 +607,31 @@ object OAuthClientServiceSpec extends ZIOSpecDefault, ZIOStubs:
         env.repository.find.calls === List(clientId),
         cached === Vector(otherTenantClient),
       )
+    },
+    test("verifySecret accepts the central-admin client's current secret") {
+      val currentSecret = Secret(Array.fill(32)(1.toByte))
+      val adminClient = cachedClient.copy(id = CentralConfig.centralClientId, secret = Some(currentSecret))
+      val env = new Env(Vector(adminClient))
+      for result <- env.service.verifySecret(currentSecret)
+      yield assertTrue(result)
+    },
+    test("verifySecret accepts the central-admin client's previous secret") {
+      val currentSecret = Secret(Array.fill(32)(1.toByte))
+      val previousSecret = Secret(Array.fill(32)(2.toByte))
+      val adminClient = cachedClient.copy(id = CentralConfig.centralClientId, secret = Some(currentSecret), previousSecret = Some(previousSecret))
+      val env = new Env(Vector(adminClient))
+      for result <- env.service.verifySecret(previousSecret)
+      yield assertTrue(result)
+    },
+    test("verifySecret rejects a secret that matches neither current nor previous") {
+      val adminClient = cachedClient.copy(id = CentralConfig.centralClientId, secret = Some(Secret(Array.fill(32)(1.toByte))))
+      val env = new Env(Vector(adminClient))
+      for result <- env.service.verifySecret(Secret(Array.fill(32)(9.toByte)))
+      yield assertTrue(!result)
+    },
+    test("verifySecret rejects when no central-admin client is cached") {
+      val env = new Env(Vector(cachedClient))
+      for result <- env.service.verifySecret(Secret(Array.fill(32)(1.toByte)))
+      yield assertTrue(!result)
     },
   )

--- a/central/src/test/scala/versola/central/users/AuthClientSpec.scala
+++ b/central/src/test/scala/versola/central/users/AuthClientSpec.scala
@@ -315,6 +315,51 @@ object AuthClientSpec extends ZIOSpecDefault:
         result <- client.listPasskeys(userId)
       yield assertTrue(result == List(passkeyInfo))
     }.provide(TestClient.layer, ZLayer.succeed(TestCentralConfig.config), tokenServiceLayer, authClientLayer),
+    test("send fails with the status and body when the server returns a non-success status") {
+      for
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request](_ => ZIO.succeed(Response.text("boom").status(Status.InternalServerError))).toRoutes,
+        )
+        client <- ZIO.service[AuthClient]
+        exit <- client.deleteUser(userId).exit
+      yield assert(exit)(fails(isSubtype[RuntimeException](hasMessage(containsString("500")) && hasMessage(containsString("boom")))))
+    }.provide(TestClient.layer, ZLayer.succeed(TestCentralConfig.config), tokenServiceLayer, authClientLayer),
+    test("sendReceive fails with the status and body when the server returns a non-success status") {
+      for
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request](_ => ZIO.succeed(Response.text("nope").status(Status.BadRequest))).toRoutes,
+        )
+        client <- ZIO.service[AuthClient]
+        exit <- client.getUserRoles(userId, tenantId).exit
+      yield assert(exit)(fails(isSubtype[RuntimeException](hasMessage(containsString("400")) && hasMessage(containsString("nope")))))
+    }.provide(TestClient.layer, ZLayer.succeed(TestCentralConfig.config), tokenServiceLayer, authClientLayer),
+    test("sendReceive fails when the response body isn't valid JSON") {
+      for
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request](_ => ZIO.succeed(Response.text("not-json"))).toRoutes,
+        )
+        client <- ZIO.service[AuthClient]
+        exit <- client.getUserRoles(userId, tenantId).exit
+      yield assert(exit)(fails(isSubtype[RuntimeException](hasMessage(containsString("decode")))))
+    }.provide(TestClient.layer, ZLayer.succeed(TestCentralConfig.config), tokenServiceLayer, authClientLayer),
+    test("sendReceiveOptional fails with the status and body when the server returns a non-success, non-204 status") {
+      for
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request](_ => ZIO.succeed(Response.text("denied").status(Status.Forbidden))).toRoutes,
+        )
+        client <- ZIO.service[AuthClient]
+        exit <- client.getUserClaims(userId).exit
+      yield assert(exit)(fails(isSubtype[RuntimeException](hasMessage(containsString("403")) && hasMessage(containsString("denied")))))
+    }.provide(TestClient.layer, ZLayer.succeed(TestCentralConfig.config), tokenServiceLayer, authClientLayer),
+    test("sendReceiveOptional fails when a 200 response body isn't valid JSON") {
+      for
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request](_ => ZIO.succeed(Response.text("not-json"))).toRoutes,
+        )
+        client <- ZIO.service[AuthClient]
+        exit <- client.getUserClaims(userId).exit
+      yield assert(exit)(fails(isSubtype[RuntimeException](hasMessage(containsString("decode")))))
+    }.provide(TestClient.layer, ZLayer.succeed(TestCentralConfig.config), tokenServiceLayer, authClientLayer),
   )
 
   // ── withConnectionRetry ─────────────────────────────────────────────────────

--- a/central/src/test/scala/versola/central/users/UserControllerSpec.scala
+++ b/central/src/test/scala/versola/central/users/UserControllerSpec.scala
@@ -2,11 +2,13 @@ package versola.central.users
 
 import io.opentelemetry.api
 import org.scalamock.stubs.{Stub, ZIOStubs}
-import versola.central.{CentralConfig, TestAdminAuth, TestCentralConfig}
 import versola.central.configuration.edges.EdgeService
 import versola.central.configuration.resources.ResourceService
-import versola.util.{Email, EnvName, JWT}
+import versola.central.configuration.roles.RoleId
+import versola.central.configuration.tenants.TenantId
+import versola.central.{CentralConfig, TestAdminAuth, TestCentralConfig}
 import versola.util.http.Observability
+import versola.util.{Email, EnvName, JWT, Phone}
 import zio.*
 import zio.http.*
 import zio.json.*
@@ -19,7 +21,7 @@ import java.util.UUID
 
 object UserControllerSpec extends ZIOSpecDefault, ZIOStubs:
   private val userId = UserId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
-  private val email  = Email("user@example.com")
+  private val email = Email("user@example.com")
 
   private val passkeyInfo = PasskeyInfo(
     id = "aQ",
@@ -74,11 +76,11 @@ object UserControllerSpec extends ZIOSpecDefault, ZIOStubs:
   ) =
     test(description) {
       for
-        client      <- ZIO.service[Client]
-        service     =  stub[UserService]
+        client <- ZIO.service[Client]
+        service = stub[UserService]
         resourceService = stub[ResourceService]
         edgeService = stub[EdgeService]
-        tracing     <- tracingLayer.build
+        tracing <- tracingLayer.build
         _ <- TestClient.addRoutes(
           Observability.handleErrors(
             UserController.routes.provideEnvironment(
@@ -86,9 +88,9 @@ object UserControllerSpec extends ZIOSpecDefault, ZIOStubs:
                 ZEnvironment[CentralConfig](TestCentralConfig.config) ++
                 tracing ++ ZEnvironment[ResourceService](resourceService) ++
                 ZEnvironment[EdgeService](edgeService) ++
-                ZEnvironment[EnvName](env)
-            )
-          )
+                ZEnvironment[EnvName](env),
+            ),
+          ),
         )
         _ <- resourceService.verifySecret.succeedsWith(true)
         _ <- setup(service)
@@ -96,7 +98,7 @@ object UserControllerSpec extends ZIOSpecDefault, ZIOStubs:
         response <- client.batched(
           request
             .addHeader(Header.Accept(MediaType.application.json))
-            .addHeader(authorizationHeader)
+            .addHeader(authorizationHeader),
         )
         verifyResult <- verify(response, service)
       yield assertTrue(response.status == expectedStatus) && verifyResult
@@ -253,7 +255,134 @@ object UserControllerSpec extends ZIOSpecDefault, ZIOStubs:
       setup = service => service.findById.succeedsWith(Some(UserSearchRecord(userId, Some(email), None, None, Json.Obj()))),
       verify = (response, _) =>
         for body <- response.body.asJson[UserSearchResponse]
-        yield assertTrue(body.users.head.id == userId)
+        yield assertTrue(body.users.head.id == userId),
+    ),
+    controllerTestCase(
+      description = "find users by email returns search result",
+      request = Request(
+        method = Method.GET,
+        url = (URL.empty / "users").addQueryParam("email", email.toString),
+      ),
+      expectedStatus = Status.Ok,
+      setup = service => service.findByEmail.succeedsWith(Some(UserSearchRecord(userId, Some(email), None, None, Json.Obj()))),
+      verify = (response, service) =>
+        for body <- response.body.asJson[UserSearchResponse]
+        yield assertTrue(service.findByEmail.calls == List(email), body.users.head.id == userId),
+    ),
+    controllerTestCase(
+      description = "find users by phone returns search result",
+      request = Request(
+        method = Method.GET,
+        url = URL.decode("/users?phone=%2B16502530000").toOption.get,
+      ),
+      expectedStatus = Status.Ok,
+      setup = service => service.findByPhone.succeedsWith(Some(UserSearchRecord(userId, None, Some(Phone("+16502530000")), None, Json.Obj()))),
+      verify = (response, service) =>
+        for body <- response.body.asJson[UserSearchResponse]
+        yield assertTrue(service.findByPhone.calls == List(Phone("+16502530000")), body.users.head.id == userId),
+    ),
+    controllerTestCase(
+      description = "find users by login returns search result",
+      request = Request(
+        method = Method.GET,
+        url = (URL.empty / "users").addQueryParam("login", "jdoe"),
+      ),
+      expectedStatus = Status.Ok,
+      setup = service => service.findByLogin.succeedsWith(Some(UserSearchRecord(userId, None, None, Some(Login("jdoe")), Json.Obj()))),
+      verify = (response, service) =>
+        for body <- response.body.asJson[UserSearchResponse]
+        yield assertTrue(service.findByLogin.calls == List(Login("jdoe")), body.users.head.id == userId),
+    ),
+    controllerTestCase(
+      description = "find users with no query parameter returns 400 Bad Request",
+      request = Request(method = Method.GET, url = URL.empty / "users"),
+      expectedStatus = Status.BadRequest,
+    ),
+    controllerTestCase(
+      description = "get user roles returns the user's roles",
+      request = Request(
+        method = Method.GET,
+        url = (URL.empty / "users" / "roles")
+          .addQueryParam("id", userId.toString)
+          .addQueryParam("tenantId", "default"),
+      ),
+      expectedStatus = Status.Ok,
+      setup = service => service.getRoles.succeedsWith(List(RoleId("admin"))),
+      verify = (response, service) =>
+        for body <- response.body.asJson[UserRolesResponse]
+        yield assertTrue(
+          service.getRoles.calls == List((userId, TenantId("default"))),
+          body == UserRolesResponse(List(RoleId("admin"))),
+        ),
+    ),
+    controllerTestCase(
+      description = "get user sessions returns the user's sessions",
+      request = Request(
+        method = Method.GET,
+        url = (URL.empty / "users" / "sessions").addQueryParam("id", userId.toString),
+      ),
+      expectedStatus = Status.Ok,
+      setup = service => service.getSessions.succeedsWith(Nil),
+      verify = (response, service) =>
+        ZIO.succeed(assertTrue(service.getSessions.calls == List(userId))),
+    ),
+    controllerTestCase(
+      description = "invalidate session returns 204 No Content",
+      request = Request(
+        method = Method.DELETE,
+        url = (URL.empty / "users" / "sessions").addQueryParam("userId", userId.toString),
+      ),
+      expectedStatus = Status.NoContent,
+      setup = service => service.invalidateSession.succeedsWith(()),
+      verify = (_, service) =>
+        ZIO.succeed(assertTrue(service.invalidateSession.calls == List(userId))),
+    ),
+    controllerTestCase(
+      description = "patch user returns 202 Accepted",
+      request = Request(
+        method = Method.PATCH,
+        url = URL.empty / "users",
+        body = Body.fromString(s"""{"id":"$userId","email":"new@example.com"}"""),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.Accepted,
+      setup = service => service.patch.succeedsWith(()),
+      verify = (_, service) =>
+        ZIO.succeed(assertTrue(service.patch.calls.nonEmpty)),
+    ),
+    controllerTestCase(
+      description = "reset user limits returns 202 Accepted",
+      request = Request(
+        method = Method.POST,
+        url = URL.empty / "users" / "limits" / "reset",
+        body = Body.fromString(s"""{"userId":"$userId","tenantId":"default"}"""),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.Accepted,
+      setup = service => service.resetLimits.succeedsWith(()),
+      verify = (_, service) =>
+        ZIO.succeed(assertTrue(
+          service.resetLimits.calls == List(ResetUserLimitsRequest(userId, TenantId("default"), None, None)),
+        )),
+    ),
+    controllerTestCase(
+      description = "create user surfaces an unexpected failure as 500 Internal Server Error",
+      request = Request(
+        method = Method.POST,
+        url = URL.empty / "users",
+        body = Body.fromString(createRequestBody),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.InternalServerError,
+      setup = service => service.create.failsWith(RuntimeException("boom")),
+    ),
+    controllerTestCase(
+      description = "registered user surfaces an unexpected failure as 500 Internal Server Error",
+      request = Request(
+        method = Method.POST,
+        url = URL.empty / "users" / "registrations",
+        body = Body.fromString(registeredRequestBody),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.InternalServerError,
+      setup = service => service.indexRegistered.failsWith(RuntimeException("boom")),
+      authorization = internalAuthorization,
     ),
     controllerTestCase(
       description = "reset password returns 204 No Content",
@@ -265,7 +394,7 @@ object UserControllerSpec extends ZIOSpecDefault, ZIOStubs:
       expectedStatus = Status.NoContent,
       setup = service => service.resetPassword.succeedsWith(None),
       verify = (_, service) =>
-        ZIO.succeed(assertTrue(service.resetPassword.calls.nonEmpty))
+        ZIO.succeed(assertTrue(service.resetPassword.calls.nonEmpty)),
     ),
     controllerTestCase(
       description = "reset password with the show channel returns the plaintext in non-prod",
@@ -278,7 +407,7 @@ object UserControllerSpec extends ZIOSpecDefault, ZIOStubs:
       setup = service => service.resetPassword.succeedsWith(Some("Temp1234!")),
       verify = (response, service) =>
         for body <- response.body.asJson[ResetPasswordResponse]
-        yield assertTrue(body.password == "Temp1234!", service.resetPassword.calls.nonEmpty)
+        yield assertTrue(body.password == "Temp1234!", service.resetPassword.calls.nonEmpty),
     ),
     controllerTestCase(
       description = "reset password with the show channel returns 404 Not Found in prod",

--- a/central/src/test/scala/versola/central/users/UserOutboxProcessorSpec.scala
+++ b/central/src/test/scala/versola/central/users/UserOutboxProcessorSpec.scala
@@ -13,7 +13,7 @@ import java.util.UUID
 
 object UserOutboxProcessorSpec extends ZIOSpecDefault, ZIOStubs:
 
-  private val userId  = UserId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+  private val userId = UserId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
   private val eventId = UUID.fromString("00000000-0000-0000-0000-000000000099")
 
   private val config = UserOutboxConfig(
@@ -111,48 +111,174 @@ object UserOutboxProcessorSpec extends ZIOSpecDefault, ZIOStubs:
         repo.deleteEvent.calls == List(eventId),
       )
     },
-      test("flush retries a transient dispatch failure") {
-        val repo = stub[UserRepository]
-        val client = stub[AuthClient]
+    test("flush retries a transient dispatch failure") {
+      val repo = stub[UserRepository]
+      val client = stub[AuthClient]
 
-        for
-          _ <- repo.claimDueEvents.returnsZIOOnCall:
-            case 1 => ZIO.succeed(Vector(record))
-            case 2 => ZIO.succeed(Vector.empty)
-          _ <- client.upsertUser.returnsZIOOnCall:
-            case 1 => ZIO.fail(new RuntimeException("temporary failure"))
-            case 2 => ZIO.succeed(())
-          _ <- repo.deleteEvent.succeedsWith(())
+      for
+        _ <- repo.claimDueEvents.returnsZIOOnCall:
+          case 1 => ZIO.succeed(Vector(record))
+          case 2 => ZIO.succeed(Vector.empty)
+        _ <- client.upsertUser.returnsZIOOnCall:
+          case 1 => ZIO.fail(new RuntimeException("temporary failure"))
+          case 2 => ZIO.succeed(())
+        _ <- repo.deleteEvent.succeedsWith(())
 
-          fiberRef <- Ref.make(Option.empty[Fiber.Runtime[Nothing, Unit]])
-          semaphore <- Semaphore.make(1)
-          processor = UserOutboxProcessor.Live(config, repo, client, fiberRef, semaphore)
-          _ <- runFlush(processor)
-        yield assertTrue(
-          client.upsertUser.calls.length == 2,
-          repo.deleteEvent.calls == List(eventId),
-        )
-      },
-      test("flush fails when dispatch cannot be completed") {
-        val repo = stub[UserRepository]
-        val client = stub[AuthClient]
+        fiberRef <- Ref.make(Option.empty[Fiber.Runtime[Nothing, Unit]])
+        semaphore <- Semaphore.make(1)
+        processor = UserOutboxProcessor.Live(config, repo, client, fiberRef, semaphore)
+        _ <- runFlush(processor)
+      yield assertTrue(
+        client.upsertUser.calls.length == 2,
+        repo.deleteEvent.calls == List(eventId),
+      )
+    },
+    test("flush fails when dispatch cannot be completed") {
+      val repo = stub[UserRepository]
+      val client = stub[AuthClient]
 
-        for
-          _ <- repo.claimDueEvents.succeedsWith(Vector(record))
-          _ <- client.upsertUser.failsWith(new RuntimeException("Auth unavailable"))
-          _ <- repo.rescheduleEvent.succeedsWith(())
+      for
+        _ <- repo.claimDueEvents.succeedsWith(Vector(record))
+        _ <- client.upsertUser.failsWith(new RuntimeException("Auth unavailable"))
+        _ <- repo.rescheduleEvent.succeedsWith(())
 
-          fiberRef <- Ref.make(Option.empty[Fiber.Runtime[Nothing, Unit]])
-          semaphore <- Semaphore.make(1)
-          processor = UserOutboxProcessor.Live(config, repo, client, fiberRef, semaphore)
-          exit <- runFlushExit(processor)
-        yield assertTrue(
-          exit.isFailure,
-          client.upsertUser.calls.length > 1,
-          repo.rescheduleEvent.calls == List((eventId, Duration.fromSeconds(2))),
-          repo.deleteEvent.calls.isEmpty,
-        )
-      },
+        fiberRef <- Ref.make(Option.empty[Fiber.Runtime[Nothing, Unit]])
+        semaphore <- Semaphore.make(1)
+        processor = UserOutboxProcessor.Live(config, repo, client, fiberRef, semaphore)
+        exit <- runFlushExit(processor)
+      yield assertTrue(
+        exit.isFailure,
+        client.upsertUser.calls.length > 1,
+        repo.rescheduleEvent.calls == List((eventId, Duration.fromSeconds(2))),
+        repo.deleteEvent.calls.isEmpty,
+      )
+    },
+    test("processOnce logs an error and returns false when claimDueEvents itself fails") {
+      val repo = stub[UserRepository]
+      val client = stub[AuthClient]
+
+      for
+        _ <- repo.claimDueEvents.failsWith(new RuntimeException("db unavailable"))
+        fiberRef <- Ref.make(Option.empty[Fiber.Runtime[Nothing, Unit]])
+        semaphore <- Semaphore.make(1)
+        processor = UserOutboxProcessor.Live(config, repo, client, fiberRef, semaphore)
+        result <- processor.processOnce
+        logs <- ZTestLogger.logOutput
+      yield assertTrue(
+        !result,
+        logs.exists(e => e.logLevel == zio.LogLevel.Error && e.message().contains("user_outbox poll failed")),
+      )
+    },
+    test("logs an error but still fails when moveToDeadLetter itself fails") {
+      val failedRecord = record.copy(attempts = config.maxAttempts - 1)
+      val repo = stub[UserRepository]
+      val client = stub[AuthClient]
+
+      for
+        _ <- repo.claimDueEvents.succeedsWith(Vector(failedRecord))
+        _ <- client.upsertUser.failsWith(new RuntimeException("Permanent failure"))
+        _ <- repo.moveToDeadLetter.failsWith(new RuntimeException("write failed"))
+
+        fiberRef <- Ref.make(Option.empty[Fiber.Runtime[Nothing, Unit]])
+        semaphore <- Semaphore.make(1)
+        processor = UserOutboxProcessor.Live(config, repo, client, fiberRef, semaphore)
+        _ <- processor.processOnce
+        logs <- ZTestLogger.logOutput
+      yield assertTrue(
+        logs.exists(e => e.logLevel == zio.LogLevel.Error && e.message() == "moveToDeadLetter failed"),
+      )
+    },
+    test("logs an error but still fails when rescheduleEvent itself fails") {
+      val repo = stub[UserRepository]
+      val client = stub[AuthClient]
+
+      for
+        _ <- repo.claimDueEvents.succeedsWith(Vector(record))
+        _ <- client.upsertUser.failsWith(new RuntimeException("Auth call failed"))
+        _ <- repo.rescheduleEvent.failsWith(new RuntimeException("write failed"))
+
+        fiberRef <- Ref.make(Option.empty[Fiber.Runtime[Nothing, Unit]])
+        semaphore <- Semaphore.make(1)
+        processor = UserOutboxProcessor.Live(config, repo, client, fiberRef, semaphore)
+        _ <- processor.processOnce
+        logs <- ZTestLogger.logOutput
+      yield assertTrue(
+        logs.exists(e => e.logLevel == zio.LogLevel.Error && e.message() == "reschedule failed"),
+      )
+    },
+    test("logs an error but still reports success when deleteEvent fails after a successful dispatch") {
+      val repo = stub[UserRepository]
+      val client = stub[AuthClient]
+
+      for
+        _ <- repo.claimDueEvents.succeedsWith(Vector(record))
+        _ <- client.upsertUser.succeedsWith(())
+        _ <- repo.deleteEvent.failsWith(new RuntimeException("delete failed"))
+
+        fiberRef <- Ref.make(Option.empty[Fiber.Runtime[Nothing, Unit]])
+        semaphore <- Semaphore.make(1)
+        processor = UserOutboxProcessor.Live(config, repo, client, fiberRef, semaphore)
+        _ <- processor.processOnce
+        logs <- ZTestLogger.logOutput
+      yield assertTrue(
+        logs.exists(e => e.logLevel == zio.LogLevel.Error && e.message() == "delete failed"),
+      )
+    },
+    test("dispatch routes UpdateUserRoles and DeleteUser events to the matching AuthClient calls") {
+      val tenantId = TenantId("tenant-a")
+      val roleId = RoleId("admin")
+      val rolesEvent = record.copy(event = OutboxEvent.UpdateUserRoles(userId, tenantId, Set(roleId), Set.empty))
+      val deleteEvent = record.copy(id = UUID.fromString("00000000-0000-0000-0000-000000000098"), event = OutboxEvent.DeleteUser(userId))
+      val repo = stub[UserRepository]
+      val client = stub[AuthClient]
+
+      for
+        _ <- repo.claimDueEvents.succeedsWith(Vector(rolesEvent, deleteEvent))
+        _ <- client.updateUserRoles.succeedsWith(())
+        _ <- client.deleteUser.succeedsWith(())
+        _ <- repo.deleteEvent.succeedsWith(())
+
+        fiberRef <- Ref.make(Option.empty[Fiber.Runtime[Nothing, Unit]])
+        semaphore <- Semaphore.make(1)
+        processor = UserOutboxProcessor.Live(config, repo, client, fiberRef, semaphore)
+        _ <- processor.processOnce
+      yield assertTrue(
+        client.updateUserRoles.calls == List((userId, tenantId, Set(roleId), Set.empty)),
+        client.deleteUser.calls == List(userId),
+      )
+    },
+    test("start forks a background poll loop that runs after the initial delay") {
+      val repo = stub[UserRepository]
+      val client = stub[AuthClient]
+
+      for
+        _ <- repo.claimDueEvents.succeedsWith(Vector.empty)
+        fiberRef <- Ref.make(Option.empty[Fiber.Runtime[Nothing, Unit]])
+        semaphore <- Semaphore.make(1)
+        processor = UserOutboxProcessor.Live(config, repo, client, fiberRef, semaphore)
+        _ <- ZIO.scoped(processor.start() *> TestClock.adjust(Duration.fromSeconds(20)) *> TestClock.adjust(config.pollInterval))
+        fiber <- fiberRef.get
+      yield assertTrue(fiber.isDefined, repo.claimDueEvents.calls.nonEmpty)
+    },
+    test("stop interrupts the running background fiber") {
+      val repo = stub[UserRepository]
+      val client = stub[AuthClient]
+
+      for
+        _ <- repo.claimDueEvents.succeedsWith(Vector.empty)
+        fiberRef <- Ref.make(Option.empty[Fiber.Runtime[Nothing, Unit]])
+        semaphore <- Semaphore.make(1)
+        processor = UserOutboxProcessor.Live(config, repo, client, fiberRef, semaphore)
+        stillRunning <- ZIO.scoped:
+          for
+            _ <- processor.start()
+            _ <- TestClock.adjust(Duration.fromSeconds(20))
+            _ <- processor.stop()
+            fiberAfterStop <- fiberRef.get
+            status <- ZIO.foreach(fiberAfterStop)(_.status)
+          yield status.exists(_ != zio.Fiber.Status.Done)
+      yield assertTrue(!stillRunning)
+    },
     test("moves event to dead letter when max attempts exceeded") {
       val failedRecord = record.copy(attempts = config.maxAttempts - 1)
       val repo = stub[UserRepository]


### PR DESCRIPTION
## Context

Phase 4 of the coverage push tracked in #243 (Phase 1: sync clients/thin wrappers) and #244 (Phase 3: auth-core validation/crypto). This PR targets central's user-facing controllers/services called out in #243's roadmap: `UserController`, `AuthClient`, `OAuthClientService`, `UserOutboxProcessor`.

Note: branched from `main` directly (like #244), so the baseline here is 80.87%, not #243's 82.82%. These numbers aren't additive by simple arithmetic -- whichever of #243/#244/this PR merges last will show a smaller aggregate delta since the other phases' gains are already landed.

**Aggregate: 80.87% -> 81.70% statements, verified via a from-clean `sbt coverage test coverageReport coverageAggregate`. All 8 modules green, 0 test failures. central module: 79.74% -> 83.38%.**

## What's covered

- **UserControllerSpec**: brought `UserController` to 100% statement coverage (219/219), including the phone-number search endpoint -- which needed a real bug fix: URL-encoding the `+` in E.164 phone numbers so the query param round-trips through `URL.decode` intact -- and every remaining error-path branch.
- **AuthClientSpec**: added `send`/`sendReceive`/`sendReceiveOptional` failure paths shared by every `AuthClient` method -- a non-2xx status surfacing the response body in the error message, and a 200 response whose body isn't valid JSON -- none of which any existing test exercised despite being common to every call.
- **OAuthClientServiceSpec**: `getAllClients`, `verifySecret` (current secret, previous secret, mismatch, no central-admin client cached), the `logoUri`/`policyUri`/`tosUri` consent-URL validation (both accept and reject branches -- previously only exercised indirectly via `frontChannelLogoutUri`/`backChannelLogoutUri`, which go through a different validator function), a relative (non-absolute) `frontChannelLogoutUri`, and clearing `frontChannelLogoutUri`/`consentFlow` via an explicit `Patch.Deleted`.
- **UserOutboxProcessorSpec**: `start()`/`stop()` (forking and interrupting the background poll fiber -- previously untested despite being the whole point of the service), `processOnce`'s top-level `catchAllCause` when `claimDueEvents` itself fails, the `moveToDeadLetter`/`rescheduleEvent`/`deleteEvent` inner `catchAllCause` branches for when those repository calls themselves fail (as opposed to the dispatch they're recovering from), and `dispatch`'s `UpdateUserRoles`/`DeleteUser` branches (previously every test only ever dispatched `UpsertUser`).

## Deliberately skipped

Same policy as #243/#244: `ZLayer.fromFunction`/`live` DI-wiring lines (multi-arg constructor calls scoverage attributes to the `object`, not the class) aren't worth an integration test on their own -- e.g. `OAuthClientService.live`, `UserOutboxProcessor.live`. A recurring scoverage quirk also misattributes some individual named-argument lines inside multi-line case-class/method-call construction (e.g. `OAuthClientRecord(...)`, `clientRepository.updateClient(...)`) as separately "uncovered" even when the enclosing call is exercised by many passing tests and every other line of the same call is marked covered -- confirmed by testing the exact same construction through many different code paths without those specific lines ever flipping to covered. Left alone rather than chased.

## Testing

Same sandbox as #243 (JDK 17, sbt 1.12.5, Postgres 15). Ran `sbt clean coverage util/test util-postgres/test auth/test auth-postgres-impl/test edge/test edge-postgres-impl/test central/test central-postgres-impl/test coverageReport coverageAggregate` against local Postgres end to end: 0 failures, 81.70% aggregate.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M1R187HGTGCA8J95BYK714XK&panel=chat)