### PR TITLE
test: bring ConversationService.Impl to near-100% statement coverage (Phase 2)

### DIFF
--- a/auth/src/test/scala/versola/oauth/conversation/ConversationControllerSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/ConversationControllerSpec.scala
@@ -2,13 +2,13 @@ package versola.oauth.conversation
 
 import org.scalamock.stubs.Stub
 import versola.auth.TestEnvConfig
-import versola.auth.model.{OtpCode, Password}
-import versola.user.model.Login
+import versola.auth.model.{OtpCode, PasskeyName, Password}
 import versola.oauth.client.OAuthConfigurationService
-import versola.oauth.jwks.JwksService
 import versola.oauth.client.model.{AuthFlow, ClientId, ScopeToken}
 import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep, Error}
+import versola.oauth.jwks.JwksService
 import versola.oauth.model.{CodeChallenge, CodeChallengeMethod, ConversationCookie}
+import versola.user.model.Login
 import versola.util.http.{ControllerSpec, NoopTracing, Observability}
 import versola.util.{Email, Phone, UnitSpecBase}
 import zio.*
@@ -67,7 +67,15 @@ object ConversationControllerSpec extends UnitSpecBase:
     state = None,
     userId = None,
     credential = None,
-    step = ConversationStep.Otp(real = None, timesRequested = 1, timesSubmitted = 0, factorIndex = 0, rateLimitExceeded = false, lockedSeconds = 0, lastSentAt = None),
+    step = ConversationStep.Otp(
+      real = None,
+      timesRequested = 1,
+      timesSubmitted = 0,
+      factorIndex = 0,
+      rateLimitExceeded = false,
+      lockedSeconds = 0,
+      lastSentAt = None,
+    ),
     requestedClaims = None,
     uiLocales = None,
     nonce = None,
@@ -126,8 +134,8 @@ object ConversationControllerSpec extends UnitSpecBase:
                   ++ ZEnvironment(configuration)
                   ++ formService
                   ++ tracing,
-              )
-          )
+              ),
+          ),
         )
         _ <- configuration.getAllowedPhonePrefixes.succeedsWith(List.empty)
         _ <- configuration.getPasswordRegex.succeedsWith(".*")
@@ -175,8 +183,8 @@ object ConversationControllerSpec extends UnitSpecBase:
                   ++ ZEnvironment(configuration)
                   ++ formService
                   ++ tracing,
-              )
-          )
+              ),
+          ),
         )
         _ <- configuration.getPasswordRegex.succeedsWith(passwordRegex)
         _ <- configuration.getIpHeader.succeedsWith("X-Real-IP")
@@ -196,7 +204,7 @@ object ConversationControllerSpec extends UnitSpecBase:
         url = URL.empty / "challenge" / "email",
         body = Body.fromURLEncodedForm(
           Form(FormField.Text("email", email, MediaType.text.plain), FormField.Text("csrf", "", MediaType.text.plain)),
-        )
+        ),
       ).addHeader(conversationCookie),
       submission = (authId, EmailSubmission(email, ""), None, None),
     ),
@@ -206,7 +214,7 @@ object ConversationControllerSpec extends UnitSpecBase:
         url = URL.empty / "challenge" / "phone",
         body = Body.fromURLEncodedForm(
           Form.fromStrings("phone" -> phone, "csrf" -> ""),
-        )
+        ),
       ).addHeader(conversationCookie),
       submission = (authId, PhoneSubmission(phone, ""), None, None),
     ),
@@ -216,7 +224,7 @@ object ConversationControllerSpec extends UnitSpecBase:
         url = URL.empty / "challenge" / "otp",
         body = Body.fromURLEncodedForm(
           Form.fromStrings("code" -> otpCode.toString, "csrf" -> ""),
-        )
+        ),
       ).addHeader(conversationCookie),
       submission = (authId, OtpSubmission(otpCode, ""), None, None),
     ),
@@ -226,7 +234,7 @@ object ConversationControllerSpec extends UnitSpecBase:
         url = URL.empty / "challenge" / "otp" / "resend",
         body = Body.fromURLEncodedForm(
           Form.fromStrings("csrf" -> ""),
-        )
+        ),
       ).addHeader(conversationCookie),
       submission = (authId, OtpResendSubmission(""), None, None),
     ),
@@ -236,7 +244,7 @@ object ConversationControllerSpec extends UnitSpecBase:
         url = (URL.empty / "challenge" / "otp").addQueryParam("ui_locale", "ru"),
         body = Body.fromURLEncodedForm(
           Form.fromStrings("code" -> otpCode.toString, "csrf" -> ""),
-        )
+        ),
       ).addHeader(conversationCookie),
       submission = (authId, OtpSubmission(otpCode, ""), Some("ru"), None),
     ),
@@ -246,7 +254,7 @@ object ConversationControllerSpec extends UnitSpecBase:
         url = URL.empty / "challenge" / "otp",
         body = Body.fromURLEncodedForm(
           Form.fromStrings("code" -> otpCode.toString, "csrf" -> ""),
-        )
+        ),
       ).addHeader(conversationCookie).addHeader("X-Real-IP", "9.9.9.9"),
       submission = (authId, OtpSubmission(otpCode, ""), None, Some("9.9.9.9")),
     ),
@@ -256,7 +264,7 @@ object ConversationControllerSpec extends UnitSpecBase:
         url = URL.empty / "challenge" / "otp",
         body = Body.fromURLEncodedForm(
           Form.fromStrings("code" -> otpCode.toString, "csrf" -> ""),
-        )
+        ),
       ).addHeader(conversationCookie).addHeader("X-Forwarded-For", "7.7.7.7, 10.0.0.1"),
       submission = (authId, OtpSubmission(otpCode, ""), None, Some("7.7.7.7")),
       ipHeader = "X-Forwarded-For",
@@ -267,7 +275,7 @@ object ConversationControllerSpec extends UnitSpecBase:
         url = URL.empty / "challenge" / "otp",
         body = Body.fromURLEncodedForm(
           Form.fromStrings("code" -> otpCode.toString, "csrf" -> ""),
-        )
+        ),
       ).addHeader(conversationCookie),
       submission = (authId, OtpSubmission(otpCode, ""), None, None),
     ),
@@ -277,7 +285,7 @@ object ConversationControllerSpec extends UnitSpecBase:
         url = URL.empty / "challenge" / "otp",
         body = Body.fromURLEncodedForm(
           Form.fromStrings("code" -> otpCode.toString, "csrf" -> ""),
-        )
+        ),
       ).addHeader(conversationCookie).addHeader("X-Real-IP", "9.9.9.9"),
       submission = (authId, OtpSubmission(otpCode, ""), None, None),
       ipHeader = "X-Forwarded-For",
@@ -288,10 +296,274 @@ object ConversationControllerSpec extends UnitSpecBase:
         url = URL.empty / "challenge" / "login-password",
         body = Body.fromURLEncodedForm(
           Form.fromStrings("login" -> "user", "password" -> "s3cret", "csrf" -> ""),
-        )
+        ),
       ).addHeader(conversationCookie),
       submission = (authId, LoginPasswordSubmission(Login("user"), Password("s3cret"), ""), None, None),
     ),
+    successfulSubmitTestCase(
+      description = "submit passkey assertion",
+      request = Request.post(
+        url = URL.empty / "challenge" / "passkey",
+        body = Body.fromURLEncodedForm(
+          Form.fromStrings("response" -> "{\"id\":\"cred-1\"}", "csrf" -> ""),
+        ),
+      ).addHeader(conversationCookie),
+      submission = (authId, PasskeyAssertionSubmission("{\"id\":\"cred-1\"}", ""), None, None),
+    ),
+    successfulSubmitTestCase(
+      description = "submit passkey enroll",
+      request = Request.post(
+        url = URL.empty / "challenge" / "passkey" / "enroll",
+        body = Body.fromURLEncodedForm(
+          Form.fromStrings("response" -> "{\"id\":\"cred-1\"}", "name" -> "My Phone", "csrf" -> ""),
+        ),
+      ).addHeader(conversationCookie),
+      submission = (authId, PasskeyEnrollSubmission("{\"id\":\"cred-1\"}", PasskeyName("My Phone"), ""), None, None),
+    ),
+    successfulSubmitTestCase(
+      description = "submit passkey skip",
+      request = Request.post(
+        url = URL.empty / "challenge" / "passkey" / "skip",
+        body = Body.fromURLEncodedForm(Form.fromStrings("csrf" -> "")),
+      ).addHeader(conversationCookie),
+      submission = (authId, PasskeySkipSubmission(""), None, None),
+    ),
+    successfulSubmitTestCase(
+      description = "submit set-password",
+      request = Request.post(
+        url = URL.empty / "challenge" / "set-password",
+        body = Body.fromURLEncodedForm(
+          Form.fromStrings("password" -> "s3cret!", "csrf" -> ""),
+        ),
+      ).addHeader(conversationCookie),
+      submission = (authId, SetPasswordSubmission(Password("s3cret!"), ""), None, None),
+    ),
+    successfulSubmitTestCase(
+      description = "submit consent allow with the selected scope",
+      request = Request.post(
+        url = URL.empty / "challenge" / "consent",
+        body = Body.fromURLEncodedForm(
+          Form.fromStrings("scope" -> "profile email", "csrf" -> ""),
+        ),
+      ).addHeader(conversationCookie),
+      submission = (authId, ConsentAllowSubmission(Set(ScopeToken("profile"), ScopeToken("email")), ""), None, None),
+    ),
+    successfulSubmitTestCase(
+      description = "submit consent allow with no scope selected",
+      request = Request.post(
+        url = URL.empty / "challenge" / "consent",
+        body = Body.fromURLEncodedForm(Form.fromStrings("csrf" -> "")),
+      ).addHeader(conversationCookie),
+      submission = (authId, ConsentAllowSubmission(Set.empty, ""), None, None),
+    ),
+    successfulSubmitTestCase(
+      description = "submit consent deny",
+      request = Request.post(
+        url = URL.empty / "challenge" / "consent" / "deny",
+        body = Body.fromURLEncodedForm(Form.fromStrings("csrf" -> "")),
+      ).addHeader(conversationCookie),
+      submission = (authId, ConsentDenySubmission(""), None, None),
+    ),
+    test("GET /challenge sends the render service's ETag when If-None-Match is present") {
+      for
+        client <- ZIO.service[Client]
+        router = stub[ConversationRouter]
+        configuration = stub[OAuthConfigurationService]
+        renderService = stub[ConversationRenderService]
+        tracing <- NoopTracing.layer.build
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            ConversationController.routes.provideEnvironment(
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
+        )
+        _ <- router.getConversation.succeedsWith(Some(record))
+        _ <- renderService.renderStep.succeedsWith(Response.text("<html>Step</html>"))
+
+        response <- client.batched(
+          Request.get(URL.empty / "challenge")
+            .addHeader(conversationCookie)
+            .addHeader(Header.IfNoneMatch.ETags(NonEmptyChunk("\"abc\""))),
+        )
+        calls = renderService.renderStep.calls
+      yield assertTrue(
+        response.status == Status.Ok,
+        calls == List((record, Some("\"abc\""), None)),
+      )
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
+    test("GET /challenge renders conversation expired when the lookup fails with ConversationExpired") {
+      for
+        client <- ZIO.service[Client]
+        router = stub[ConversationRouter]
+        configuration = stub[OAuthConfigurationService]
+        renderService = stub[ConversationRenderService]
+        tracing <- NoopTracing.layer.build
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            ConversationController.routes.provideEnvironment(
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
+        )
+        _ <- router.getConversation.failsWith(Error.ConversationExpired)
+        _ <- renderService.renderExpired.succeedsWith(Response.text("<html>Expired</html>"))
+
+        response <- client.batched(Request.get(URL.empty / "challenge").addHeader(conversationCookie))
+        body <- response.body.asString
+      yield assertTrue(response.status == Status.Ok, body == "<html>Expired</html>")
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
+    test("GET /challenge returns 400 when the lookup fails with a plain Error") {
+      for
+        client <- ZIO.service[Client]
+        router = stub[ConversationRouter]
+        configuration = stub[OAuthConfigurationService]
+        renderService = stub[ConversationRenderService]
+        tracing <- NoopTracing.layer.build
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            ConversationController.routes.provideEnvironment(
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
+        )
+        _ <- router.getConversation.failsWith(Error.BadRequest)
+
+        response <- client.batched(Request.get(URL.empty / "challenge").addHeader(conversationCookie))
+      yield assertTrue(response.status == Status.BadRequest)
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
+    test("GET /challenge surfaces an unexpected failure as 500") {
+      for
+        client <- ZIO.service[Client]
+        router = stub[ConversationRouter]
+        configuration = stub[OAuthConfigurationService]
+        renderService = stub[ConversationRenderService]
+        tracing <- NoopTracing.layer.build
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            ConversationController.routes.provideEnvironment(
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
+        )
+        _ <- router.getConversation.failsWith(new RuntimeException("boom"))
+
+        response <- client.batched(Request.get(URL.empty / "challenge").addHeader(conversationCookie))
+      yield assertTrue(response.status == Status.InternalServerError)
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
+    test("POST /challenge renders conversation expired when submit fails with ConversationExpired") {
+      for
+        client <- ZIO.service[Client]
+        router = stub[ConversationRouter]
+        configuration = stub[OAuthConfigurationService]
+        renderService = stub[ConversationRenderService]
+        tracing <- NoopTracing.layer.build
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            ConversationController.routes.provideEnvironment(
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
+        )
+        _ <- configuration.getIpHeader.succeedsWith("X-Real-IP")
+        _ <- router.submit.failsWith(Error.ConversationExpired)
+        _ <- renderService.renderExpired.succeedsWith(Response.text("<html>Expired</html>"))
+
+        response <- client.batched(
+          Request.post(
+            url = URL.empty / "challenge" / "email",
+            body = Body.fromURLEncodedForm(Form.fromStrings("email" -> email, "csrf" -> "")),
+          ).addHeader(conversationCookie),
+        )
+        body <- response.body.asString
+      yield assertTrue(response.status == Status.Ok, body == "<html>Expired</html>")
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
+    test("POST /challenge surfaces an unexpected submit failure as 500") {
+      for
+        client <- ZIO.service[Client]
+        router = stub[ConversationRouter]
+        configuration = stub[OAuthConfigurationService]
+        renderService = stub[ConversationRenderService]
+        tracing <- NoopTracing.layer.build
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            ConversationController.routes.provideEnvironment(
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
+        )
+        _ <- configuration.getIpHeader.succeedsWith("X-Real-IP")
+        _ <- router.submit.failsWith(new RuntimeException("boom"))
+
+        response <- client.batched(
+          Request.post(
+            url = URL.empty / "challenge" / "email",
+            body = Body.fromURLEncodedForm(Form.fromStrings("email" -> email, "csrf" -> "")),
+          ).addHeader(conversationCookie),
+        )
+      yield assertTrue(response.status == Status.InternalServerError)
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
+    test("requests without a conversation cookie are rejected with 400") {
+      for
+        client <- ZIO.service[Client]
+        router = stub[ConversationRouter]
+        configuration = stub[OAuthConfigurationService]
+        renderService = stub[ConversationRenderService]
+        tracing <- NoopTracing.layer.build
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            ConversationController.routes.provideEnvironment(
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
+        )
+        response <- client.batched(Request.get(URL.empty / "challenge"))
+      yield assertTrue(response.status == Status.BadRequest)
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
+    test("GET /challenge/passkey/options returns 400 when the router yields no options") {
+      for
+        client <- ZIO.service[Client]
+        router = stub[ConversationRouter]
+        configuration = stub[OAuthConfigurationService]
+        renderService = stub[ConversationRenderService]
+        tracing <- NoopTracing.layer.build
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            ConversationController.routes.provideEnvironment(
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
+        )
+        _ <- router.startPasskeyOptions.succeedsWith(None)
+
+        response <- client.batched(Request.get(URL.empty / "challenge" / "passkey" / "options").addHeader(conversationCookie))
+      yield assertTrue(
+        response.status == Status.BadRequest,
+        response.headers.get(Header.CacheControl).contains(Header.CacheControl.NoStore),
+      )
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
+    test("GET /challenge/passkey/options returns 500 with no-store when the lookup fails with ServiceUnavailable") {
+      for
+        client <- ZIO.service[Client]
+        router = stub[ConversationRouter]
+        configuration = stub[OAuthConfigurationService]
+        renderService = stub[ConversationRenderService]
+        tracing <- NoopTracing.layer.build
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            ConversationController.routes.provideEnvironment(
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
+        )
+        _ <- router.startPasskeyOptions.failsWith(Error.ServiceUnavailable)
+
+        response <- client.batched(Request.get(URL.empty / "challenge" / "passkey" / "options").addHeader(conversationCookie))
+      yield assertTrue(
+        response.status == Status.InternalServerError,
+        response.headers.get(Header.CacheControl).contains(Header.CacheControl.NoStore),
+      )
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
     test("POST /challenge renders service unavailable when conversation lookup fails") {
       for
         client <- ZIO.service[Client]
@@ -302,9 +574,9 @@ object ConversationControllerSpec extends UnitSpecBase:
         _ <- TestClient.addRoutes(
           Observability.handleErrors(
             ConversationController.routes.provideEnvironment(
-              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing
-            )
-          )
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
         )
         _ <- configuration.getIpHeader.succeedsWith("X-Real-IP")
         _ <- router.submit.failsWith(Error.ServiceUnavailable)
@@ -314,7 +586,7 @@ object ConversationControllerSpec extends UnitSpecBase:
           Request.post(
             url = URL.empty / "challenge" / "email",
             body = Body.fromURLEncodedForm(Form.fromStrings("email" -> email, "csrf" -> "test-csrf")),
-          ).addHeader(conversationCookie)
+          ).addHeader(conversationCookie),
         )
         body <- response.body.asString
       yield assertTrue(
@@ -333,9 +605,9 @@ object ConversationControllerSpec extends UnitSpecBase:
         _ <- TestClient.addRoutes(
           Observability.handleErrors(
             ConversationController.routes.provideEnvironment(
-              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing
-            )
-          )
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
         )
         _ <- router.getConversation.succeedsWith(Some(record))
         _ <- renderService.renderStep.succeedsWith(Response.text("<html>Step</html>"))
@@ -343,10 +615,9 @@ object ConversationControllerSpec extends UnitSpecBase:
         response <- client.batched(Request.get(URL.empty / "challenge").addHeader(conversationCookie))
       yield assertTrue(
         response.status == Status.Ok,
-        response.headers.get(Header.ContentType).exists(_.mediaType == MediaType.text.plain) // text() defaults to text/plain in tests
+        response.headers.get(Header.ContentType).exists(_.mediaType == MediaType.text.plain), // text() defaults to text/plain in tests
       )
     }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
-
     test("GET /challenge renders conversation expired when the record is missing") {
       for
         client <- ZIO.service[Client]
@@ -357,9 +628,9 @@ object ConversationControllerSpec extends UnitSpecBase:
         _ <- TestClient.addRoutes(
           Observability.handleErrors(
             ConversationController.routes.provideEnvironment(
-              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing
-            )
-          )
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
         )
         _ <- router.getConversation.succeedsWith(None)
         _ <- renderService.renderExpired.succeedsWith(Response.text("<html>Expired</html>"))
@@ -372,7 +643,6 @@ object ConversationControllerSpec extends UnitSpecBase:
         renderService.renderExpired.calls == List((clientId, "https://example.com/callback", Some("test-state"), false)),
       )
     }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
-
     test("GET /challenge renders service unavailable when conversation lookup fails") {
       for
         client <- ZIO.service[Client]
@@ -383,9 +653,9 @@ object ConversationControllerSpec extends UnitSpecBase:
         _ <- TestClient.addRoutes(
           Observability.handleErrors(
             ConversationController.routes.provideEnvironment(
-              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing
-            )
-          )
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
         )
         _ <- router.getConversation.failsWith(Error.ServiceUnavailable)
         _ <- renderService.renderServiceUnavailable.succeedsWith(Response.text("<html>Unavailable</html>"))
@@ -398,7 +668,6 @@ object ConversationControllerSpec extends UnitSpecBase:
         renderService.renderServiceUnavailable.calls == List((clientId, "https://example.com/callback", Some("test-state"), false)),
       )
     }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
-
     test("GET /challenge/passkey/options returns options") {
       for
         client <- ZIO.service[Client]
@@ -409,9 +678,9 @@ object ConversationControllerSpec extends UnitSpecBase:
         _ <- TestClient.addRoutes(
           Observability.handleErrors(
             ConversationController.routes.provideEnvironment(
-              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing
-            )
-          )
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
         )
         _ <- router.startPasskeyOptions.succeedsWith(Some("{\"opt\":1}"))
 
@@ -422,7 +691,6 @@ object ConversationControllerSpec extends UnitSpecBase:
         response.headers.get(Header.CacheControl).contains(Header.CacheControl.NoStore),
       )
     }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
-
     test("GET /challenge/passkey/options returns 410 with no-store when conversation expired") {
       for
         client <- ZIO.service[Client]
@@ -433,9 +701,9 @@ object ConversationControllerSpec extends UnitSpecBase:
         _ <- TestClient.addRoutes(
           Observability.handleErrors(
             ConversationController.routes.provideEnvironment(
-              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing
-            )
-          )
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
         )
         _ <- router.startPasskeyOptions.failsWith(Error.ConversationExpired)
 
@@ -445,7 +713,6 @@ object ConversationControllerSpec extends UnitSpecBase:
         response.headers.get(Header.CacheControl).contains(Header.CacheControl.NoStore),
       )
     }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
-
     test("GET /challenge/passkey/options returns 500 with no-store on unexpected failure") {
       for
         client <- ZIO.service[Client]
@@ -456,9 +723,9 @@ object ConversationControllerSpec extends UnitSpecBase:
         _ <- TestClient.addRoutes(
           Observability.handleErrors(
             ConversationController.routes.provideEnvironment(
-              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing
-            )
-          )
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
         )
         _ <- router.startPasskeyOptions.failsWith(new RuntimeException("boom"))
 
@@ -468,13 +735,111 @@ object ConversationControllerSpec extends UnitSpecBase:
         response.headers.get(Header.CacheControl).contains(Header.CacheControl.NoStore),
       )
     }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
+    test("reject password that fails the configured regex, once the request itself is well-formed") {
+      for
+        client <- ZIO.service[Client]
+        router = stub[ConversationRouter]
+        configuration = stub[OAuthConfigurationService]
+        renderService = stub[ConversationRenderService]
+        tracing <- NoopTracing.layer.build
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            ConversationController.routes.provideEnvironment(
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
+        )
+        _ <- configuration.getIpHeader.succeedsWith("X-Real-IP")
+        _ <- configuration.getPasswordRegex.succeedsWith("^[0-9]+$")
+
+        response <- client.batched(
+          Request.post(
+            url = URL.empty / "challenge" / "password",
+            body = Body.fromURLEncodedForm(Form.fromStrings("password" -> "abc", "csrf" -> "")),
+          ).addHeader(conversationCookie),
+        )
+      yield assertTrue(response.status == Status.BadRequest, router.submit.calls.isEmpty)
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
+    test("reject a phone number that doesn't match any configured prefix, once the request itself is well-formed") {
+      for
+        client <- ZIO.service[Client]
+        router = stub[ConversationRouter]
+        configuration = stub[OAuthConfigurationService]
+        renderService = stub[ConversationRenderService]
+        tracing <- NoopTracing.layer.build
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            ConversationController.routes.provideEnvironment(
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
+        )
+        _ <- configuration.getIpHeader.succeedsWith("X-Real-IP")
+        _ <- configuration.getAllowedPhonePrefixes.succeedsWith(List("+44"))
+
+        response <- client.batched(
+          Request.post(
+            url = URL.empty / "challenge" / "phone",
+            body = Body.fromURLEncodedForm(Form.fromStrings("phone" -> phone, "csrf" -> "")),
+          ).addHeader(conversationCookie),
+        )
+      yield assertTrue(response.status == Status.BadRequest, router.submit.calls.isEmpty)
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
+    test("accepts a password when the configured regex is invalid, failing open") {
+      for
+        client <- ZIO.service[Client]
+        router = stub[ConversationRouter]
+        configuration = stub[OAuthConfigurationService]
+        renderService = stub[ConversationRenderService]
+        tracing <- NoopTracing.layer.build
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            ConversationController.routes.provideEnvironment(
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
+        )
+        _ <- configuration.getIpHeader.succeedsWith("X-Real-IP")
+        _ <- configuration.getPasswordRegex.succeedsWith("[") // invalid regex syntax
+        _ <- router.submit.succeedsWith((conversationResult, record))
+        _ <- renderService.renderSubmit.succeedsWith(Response.seeOther(URL.decode("/challenge").toOption.get))
+
+        response <- client.batched(
+          Request.post(
+            url = URL.empty / "challenge" / "password",
+            body = Body.fromURLEncodedForm(Form.fromStrings("password" -> "abc", "csrf" -> "")),
+          ).addHeader(conversationCookie),
+        )
+      yield assertTrue(response.status == Status.SeeOther, router.submit.calls.nonEmpty)
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
+    test("GET /challenge with a malformed conversation cookie is rejected with 400") {
+      for
+        client <- ZIO.service[Client]
+        router = stub[ConversationRouter]
+        configuration = stub[OAuthConfigurationService]
+        renderService = stub[ConversationRenderService]
+        tracing <- NoopTracing.layer.build
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            ConversationController.routes.provideEnvironment(
+              ZEnvironment(router) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(configuration) ++ ZEnvironment(renderService) ++ tracing,
+            ),
+          ),
+        )
+        response <- client.batched(
+          Request.get(URL.empty / "challenge").addHeader(
+            Header.Cookie(NonEmptyChunk(Cookie.Request(ConversationCookie.name, "not-a-valid-cookie"))),
+          ),
+        )
+      yield assertTrue(response.status == Status.BadRequest)
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
     rejectedSubmitTestCase(
       description = "reject login-password violating configured password regex",
       request = Request.post(
         url = URL.empty / "challenge" / "login-password",
         body = Body.fromURLEncodedForm(
           Form.fromStrings("login" -> "user", "password" -> "abc"),
-        )
+        ),
       ).addHeader(conversationCookie),
     ),
     rejectedSubmitTestCase(
@@ -483,7 +848,7 @@ object ConversationControllerSpec extends UnitSpecBase:
         url = URL.empty / "challenge" / "password",
         body = Body.fromURLEncodedForm(
           Form.fromStrings("password" -> "abc"),
-        )
+        ),
       ).addHeader(conversationCookie),
     ),
   )

--- a/auth/src/test/scala/versola/oauth/conversation/ConversationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/ConversationServiceSpec.scala
@@ -1,31 +1,31 @@
 package versola.oauth.conversation
 
 import versola.auth.TestEnvConfig
-import versola.auth.model.{CredentialId, CredentialDeviceType, OtpCode, PasskeyRecord, Password}
+import versola.auth.model.{CredentialDeviceType, CredentialId, OtpCode, PasskeyRecord, Password}
 import versola.oauth.authorize.AcrResolutionService
 import versola.oauth.authorize.model.{Prompt, ResponseTypeEntry}
-import versola.oauth.consent.ConsentDecision
-import zio.prelude.NonEmptyList
 import versola.oauth.challenge.passkey.PasskeyRepository
 import versola.oauth.challenge.password.PasswordService
 import versola.oauth.challenge.password.model.CheckPassword
 import versola.oauth.client.OAuthConfigurationService
 import versola.oauth.client.model.*
+import versola.oauth.consent.ConsentDecision
 import versola.oauth.conversation.limit.{ChallengeType, LimitStatus, SubmissionLimiter}
 import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep}
 import versola.oauth.conversation.otp.OtpService
 import versola.oauth.conversation.otp.model.SubmitOtpResult
 import versola.oauth.model.*
-import versola.oauth.session.{SessionRepository, UserAgentRepository}
-import versola.oauth.session.model.PriorSession
 import versola.oauth.session.model.*
+import versola.oauth.session.model.PriorSession
+import versola.oauth.session.{SessionRepository, UserAgentRepository}
 import versola.oauth.token.AuthorizationCodeRepository
 import versola.oauth.userinfo.UserInfoService
-import versola.user.{UserRepository, UserService}
 import versola.user.model.*
+import versola.user.{UserRepository, UserService}
 import versola.util.*
 import zio.*
 import zio.json.ast.Json
+import zio.prelude.NonEmptyList
 import zio.test.*
 
 import java.time.Instant
@@ -47,7 +47,7 @@ object ConversationServiceSpec extends UnitSpecBase:
     phone = None,
     login = Some(Login("testuser")),
     claims = Json.Obj("name" -> Json.Str("Test User")),
-    uiLocales = None
+    uiLocales = None,
   )
 
   private val conversationRecord = ConversationRecord(
@@ -73,7 +73,7 @@ object ConversationServiceSpec extends UnitSpecBase:
     registrationStep = None,
     userAgent = None,
     userAgentCookie = None,
-        version = 1,
+    version = 1,
     amr = Map.empty,
     needsPasswordChange = false,
     targetAcr = None,
@@ -197,6 +197,15 @@ object ConversationServiceSpec extends UnitSpecBase:
     yield ()
 
   def spec = suite("ConversationService")(
+    suite("find")(
+      test("delegates to the conversation repository") {
+        val env = Env()
+        for
+          _ <- env.conversationRepository.find.succeedsWith(Some(conversationRecord))
+          result <- env.service.find(authId)
+        yield assertTrue(result == Some(conversationRecord), env.conversationRepository.find.calls == List(authId))
+      },
+    ),
     suite("prepareInitialOtp")(
       test("prepares and sends OTP when allowed") {
         val env = Env()
@@ -222,8 +231,7 @@ object ConversationServiceSpec extends UnitSpecBase:
             Left(email),
             0,
           )
-        yield
-          assertTrue(result == ConversationResult.RenderStep(otpStep))
+        yield assertTrue(result == ConversationResult.RenderStep(otpStep))
       },
       test("denies access when rate limited") {
         val env = Env()
@@ -231,9 +239,8 @@ object ConversationServiceSpec extends UnitSpecBase:
           _ <- env.submissionLimiter.statusFor.succeedsWith(LimitStatus.Banned)
           _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.prepareInitialOtp(authId, conversationRecord, Left(email), 0)
-        yield
-          assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
-      }
+        yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
+      },
     ),
     suite("startRegistration")(
       test("enters the flow without creating or reserving an account") {
@@ -322,6 +329,17 @@ object ConversationServiceSpec extends UnitSpecBase:
           env.userService.register.calls.map(_._3) == List(roleIds),
         )
       },
+      test("reports a write conflict when the conversation moved on") {
+        val env = Env()
+        val pending = registrationConversation.copy(registrationStep = Some(1))
+        val newUser = UserRecord(userId, Some(email), None, None, Json.Obj(), None)
+        for
+          _ <- env.configService.get.succeedsWith(registrationClient)
+          _ <- env.userService.register.succeedsWith(newUser)
+          _ <- env.conversationRepository.overwrite.succeedsWith(false)
+          result <- env.service.registerVerifiedUser(authId, pending, registrationFlow, Left(email))
+        yield assertTrue(result == ConversationResult.WriteConflict)
+      },
     ),
     suite("checkOtp")(
       test("returns StepPassed on successful OTP check") {
@@ -336,11 +354,10 @@ object ConversationServiceSpec extends UnitSpecBase:
           _ <- env.otpService.checkOtp.succeedsWith(SubmitOtpResult.Success)
           _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.checkOtp(record, otpStep, OtpCode("123456"), authId)
-        yield
-          result match
-            case ConversationResult.StepPassed(updated) =>
-              assertTrue(updated.amr.contains(PassedAuthFactor.otp))
-            case _ => assertTrue(false)
+        yield result match
+          case ConversationResult.StepPassed(updated) =>
+            assertTrue(updated.amr.contains(PassedAuthFactor.otp))
+          case _ => assertTrue(false)
       },
       test("records limit and re-renders on OTP failure") {
         val env = Env()
@@ -353,12 +370,11 @@ object ConversationServiceSpec extends UnitSpecBase:
           _ <- env.submissionLimiter.recordLimit.succeedsWith(LimitStatus.Allowed)
           _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.checkOtp(record, otpStep, OtpCode("wrong"), authId)
-        yield
-          result match
-            case ConversationResult.RenderStep(step: ConversationStep.Otp) =>
-              assertTrue(step.timesSubmitted == 1)
-            case _ => assertTrue(false)
-      }
+        yield result match
+          case ConversationResult.RenderStep(step: ConversationStep.Otp) =>
+            assertTrue(step.timesSubmitted == 1)
+          case _ => assertTrue(false)
+      },
     ),
     suite("checkPassword")(
       test("returns StepPassed on successful password check") {
@@ -373,14 +389,51 @@ object ConversationServiceSpec extends UnitSpecBase:
           _ <- env.passwordService.verifyPassword.succeedsWith(CheckPassword.Success)
           _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.checkPassword(record, passStep, Password("secret"), authId)
-        yield
-          result match
-            case ConversationResult.StepPassed(updated) =>
-              assertTrue(updated.amr.contains(PassedAuthFactor.password))
-            case _ => assertTrue(false)
-      }
+        yield result match
+          case ConversationResult.StepPassed(updated) =>
+            assertTrue(updated.amr.contains(PassedAuthFactor.password))
+          case _ => assertTrue(false)
+      },
     ),
     suite("finish")(
+      test("denies access when the conversation never resolved a user") {
+        val env = Env()
+        for
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.finish(authId, conversationRecord)
+        yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
+      },
+      test("reports a write conflict when the conversation was already claimed") {
+        val env = Env()
+        val now = Instant.parse("2026-07-13T10:00:00Z")
+        val record = consentedRecord.copy(userId = Some(userId))
+        for
+          _ <- TestClock.setTime(now)
+          _ <- issueCodeStubs(env)
+          _ <- env.conversationRepository.delete.succeedsWith(false)
+          result <- env.service.finish(authId, record)
+        yield assertTrue(result == ConversationResult.WriteConflict)
+      },
+      test("migrates the prior session's tokens instead of invalidating it when offline_access is granted") {
+        val env = Env()
+        val now = Instant.parse("2026-07-13T10:00:00Z")
+        val priorSessionIdMac = MAC(Array.fill(32)(2.toByte))
+        val record = consentedRecord.copy(
+          userId = Some(userId),
+          priorSessionId = Some(priorSessionIdMac),
+          scope = consentedRecord.scope + ScopeToken.OfflineAccess,
+          grantedScope = Some(consentedRecord.scope + ScopeToken.OfflineAccess),
+        )
+        for
+          _ <- TestClock.setTime(now)
+          _ <- issueCodeStubs(env)
+          result <- env.service.finish(authId, record)
+          sessionCalls = env.sessionRepository.create.calls
+        yield assertTrue(
+          result.isInstanceOf[ConversationResult.Complete],
+          sessionCalls.head._5 == Some(PriorSession.MigrateTokens(priorSessionIdMac, Set.empty, now, None)),
+        )
+      },
       test("completes conversation and creates session/code") {
         val env = Env()
         val now = Instant.parse("2026-07-13T10:00:00Z")
@@ -407,13 +460,12 @@ object ConversationServiceSpec extends UnitSpecBase:
           _ <- env.secureRandom.nextUUIDv7.succeedsWith(UUID.randomUUID())
           _ <- env.userAgentRepository.create.succeedsWith(())
           result <- env.service.finish(authId, record)
-        yield
-          result match
-            case ConversationResult.Complete(uri, _, c, s, _, _, _) =>
-              assertTrue(uri == redirectUri) &&
-              assertTrue(c == code) &&
-              assertTrue(s == sessionId)
-            case _ => assertTrue(false)
+        yield result match
+          case ConversationResult.Complete(uri, _, c, s, _, _, _) =>
+            assertTrue(uri == redirectUri) &&
+            assertTrue(c == code) &&
+            assertTrue(s == sessionId)
+          case _ => assertTrue(false)
       },
       test("creates new session and issues cookie during step-up") {
         val env = Env()
@@ -449,14 +501,13 @@ object ConversationServiceSpec extends UnitSpecBase:
           _ <- env.userAgentRepository.create.succeedsWith(())
           result <- env.service.finish(authId, record)
           createCalls = env.sessionRepository.create.calls
-        yield
-          result match
-            case ConversationResult.Complete(_, _, _, s, _, _, _) =>
-              assertTrue(s == sessionId) &&
-              assertTrue(createCalls.nonEmpty) &&
-              assertTrue(createCalls.head._1 == sessionIdMac) &&
-              assertTrue(createCalls.head._5 == Some(PriorSession.Invalidate(priorSessionIdMac)))
-            case _ => assertTrue(false)
+        yield result match
+          case ConversationResult.Complete(_, _, _, s, _, _, _) =>
+            assertTrue(s == sessionId) &&
+            assertTrue(createCalls.nonEmpty) &&
+            assertTrue(createCalls.head._1 == sessionIdMac) &&
+            assertTrue(createCalls.head._5 == Some(PriorSession.Invalidate(priorSessionIdMac)))
+          case _ => assertTrue(false)
       },
       test("invalidates prior session and creates new one during re-auth") {
         val env = Env()
@@ -492,14 +543,13 @@ object ConversationServiceSpec extends UnitSpecBase:
           _ <- env.userAgentRepository.create.succeedsWith(())
           result <- env.service.finish(authId, record)
           createCalls = env.sessionRepository.create.calls
-        yield
-          result match
-            case ConversationResult.Complete(_, _, _, s, _, _, _) =>
-              assertTrue(s == sessionId) &&
-              assertTrue(createCalls.nonEmpty) &&
-              assertTrue(createCalls.head._1 == sessionIdMac) &&
-              assertTrue(createCalls.head._5 == Some(PriorSession.Invalidate(priorSessionIdMac)))
-            case _ => assertTrue(false)
+        yield result match
+          case ConversationResult.Complete(_, _, _, s, _, _, _) =>
+            assertTrue(s == sessionId) &&
+            assertTrue(createCalls.nonEmpty) &&
+            assertTrue(createCalls.head._1 == sessionIdMac) &&
+            assertTrue(createCalls.head._5 == Some(PriorSession.Invalidate(priorSessionIdMac)))
+          case _ => assertTrue(false)
       },
       test("reuses the cookie's user agent id when the row is still present") {
         val env = Env()
@@ -536,13 +586,12 @@ object ConversationServiceSpec extends UnitSpecBase:
           result <- env.service.finish(authId, record)
           sessionCalls = env.sessionRepository.create.calls
           createCalls = env.userAgentRepository.create.calls
-        yield
-          result match
-            case ConversationResult.Complete(_, _, _, _, _, uaId, _) =>
-              assertTrue(uaId == cookieUserAgentId) &&
-              assertTrue(createCalls.isEmpty) &&
-              assertTrue(sessionCalls.head._2.userAgentId == cookieUserAgentId)
-            case _ => assertTrue(false)
+        yield result match
+          case ConversationResult.Complete(_, _, _, _, _, uaId, _) =>
+            assertTrue(uaId == cookieUserAgentId) &&
+            assertTrue(createCalls.isEmpty) &&
+            assertTrue(sessionCalls.head._2.userAgentId == cookieUserAgentId)
+          case _ => assertTrue(false)
       },
       test("recreates the user agent row when the cookie points at a swept id") {
         val env = Env()
@@ -582,16 +631,14 @@ object ConversationServiceSpec extends UnitSpecBase:
           result <- env.service.finish(authId, record)
           sessionCalls = env.sessionRepository.create.calls
           createCalls = env.userAgentRepository.create.calls
-        yield
-          result match
-            case ConversationResult.Complete(_, _, _, _, _, uaId, _) =>
-              assertTrue(uaId == UserAgentId(freshUserAgentId)) &&
-              assertTrue(createCalls.map(_._1) == List(UserAgentId(freshUserAgentId))) &&
-              assertTrue(sessionCalls.head._2.userAgentId == UserAgentId(freshUserAgentId))
-            case _ => assertTrue(false)
+        yield result match
+          case ConversationResult.Complete(_, _, _, _, _, uaId, _) =>
+            assertTrue(uaId == UserAgentId(freshUserAgentId)) &&
+            assertTrue(createCalls.map(_._1) == List(UserAgentId(freshUserAgentId))) &&
+            assertTrue(sessionCalls.head._2.userAgentId == UserAgentId(freshUserAgentId))
+          case _ => assertTrue(false)
       },
     ),
-
     suite("consent")(
       test("finish renders the consent step when a grant is still needed") {
         val env = Env()
@@ -719,7 +766,6 @@ object ConversationServiceSpec extends UnitSpecBase:
         )
       },
     ),
-
     suite("checkLoginPassword")(
       test("authenticates login+password and returns StepPassed") {
         val env = Env()
@@ -732,15 +778,13 @@ object ConversationServiceSpec extends UnitSpecBase:
           _ <- env.passwordService.verifyPassword.succeedsWith(CheckPassword.Success)
           _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.checkLoginPassword(authId, conversationRecord, Login("testuser"), Password("secret"))
-        yield
-          result match
-            case ConversationResult.StepPassed(updated) =>
-              assertTrue(updated.userId.contains(userId)) &&
-              assertTrue(updated.amr.contains(PassedAuthFactor.password))
-            case _ => assertTrue(false)
-      }
+        yield result match
+          case ConversationResult.StepPassed(updated) =>
+            assertTrue(updated.userId.contains(userId)) &&
+            assertTrue(updated.amr.contains(PassedAuthFactor.password))
+          case _ => assertTrue(false)
+      },
     ),
-
     suite("offerPasskeyEnroll")(
       test("starts registration if user has no passkeys") {
         val env = Env()
@@ -754,11 +798,10 @@ object ConversationServiceSpec extends UnitSpecBase:
           _ <- env.webAuthnService.startRegistration.succeedsWith(ceremony)
           _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.offerPasskeyEnroll(authId, record)
-        yield
-          result match
-            case ConversationResult.RenderStep(ConversationStep.PasskeyEnroll(req, opt, _)) =>
-              assertTrue(req == "request") && assertTrue(opt == "options")
-            case _ => assertTrue(false)
+        yield result match
+          case ConversationResult.RenderStep(ConversationStep.PasskeyEnroll(req, opt, _)) =>
+            assertTrue(req == "request") && assertTrue(opt == "options")
+          case _ => assertTrue(false)
       },
       test("skips enrollment if user already has passkeys") {
         val env = Env()
@@ -803,8 +846,7 @@ object ConversationServiceSpec extends UnitSpecBase:
           _ <- env.secureRandom.nextUUIDv7.succeedsWith(UUID.randomUUID())
           _ <- env.userAgentRepository.create.succeedsWith(())
           result <- env.service.offerPasskeyEnroll(authId, record)
-        yield
-          assertTrue(result.isInstanceOf[ConversationResult.Complete])
-      }
-    )
+        yield assertTrue(result.isInstanceOf[ConversationResult.Complete])
+      },
+    ),
   )

--- a/auth/src/test/scala/versola/oauth/conversation/OtpConversationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/OtpConversationServiceSpec.scala
@@ -1,9 +1,9 @@
 package versola.oauth.conversation
 
 import versola.auth.TestEnvConfig
+import versola.auth.model.OtpCode
 import versola.oauth.authorize.AcrResolutionService
 import versola.oauth.challenge.passkey.{PasskeyRepository, WebAuthnService}
-import versola.auth.model.OtpCode
 import versola.oauth.challenge.password.PasswordService
 import versola.oauth.client.OAuthConfigurationService
 import versola.oauth.client.model.{AuthFlow, AuthMethodRef, ClientId, PassedAuthFactor, PassedFactorRecord, PrimaryCredential, ScopeToken}
@@ -17,13 +17,13 @@ import versola.oauth.session.{SessionRepository, UserAgentRepository}
 import versola.oauth.token.AuthorizationCodeRepository
 import versola.oauth.userinfo.UserInfoService
 import versola.oauth.userinfo.model.UserInfoResponse
-import versola.user.{UserRepository, UserService}
 import versola.user.model.{UserId, UserRecord}
+import versola.user.{UserRepository, UserService}
 import versola.util.{AuthPropertyGenerator, CoreConfig, Email, EnvName, Secret, SecureRandom, SecurityService, UnitSpecBase}
-import zio.{Ref, ZIO}
 import zio.http.URL
 import zio.json.ast
 import zio.test.*
+import zio.{Ref, ZIO}
 
 import java.security.KeyFactory
 import java.security.spec.RSAPublicKeySpec
@@ -316,7 +316,7 @@ object OtpConversationServiceSpec extends UnitSpecBase:
           registrationStep = None,
           userAgent = None,
           userAgentCookie = None,
-                    version = 0,
+          version = 0,
           amr = Map.empty,
           needsPasswordChange = false,
           targetAcr = None,
@@ -333,6 +333,15 @@ object OtpConversationServiceSpec extends UnitSpecBase:
           _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.checkOtp(record, otp, otpCode, authId)
         yield assertTrue(result.isInstanceOf[ConversationResult.StepPassed])
+      },
+      test("reports a write conflict when the conversation moved on") {
+        val env = Env()
+        for
+          _ <- env.submissionLimiter.isBanned.succeedsWith(LimitStatus.Allowed)
+          _ <- env.otpService.checkOtp.succeedsWith(SubmitOtpResult.Success)
+          _ <- env.conversationRepository.overwrite.succeedsWith(false)
+          result <- env.service.checkOtp(otpRecord, submittedOtp, otpCode, authId)
+        yield assertTrue(result == ConversationResult.WriteConflict)
       },
       test("return AccessDenied when subject is banned") {
         val env = Env()
@@ -360,7 +369,7 @@ object OtpConversationServiceSpec extends UnitSpecBase:
           registrationStep = None,
           userAgent = None,
           userAgentCookie = None,
-                    version = 0,
+          version = 0,
           amr = Map.empty,
           needsPasswordChange = false,
           targetAcr = None,
@@ -469,7 +478,7 @@ object OtpConversationServiceSpec extends UnitSpecBase:
           _ <- env.userInfoService.getUserInfoForIdToken.succeedsWith(
             UserInfoResponse(
               claims = Map("sub" -> ast.Json.Str(userId.toString), "email" -> ast.Json.Str(userEmail)),
-            )
+            ),
           )
           result <- env.service.finish(authId, conversation)
         yield result match

--- a/auth/src/test/scala/versola/oauth/conversation/PasskeyConversationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/PasskeyConversationServiceSpec.scala
@@ -6,7 +6,16 @@ import versola.oauth.authorize.AcrResolutionService
 import versola.oauth.challenge.passkey.{AssertionOutcome, PasskeyCeremony, PasskeyRepository, WebAuthnService}
 import versola.oauth.challenge.password.PasswordService
 import versola.oauth.client.OAuthConfigurationService
-import versola.oauth.client.model.{AuthFlow, ClientId, PasskeyAuthFlow, PasskeySettings, PrimaryCredential, ScopeToken}
+import versola.oauth.client.model.{
+  AuthFlow,
+  AuthMethodRef,
+  ClientId,
+  PassedAuthFactor,
+  PasskeyAuthFlow,
+  PasskeySettings,
+  PrimaryCredential,
+  ScopeToken,
+}
 import versola.oauth.conversation.limit.{ChallengeType, LimitStatus, SubmissionLimiter}
 import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep}
 import versola.oauth.conversation.otp.OtpService
@@ -14,8 +23,8 @@ import versola.oauth.model.{CodeChallenge, CodeChallengeMethod}
 import versola.oauth.session.{SessionRepository, UserAgentRepository}
 import versola.oauth.token.AuthorizationCodeRepository
 import versola.oauth.userinfo.UserInfoService
-import versola.user.{UserRepository, UserService}
 import versola.user.model.{UserId, UserRecord}
+import versola.user.{UserRepository, UserService}
 import versola.util.{AuthPropertyGenerator, SecureRandom, SecurityService, UnitSpecBase}
 import zio.http.URL
 import zio.test.*
@@ -37,7 +46,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
     rpId = "localhost",
     rpName = "Versola",
     origins = List("http://localhost:3000"),
-    userVerification = "preferred"
+    userVerification = "preferred",
   )
 
   // Passkey login enabled at the client level, mirroring what AuthorizeEndpointService persists.
@@ -90,7 +99,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
     primaryCredentials = List(PrimaryCredential.email),
     inlinePassword = false,
     passkey = true,
-    passkeyRequest = None
+    passkeyRequest = None,
   )
 
   val baseRecord = ConversationRecord(
@@ -142,9 +151,16 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           result <- env.service.startPasskeyAssertion(authId, baseRecord, credentialStep, passkeySettings)
         yield assertTrue(
           result == "{}",
-          env.conversationRepository.overwrite.calls.head._2.step == credentialStep.copy(passkeyRequest = Some("req-state"))
+          env.conversationRepository.overwrite.calls.head._2.step == credentialStep.copy(passkeyRequest = Some("req-state")),
         )
-      }
+      },
+      test("propagate a failure from the WebAuthn service") {
+        val env = Env()
+        for
+          _ <- env.webAuthnService.startAssertion.failsWith(versola.oauth.challenge.passkey.WebAuthnError.PasskeysNotEnabled)
+          exit <- env.service.startPasskeyAssertion(authId, baseRecord, credentialStep, passkeySettings).exit
+        yield assertTrue(exit.isFailure, env.conversationRepository.overwrite.calls.isEmpty)
+      },
     ),
     suite("finishPasskeyAssertion")(
       test("succeed and move to enrollment check, resetting the throttle counter") {
@@ -199,7 +215,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.finishPasskeyAssertion(authId, recordWithRequest, assertionResponse, None)
         yield assertTrue(
-          result == ConversationResult.RenderStep(credentialStep.copy(passkeyRequest = None, passkeyFailed = true))
+          result == ConversationResult.RenderStep(credentialStep.copy(passkeyRequest = None, passkeyFailed = true)),
         )
       },
       test("re-render credential step when the credential is not found") {
@@ -214,7 +230,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.finishPasskeyAssertion(authId, recordWithRequest, assertionResponse, None)
         yield assertTrue(
-          result == ConversationResult.RenderStep(credentialStep.copy(passkeyRequest = None, passkeyFailed = true))
+          result == ConversationResult.RenderStep(credentialStep.copy(passkeyRequest = None, passkeyFailed = true)),
         )
       },
       test("return AccessDenied immediately when a subject is already banned") {
@@ -258,6 +274,19 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           result == ConversationResult.RenderStep(ConversationStep.AccessDenied),
           banSubjects == List("cred-123"),
           env.webAuthnService.finishAssertion.calls.isEmpty,
+        )
+      },
+      test("re-render without recording when the response has no credential id and no IP is available") {
+        val env = Env()
+        val recordWithRequest = baseRecord.copy(step = credentialStep.copy(passkeyRequest = Some("req-state")))
+        for
+          _ <- env.webAuthnService.credentialIdFromResponse.succeedsWith(None)
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.finishPasskeyAssertion(authId, recordWithRequest, """{"foo":"bar"}""", None)
+        yield assertTrue(
+          result == ConversationResult.RenderStep(credentialStep.copy(passkeyRequest = None, passkeyFailed = true)),
+          env.submissionLimiter.statusForSubjects.calls.isEmpty,
+          env.submissionLimiter.recordLimit.calls.isEmpty,
         )
       },
       test("throttle the IP and clear the request when the response has no credential id") {
@@ -317,7 +346,140 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
         for
           result <- env.service.finishPasskeyAssertion(authId, record, "response-json", None)
         yield assertTrue(result == ConversationResult.BadRequest)
-      }
+      },
+      test("return BadRequest when no ceremony is pending (duplicate or replayed submission)") {
+        val env = Env()
+        for
+          result <- env.service.finishPasskeyAssertion(authId, baseRecord, assertionResponse, None)
+        yield assertTrue(result == ConversationResult.BadRequest, env.webAuthnService.credentialIdFromResponse.calls.isEmpty)
+      },
+      test("deny access when passkey settings vanish mid-ceremony") {
+        val env = Env()
+        val recordWithRequest = baseRecord.copy(step = credentialStep.copy(passkeyRequest = Some("req-state")))
+        for
+          _ <- env.webAuthnService.credentialIdFromResponse.succeedsWith(Some("cred-123"))
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.configService.getPasskeySettings.succeedsWith(None)
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.finishPasskeyAssertion(authId, recordWithRequest, assertionResponse, None)
+        yield assertTrue(
+          result == ConversationResult.RenderStep(ConversationStep.AccessDenied),
+          env.webAuthnService.finishAssertion.calls.isEmpty,
+        )
+      },
+      test("deny access when the resolved user no longer exists") {
+        val env = Env()
+        val recordWithRequest = baseRecord.copy(step = credentialStep.copy(passkeyRequest = Some("req-state")))
+        val outcome = AssertionOutcome(userId, CredentialId.fromString("id"), 1L)
+        for
+          _ <- env.webAuthnService.credentialIdFromResponse.succeedsWith(Some("cred-123"))
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.submissionLimiter.reset.succeedsWith(())
+          _ <- env.configService.getPasskeySettings.succeedsWith(Some(passkeySettings))
+          _ <- env.webAuthnService.finishAssertion.succeedsWith(outcome)
+          _ <- env.userRepository.find.succeedsWith(None)
+          _ <- env.passkeyRepository.findByCredentialIdAndUser.succeedsWith(None)
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.finishPasskeyAssertion(authId, recordWithRequest, assertionResponse, None)
+        yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
+      },
+      test("deny access when the assertion resolves to a different user than the conversation already verified") {
+        val env = Env()
+        val otherUserId = UserId(UUID.randomUUID())
+        val recordWithRequest = baseRecord.copy(
+          userId = Some(otherUserId),
+          step = credentialStep.copy(passkeyRequest = Some("req-state")),
+        )
+        val outcome = AssertionOutcome(userId, CredentialId.fromString("id"), 1L)
+        val user = UserRecord.empty(userId)
+        for
+          _ <- env.webAuthnService.credentialIdFromResponse.succeedsWith(Some("cred-123"))
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.submissionLimiter.reset.succeedsWith(())
+          _ <- env.configService.getPasskeySettings.succeedsWith(Some(passkeySettings))
+          _ <- env.webAuthnService.finishAssertion.succeedsWith(outcome)
+          _ <- env.userRepository.find.succeedsWith(Some(user))
+          _ <- env.passkeyRepository.findByCredentialIdAndUser.succeedsWith(None)
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.finishPasskeyAssertion(authId, recordWithRequest, assertionResponse, None)
+        yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
+      },
+      test("records swk for a multi-device passkey and reports a write conflict when persistence fails") {
+        val env = Env()
+        val recordWithRequest = baseRecord.copy(step = credentialStep.copy(passkeyRequest = Some("req-state")))
+        val outcome = AssertionOutcome(userId, CredentialId.fromString("id"), 1L)
+        val user = UserRecord.empty(userId)
+        val existingPasskey = PasskeyRecord(
+          id = CredentialId.fromString("id"),
+          userId = userId,
+          publicKey = Array.empty,
+          signatureCounter = 1L,
+          deviceType = CredentialDeviceType.MultiDevice,
+          backedUp = true,
+          backupEligible = true,
+          transports = Nil,
+          attestationObject = None,
+          clientDataJson = None,
+          aaguid = None,
+          name = None,
+          lastUsedAt = None,
+          createdAt = Instant.now(),
+          updatedAt = Instant.now(),
+        )
+        for
+          _ <- env.webAuthnService.credentialIdFromResponse.succeedsWith(Some("cred-123"))
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.submissionLimiter.reset.succeedsWith(())
+          _ <- env.configService.getPasskeySettings.succeedsWith(Some(passkeySettings))
+          _ <- env.webAuthnService.finishAssertion.succeedsWith(outcome)
+          _ <- env.userRepository.find.succeedsWith(Some(user))
+          _ <- env.passkeyRepository.findByCredentialIdAndUser.succeedsWith(Some(existingPasskey))
+          _ <- env.conversationRepository.overwrite.succeedsWith(false)
+          result <- env.service.finishPasskeyAssertion(authId, recordWithRequest, assertionResponse, None)
+          overwriteCalls = env.conversationRepository.overwrite.calls
+        yield assertTrue(
+          result == ConversationResult.WriteConflict,
+          overwriteCalls.head._2.amr(PassedAuthFactor.passkey).methods.contains(AuthMethodRef.swk),
+        )
+      },
+      test("records hwk for a single-device passkey") {
+        val env = Env()
+        val recordWithRequest = baseRecord.copy(step = credentialStep.copy(passkeyRequest = Some("req-state")))
+        val outcome = AssertionOutcome(userId, CredentialId.fromString("id"), 1L)
+        val user = UserRecord.empty(userId)
+        val existingPasskey = PasskeyRecord(
+          id = CredentialId.fromString("id"),
+          userId = userId,
+          publicKey = Array.empty,
+          signatureCounter = 1L,
+          deviceType = CredentialDeviceType.SingleDevice,
+          backedUp = false,
+          backupEligible = false,
+          transports = Nil,
+          attestationObject = None,
+          clientDataJson = None,
+          aaguid = None,
+          name = None,
+          lastUsedAt = None,
+          createdAt = Instant.now(),
+          updatedAt = Instant.now(),
+        )
+        for
+          _ <- env.webAuthnService.credentialIdFromResponse.succeedsWith(Some("cred-123"))
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.submissionLimiter.reset.succeedsWith(())
+          _ <- env.configService.getPasskeySettings.succeedsWith(Some(passkeySettings))
+          _ <- env.webAuthnService.finishAssertion.succeedsWith(outcome)
+          _ <- env.userRepository.find.succeedsWith(Some(user))
+          _ <- env.passkeyRepository.findByCredentialIdAndUser.succeedsWith(Some(existingPasskey))
+          _ <- env.conversationRepository.overwrite.succeedsWith(false)
+          result <- env.service.finishPasskeyAssertion(authId, recordWithRequest, assertionResponse, None)
+          overwriteCalls = env.conversationRepository.overwrite.calls
+        yield assertTrue(
+          result == ConversationResult.WriteConflict,
+          overwriteCalls.head._2.amr(PassedAuthFactor.passkey).methods.contains(AuthMethodRef.hwk),
+        )
+      },
     ),
     suite("offerPasskeyEnroll")(
       test("render enrollment step if user has no passkeys") {
@@ -330,28 +492,89 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.offerPasskeyEnroll(authId, recordWithUser)
         yield assertTrue(
-          result == ConversationResult.RenderStep(ConversationStep.PasskeyEnroll("reg-req", "{}"))
+          result == ConversationResult.RenderStep(ConversationStep.PasskeyEnroll("reg-req", "{}")),
         )
+      },
+      test("deny access when reached without a resolved user") {
+        val env = Env()
+        for
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.offerPasskeyEnroll(authId, baseRecord)
+        yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
+      },
+      test("finish directly when passkeys are not configured for the client") {
+        val env = Env()
+        val recordWithUser = baseRecord.copy(userId = Some(userId), grantedScope = Some(baseRecord.scope))
+        val testCode = versola.oauth.model.AuthorizationCode(Array.fill(32)(1.toByte))
+        val testSessionId = versola.oauth.session.model.SessionId(Array.fill(32)(2.toByte))
+        val testPublicSessionId = versola.oauth.session.model.PublicSessionId("public-session")
+        val testAccessToken = versola.oauth.model.AccessToken(Array.fill(32)(3.toByte))
+        val testMac = versola.util.MAC(Array.fill(32)(4.toByte))
+        for
+          _ <- env.configService.getPasskeySettings.succeedsWith(None)
+          _ <- env.authPropertyGenerator.nextAuthorizationCode.succeedsWith(testCode)
+          _ <- env.authPropertyGenerator.nextSessionId.succeedsWith(testSessionId)
+          _ <- env.authPropertyGenerator.nextPublicSessionId.succeedsWith(testPublicSessionId)
+          _ <- env.securityService.mac.succeedsWith(testMac)
+          _ <- env.authPropertyGenerator.nextAccessToken.succeedsWith(testAccessToken)
+          _ <- env.authorizationCodeRepository.create.succeedsWith(())
+          _ <- env.sessionRepository.create.succeedsWith(())
+          _ <- env.conversationRepository.delete.succeedsWith(true)
+          _ <- env.configService.getSessionTtl.succeedsWith(zio.Duration.fromSeconds(86400))
+          _ <- env.configService.getUserAgentTtl.succeedsWith(zio.Duration.fromSeconds(15552000))
+          _ <- env.configService.getSessionIdleTtl.succeedsWith(Option.empty[zio.Duration])
+          _ <- env.secureRandom.nextUUIDv7.succeedsWith(java.util.UUID.randomUUID())
+          _ <- env.userAgentRepository.create.succeedsWith(())
+          result <- env.service.offerPasskeyEnroll(authId, recordWithUser)
+        yield assertTrue(result.isInstanceOf[ConversationResult.Complete], env.passkeyRepository.listByUser.calls.isEmpty)
+      },
+      test("finish directly when starting the registration ceremony fails") {
+        val env = Env()
+        val recordWithUser = baseRecord.copy(userId = Some(userId), grantedScope = Some(baseRecord.scope))
+        val testCode = versola.oauth.model.AuthorizationCode(Array.fill(32)(1.toByte))
+        val testSessionId = versola.oauth.session.model.SessionId(Array.fill(32)(2.toByte))
+        val testPublicSessionId = versola.oauth.session.model.PublicSessionId("public-session")
+        val testAccessToken = versola.oauth.model.AccessToken(Array.fill(32)(3.toByte))
+        val testMac = versola.util.MAC(Array.fill(32)(4.toByte))
+        for
+          _ <- env.configService.getPasskeySettings.succeedsWith(Some(passkeySettings))
+          _ <- env.passkeyRepository.listByUser.succeedsWith(Vector.empty)
+          _ <- env.webAuthnService.startRegistration.failsWith(versola.oauth.challenge.passkey.WebAuthnError.PasskeysNotEnabled)
+          _ <- env.authPropertyGenerator.nextAuthorizationCode.succeedsWith(testCode)
+          _ <- env.authPropertyGenerator.nextSessionId.succeedsWith(testSessionId)
+          _ <- env.authPropertyGenerator.nextPublicSessionId.succeedsWith(testPublicSessionId)
+          _ <- env.securityService.mac.succeedsWith(testMac)
+          _ <- env.authPropertyGenerator.nextAccessToken.succeedsWith(testAccessToken)
+          _ <- env.authorizationCodeRepository.create.succeedsWith(())
+          _ <- env.sessionRepository.create.succeedsWith(())
+          _ <- env.conversationRepository.delete.succeedsWith(true)
+          _ <- env.configService.getSessionTtl.succeedsWith(zio.Duration.fromSeconds(86400))
+          _ <- env.configService.getUserAgentTtl.succeedsWith(zio.Duration.fromSeconds(15552000))
+          _ <- env.configService.getSessionIdleTtl.succeedsWith(Option.empty[zio.Duration])
+          _ <- env.secureRandom.nextUUIDv7.succeedsWith(java.util.UUID.randomUUID())
+          _ <- env.userAgentRepository.create.succeedsWith(())
+          result <- env.service.offerPasskeyEnroll(authId, recordWithUser)
+        yield assertTrue(result.isInstanceOf[ConversationResult.Complete])
       },
       test("finish conversation if user already has passkeys") {
         val env = Env()
         val recordWithUser = baseRecord.copy(userId = Some(userId), grantedScope = Some(baseRecord.scope))
         val existingPasskey = PasskeyRecord(
-           id = CredentialId(Array.empty),
-           userId = userId,
-           publicKey = Array.empty,
-           signatureCounter = 0,
-           deviceType = CredentialDeviceType.SingleDevice,
-           backedUp = true,
-           backupEligible = true,
-           transports = Nil,
-           attestationObject = None,
-           clientDataJson = None,
-           aaguid = None,
-           name = None,
-           lastUsedAt = None,
-           createdAt = Instant.now(),
-           updatedAt = Instant.now()
+          id = CredentialId(Array.empty),
+          userId = userId,
+          publicKey = Array.empty,
+          signatureCounter = 0,
+          deviceType = CredentialDeviceType.SingleDevice,
+          backedUp = true,
+          backupEligible = true,
+          transports = Nil,
+          attestationObject = None,
+          clientDataJson = None,
+          aaguid = None,
+          name = None,
+          lastUsedAt = None,
+          createdAt = Instant.now(),
+          updatedAt = Instant.now(),
         )
         val testCode = versola.oauth.model.AuthorizationCode(Array.fill(32)(1.toByte))
         val testSessionId = versola.oauth.session.model.SessionId(Array.fill(32)(2.toByte))
@@ -376,9 +599,17 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.userAgentRepository.create.succeedsWith(())
           result <- env.service.offerPasskeyEnroll(authId, recordWithUser)
         yield assertTrue(result.isInstanceOf[ConversationResult.Complete])
-      }
+      },
     ),
     suite("finishPasskeyEnroll")(
+      test("deny access when reached without a resolved user") {
+        val env = Env()
+        val enrollStep = ConversationStep.PasskeyEnroll("reg-req", "{}")
+        for
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.finishPasskeyEnroll(authId, baseRecord, enrollStep, "resp", PasskeyName("my-passkey"))
+        yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
+      },
       test("pass the step on success so the caller decides what follows") {
         val env = Env()
         val recordWithUser = baseRecord.copy(userId = Some(userId))
@@ -434,7 +665,7 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.finishPasskeyEnroll(authId, recordWithUser, enrollStep, "resp", PasskeyName("my-passkey"))
         yield assertTrue(result == ConversationResult.RenderStep(enrollStep.copy(enrollFailed = true)))
-      }
+      },
     ),
     suite("skipPasskey")(
       test("pass the step so the caller decides what follows") {
@@ -461,6 +692,6 @@ object PasskeyConversationServiceSpec extends UnitSpecBase:
           _ <- env.userAgentRepository.create.succeedsWith(())
           result <- env.service.skipPasskey(authId, recordWithUser)
         yield assertTrue(result == ConversationResult.StepPassed(recordWithUser))
-      }
-    )
+      },
+    ),
   )

--- a/auth/src/test/scala/versola/oauth/conversation/PasswordConversationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/PasswordConversationServiceSpec.scala
@@ -210,6 +210,13 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
           checkedSubjects == Set(userId.toString, email.toString),
         )
       },
+      test("reports a write conflict when the conversation moved on") {
+        val env = Env()
+        for
+          _ <- env.conversationRepository.overwrite.succeedsWith(false)
+          result <- env.service.prepareInitialPassword(authId, baseRecord, Left(email), factorIndex = 0)
+        yield assertTrue(result == ConversationResult.WriteConflict)
+      },
     ),
     suite("preparePasswordStep")(
       test("render fresh password step") {
@@ -218,6 +225,13 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
           _ <- env.conversationRepository.overwrite.succeedsWith(true)
           result <- env.service.preparePasswordStep(authId, passwordRecord, factorIndex = 0)
         yield assertTrue(result == ConversationResult.RenderStep(passwordStep))
+      },
+      test("reports a write conflict when the conversation moved on") {
+        val env = Env()
+        for
+          _ <- env.conversationRepository.overwrite.succeedsWith(false)
+          result <- env.service.preparePasswordStep(authId, passwordRecord, factorIndex = 0)
+        yield assertTrue(result == ConversationResult.WriteConflict)
       },
     ),
     suite("checkPassword")(
@@ -310,6 +324,105 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
           ),
         )
       },
+      test("re-render step with oldPasswordChangedAt and rate limit flag when old password is rate limited") {
+        val env = Env()
+        val changedAt = Instant.parse("2024-01-01T00:00:00Z")
+        for
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.passwordService.verifyPassword.succeedsWith(CheckPassword.OldPassword(changedAt))
+          _ <- env.submissionLimiter.recordLimitAll.succeedsWith(LimitStatus.RateLimited(30L))
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.checkPassword(passwordRecord, passwordStep, password, authId)
+        yield assertTrue(
+          result == ConversationResult.RenderStep(
+            passwordStep.copy(
+              timesSubmitted = 1,
+              oldPasswordChangedAt = Some(changedAt),
+              rateLimitExceeded = true,
+            ),
+          ),
+        )
+      },
+      test("return AccessDenied when recording an old-password failure applies a ban") {
+        val env = Env()
+        val changedAt = Instant.parse("2024-01-01T00:00:00Z")
+        for
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.passwordService.verifyPassword.succeedsWith(CheckPassword.OldPassword(changedAt))
+          _ <- env.submissionLimiter.recordLimitAll.succeedsWith(LimitStatus.Banned)
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.checkPassword(passwordRecord, passwordStep, password, authId)
+        yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
+      },
+      test("return StepPassed with needsPasswordChange when a temporary password is correct") {
+        val env = Env()
+        for
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.passwordService.verifyPassword.succeedsWith(CheckPassword.Temporary)
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.checkPassword(passwordRecord, passwordStep, password, authId)
+        yield assertTrue(
+          result match
+            case ConversationResult.StepPassed(updated) => updated.needsPasswordChange
+            case _ => false,
+        )
+      },
+      test("reports a write conflict when accepting a temporary password cannot be persisted") {
+        val env = Env()
+        for
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.passwordService.verifyPassword.succeedsWith(CheckPassword.Temporary)
+          _ <- env.conversationRepository.overwrite.succeedsWith(false)
+          result <- env.service.checkPassword(passwordRecord, passwordStep, password, authId)
+        yield assertTrue(result == ConversationResult.WriteConflict)
+      },
+      test("reports a write conflict when accepting a correct password cannot be persisted") {
+        val env = Env()
+        for
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.passwordService.verifyPassword.succeedsWith(CheckPassword.Success)
+          _ <- env.conversationRepository.overwrite.succeedsWith(false)
+          result <- env.service.checkPassword(passwordRecord, passwordStep, password, authId)
+        yield assertTrue(result == ConversationResult.WriteConflict)
+      },
+      test("re-render step with temporaryExpired flag when the temporary password has expired") {
+        val env = Env()
+        for
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.passwordService.verifyPassword.succeedsWith(CheckPassword.TemporaryExpired)
+          _ <- env.submissionLimiter.recordLimitAll.succeedsWith(LimitStatus.Allowed)
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.checkPassword(passwordRecord, passwordStep, password, authId)
+        yield assertTrue(
+          result == ConversationResult.RenderStep(
+            passwordStep.copy(timesSubmitted = 1, temporaryExpired = true, rateLimitExceeded = false),
+          ),
+        )
+      },
+      test("re-render step with temporaryExpired and rate limit flags when rate limited") {
+        val env = Env()
+        for
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.passwordService.verifyPassword.succeedsWith(CheckPassword.TemporaryExpired)
+          _ <- env.submissionLimiter.recordLimitAll.succeedsWith(LimitStatus.RateLimited(30L))
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.checkPassword(passwordRecord, passwordStep, password, authId)
+        yield assertTrue(
+          result == ConversationResult.RenderStep(
+            passwordStep.copy(timesSubmitted = 1, temporaryExpired = true, rateLimitExceeded = true),
+          ),
+        )
+      },
+      test("return AccessDenied when recording a temporary-expired failure applies a ban") {
+        val env = Env()
+        for
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.passwordService.verifyPassword.succeedsWith(CheckPassword.TemporaryExpired)
+          _ <- env.submissionLimiter.recordLimitAll.succeedsWith(LimitStatus.Banned)
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.checkPassword(passwordRecord, passwordStep, password, authId)
+        yield assertTrue(result == ConversationResult.RenderStep(ConversationStep.AccessDenied))
+      },
       test("deny access when only the credential subject is banned") {
         val env = Env()
         for
@@ -373,6 +486,40 @@ object PasswordConversationServiceSpec extends UnitSpecBase:
           overwriteCalls.head._2.userLogin.contains(login),
           overwriteCalls.head._2.userClaims.contains(loginUser.claims),
         )
+      },
+      test("reports a write conflict when accepting a correct password cannot be persisted") {
+        val env = Env()
+        for
+          _ <- env.userRepository.findByLogin.succeedsWith(Some(loginUser))
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.passwordService.verifyPassword.succeedsWith(CheckPassword.Success)
+          _ <- env.conversationRepository.overwrite.succeedsWith(false)
+          result <- env.service.checkLoginPassword(authId, baseRecord, login, password)
+        yield assertTrue(result == ConversationResult.WriteConflict)
+      },
+      test("return StepPassed with needsPasswordChange when a temporary password is correct") {
+        val env = Env()
+        for
+          _ <- env.userRepository.findByLogin.succeedsWith(Some(loginUser))
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.passwordService.verifyPassword.succeedsWith(CheckPassword.Temporary)
+          _ <- env.conversationRepository.overwrite.succeedsWith(true)
+          result <- env.service.checkLoginPassword(authId, baseRecord, login, password)
+        yield assertTrue(
+          result match
+            case ConversationResult.StepPassed(updated) => updated.needsPasswordChange && updated.userId.contains(userId)
+            case _ => false,
+        )
+      },
+      test("reports a write conflict when accepting a temporary password cannot be persisted") {
+        val env = Env()
+        for
+          _ <- env.userRepository.findByLogin.succeedsWith(Some(loginUser))
+          _ <- env.submissionLimiter.statusForSubjects.succeedsWith(LimitStatus.Allowed)
+          _ <- env.passwordService.verifyPassword.succeedsWith(CheckPassword.Temporary)
+          _ <- env.conversationRepository.overwrite.succeedsWith(false)
+          result <- env.service.checkLoginPassword(authId, baseRecord, login, password)
+        yield assertTrue(result == ConversationResult.WriteConflict)
       },
       test("deny access when either subject is banned, checking both subjects in one query") {
         val env = Env()


### PR DESCRIPTION
Continuation of the conversation-subsystem coverage push (follows the ConversationController coverage commit). Closes the statement-coverage gaps in `ConversationService.Impl`, split across its four existing spec files: `ConversationServiceSpec`, `OtpConversationServiceSpec`, `PasskeyConversationServiceSpec`, `PasswordConversationServiceSpec`.

## Methodology note
Earlier gap analysis in this effort used a filename filter (`fn.endsWith("ConversationService.scala")`) that also matched `ConversationRenderService.scala`, silently conflating two files' statements under one "missing" count. Recomputed correctly (basename match), the real gap was ~48 lines, not the ~190-220 previously reported.

## Tests added

**PasswordConversationServiceSpec**
- `prepareInitialPassword`/`preparePasswordStep`: write-conflict branch.
- `checkPassword`: `CheckPassword.Temporary` (success + write conflict), `TemporaryExpired` under all three limit statuses, `OldPassword` under `RateLimited`/`Banned`, `Success`'s write conflict.
- `checkLoginPassword`: mirrored Temporary/Success write-conflict gaps.

**OtpConversationServiceSpec**
- `checkOtp`: write-conflict on the `Success` branch.

**PasskeyConversationServiceSpec**
- `startPasskeyAssertion`: propagates a `WebAuthnService` failure.
- `finishPasskeyAssertion`: no-pending-ceremony, passkey settings vanishing mid-ceremony, orphaned-user invariant, identity-mismatch check, hwk vs swk AMR recording, final write-conflict branch, malformed-payload-with-no-IP path.
- `offerPasskeyEnroll`: missing-user invariant, no passkey settings configured, `startRegistration` failure (all fall through to `finish()`).
- `finishPasskeyEnroll`: missing-user invariant.

**ConversationServiceSpec**
- `find`: delegates to the repository (previously never exercised).
- `finish`: no-user `AccessDenied` branch, delete-race `WriteConflict` branch, priorSession migration vs invalidation (existing tests never set `offline_access`, so `MigrateTokens` was dead in the suite).
- `registerVerifiedUser`: write-conflict branch.

## Result
`ConversationService.Impl`: 48/434 tracked statements uncovered -> 8/434. The remaining 8 are two genuinely dead branches this work surfaced (report only, no production changes per scope):
- `worstStatus` (lines 241-246): private helper never called anywhere in the file.
- `decideConsent`'s own `None`-userId case (lines 624-625): unreachable, since its only caller (`finish`) already pattern-matches `conversation.userId` to `Some(_)` before invoking it.

The remaining 2 lines in the `ConversationService` companion object (201-202, `live` ZLayer wiring) are DI plumbing, consistent with the same false-positive pattern already documented for `ConversationController`.

**auth module: 1056 -> 1087 tests, 0 failures.** No production source files touched (`ConversationService.scala` diff is empty).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M1R187HGTGCA8J95BYK714XK&panel=chat)