### PR TITLE
test: cover ConversationRouter, ConversationRenderService, AuthorizeEndpointService, and central admin CRUD gaps (Phase 3)

### DIFF
--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
@@ -1,12 +1,30 @@
 package versola.oauth.authorize
 
+import com.nimbusds.jose.crypto.RSASSASigner
+import com.nimbusds.jose.{JOSEObjectType, JWSAlgorithm, JWSHeader}
+import com.nimbusds.jwt.{JWTClaimsSet, SignedJWT}
 import versola.auth.TestEnvConfig
 import versola.oauth.authorize.model.{AuthorizeRequest, AuthorizeResponse, Error, Prompt, ResponseTypeEntry}
-import versola.oauth.jwks.JwksService
 import versola.oauth.client.OAuthConfigurationService
-import versola.oauth.client.model.{Acr, AuthFactor, AuthFactorType, AuthFlow, AuthMethodRef, ClientId, OAuthClientRecord, OtpType, PassedAuthFactor, PassedFactorRecord, PrimaryAuthFlow, PrimaryCredential, ScopeToken, TenantId}
+import versola.oauth.client.model.{
+  Acr,
+  AuthFactor,
+  AuthFactorType,
+  AuthFlow,
+  AuthMethodRef,
+  ClientId,
+  OAuthClientRecord,
+  OtpType,
+  PassedAuthFactor,
+  PassedFactorRecord,
+  PrimaryAuthFlow,
+  PrimaryCredential,
+  ScopeToken,
+  TenantId,
+}
 import versola.oauth.consent.{ConsentDecision, ConsentService}
 import versola.oauth.conversation.{ConversationRepository, ConversationResult, ConversationRouter, EmailSubmission, PhoneSubmission}
+import versola.oauth.jwks.JwksService
 import versola.oauth.model.{AccessToken, AuthorizationCode, CodeChallenge, CodeChallengeMethod, State}
 import versola.oauth.session.SessionService
 import versola.oauth.session.model.{ClientEntry, PublicSessionId, SessionId, SessionInfo, SessionRecord, UserAgentId}
@@ -15,18 +33,14 @@ import versola.oauth.userinfo.UserInfoService
 import versola.user.UserRepository
 import versola.user.model.UserRecord
 import versola.util.{AuthPropertyGenerator, Email, MAC, Phone, Secret, SecureRandom, SecurityService, UnitSpecBase}
-import zio.{ZIO, Exit}
+import zio.*
 import zio.http.URL
 import zio.prelude.{NonEmptyList, NonEmptySet}
-import zio.*
 import zio.test.*
-
+import zio.{Exit, ZIO}
 
 import java.time.Instant
 import java.util.UUID
-import com.nimbusds.jose.crypto.RSASSASigner
-import com.nimbusds.jose.{JOSEObjectType, JWSAlgorithm, JWSHeader}
-import com.nimbusds.jwt.{JWTClaimsSet, SignedJWT}
 
 object AuthorizeEndpointServiceSpec extends UnitSpecBase:
 
@@ -263,7 +277,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
         _ <- env.sessionService.find.succeedsWith(None)
         result <- env.service.authorize(
-          baseRequest.copy(sessionId = Some(rawSessionId), prompt = Set(Prompt.none))
+          baseRequest.copy(sessionId = Some(rawSessionId), prompt = Set(Prompt.none)),
         ).exit
       yield assertTrue(result.isFailure)
     },
@@ -324,7 +338,8 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
       val code = AuthorizationCode(Array.fill(16)(3.toByte))
       val accessToken = AccessToken(Array.fill(16)(4.toByte))
       val codeMac = MAC(Array.fill(32)(2.toByte))
-      val session = sessionWithAmr(Map(PassedAuthFactor.passkey -> PassedFactorRecord(now, Set(AuthMethodRef.swk, AuthMethodRef.user, AuthMethodRef.mfa))))
+      val session =
+        sessionWithAmr(Map(PassedAuthFactor.passkey -> PassedFactorRecord(now, Set(AuthMethodRef.swk, AuthMethodRef.user, AuthMethodRef.mfa))))
       for
         _ <- env.configurationService.find.succeedsWith(Some(clientWithEquivalents))
         _ <- env.sessionService.find.succeedsWith(Some(SessionInfo(sessionMac, session)))
@@ -525,7 +540,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         _ <- env.sessionService.find.succeedsWith(Some(SessionInfo(sessionMac, oldSession)))
         _ <- env.configurationService.getAcrVocabulary.succeedsWith(Map.empty)
         result <- env.service.authorize(
-          baseRequest.copy(sessionId = Some(rawSessionId), maxAge = Some(0), prompt = Set(Prompt.none))
+          baseRequest.copy(sessionId = Some(rawSessionId), maxAge = Some(0), prompt = Set(Prompt.none)),
         ).exit
       yield assertTrue(result.isFailure)
     },
@@ -590,7 +605,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         _ <- env.configurationService.getAcrVocabulary.succeedsWith(Map.empty)
         _ <- env.acrResolver.checkAcrSatisfaction.succeedsWith(None)
         result <- env.service.authorize(
-          baseRequest.copy(sessionId = Some(rawSessionId), acrValues = Some(NonEmptyList(Acr("mfa"))), prompt = Set(Prompt.none))
+          baseRequest.copy(sessionId = Some(rawSessionId), acrValues = Some(NonEmptyList(Acr("mfa"))), prompt = Set(Prompt.none)),
         ).exit
       yield assertTrue(result.isFailure)
     },
@@ -624,7 +639,10 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
         _ <- env.configurationService.getAuthConversationTtl.succeedsWith(zio.Duration.fromSeconds(900))
         _ <- env.sessionService.find.succeedsWith(Some(SessionInfo(sessionMac, session)))
-        _ <- env.configurationService.getAcrVocabulary.succeedsWith(Map(Acr("company_mfa") -> NonEmptyList(PassedAuthFactor.password, PassedAuthFactor.otp)))
+        _ <- env.configurationService.getAcrVocabulary.succeedsWith(Map(Acr("company_mfa") -> NonEmptyList(
+          PassedAuthFactor.password,
+          PassedAuthFactor.otp,
+        )))
         _ <- env.acrResolver.checkAcrSatisfaction.succeedsWith(None)
         _ <- env.acrResolver.resolveAchievableAcr.succeedsWith(Some(Acr("company_mfa")))
         _ <- env.secureRandom.nextUUIDv7.succeedsWith(uuid)
@@ -727,7 +745,8 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         _ <- env.sessionService.find.succeedsWith(Some(SessionInfo(sessionMac, session)))
         _ <- env.configurationService.getAcrVocabulary.succeedsWith(Map.empty)
         _ <- env.acrResolver.resolveAchievableAcr.succeedsWith(None)
-        result <- env.service.authorize(baseRequest.copy(sessionId = Some(rawSessionId), acrValues = Some(NonEmptyList(Acr("completely_unknown_acr"))))).exit
+        result <-
+          env.service.authorize(baseRequest.copy(sessionId = Some(rawSessionId), acrValues = Some(NonEmptyList(Acr("completely_unknown_acr"))))).exit
       yield assertTrue(result.isFailure)
     },
     test("accept expired id_token_hint and force re-authentication when subject differs") {
@@ -782,7 +801,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
         _ <- env.acrResolver.resolveAchievableAcr.succeedsWith(None)
         result <- env.service.authorize(
-          baseRequest.copy(idTokenHint = Some(idTokenHintStr), acrValues = Some(NonEmptyList(Acr("mfa"))))
+          baseRequest.copy(idTokenHint = Some(idTokenHintStr), acrValues = Some(NonEmptyList(Acr("mfa")))),
         ).exit
       yield assertTrue(result.isFailure)
     },
@@ -813,7 +832,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         _ <- env.userRepository.find.succeedsWith(Some(UserRecord.empty(hintUserId)))
         _ <- env.conversationRouter.advance.succeedsWith(())
         result <- env.service.authorize(
-          baseRequest.copy(idTokenHint = Some(idTokenHintStr), acrValues = Some(NonEmptyList(targetAcr)))
+          baseRequest.copy(idTokenHint = Some(idTokenHintStr), acrValues = Some(NonEmptyList(targetAcr))),
         )
         createCalls = env.conversationRepository.create.calls
       yield assertTrue(
@@ -882,7 +901,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
             sessionId = Some(rawSessionId),
             idTokenHint = Some(idTokenHintStr),
             acrValues = Some(NonEmptyList(Acr("mfa"))),
-          )
+          ),
         ).exit
       yield assertTrue(result.isFailure)
     },
@@ -920,7 +939,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
             sessionId = Some(rawSessionId),
             idTokenHint = Some(idTokenHintStr),
             acrValues = Some(NonEmptyList(targetAcr)),
-          )
+          ),
         )
         createCalls = env.conversationRepository.create.calls
       yield assertTrue(
@@ -1039,7 +1058,6 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         advanceCalls.isEmpty,
       )
     },
-
     test("skip the consent decision entirely for a client without a consent flow") {
       val env = Env()
       val session = sessionWithAmr(Map(PassedAuthFactor.otp -> PassedFactorRecord(now, Set(AuthMethodRef.otp))))
@@ -1217,5 +1235,332 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         result == Error.ConsentRequired(redirectUri, baseRequest.state, useFragment = true),
         createTimes == 0,
       )
+    },
+    // ── client / hint validation gaps ─────────────────────────────────────────
+    test("fail with AuthFlowMissing when client is not found") {
+      val env = Env()
+      for
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(UUID.randomUUID())
+        _ <- env.configurationService.find.succeedsWith(None)
+        result <- env.service.authorize(baseRequest).flip
+      yield assertTrue(result == Error.AuthFlowMissing(redirectUri, baseRequest.state, useFragment = false))
+    },
+    test("fail with ConflictingHints when both login_hint and id_token_hint are provided") {
+      val env = Env()
+      for
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(UUID.randomUUID())
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
+        result <- env.service.authorize(
+          baseRequest.copy(loginHint = Some(Left(emailHint)), idTokenHint = Some("dummy-token")),
+        ).flip
+      yield assertTrue(result == Error.ConflictingHints(redirectUri, baseRequest.state, useFragment = false))
+    },
+    test("fail with IdTokenHintInvalid when id_token_hint is not a valid JWT") {
+      val env = Env()
+      for
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(UUID.randomUUID())
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
+        result <- env.service.authorize(baseRequest.copy(idTokenHint = Some("not-a-valid-jwt"))).flip
+      yield assertTrue(result == Error.IdTokenHintInvalid(redirectUri, baseRequest.state, useFragment = false))
+    },
+    test("fail with IdTokenHintInvalid when id_token_hint has no audience claim") {
+      val env = Env()
+      val header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+        .keyID("test-key-id")
+        .`type`(JOSEObjectType.JWT)
+        .build()
+      val hintClaims = new JWTClaimsSet.Builder()
+        .subject(UUID.randomUUID().toString)
+        .issuer("https://versolauth.com")
+        .build()
+      val jwtToken = new SignedJWT(header, hintClaims)
+      jwtToken.sign(new RSASSASigner(TestEnvConfig.privateKey))
+      for
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(UUID.randomUUID())
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
+        result <- env.service.authorize(baseRequest.copy(idTokenHint = Some(jwtToken.serialize()))).flip
+      yield assertTrue(result == Error.IdTokenHintInvalid(redirectUri, baseRequest.state, useFragment = false))
+    },
+    test("resolve id_token_hint subject when audience claim is a JSON array containing this client") {
+      val env = Env()
+      val uuid = UUID.randomUUID()
+      val hintUserId = versola.user.model.UserId(UUID.randomUUID())
+      val header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+        .keyID("test-key-id")
+        .`type`(JOSEObjectType.JWT)
+        .build()
+      val hintClaims = new JWTClaimsSet.Builder()
+        .subject(hintUserId.toString)
+        .audience(java.util.List.of(clientId.toString, "other-client"))
+        .issuer("https://versolauth.com")
+        .build()
+      val jwtToken = new SignedJWT(header, hintClaims)
+      jwtToken.sign(new RSASSASigner(TestEnvConfig.privateKey))
+      val idTokenHintStr = jwtToken.serialize()
+      for
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
+        _ <- env.configurationService.getAuthConversationTtl.succeedsWith(zio.Duration.fromSeconds(900))
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(uuid)
+        _ <- env.secureRandom.nextAlphanumeric.succeedsWith("testcsrf1")
+        _ <- env.conversationRepository.create.succeedsWith(())
+        _ <- env.userRepository.find.succeedsWith(Some(UserRecord.empty(hintUserId)))
+        _ <- env.conversationRouter.advance.succeedsWith(())
+        result <- env.service.authorize(baseRequest.copy(idTokenHint = Some(idTokenHintStr)))
+        createCalls = env.conversationRepository.create.calls
+      yield assertTrue(
+        result == AuthorizeResponse.Initialize(versola.oauth.conversation.model.AuthId(uuid)),
+        createCalls.nonEmpty,
+        createCalls.head._2.userId == Some(hintUserId),
+      )
+    },
+    // ── acr resolution failure branches without forceReauth ───────────────────
+    test("fail with UnmetAuthenticationRequirements when no session, id_token_hint resolves a user, and acr not achievable") {
+      val env = Env()
+      val hintUserId = versola.user.model.UserId(UUID.randomUUID())
+      val header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+        .keyID("test-key-id")
+        .`type`(JOSEObjectType.JWT)
+        .build()
+      val hintClaims = new JWTClaimsSet.Builder()
+        .subject(hintUserId.toString)
+        .audience(clientId.toString)
+        .issuer("https://versolauth.com")
+        .build()
+      val jwtToken = new SignedJWT(header, hintClaims)
+      jwtToken.sign(new RSASSASigner(TestEnvConfig.privateKey))
+      val idTokenHintStr = jwtToken.serialize()
+      for
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(UUID.randomUUID())
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
+        _ <- env.acrResolver.resolveAchievableAcr.succeedsWith(None)
+        result <- env.service.authorize(
+          baseRequest.copy(idTokenHint = Some(idTokenHintStr), acrValues = Some(NonEmptyList(Acr("mfa")))),
+        ).flip
+      yield assertTrue(result == Error.UnmetAuthenticationRequirements(redirectUri, baseRequest.state, useFragment = false))
+    },
+    test("fail with UnmetAuthenticationRequirements when forceReauth and ACR not achievable for the known user") {
+      val env = Env()
+      val session = sessionWithAmr(Map(PassedAuthFactor.otp -> PassedFactorRecord(now, Set(AuthMethodRef.otp))))
+      val differentUserId = versola.user.model.UserId(UUID.randomUUID())
+      val header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+        .keyID("test-key-id")
+        .`type`(JOSEObjectType.JWT)
+        .build()
+      val hintClaims = new JWTClaimsSet.Builder()
+        .subject(differentUserId.toString)
+        .audience(clientId.toString)
+        .issuer("https://versolauth.com")
+        .build()
+      val jwtToken = new SignedJWT(header, hintClaims)
+      jwtToken.sign(new RSASSASigner(TestEnvConfig.privateKey))
+      val idTokenHintStr = jwtToken.serialize()
+      for
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(UUID.randomUUID())
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
+        _ <- env.sessionService.find.succeedsWith(Some(SessionInfo(sessionMac, session)))
+        _ <- env.acrResolver.checkAcrSatisfaction.succeedsWith(None)
+        _ <- env.acrResolver.resolveAchievableAcr.succeedsWith(None)
+        result <- env.service.authorize(
+          baseRequest.copy(
+            sessionId = Some(rawSessionId),
+            idTokenHint = Some(idTokenHintStr),
+            acrValues = Some(NonEmptyList(Acr("mfa"))),
+          ),
+        ).flip
+      yield assertTrue(result == Error.UnmetAuthenticationRequirements(redirectUri, baseRequest.state, useFragment = false))
+    },
+    test("fail with AccessDenied when acr not satisfied by session and session user no longer exists") {
+      val env = Env()
+      val session = sessionWithAmr(Map(PassedAuthFactor.otp -> PassedFactorRecord(now, Set(AuthMethodRef.otp))))
+      for
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(UUID.randomUUID())
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
+        _ <- env.sessionService.find.succeedsWith(Some(SessionInfo(sessionMac, session)))
+        _ <- env.acrResolver.checkAcrSatisfaction.succeedsWith(None)
+        _ <- env.userRepository.find.succeedsWith(None)
+        result <- env.service.authorize(
+          baseRequest.copy(sessionId = Some(rawSessionId), acrValues = Some(NonEmptyList(Acr("mfa")))),
+        ).flip
+      yield assertTrue(result == Error.AccessDenied(redirectUri, baseRequest.state, useFragment = false))
+    },
+    test("fail with UnmetAuthenticationRequirements when acr not satisfied by session but user still exists") {
+      val env = Env()
+      val session = sessionWithAmr(Map(PassedAuthFactor.otp -> PassedFactorRecord(now, Set(AuthMethodRef.otp))))
+      for
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(UUID.randomUUID())
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
+        _ <- env.sessionService.find.succeedsWith(Some(SessionInfo(sessionMac, session)))
+        _ <- env.acrResolver.checkAcrSatisfaction.succeedsWith(None)
+        _ <- env.userRepository.find.succeedsWith(Some(UserRecord.empty(session.userId)))
+        _ <- env.acrResolver.resolveAchievableAcr.succeedsWith(None)
+        result <- env.service.authorize(
+          baseRequest.copy(sessionId = Some(rawSessionId), acrValues = Some(NonEmptyList(Acr("mfa")))),
+        ).flip
+      yield assertTrue(result == Error.UnmetAuthenticationRequirements(redirectUri, baseRequest.state, useFragment = false))
+    },
+    // ── createConversation field population branches ──────────────────────────
+    test("mark the credential step as offering registration when the client has a registration flow and no known user") {
+      val env = Env()
+      val uuid = UUID.randomUUID()
+      val clientWithRegistration = clientWithOtpFlow.copy(
+        registrationFlow = Some(versola.oauth.client.model.RegistrationFlow(
+          credential = versola.oauth.client.model.RegistrationCredential.phone,
+          steps = List(versola.oauth.client.model.RegistrationStep.Otp()),
+          roleIds = Set.empty,
+        )),
+      )
+      for
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithRegistration))
+        _ <- env.configurationService.getAuthConversationTtl.succeedsWith(zio.Duration.fromSeconds(900))
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(uuid)
+        _ <- env.secureRandom.nextAlphanumeric.succeedsWith("testcsrf1")
+        _ <- env.conversationRepository.create.succeedsWith(())
+        result <- env.service.authorize(baseRequest)
+        createCalls = env.conversationRepository.create.calls
+      yield assertTrue(
+        result == AuthorizeResponse.Initialize(versola.oauth.conversation.model.AuthId(uuid)),
+        createCalls.nonEmpty,
+        createCalls.head._2.step.asInstanceOf[versola.oauth.conversation.model.ConversationStep.Credential].registration,
+      )
+    },
+    test("sanitize non-printable characters from user agent when starting a new conversation") {
+      val env = Env()
+      val uuid = UUID.randomUUID()
+      for
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
+        _ <- env.configurationService.getAuthConversationTtl.succeedsWith(zio.Duration.fromSeconds(900))
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(uuid)
+        _ <- env.secureRandom.nextAlphanumeric.succeedsWith("testcsrf1")
+        _ <- env.conversationRepository.create.succeedsWith(())
+        result <- env.service.authorize(baseRequest.copy(userAgent = Some("Mozilla/5.0\u0007")))
+        createCalls = env.conversationRepository.create.calls
+      yield assertTrue(
+        result == AuthorizeResponse.Initialize(versola.oauth.conversation.model.AuthId(uuid)),
+        createCalls.head._2.userAgent == Some("Mozilla/5.0"),
+      )
+    },
+    test("skip login hint application when a step-up hint fails to resolve to a user") {
+      val env = Env()
+      val uuid = UUID.randomUUID()
+      val hintUserId = versola.user.model.UserId(UUID.randomUUID())
+      val targetAcr = Acr("mfa")
+      val header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+        .keyID("test-key-id")
+        .`type`(JOSEObjectType.JWT)
+        .build()
+      val hintClaims = new JWTClaimsSet.Builder()
+        .subject(hintUserId.toString)
+        .audience(clientId.toString)
+        .issuer("https://versolauth.com")
+        .build()
+      val jwtToken = new SignedJWT(header, hintClaims)
+      jwtToken.sign(new RSASSASigner(TestEnvConfig.privateKey))
+      val idTokenHintStr = jwtToken.serialize()
+      for
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
+        _ <- env.configurationService.getAuthConversationTtl.succeedsWith(zio.Duration.fromSeconds(900))
+        _ <- env.acrResolver.resolveAchievableAcr.succeedsWith(Some(targetAcr))
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(uuid)
+        _ <- env.secureRandom.nextAlphanumeric.succeedsWith("testcsrf1")
+        _ <- env.conversationRepository.create.succeedsWith(())
+        _ <- env.userRepository.find.succeedsWith(None)
+        result <- env.service.authorize(
+          baseRequest.copy(idTokenHint = Some(idTokenHintStr), acrValues = Some(NonEmptyList(targetAcr))),
+        )
+        createCalls = env.conversationRepository.create.calls
+        submitCalls = env.conversationRouter.submit.calls
+        advanceCalls = env.conversationRouter.advance.calls
+      yield assertTrue(
+        result == AuthorizeResponse.Initialize(versola.oauth.conversation.model.AuthId(uuid)),
+        createCalls.nonEmpty,
+        createCalls.head._2.userId == None,
+        submitCalls.isEmpty,
+        advanceCalls.isEmpty,
+      )
+    },
+    // ── silent authorization side effects and hybrid id_token issuance ────────
+    test("prolong the session idle ttl when configured for a client without offline access") {
+      val env = Env()
+      val code = AuthorizationCode(Array.fill(16)(3.toByte))
+      val accessToken = AccessToken(Array.fill(16)(4.toByte))
+      val codeMac = MAC(Array.fill(32)(2.toByte))
+      val session = sessionWithAmr(Map(PassedAuthFactor.otp -> PassedFactorRecord(now, Set(AuthMethodRef.otp))))
+      val idleTtl = zio.durationInt(30).minutes
+      for
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
+        _ <- env.sessionService.find.succeedsWith(Some(SessionInfo(sessionMac, session)))
+        _ <- env.configurationService.getAcrVocabulary.succeedsWith(Map.empty)
+        _ <- env.configurationService.getSessionIdleTtl.succeedsWith(Some(idleTtl))
+        _ <- env.sessionService.registerClient.succeedsWith(())
+        _ <- env.sessionService.prolongIdle.succeedsWith(())
+        _ <- env.authPropertyGenerator.nextAuthorizationCode.succeedsWith(code)
+        _ <- env.authPropertyGenerator.nextAccessToken.succeedsWith(accessToken)
+        _ <- env.securityService.mac.succeedsWith(codeMac)
+        _ <- env.authorizationCodeRepository.create.succeedsWith(())
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(UUID.randomUUID())
+        result <- env.service.authorize(baseRequest.copy(sessionId = Some(rawSessionId)))
+        prolongCalls = env.sessionService.prolongIdle.calls
+      yield assertTrue(
+        result == AuthorizeResponse.Authorized(code, None),
+        prolongCalls.nonEmpty,
+        prolongCalls.head._2 == idleTtl,
+      )
+    },
+    test("issue a signed id_token for a hybrid silent authorization") {
+      val env = Env()
+      val session = sessionWithAmr(Map(PassedAuthFactor.otp -> PassedFactorRecord(now, Set(AuthMethodRef.otp))))
+      val user = UserRecord.empty(session.userId)
+      val hybridRequest = baseRequest.copy(
+        sessionId = Some(rawSessionId),
+        responseType = NonEmptySet(ResponseTypeEntry.Code, ResponseTypeEntry.IdToken),
+      )
+      for
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
+        _ <- env.sessionService.find.succeedsWith(Some(SessionInfo(sessionMac, session)))
+        _ <- silentAuthorizeStubs(env)
+        _ <- env.userRepository.find.succeedsWith(Some(user))
+        _ <- env.userInfoService.getUserInfoForIdToken.succeedsWith(versola.oauth.userinfo.model.UserInfoResponse(Map.empty))
+        result <- env.service.authorize(hybridRequest)
+      yield result match
+        case AuthorizeResponse.Authorized(_, Some(idToken)) => assertTrue(idToken.nonEmpty)
+        case _ => assertTrue(false)
+    },
+    // ── ui_locales negotiation ─────────────────────────────────────────────────
+    test("resolve ui_locales to the intersection with configured locales") {
+      val env = Env()
+      val uuid = UUID.randomUUID()
+      for
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
+        _ <- env.configurationService.getLocales.succeedsWith(
+          versola.oauth.client.model.Locales(
+            Vector(
+              versola.oauth.client.model.LocaleRecord("en", "English"),
+              versola.oauth.client.model.LocaleRecord("fr", "French"),
+            ),
+            "en",
+          ),
+        )
+        _ <- env.configurationService.getAuthConversationTtl.succeedsWith(zio.Duration.fromSeconds(900))
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(uuid)
+        _ <- env.secureRandom.nextAlphanumeric.succeedsWith("testcsrf1")
+        _ <- env.conversationRepository.create.succeedsWith(())
+        result <- env.service.authorize(baseRequest.copy(uiLocales = Some(List("fr", "de"))))
+        createCalls = env.conversationRepository.create.calls
+      yield assertTrue(
+        result == AuthorizeResponse.Initialize(versola.oauth.conversation.model.AuthId(uuid)),
+        createCalls.nonEmpty,
+        createCalls.head._2.uiLocales == Some(List("fr")),
+      )
+    },
+    test("fail with UnsupportedUiLocales when requested locales don't overlap with configured locales") {
+      val env = Env()
+      for
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(UUID.randomUUID())
+        _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
+        _ <- env.configurationService.getLocales.succeedsWith(
+          versola.oauth.client.model.Locales(Vector(versola.oauth.client.model.LocaleRecord("en", "English")), "en"),
+        )
+        result <- env.service.authorize(baseRequest.copy(uiLocales = Some(List("de")))).flip
+      yield assertTrue(result == Error.UnsupportedUiLocales(redirectUri, baseRequest.state, useFragment = false))
     },
   )

--- a/auth/src/test/scala/versola/oauth/conversation/ConversationRenderServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/ConversationRenderServiceSpec.scala
@@ -3,11 +3,11 @@ package versola.oauth.conversation
 import versola.auth.TestEnvConfig
 import versola.oauth.client.OAuthConfigurationService
 import versola.oauth.client.model.*
-import versola.oauth.conversation.model.*
 import versola.oauth.conversation.ConversationRenderService.StepView
+import versola.oauth.conversation.model.*
 import versola.oauth.jwks.JwksService
 import versola.oauth.model.{AuthorizationCode, CodeChallenge, CodeChallengeMethod, SessionCookie, State, UserAgentData}
-import versola.oauth.session.model.{PublicSessionId, SessionId, UserAgentDetails, UserAgentId}
+import versola.oauth.session.model.{ClientEntry, PublicSessionId, SessionId, SessionInfo, SessionRecord, UserAgentDetails, UserAgentId}
 import versola.user.model.UserId
 import versola.util.*
 import zio.*
@@ -64,9 +64,9 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
     jsCompiled = Some("console.log('init');"),
     localizations = Map(
       "en" -> Map("page_title" -> "Sign In Test", "login_label" -> "Email"),
-      "fr" -> Map("page_title" -> "Connexion", "login_label" -> "Email")
+      "fr" -> Map("page_title" -> "Connexion", "login_label" -> "Email"),
     ),
-    properties = Vector.empty
+    properties = Vector.empty,
   )
 
   private val conversationRecord = ConversationRecord(
@@ -92,7 +92,7 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
     registrationStep = None,
     userAgent = None,
     userAgentCookie = None,
-        version = 1,
+    version = 1,
     amr = Map.empty,
     needsPasswordChange = false,
     targetAcr = None,
@@ -123,8 +123,8 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
 
   class Env:
     val configuration = stub[OAuthConfigurationService]
-    val jwksService   = stub[JwksService]
-    val service       = ConversationRenderService.Impl(TestEnvConfig.coreConfig, configuration, jwksService)
+    val jwksService = stub[JwksService]
+    val service = ConversationRenderService.Impl(TestEnvConfig.coreConfig, configuration, jwksService)
 
   def spec = suite("ConversationRenderService")(
     suite("renderStep")(
@@ -143,8 +143,7 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           faviconSvg = """<link rel="icon" href="data:image/svg\+xml;base64,([^"]+)">""".r
             .findFirstMatchIn(body)
             .map(matchValue => String(java.util.Base64.getDecoder.decode(matchValue.group(1)), StandardCharsets.UTF_8))
-        yield
-          assertTrue(response.status == Status.Ok) &&
+        yield assertTrue(response.status == Status.Ok) &&
           assertTrue(response.header(Header.ContentType).exists(_.mediaType == MediaType.text.html)) &&
           assertTrue(body.contains("Sign In Test")) &&
           assertTrue(body.contains(".body { color: red; }")) &&
@@ -165,27 +164,27 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           _ <- env.configuration.getPasswordRegex.succeedsWith(".*")
           _ <- env.configuration.getAllowedPhonePrefixes.succeedsWith(List("+1"))
           response <- env.service.renderStep(conversationRecord, None)
-          body     <- response.body.asString
+          body <- response.body.asString
         yield assertTrue(body.contains("""<link rel="icon" href="https://acme.test/logo.svg?a=1&amp;b=2">""")) &&
           assertTrue(body.contains(""""logo":"https://acme.test/logo.svg?a=1\u0026b=2""""))
-        },
-        test("escapes form config JSON so a logo cannot terminate its script element") {
-          val env = Env()
-          val maliciousLogo = "https://acme.test/logo.svg?</script><script>alert(1)</script>"
-          for
-            _ <- env.configuration.find.succeedsWith(Some(clientRecord))
-            _ <- env.configuration.getTheme.succeedsWith(Some(theme))
-            _ <- env.configuration.getForm.succeedsWith(Some(formRecord))
-            _ <- env.configuration.getLocales.succeedsWith(locales)
-            _ <- env.configuration.getIdentityProviderLogo.succeedsWith(Some(maliciousLogo))
-            _ <- env.configuration.getPasswordRegex.succeedsWith(".*")
-            _ <- env.configuration.getAllowedPhonePrefixes.succeedsWith(List("+1"))
-            response <- env.service.renderStep(conversationRecord, None)
-            body     <- response.body.asString
-          yield assertTrue(
-            !body.contains("</script><script>alert(1)</script>"),
-            body.contains("\\u003c/script\\u003e\\u003cscript\\u003ealert(1)"),
-          )
+      },
+      test("escapes form config JSON so a logo cannot terminate its script element") {
+        val env = Env()
+        val maliciousLogo = "https://acme.test/logo.svg?</script><script>alert(1)</script>"
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getTheme.succeedsWith(Some(theme))
+          _ <- env.configuration.getForm.succeedsWith(Some(formRecord))
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(Some(maliciousLogo))
+          _ <- env.configuration.getPasswordRegex.succeedsWith(".*")
+          _ <- env.configuration.getAllowedPhonePrefixes.succeedsWith(List("+1"))
+          response <- env.service.renderStep(conversationRecord, None)
+          body <- response.body.asString
+        yield assertTrue(
+          !body.contains("</script><script>alert(1)</script>"),
+          body.contains("\\u003c/script\\u003e\\u003cscript\\u003ealert(1)"),
+        )
       },
       test("escapes injected markup so it cannot close the script or style blocks") {
         val env = Env()
@@ -208,10 +207,10 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           // The page owns exactly one <style> and two <script> blocks; any extra closing tag
           // means injected text ended one of them early.
           assertTrue(body.sliding("</style>".length).count(_ == "</style>") == 1) &&
-          assertTrue(body.sliding("</script>".length).count(_ == "</script>") == 2) &&
-          assertTrue(body.contains("\\3c /style>")) &&
-          assertTrue(body.contains("&lt;/script&gt;")) &&
-          assertTrue(body.contains("\\u003c/script\\u003e"))
+            assertTrue(body.sliding("</script>".length).count(_ == "</script>") == 2) &&
+            assertTrue(body.contains("\\3c /style>")) &&
+            assertTrue(body.contains("&lt;/script&gt;")) &&
+            assertTrue(body.contains("\\u003c/script\\u003e"))
       },
       test("returns 304 if ETag matches") {
         val env = Env()
@@ -226,8 +225,7 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           firstResponse <- env.service.renderStep(conversationRecord, None)
           etag = firstResponse.headers.get("ETag").getOrElse("")
           secondResponse <- env.service.renderStep(conversationRecord, Some(etag))
-        yield
-          assertTrue(secondResponse.status == Status.NotModified)
+        yield assertTrue(secondResponse.status == Status.NotModified)
       },
       test("uses default theme if client theme is missing") {
         val env = Env()
@@ -242,8 +240,7 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           _ <- env.configuration.getAllowedPhonePrefixes.succeedsWith(List("+1"))
           response <- env.service.renderStep(conversationRecord, None)
           body <- response.body.asString
-        yield
-          assertTrue(body.contains(".body { color: black; }"))
+        yield assertTrue(body.contains(".body { color: black; }"))
       },
       test("renders 404 if form not found") {
         val env = Env()
@@ -257,8 +254,7 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           _ <- env.configuration.getAllowedPhonePrefixes.succeedsWith(List("+1"))
           response <- env.service.renderStep(conversationRecord, None)
           body <- response.body.asString
-        yield
-          assertTrue(response.status == Status.NotFound) &&
+        yield assertTrue(response.status == Status.NotFound) &&
           assertTrue(body.contains("Page not found"))
       },
       test("renders Otp step with resend timer") {
@@ -279,8 +275,7 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           _ <- env.configuration.getOtpSettings.succeedsWith(otpSettings)
           response <- env.service.renderStep(record, None)
           body <- response.body.asString
-        yield
-          assertTrue(body.contains("\"resendAfter\":30"))
+        yield assertTrue(body.contains("\"resendAfter\":30"))
       },
       test("renders a masked destination for the OTP recipient") {
         val env = Env()
@@ -299,8 +294,7 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           _ <- env.configuration.getOtpSettings.succeedsWith(otpSettings)
           response <- env.service.renderStep(record, None)
           body <- response.body.asString
-        yield
-          assertTrue(body.contains("\"destination\":\"j•••n@example.com\""))
+        yield assertTrue(body.contains("\"destination\":\"j•••n@example.com\""))
       },
       test("omits the destination when no credential is on the conversation") {
         val env = Env()
@@ -319,8 +313,7 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           _ <- env.configuration.getOtpSettings.succeedsWith(otpSettings)
           response <- env.service.renderStep(record, None)
           body <- response.body.asString
-        yield
-          assertTrue(!body.contains("\"destination\""))
+        yield assertTrue(!body.contains("\"destination\""))
       },
       test("includes all localized scope and claim labels in the consent payload") {
         val env = Env()
@@ -338,31 +331,30 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           _ <- env.configuration.getScopes.succeedsWith(Vector(consentScope))
           response <- env.service.renderStep(consentRecord.copy(userEmail = Some(Email("john@example.com"))), None)
           body <- response.body.asString
-        yield
-          assertTrue(body.contains("descriptionLocalizations")) &&
+        yield assertTrue(body.contains("descriptionLocalizations")) &&
           assertTrue(body.contains("Profile")) &&
           assertTrue(body.contains("Profil")) &&
           assertTrue(body.contains("claimLocalizations")) &&
           assertTrue(body.contains("Email address")) &&
           assertTrue(body.contains("Adresse e-mail"))
       },
-        test("uses the identity provider logo as consent favicon but omits it from the consent config") {
-          val env = Env()
-          val consentForm = formRecord.copy(id = "consent")
-          for
-            _ <- env.configuration.find.succeedsWith(Some(clientRecord))
-            _ <- env.configuration.getTheme.succeedsWith(Some(theme))
-            _ <- env.configuration.getForm.succeedsWith(Some(consentForm))
-            _ <- env.configuration.getLocales.succeedsWith(locales)
-            _ <- env.configuration.getIdentityProviderLogo.succeedsWith(Some("https://acme.test/logo.svg"))
-            _ <- env.configuration.getScopes.succeedsWith(Vector(consentScope))
-            response <- env.service.renderStep(consentRecord, None)
-            body     <- response.body.asString
-          yield assertTrue(
-            body.contains("""<link rel="icon" href="https://acme.test/logo.svg">"""),
-            !body.contains("\"logo\""),
-          )
-        },
+      test("uses the identity provider logo as consent favicon but omits it from the consent config") {
+        val env = Env()
+        val consentForm = formRecord.copy(id = "consent")
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getTheme.succeedsWith(Some(theme))
+          _ <- env.configuration.getForm.succeedsWith(Some(consentForm))
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(Some("https://acme.test/logo.svg"))
+          _ <- env.configuration.getScopes.succeedsWith(Vector(consentScope))
+          response <- env.service.renderStep(consentRecord, None)
+          body <- response.body.asString
+        yield assertTrue(
+          body.contains("""<link rel="icon" href="https://acme.test/logo.svg">"""),
+          !body.contains("\"logo\""),
+        )
+      },
       test("puts the openid scope first in the consent payload") {
         val env = Env()
         val consentForm = formRecord.copy(
@@ -405,10 +397,9 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           openidIndex = body.indexOf("\"scope\":\"openid\"")
           emailIndex = body.indexOf("\"scope\":\"email\"")
           offlineIndex = body.indexOf("\"scope\":\"offline_access\"")
-        yield
-          assertTrue(openidIndex >= 0) &&
-            assertTrue(openidIndex < emailIndex) &&
-            assertTrue(openidIndex < offlineIndex)
+        yield assertTrue(openidIndex >= 0) &&
+          assertTrue(openidIndex < emailIndex) &&
+          assertTrue(openidIndex < offlineIndex)
       },
       test("includes only claims that are available for the authenticated user") {
         val env = Env()
@@ -433,8 +424,7 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           _ <- env.configuration.getScopes.succeedsWith(Vector(scope))
           response <- env.service.renderStep(record, None)
           body <- response.body.asString
-        yield
-          assertTrue(body.contains("Email address")) &&
+        yield assertTrue(body.contains("Email address")) &&
           assertTrue(!body.contains("Email verification status"))
       },
       test("treats localized user claims as available and ignores empty values") {
@@ -462,31 +452,248 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           _ <- env.configuration.getScopes.succeedsWith(Vector(scope))
           response <- env.service.renderStep(record, None)
           body <- response.body.asString
-        yield
-          assertTrue(body.contains("Name")) &&
+        yield assertTrue(body.contains("Name")) &&
           assertTrue(!body.contains("Email verification status"))
       },
-      ),
-      suite("renderAccount")(
-        test("renders the account payload without a logout URL") {
-          val env = Env()
-          for
-            _ <- env.configuration.find.succeedsWith(Some(clientRecord))
-            _ <- env.configuration.getTheme.succeedsWith(Some(theme))
-            _ <- env.configuration.getForm.succeedsWith(Some(formRecord.copy(id = "auth-settings")))
-            _ <- env.configuration.getLocales.succeedsWith(locales)
-            _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
-            response <- env.service.renderAccount(
-              clientId,
-              StepView.AccountSettings(Nil, Nil),
-              None,
-            )
-            body <- response.body.asString
-          yield assertTrue(
-            !body.contains("\"logoutUrl\""),
+      test("includes array, object, and boolean claim values and flags an invalid grant") {
+        val env = Env()
+        val consentForm = formRecord.copy(
+          id = "consent",
+          localizations = Map("en" -> Map("page_title" -> "Authorize")),
+        )
+        val scope = consentScope.copy(
+          claims = Vector(
+            ClaimRecord(Claim("arr_claim"), Map("en" -> "Array claim")),
+            ClaimRecord(Claim("obj_claim"), Map("en" -> "Object claim")),
+            ClaimRecord(Claim("bool_claim"), Map("en" -> "Boolean claim")),
+          ),
+        )
+        val record = consentRecord.copy(
+          step = ConversationStep.Consent(Set(ScopeToken("profile")), allowPartial = true, invalidGrant = true),
+          userId = Some(UserId(UUID.randomUUID())),
+          userPhone = Some(Phone("+12025551234")),
+          userClaims = Some(Json.Obj(
+            "arr_claim" -> Json.Arr(Chunk(Json.Str("x"))),
+            "obj_claim" -> Json.Obj(Chunk("k" -> Json.Str("v"))),
+            "bool_claim" -> Json.Bool(true),
+          )),
+        )
+
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getTheme.succeedsWith(Some(theme))
+          _ <- env.configuration.getForm.succeedsWith(Some(consentForm))
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
+          _ <- env.configuration.getScopes.succeedsWith(Vector(scope))
+          response <- env.service.renderStep(record, None)
+          body <- response.body.asString
+        yield assertTrue(body.contains("\"error\":\"invalid_consent\"")) &&
+          assertTrue(body.contains("Array claim")) &&
+          assertTrue(body.contains("Object claim")) &&
+          assertTrue(body.contains("Boolean claim"))
+      },
+      test("renders a Password step and surfaces the rate_limit_exceeded error") {
+        val env = Env()
+        val step = ConversationStep.Password(0, None, 0, true)
+        val record = conversationRecord.copy(step = step)
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getTheme.succeedsWith(Some(theme))
+          _ <- env.configuration.getForm.succeedsWith(Some(formRecord.copy(id = "password")))
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
+          _ <- env.configuration.getPasswordRegex.succeedsWith(".*")
+          response <- env.service.renderStep(record, None)
+          body <- response.body.asString
+        yield assertTrue(body.contains("versola-step\" content=\"password\"")) &&
+          assertTrue(body.contains("\"error\":\"rate_limit_exceeded\""))
+      },
+      test("renders a Password step and surfaces the temporary_expired error") {
+        val env = Env()
+        val step = ConversationStep.Password(1, None, 0, false, true)
+        val record = conversationRecord.copy(step = step)
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getTheme.succeedsWith(Some(theme))
+          _ <- env.configuration.getForm.succeedsWith(Some(formRecord.copy(id = "password")))
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
+          _ <- env.configuration.getPasswordRegex.succeedsWith(".*")
+          response <- env.service.renderStep(record, None)
+          body <- response.body.asString
+        yield assertTrue(body.contains("\"error\":\"temporary_expired\""))
+      },
+      test("renders a Password step and surfaces the password_wrong error") {
+        val env = Env()
+        val step = ConversationStep.Password(1, None, 0, false, false)
+        val record = conversationRecord.copy(step = step)
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getTheme.succeedsWith(Some(theme))
+          _ <- env.configuration.getForm.succeedsWith(Some(formRecord.copy(id = "password")))
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
+          _ <- env.configuration.getPasswordRegex.succeedsWith(".*")
+          response <- env.service.renderStep(record, None)
+          body <- response.body.asString
+        yield assertTrue(body.contains("\"error\":\"password_wrong\""))
+      },
+      test("renders a SetPassword step and surfaces the rate_limit_exceeded error") {
+        val env = Env()
+        val step = ConversationStep.SetPassword(0, 0, true, false)
+        val record = conversationRecord.copy(step = step)
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getTheme.succeedsWith(Some(theme))
+          _ <- env.configuration.getForm.succeedsWith(Some(formRecord.copy(id = "set-password")))
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
+          _ <- env.configuration.getPasswordRegex.succeedsWith(".*")
+          response <- env.service.renderStep(record, None)
+          body <- response.body.asString
+        yield assertTrue(body.contains("versola-step\" content=\"set-password\"")) &&
+          assertTrue(body.contains("\"error\":\"rate_limit_exceeded\""))
+      },
+      test("renders a SetPassword step and surfaces the password_reused error") {
+        val env = Env()
+        val step = ConversationStep.SetPassword(0, 0, false, true)
+        val record = conversationRecord.copy(step = step)
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getTheme.succeedsWith(Some(theme))
+          _ <- env.configuration.getForm.succeedsWith(Some(formRecord.copy(id = "set-password")))
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
+          _ <- env.configuration.getPasswordRegex.succeedsWith(".*")
+          response <- env.service.renderStep(record, None)
+          body <- response.body.asString
+        yield assertTrue(body.contains("\"error\":\"password_reused\""))
+      },
+      test("renders a PasskeyEnroll step and surfaces the enroll_failed error") {
+        val env = Env()
+        val step = ConversationStep.PasskeyEnroll("req-state", "{}", true)
+        val record = conversationRecord.copy(step = step)
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getTheme.succeedsWith(Some(theme))
+          _ <- env.configuration.getForm.succeedsWith(Some(formRecord.copy(id = "passkey-enroll")))
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
+          response <- env.service.renderStep(record, None)
+          body <- response.body.asString
+        yield assertTrue(body.contains("versola-step\" content=\"passkey-enroll\"")) &&
+          assertTrue(body.contains("\"error\":\"enroll_failed\""))
+      },
+      test("renders an AccessDenied step") {
+        val env = Env()
+        val record = conversationRecord.copy(step = ConversationStep.AccessDenied)
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getTheme.succeedsWith(Some(theme))
+          _ <- env.configuration.getForm.succeedsWith(Some(formRecord.copy(id = "access-denied")))
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
+          response <- env.service.renderStep(record, None)
+          body <- response.body.asString
+        yield assertTrue(response.status == Status.Ok) &&
+          assertTrue(body.contains("versola-step\" content=\"access-denied\""))
+      },
+      test("surfaces the login_failed error on a Credential step") {
+        val env = Env()
+        val step = ConversationStep.Credential(List(PrimaryCredential.email), true, false, loginFailed = true)
+        val record = conversationRecord.copy(step = step)
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getTheme.succeedsWith(Some(theme))
+          _ <- env.configuration.getForm.succeedsWith(Some(formRecord))
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
+          _ <- env.configuration.getPasswordRegex.succeedsWith(".*")
+          response <- env.service.renderStep(record, None)
+          body <- response.body.asString
+        yield assertTrue(body.contains("\"error\":\"login_failed\""))
+      },
+      test("surfaces the passkey_failed error on a Credential step") {
+        val env = Env()
+        val step = ConversationStep.Credential(List(PrimaryCredential.email), true, false, passkeyFailed = true)
+        val record = conversationRecord.copy(step = step)
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getTheme.succeedsWith(Some(theme))
+          _ <- env.configuration.getForm.succeedsWith(Some(formRecord))
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
+          _ <- env.configuration.getPasswordRegex.succeedsWith(".*")
+          response <- env.service.renderStep(record, None)
+          body <- response.body.asString
+        yield assertTrue(body.contains("\"error\":\"passkey_failed\""))
+      },
+      test("fetches allowed phone prefixes and skips the password regex for a phone-only Credential step") {
+        val env = Env()
+        val step = ConversationStep.Credential(List(PrimaryCredential.phone), false, false)
+        val record = conversationRecord.copy(step = step)
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getTheme.succeedsWith(Some(theme))
+          _ <- env.configuration.getForm.succeedsWith(Some(formRecord))
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
+          _ <- env.configuration.getAllowedPhonePrefixes.succeedsWith(List("+1"))
+          response <- env.service.renderStep(record, None)
+          body <- response.body.asString
+        yield assertTrue(body.contains("\"+1\""))
+      },
+      test("surfaces the otp_wrong error once an OTP has been submitted") {
+        val env = Env()
+        val otpStep = ConversationStep.Otp(None, 1, 1, 0, false, 0, None)
+        val record = conversationRecord.copy(step = otpStep)
+        val otpSettings = OtpSettings(6, 60)
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getTheme.succeedsWith(Some(theme))
+          _ <- env.configuration.getForm.succeedsWith(Some(formRecord.copy(id = "otp")))
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
+          _ <- env.configuration.getOtpSettings.succeedsWith(otpSettings)
+          response <- env.service.renderStep(record, None)
+          body <- response.body.asString
+        yield assertTrue(body.contains("\"error\":\"otp_wrong\""))
+      },
+    ),
+    suite("renderAccount")(
+      test("renders the account payload without a logout URL") {
+        val env = Env()
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getTheme.succeedsWith(Some(theme))
+          _ <- env.configuration.getForm.succeedsWith(Some(formRecord.copy(id = "auth-settings")))
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
+          response <- env.service.renderAccount(
+            clientId,
+            StepView.AccountSettings(Nil, Nil),
+            None,
           )
-        },
-      ),
+          body <- response.body.asString
+        yield assertTrue(
+          !body.contains("\"logoutUrl\""),
+        )
+      },
+      test("renders 404 if the auth-settings form is not found") {
+        val env = Env()
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getTheme.succeedsWith(Some(theme))
+          _ <- env.configuration.getForm.succeedsWith(None)
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
+          response <- env.service.renderAccount(clientId, StepView.AccountSettings(Nil, Nil), None)
+          body <- response.body.asString
+        yield assertTrue(response.status == Status.NotFound) &&
+          assertTrue(body.contains("Page not found"))
+      },
+    ),
     suite("renderExpired")(
       test("renders the expired page with an OAuth error return URI") {
         val env = Env()
@@ -502,13 +709,106 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           _ <- env.configuration.getIdentityProviderLogo.succeedsWith(Some("https://acme.test/logo.svg"))
           response <- env.service.renderExpired(clientId, redirectUri.encode, Some("test-state"), false)
           body <- response.body.asString
-        yield
-          assertTrue(response.status == Status.Ok) &&
+        yield assertTrue(response.status == Status.Ok) &&
           assertTrue(body.contains("conversation-expired")) &&
           assertTrue(body.contains("error=login_required")) &&
           assertTrue(body.contains("state=test-state")) &&
           assertTrue(body.contains("""<link rel="icon" href="https://acme.test/logo.svg">""")) &&
           assertTrue(!body.contains("\"logo\""))
+      },
+      test("renders the expired page with a fragment-based OAuth error return URI when useFragment is set") {
+        val env = Env()
+        val expiredForm = formRecord.copy(
+          id = "conversation-expired",
+          localizations = Map("en" -> Map("page_title" -> "Conversation expired", "title" -> "Expired")),
+        )
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getTheme.succeedsWith(Some(theme))
+          _ <- env.configuration.getForm.succeedsWith(Some(expiredForm))
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
+          response <- env.service.renderExpired(clientId, redirectUri.encode, Some("test-state"), true)
+          body <- response.body.asString
+        yield assertTrue(response.status == Status.Ok) &&
+          assertTrue(body.contains("#error=login_required")) &&
+          assertTrue(!body.contains("?error=login_required"))
+      },
+      test("renders 404 if the conversation-expired form is not found") {
+        val env = Env()
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getTheme.succeedsWith(Some(theme))
+          _ <- env.configuration.getForm.succeedsWith(None)
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
+          response <- env.service.renderExpired(clientId, redirectUri.encode, Some("test-state"), false)
+          body <- response.body.asString
+        yield assertTrue(response.status == Status.NotFound) &&
+          assertTrue(body.contains("Page not found"))
+      },
+    ),
+    suite("renderLogoutConfirm")(
+      test("renders the logout confirmation page") {
+        val env = Env()
+        val confirmForm = formRecord.copy(
+          id = "confirm-logout",
+          localizations = Map("en" -> Map("page_title" -> "Sign out?")),
+        )
+        val mac = MAC(Array.fill(32)(1.toByte))
+        val sessionRecord = SessionRecord(
+          userId = UserId(UUID.randomUUID()),
+          clients = List(ClientEntry(clientId, Instant.EPOCH)),
+          userAgentId = testUserAgentId,
+          createdAt = Instant.EPOCH,
+          amr = Map.empty,
+          publicId = PublicSessionId("public-session-1"),
+          expiresAt = Instant.EPOCH,
+        )
+        val session = SessionInfo(mac, sessionRecord)
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          _ <- env.configuration.getTheme.succeedsWith(Some(theme))
+          _ <- env.configuration.getForm.succeedsWith(Some(confirmForm))
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
+          response <- env.service.renderLogoutConfirm(
+            session,
+            "csrf-token-1",
+            Some("https://example.com/post-logout"),
+            Some(State("test-state")),
+            Some(List("en")),
+          )
+          body <- response.body.asString
+        yield assertTrue(response.status == Status.Ok) &&
+          assertTrue(response.header(Header.ContentType).exists(_.mediaType == MediaType.text.html)) &&
+          assertTrue(body.contains("Sign out?")) &&
+          assertTrue(body.contains("csrf-token-1")) &&
+          assertTrue(body.contains("https://example.com/post-logout")) &&
+          assertTrue(body.contains("test-state"))
+      },
+      test("renders 404 if the confirm-logout form is not found") {
+        val env = Env()
+        val mac = MAC(Array.fill(32)(1.toByte))
+        val sessionRecord = SessionRecord(
+          userId = UserId(UUID.randomUUID()),
+          clients = Nil,
+          userAgentId = testUserAgentId,
+          createdAt = Instant.EPOCH,
+          amr = Map.empty,
+          publicId = PublicSessionId("public-session-2"),
+          expiresAt = Instant.EPOCH,
+        )
+        val session = SessionInfo(mac, sessionRecord)
+        for
+          _ <- env.configuration.getTheme.succeedsWith(Some(defaultTheme))
+          _ <- env.configuration.getForm.succeedsWith(None)
+          _ <- env.configuration.getLocales.succeedsWith(locales)
+          _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
+          response <- env.service.renderLogoutConfirm(session, "csrf-token-2", None, None, None)
+          body <- response.body.asString
+        yield assertTrue(response.status == Status.NotFound) &&
+          assertTrue(body.contains("Page not found"))
       },
     ),
     suite("renderServiceUnavailable")(
@@ -526,8 +826,7 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
           response <- env.service.renderServiceUnavailable(clientId, redirectUri.encode, Some("test-state"), false)
           body <- response.body.asString
-        yield
-          assertTrue(response.status == Status.Ok) &&
+        yield assertTrue(response.status == Status.Ok) &&
           assertTrue(body.contains("service-unavailable")) &&
           assertTrue(body.contains("error=temporarily_unavailable")) &&
           assertTrue(body.contains("state=test-state"))
@@ -539,16 +838,14 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
         val step = ConversationStep.Password(0, None, 0, false)
         for
           response <- env.service.renderSubmit(ConversationResult.RenderStep(step), conversationRecord)
-        yield
-          assertTrue(response.status == Status.SeeOther) &&
+        yield assertTrue(response.status == Status.SeeOther) &&
           assertTrue(response.header(Header.Location).exists(_.url.path.encode == "/challenge"))
       },
       test("redirects to /challenge on BadRequest") {
         val env = Env()
         for
           response <- env.service.renderSubmit(ConversationResult.BadRequest, conversationRecord)
-        yield
-          assertTrue(response.status == Status.SeeOther) &&
+        yield assertTrue(response.status == Status.SeeOther) &&
           assertTrue(response.header(Header.Location).exists(_.url.path.encode == "/challenge"))
       },
       test("renders step with error on ServiceUnavailable") {
@@ -563,8 +860,7 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           _ <- env.configuration.getAllowedPhonePrefixes.succeedsWith(List("+1"))
           response <- env.service.renderSubmit(ConversationResult.ServiceUnavailable, conversationRecord)
           body <- response.body.asString
-        yield
-          assertTrue(response.status == Status.Ok) &&
+        yield assertTrue(response.status == Status.Ok) &&
           assertTrue(body.contains("service_unavailable"))
       },
       test("redirects with code and session cookie on Complete") {
@@ -572,16 +868,25 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
         val code = AuthorizationCode(Array.fill(16)(1.toByte))
         val sessionId = SessionId(Array.fill(32)(2.toByte))
         val userId = UserId(UUID.randomUUID())
-        val result = ConversationResult.Complete(redirectUri, Some(State("test-state")), code, sessionId, None, testUserAgentId, UserAgentData(None, userId, UserAgentDetails.parse(None)))
+        val result = ConversationResult.Complete(
+          redirectUri,
+          Some(State("test-state")),
+          code,
+          sessionId,
+          None,
+          testUserAgentId,
+          UserAgentData(None, userId, UserAgentDetails.parse(None)),
+        )
         for
           _ <- env.configuration.getSessionTtl.succeedsWith(1.hour)
           _ <- env.configuration.getUserAgentTtl.succeedsWith(180.days)
           response <- env.service.renderSubmit(result, conversationRecord)
-        yield
-          assertTrue(response.status == Status.SeeOther) &&
+        yield assertTrue(response.status == Status.SeeOther) &&
           assertTrue(response.header(Header.Location).exists(_.url.encode.contains("code=" + versola.util.Base64Url.encode(code)))) &&
           assertTrue(response.headers.get(Header.SetCookie).exists(_.renderedValue.contains("SSO_SESSION"))) &&
-          assertTrue(response.headers.getAll(Header.SetCookie).exists(c => c.value.name == "SSO_CONVERSATION" && c.value.maxAge.contains(Duration.Zero)))
+          assertTrue(response.headers.getAll(Header.SetCookie).exists(c =>
+            c.value.name == "SSO_CONVERSATION" && c.value.maxAge.contains(Duration.Zero),
+          ))
       },
       test("includes id_token if provided in Complete") {
         val env = Env()
@@ -589,16 +894,23 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
         val sessionId = SessionId(Array.fill(32)(2.toByte))
         val userId = UserId(java.util.UUID.randomUUID())
         val idTokenData = ConversationResult.IdTokenData(userId, Map.empty, clientId, PublicSessionId("public-session-1"))
-        val result = ConversationResult.Complete(redirectUri, Some(State("test-state")), code, sessionId, Some(idTokenData), testUserAgentId, UserAgentData(None, userId, UserAgentDetails.parse(None)))
+        val result = ConversationResult.Complete(
+          redirectUri,
+          Some(State("test-state")),
+          code,
+          sessionId,
+          Some(idTokenData),
+          testUserAgentId,
+          UserAgentData(None, userId, UserAgentDetails.parse(None)),
+        )
 
         for
           _ <- env.configuration.getSessionTtl.succeedsWith(1.hour)
           _ <- env.configuration.getUserAgentTtl.succeedsWith(180.days)
           _ <- env.jwksService.signingKey.succeedsWith(TestEnvConfig.publicKeys.active)
           response <- env.service.renderSubmit(result, conversationRecord)
-        yield
-          assertTrue(response.header(Header.Location).exists(_.url.encode.contains("id_token=")))
-      }
+        yield assertTrue(response.header(Header.Location).exists(_.url.encode.contains("id_token=")))
+      },
     ),
     suite("renderLogout")(
       test("renders SignedOut view with encoded logout URIs and redirect URI including state") {
@@ -612,8 +924,7 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
           response <- env.service.renderLogout(List(logoutUri1, logoutUri2), Some(redirectUri), Some("st-1"))
           body <- response.body.asString
-        yield
-          assertTrue(response.status == Status.Ok) &&
+        yield assertTrue(response.status == Status.Ok) &&
           assertTrue(response.header(Header.ContentType).exists(_.mediaType == MediaType.text.html)) &&
           assertTrue(response.headers.get("Cache-Control").contains("no-cache, no-store")) &&
           assertTrue(response.headers.get("Referrer-Policy").contains("no-referrer")) &&
@@ -632,8 +943,7 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
           response <- env.service.renderLogout(Nil, None, None)
           body <- response.body.asString
-        yield
-          assertTrue(response.status == Status.Ok) &&
+        yield assertTrue(response.status == Status.Ok) &&
           assertTrue(!body.contains("\"redirectUri\"")) &&
           assertTrue(body.contains("\"logoutUris\":[]"))
       },
@@ -646,8 +956,7 @@ object ConversationRenderServiceSpec extends UnitSpecBase:
           _ <- env.configuration.getIdentityProviderLogo.succeedsWith(None)
           response <- env.service.renderLogout(Nil, Some(redirectUri), None)
           body <- response.body.asString
-        yield
-          assertTrue(response.status == Status.NotFound) &&
+        yield assertTrue(response.status == Status.NotFound) &&
           assertTrue(body.contains("Page not found"))
       },
     ),

--- a/auth/src/test/scala/versola/oauth/conversation/ConversationRouterSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/ConversationRouterSpec.scala
@@ -1,10 +1,26 @@
 package versola.oauth.conversation
 
-import versola.auth.model.{OtpCode, Password}
+import versola.auth.model.{OtpCode, PasskeyName, Password}
 import versola.oauth.client.OAuthConfigurationService
-import versola.oauth.client.model.{AuthFactor, AuthFactorType, AuthFlow, AuthMethodRef, ClientId, OtpType, PassedAuthFactor, PassedFactorRecord, PrimaryAuthFlow, PrimaryCredential, RegistrationCredential, RegistrationFlow, RegistrationStep, ScopeToken}
+import versola.oauth.client.model.{
+  AuthFactor,
+  AuthFactorType,
+  AuthFlow,
+  AuthMethodRef,
+  ClientId,
+  OtpType,
+  PassedAuthFactor,
+  PassedFactorRecord,
+  PasskeyAuthFlow,
+  PasskeySettings,
+  PrimaryAuthFlow,
+  PrimaryCredential,
+  RegistrationCredential,
+  RegistrationFlow,
+  RegistrationStep,
+  ScopeToken,
+}
 import versola.oauth.conversation.model.{AuthId, ConversationRecord, ConversationStep, Error}
-import zio.{ZIO, Exit}
 import versola.oauth.model.{AuthorizationCode, CodeChallenge, CodeChallengeMethod, State, UserAgentData}
 import versola.oauth.session.model.{SessionId, UserAgentDetails, UserAgentId}
 import versola.role.model.RoleId
@@ -14,6 +30,7 @@ import versola.util.{Email, Phone, SecureRandom, UnitSpecBase}
 import zio.http.URL
 import zio.json.ast.Json
 import zio.test.*
+import zio.{Exit, ZIO}
 
 import java.time.Instant
 import java.util.UUID
@@ -65,7 +82,15 @@ object ConversationRouterSpec extends UnitSpecBase:
     state = Some(State("test-state")),
     userId = None,
     credential = None,
-    step = ConversationStep.Credential(List(PrimaryCredential.phone), inlinePassword = false, passkey = false, registration = false, passkeyRequest = None, passkeyFailed = false, loginFailed = false),
+    step = ConversationStep.Credential(
+      List(PrimaryCredential.phone),
+      inlinePassword = false,
+      passkey = false,
+      registration = false,
+      passkeyRequest = None,
+      passkeyFailed = false,
+      loginFailed = false,
+    ),
     requestedClaims = None,
     uiLocales = None,
     nonce = None,
@@ -144,9 +169,16 @@ object ConversationRouterSpec extends UnitSpecBase:
 
   val roleId = RoleId("user")
 
+  val passkeySettings = PasskeySettings(
+    rpId = "localhost",
+    rpName = "Versola",
+    origins = List("http://localhost:3000"),
+    userVerification = "preferred",
+  )
+
   /** A conversation for a client that offers registration alongside sign-in. */
   val registrationRecord = initialRecord.copy(
-        registrationFlow = Some(RegistrationFlow(RegistrationCredential.phone, List(RegistrationStep.Otp(), RegistrationStep.SetPassword()), Set(roleId))),
+    registrationFlow = Some(RegistrationFlow(RegistrationCredential.phone, List(RegistrationStep.Otp(), RegistrationStep.SetPassword()), Set(roleId))),
   )
 
   class Env:
@@ -281,7 +313,15 @@ object ConversationRouterSpec extends UnitSpecBase:
         val successResult = ConversationResult.StepPassed(otpRecord)
         val testCode = AuthorizationCode(Array.fill(32)(1.toByte))
         val testSessionId: SessionId = SessionId(Array.fill(32)(2.toByte))
-        val completeResult = ConversationResult.Complete(redirectUri, Some(State("test-state")), testCode, testSessionId, None, testUserAgentId, UserAgentData(None, testUserId, UserAgentDetails.parse(None)))
+        val completeResult = ConversationResult.Complete(
+          redirectUri,
+          Some(State("test-state")),
+          testCode,
+          testSessionId,
+          None,
+          testUserAgentId,
+          UserAgentData(None, testUserId, UserAgentDetails.parse(None)),
+        )
         for
           _ <- env.otpConversationService.find.succeedsWith(Some(otpRecord))
           _ <- env.otpConversationService.checkOtp.succeedsWith(successResult)
@@ -323,7 +363,15 @@ object ConversationRouterSpec extends UnitSpecBase:
         )
         val testCode = AuthorizationCode(Array.fill(32)(1.toByte))
         val testSessionId = SessionId(Array.fill(32)(2.toByte))
-        val completeResult = ConversationResult.Complete(redirectUri, Some(State("test-state")), testCode, testSessionId, None, testUserAgentId, UserAgentData(None, testUserId, UserAgentDetails.parse(None)))
+        val completeResult = ConversationResult.Complete(
+          redirectUri,
+          Some(State("test-state")),
+          testCode,
+          testSessionId,
+          None,
+          testUserAgentId,
+          UserAgentData(None, testUserId, UserAgentDetails.parse(None)),
+        )
         for
           _ <- env.otpConversationService.find.succeedsWith(Some(recordWithPasskeyAmr))
           _ <- env.userRepository.findByCredential.succeedsWith(None)
@@ -344,7 +392,15 @@ object ConversationRouterSpec extends UnitSpecBase:
         val successResult = ConversationResult.StepPassed(loginRecord)
         val testCode = AuthorizationCode(Array.fill(32)(1.toByte))
         val testSessionId: SessionId = SessionId(Array.fill(32)(2.toByte))
-        val completeResult = ConversationResult.Complete(redirectUri, Some(State("test-state")), testCode, testSessionId, None, testUserAgentId, UserAgentData(None, testUserId, UserAgentDetails.parse(None)))
+        val completeResult = ConversationResult.Complete(
+          redirectUri,
+          Some(State("test-state")),
+          testCode,
+          testSessionId,
+          None,
+          testUserAgentId,
+          UserAgentData(None, testUserId, UserAgentDetails.parse(None)),
+        )
         for
           _ <- env.otpConversationService.find.succeedsWith(Some(loginRecord))
           _ <- env.otpConversationService.checkLoginPassword.succeedsWith(successResult)
@@ -456,10 +512,10 @@ object ConversationRouterSpec extends UnitSpecBase:
           _ <- env.otpConversationService.find.succeedsWith(Some(registrationRecord))
           _ <- env.userRepository.findByCredential.succeedsWith(None)
           _ <- env.otpConversationService.startRegistration.succeedsWith(
-                 RegistrationEntry.Registering(
-                   registrationRecord.copy(registrationStep = Some(0), credential = Some(Right(phone))),
-                 ),
-               )
+            RegistrationEntry.Registering(
+              registrationRecord.copy(registrationStep = Some(0), credential = Some(Right(phone))),
+            ),
+          )
           _ <- env.otpConversationService.prepareInitialOtp.succeedsWith(conversationResult)
           (result, _) <- env.router.submit(authId, PhoneSubmission(phone, "test-csrf"), None, None)
           prepareOtpTimes = env.otpConversationService.prepareInitialOtp.times
@@ -501,8 +557,8 @@ object ConversationRouterSpec extends UnitSpecBase:
           _ <- env.otpConversationService.find.succeedsWith(Some(registrationRecord))
           _ <- env.userRepository.findByCredential.succeedsWith(None)
           _ <- env.otpConversationService.startRegistration.succeedsWith(
-                 RegistrationEntry.Registering(registrationRecord.copy(registrationStep = Some(0), credential = Some(Right(phone)))),
-               )
+            RegistrationEntry.Registering(registrationRecord.copy(registrationStep = Some(0), credential = Some(Right(phone)))),
+          )
           _ <- env.otpConversationService.prepareInitialOtp.succeedsWith(conversationResult)
           (result, _) <- env.router.submit(authId, PhoneSubmission(phone, "test-csrf"), None, None)
         yield assertTrue(
@@ -752,7 +808,15 @@ object ConversationRouterSpec extends UnitSpecBase:
         val now = Instant.now()
         val testCode = AuthorizationCode(Array.fill(32)(1.toByte))
         val testSessionId = SessionId(Array.fill(32)(2.toByte))
-        val completeResult = ConversationResult.Complete(redirectUri, Some(State("test-state")), testCode, testSessionId, None, testUserAgentId, UserAgentData(None, testUserId, UserAgentDetails.parse(None)))
+        val completeResult = ConversationResult.Complete(
+          redirectUri,
+          Some(State("test-state")),
+          testCode,
+          testSessionId,
+          None,
+          testUserAgentId,
+          UserAgentData(None, testUserId, UserAgentDetails.parse(None)),
+        )
         val record = otpRecord.copy(
           amr = Map(PassedAuthFactor.otp -> PassedFactorRecord(now, Set(AuthMethodRef.otp))),
         )
@@ -768,7 +832,6 @@ object ConversationRouterSpec extends UnitSpecBase:
         )
       },
     ),
-
     suite("consent submissions")(
       test("routes an allow submission to allowConsent with the submitted scope") {
         val env = Env()
@@ -825,6 +888,564 @@ object ConversationRouterSpec extends UnitSpecBase:
           exit <- env.router.submit(authId, ConsentAllowSubmission(Set(ScopeToken.OpenId), "wrong"), None, None).exit
           allowTimes = env.otpConversationService.allowConsent.times
         yield assertTrue(exit == Exit.fail(Error.BadRequest), allowTimes == 0)
+      },
+      test("re-renders consent step with invalid grant flag when the submitted scope is rejected") {
+        val env = Env()
+        val consentStep = ConversationStep.Consent(requestedScope = Set(ScopeToken.OpenId), allowPartial = true)
+        val record = otpRecord.copy(step = consentStep)
+        val invalidResult = ConversationResult.RenderStep(consentStep.copy(invalidGrant = true))
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          _ <- env.otpConversationService.allowConsent.succeedsWith(invalidResult)
+          (result, _) <- env.router.submit(authId, ConsentAllowSubmission(Set(ScopeToken.OpenId), "test-csrf"), None, None)
+        yield assertTrue(result == invalidResult)
+      },
+    ),
+    suite("startPasskeyOptions")(
+      test("fail with ServiceUnavailable when conversation lookup fails") {
+        val env = Env()
+        val boom = new RuntimeException("db down")
+        for
+          _ <- env.otpConversationService.find.failsWith(boom)
+          exit <- env.router.startPasskeyOptions(authId).exit
+        yield assertTrue(exit == Exit.fail(Error.ServiceUnavailable))
+      },
+      test("fail with ConversationExpired when conversation does not exist") {
+        val env = Env()
+        for
+          _ <- env.otpConversationService.find.succeedsWith(None)
+          exit <- env.router.startPasskeyOptions(authId).exit
+        yield assertTrue(exit == Exit.fail(Error.ConversationExpired))
+      },
+      test("start a passkey assertion when the credential step has passkey enabled for the flow") {
+        val env = Env()
+        val credStep = ConversationStep.Credential(List(PrimaryCredential.phone), inlinePassword = false, passkey = true)
+        val record = initialRecord.copy(step = credStep, authFlow = otpAuthFlow.copy(passkey = Some(PasskeyAuthFlow(factors = Nil))))
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          _ <- env.configService.getPasskeySettings.succeedsWith(Some(passkeySettings))
+          _ <- env.otpConversationService.startPasskeyAssertion.succeedsWith("public-key-json")
+          result <- env.router.startPasskeyOptions(authId)
+        yield assertTrue(result.contains("public-key-json"))
+      },
+      test("fail when passkeys are not configured for the tenant") {
+        val env = Env()
+        val credStep = ConversationStep.Credential(List(PrimaryCredential.phone), inlinePassword = false, passkey = true)
+        val record = initialRecord.copy(step = credStep, authFlow = otpAuthFlow.copy(passkey = Some(PasskeyAuthFlow(factors = Nil))))
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          _ <- env.configService.getPasskeySettings.succeedsWith(None)
+          exit <- env.router.startPasskeyOptions(authId).exit
+        yield assertTrue(exit.isFailure)
+      },
+      test("return None when the credential step's auth flow doesn't have passkey enabled") {
+        val env = Env()
+        val credStep = ConversationStep.Credential(List(PrimaryCredential.phone), inlinePassword = false, passkey = false)
+        val record = initialRecord.copy(step = credStep)
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          result <- env.router.startPasskeyOptions(authId)
+        yield assertTrue(result.isEmpty)
+      },
+      test("fail when called outside the credential step") {
+        val env = Env()
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(otpRecord))
+          exit <- env.router.startPasskeyOptions(authId).exit
+        yield assertTrue(exit.isFailure)
+      },
+    ),
+    suite("submit additional dispatch branches")(
+      test("handle OTP resend submission") {
+        val env = Env()
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(otpRecord))
+          _ <- env.otpConversationService.prepareInitialOtp.succeedsWith(conversationResult)
+          (result, _) <- env.router.submit(authId, OtpResendSubmission("test-csrf"), None, None)
+          prepareTimes = env.otpConversationService.prepareInitialOtp.times
+        yield assertTrue(result == conversationResult, prepareTimes == 1)
+      },
+      test("handle password submission and finish when no further factors remain") {
+        val env = Env()
+        val passwordStep = ConversationStep.Password(timesSubmitted = 0, oldPasswordChangedAt = None, factorIndex = 0, rateLimitExceeded = false)
+        val passwordFlow =
+          otpAuthFlow.copy(primary = otpAuthFlow.primary.copy(factors = List(AuthFactor(`type` = AuthFactorType.password, required = true))))
+        val record = initialRecord.copy(step = passwordStep, authFlow = passwordFlow)
+        val completeResult = ConversationResult.Complete(
+          redirectUri,
+          Some(State("test-state")),
+          AuthorizationCode(Array.fill(32)(1.toByte)),
+          SessionId(Array.fill(32)(2.toByte)),
+          None,
+          testUserAgentId,
+          UserAgentData(None, testUserId, UserAgentDetails.parse(None)),
+        )
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          _ <- env.otpConversationService.checkPassword.succeedsWith(ConversationResult.StepPassed(record))
+          _ <- env.configService.getAcrVocabulary.succeedsWith(Map.empty)
+          _ <- env.otpConversationService.finish.succeedsWith(completeResult)
+          (result, _) <- env.router.submit(authId, PasswordSubmission(password, "test-csrf"), None, None)
+        yield assertTrue(result == completeResult)
+      },
+      test("return the render result directly when the password check does not pass") {
+        val env = Env()
+        val passwordStep = ConversationStep.Password(timesSubmitted = 0, oldPasswordChangedAt = None, factorIndex = 0, rateLimitExceeded = false)
+        val record = initialRecord.copy(step = passwordStep)
+        val renderResult = ConversationResult.RenderStep(passwordStep.copy(timesSubmitted = 1))
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          _ <- env.otpConversationService.checkPassword.succeedsWith(renderResult)
+          (result, _) <- env.router.submit(authId, PasswordSubmission(password, "test-csrf"), None, None)
+        yield assertTrue(result == renderResult)
+      },
+      test("handle passkey assertion submission that completes the conversation") {
+        val env = Env()
+        val completeResult = ConversationResult.Complete(
+          redirectUri,
+          Some(State("test-state")),
+          AuthorizationCode(Array.fill(32)(1.toByte)),
+          SessionId(Array.fill(32)(2.toByte)),
+          None,
+          testUserAgentId,
+          UserAgentData(None, testUserId, UserAgentDetails.parse(None)),
+        )
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(otpRecord))
+          _ <- env.otpConversationService.finishPasskeyAssertion.succeedsWith(completeResult)
+          (result, _) <- env.router.submit(authId, PasskeyAssertionSubmission("resp", "test-csrf"), None, None)
+        yield assertTrue(result == completeResult)
+      },
+      test("re-render on a failed passkey assertion") {
+        val env = Env()
+        val credStep = ConversationStep.Credential(List(PrimaryCredential.phone), inlinePassword = false, passkey = true, passkeyFailed = true)
+        val renderResult = ConversationResult.RenderStep(credStep)
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(otpRecord))
+          _ <- env.otpConversationService.finishPasskeyAssertion.succeedsWith(renderResult)
+          (result, _) <- env.router.submit(authId, PasskeyAssertionSubmission("resp", "test-csrf"), None, None)
+        yield assertTrue(result == renderResult)
+      },
+      test("advances to the next registration step when passkey enrollment passes during registration") {
+        val env = Env()
+        val enrollStep = ConversationStep.PasskeyEnroll("req", "{}")
+        val twoStepFlow = RegistrationFlow(RegistrationCredential.email, List(RegistrationStep.Otp(), RegistrationStep.PasskeyEnroll()), Set(roleId))
+        val record = initialRecord.copy(
+          step = enrollStep,
+          registrationStep = Some(1),
+          registrationFlow = Some(twoStepFlow),
+          userId = Some(testUserId),
+        )
+        val completeResult = ConversationResult.Complete(
+          redirectUri,
+          Some(State("test-state")),
+          AuthorizationCode(Array.fill(32)(1.toByte)),
+          SessionId(Array.fill(32)(2.toByte)),
+          None,
+          testUserAgentId,
+          UserAgentData(None, testUserId, UserAgentDetails.parse(None)),
+        )
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          _ <- env.otpConversationService.finishPasskeyEnroll.succeedsWith(ConversationResult.StepPassed(record))
+          _ <- env.otpConversationService.finish.succeedsWith(completeResult)
+          (result, _) <- env.router.submit(authId, PasskeyEnrollSubmission("resp", PasskeyName("my-passkey"), "test-csrf"), None, None)
+          finishTimes = env.otpConversationService.finish.times
+        yield assertTrue(result == completeResult, finishTimes == 1)
+      },
+      test("finishes the conversation when passkey enrollment passes outside registration") {
+        val env = Env()
+        val enrollStep = ConversationStep.PasskeyEnroll("req", "{}")
+        val record = initialRecord.copy(step = enrollStep, userId = Some(testUserId))
+        val completeResult = ConversationResult.Complete(
+          redirectUri,
+          Some(State("test-state")),
+          AuthorizationCode(Array.fill(32)(1.toByte)),
+          SessionId(Array.fill(32)(2.toByte)),
+          None,
+          testUserAgentId,
+          UserAgentData(None, testUserId, UserAgentDetails.parse(None)),
+        )
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          _ <- env.otpConversationService.finishPasskeyEnroll.succeedsWith(ConversationResult.StepPassed(record))
+          _ <- env.otpConversationService.finish.succeedsWith(completeResult)
+          (result, _) <- env.router.submit(authId, PasskeyEnrollSubmission("resp", PasskeyName("my-passkey"), "test-csrf"), None, None)
+          finishTimes = env.otpConversationService.finish.times
+        yield assertTrue(result == completeResult, finishTimes == 1)
+      },
+      test("re-renders the enrollment step with enrollFailed when the ceremony fails") {
+        val env = Env()
+        val enrollStep = ConversationStep.PasskeyEnroll("req", "{}")
+        val record = initialRecord.copy(step = enrollStep, userId = Some(testUserId))
+        val failedResult = ConversationResult.RenderStep(enrollStep.copy(enrollFailed = true))
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          _ <- env.otpConversationService.finishPasskeyEnroll.succeedsWith(failedResult)
+          (result, _) <- env.router.submit(authId, PasskeyEnrollSubmission("resp", PasskeyName("my-passkey"), "test-csrf"), None, None)
+        yield assertTrue(result == failedResult)
+      },
+      test("treats a non-failed enrollment render as passed for metrics purposes") {
+        val env = Env()
+        val enrollStep = ConversationStep.PasskeyEnroll("req", "{}")
+        val record = initialRecord.copy(step = enrollStep, userId = Some(testUserId))
+        val renderResult = ConversationResult.RenderStep(enrollStep)
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          _ <- env.otpConversationService.finishPasskeyEnroll.succeedsWith(renderResult)
+          (result, _) <- env.router.submit(authId, PasskeyEnrollSubmission("resp", PasskeyName("my-passkey"), "test-csrf"), None, None)
+        yield assertTrue(result == renderResult)
+      },
+      test("skips passkey enrollment and advances the registration step") {
+        val env = Env()
+        val enrollStep = ConversationStep.PasskeyEnroll("req", "{}")
+        val twoStepFlow = RegistrationFlow(RegistrationCredential.email, List(RegistrationStep.Otp(), RegistrationStep.PasskeyEnroll()), Set(roleId))
+        val record = initialRecord.copy(
+          step = enrollStep,
+          registrationStep = Some(1),
+          registrationFlow = Some(twoStepFlow),
+          userId = Some(testUserId),
+        )
+        val completeResult = ConversationResult.Complete(
+          redirectUri,
+          Some(State("test-state")),
+          AuthorizationCode(Array.fill(32)(1.toByte)),
+          SessionId(Array.fill(32)(2.toByte)),
+          None,
+          testUserAgentId,
+          UserAgentData(None, testUserId, UserAgentDetails.parse(None)),
+        )
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          _ <- env.otpConversationService.skipPasskey.succeedsWith(ConversationResult.StepPassed(record))
+          _ <- env.otpConversationService.finish.succeedsWith(completeResult)
+          (result, _) <- env.router.submit(authId, PasskeySkipSubmission("test-csrf"), None, None)
+          finishTimes = env.otpConversationService.finish.times
+        yield assertTrue(result == completeResult, finishTimes == 1)
+      },
+      test("skips passkey enrollment and finishes outside registration") {
+        val env = Env()
+        val enrollStep = ConversationStep.PasskeyEnroll("req", "{}")
+        val record = initialRecord.copy(step = enrollStep, userId = Some(testUserId))
+        val completeResult = ConversationResult.Complete(
+          redirectUri,
+          Some(State("test-state")),
+          AuthorizationCode(Array.fill(32)(1.toByte)),
+          SessionId(Array.fill(32)(2.toByte)),
+          None,
+          testUserAgentId,
+          UserAgentData(None, testUserId, UserAgentDetails.parse(None)),
+        )
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          _ <- env.otpConversationService.skipPasskey.succeedsWith(ConversationResult.StepPassed(record))
+          _ <- env.otpConversationService.finish.succeedsWith(completeResult)
+          (result, _) <- env.router.submit(authId, PasskeySkipSubmission("test-csrf"), None, None)
+          finishTimes = env.otpConversationService.finish.times
+        yield assertTrue(result == completeResult, finishTimes == 1)
+      },
+      test("returns a render result directly from a skip submission") {
+        val env = Env()
+        val enrollStep = ConversationStep.PasskeyEnroll("req", "{}")
+        val record = initialRecord.copy(step = enrollStep, userId = Some(testUserId))
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          _ <- env.otpConversationService.skipPasskey.succeedsWith(ConversationResult.BadRequest)
+          (result, _) <- env.router.submit(authId, PasskeySkipSubmission("test-csrf"), None, None)
+        yield assertTrue(result == ConversationResult.BadRequest)
+      },
+      test("advances to the next auth factor after a password reset") {
+        val env = Env()
+        val setPasswordStep = ConversationStep.SetPassword(factorIndex = 0, timesSubmitted = 0, rateLimitExceeded = false, passwordReused = false)
+        val flow = otpAuthFlow.copy(primary = otpAuthFlow.primary.copy(factors = List(AuthFactor(`type` = AuthFactorType.password, required = true))))
+        val record = initialRecord.copy(step = setPasswordStep, authFlow = flow)
+        val completeResult = ConversationResult.Complete(
+          redirectUri,
+          Some(State("test-state")),
+          AuthorizationCode(Array.fill(32)(1.toByte)),
+          SessionId(Array.fill(32)(2.toByte)),
+          None,
+          testUserAgentId,
+          UserAgentData(None, testUserId, UserAgentDetails.parse(None)),
+        )
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          _ <- env.otpConversationService.setNewPassword.succeedsWith(ConversationResult.StepPassed(record))
+          _ <- env.configService.getAcrVocabulary.succeedsWith(Map.empty)
+          _ <- env.otpConversationService.finish.succeedsWith(completeResult)
+          (result, _) <- env.router.submit(authId, SetPasswordSubmission(password, "test-csrf"), None, None)
+        yield assertTrue(result == completeResult)
+      },
+      test("advances the registration step after a password reset during registration") {
+        val env = Env()
+        val setPasswordStep = ConversationStep.SetPassword(factorIndex = 0, timesSubmitted = 0, rateLimitExceeded = false, passwordReused = false)
+        val flow = RegistrationFlow(RegistrationCredential.email, List(RegistrationStep.Otp(), RegistrationStep.SetPassword()), Set(roleId))
+        val record = initialRecord.copy(
+          step = setPasswordStep,
+          registrationStep = Some(1),
+          registrationFlow = Some(flow),
+          userId = Some(testUserId),
+        )
+        val completeResult = ConversationResult.Complete(
+          redirectUri,
+          Some(State("test-state")),
+          AuthorizationCode(Array.fill(32)(1.toByte)),
+          SessionId(Array.fill(32)(2.toByte)),
+          None,
+          testUserAgentId,
+          UserAgentData(None, testUserId, UserAgentDetails.parse(None)),
+        )
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          _ <- env.otpConversationService.setNewPassword.succeedsWith(ConversationResult.StepPassed(record))
+          _ <- env.otpConversationService.finish.succeedsWith(completeResult)
+          (result, _) <- env.router.submit(authId, SetPasswordSubmission(password, "test-csrf"), None, None)
+          finishTimes = env.otpConversationService.finish.times
+        yield assertTrue(result == completeResult, finishTimes == 1)
+      },
+      test("re-renders with passwordReused when the new password fails validation") {
+        val env = Env()
+        val setPasswordStep = ConversationStep.SetPassword(factorIndex = 0, timesSubmitted = 0, rateLimitExceeded = false, passwordReused = false)
+        val record = initialRecord.copy(step = setPasswordStep)
+        val renderResult = ConversationResult.RenderStep(setPasswordStep.copy(passwordReused = true))
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          _ <- env.otpConversationService.setNewPassword.succeedsWith(renderResult)
+          (result, _) <- env.router.submit(authId, SetPasswordSubmission(password, "test-csrf"), None, None)
+        yield assertTrue(result == renderResult)
+      },
+      test("returns ServiceUnavailable render when the underlying dispatch fails unexpectedly") {
+        val env = Env()
+        val boom = new RuntimeException("boom")
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(initialRecord))
+          _ <- env.userRepository.findByCredential.failsWith(boom)
+          (result, record) <- env.router.submit(authId, PhoneSubmission(phone, "test-csrf"), None, None)
+        yield assertTrue(result == ConversationResult.ServiceUnavailable, record == initialRecord)
+      },
+    ),
+    suite("afterAuthenticationCredential branches")(
+      test("routes to password step when the auth flow's factor is password") {
+        val env = Env()
+        val passwordFactorFlow = otpAuthFlow.copy(
+          primary = otpAuthFlow.primary.copy(factors = List(AuthFactor(`type` = AuthFactorType.password, required = true))),
+        )
+        val record = initialRecord.copy(authFlow = passwordFactorFlow)
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          _ <- env.userRepository.findByCredential.succeedsWith(None)
+          _ <- env.configService.getAcrVocabulary.succeedsWith(Map.empty)
+          _ <- env.otpConversationService.prepareInitialPassword.succeedsWith(conversationResult)
+          (result, _) <- env.router.submit(authId, PhoneSubmission(phone, "test-csrf"), None, None)
+          prepareTimes = env.otpConversationService.prepareInitialPassword.times
+        yield assertTrue(result == conversationResult, prepareTimes == 1)
+      },
+      test("denies access when passkeyEnroll is misconfigured as a primary factor") {
+        val env = Env()
+        val badFlow = otpAuthFlow.copy(
+          primary = otpAuthFlow.primary.copy(factors = List(AuthFactor(`type` = AuthFactorType.passkeyEnroll, required = true))),
+        )
+        val record = initialRecord.copy(authFlow = badFlow)
+        val accessDeniedResult = ConversationResult.RenderStep(ConversationStep.AccessDenied)
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          _ <- env.userRepository.findByCredential.succeedsWith(None)
+          _ <- env.configService.getAcrVocabulary.succeedsWith(Map.empty)
+          _ <- env.otpConversationService.accessDenied.succeedsWith(accessDeniedResult)
+          (result, _) <- env.router.submit(authId, PhoneSubmission(phone, "test-csrf"), None, None)
+        yield assertTrue(result == accessDeniedResult)
+      },
+      test("finishes directly when the auth flow has no further factors after the credential") {
+        val env = Env()
+        val noFactorsFlow = otpAuthFlow.copy(primary = otpAuthFlow.primary.copy(factors = List.empty))
+        val record = initialRecord.copy(authFlow = noFactorsFlow)
+        val completeResult = ConversationResult.Complete(
+          redirectUri,
+          Some(State("test-state")),
+          AuthorizationCode(Array.fill(32)(1.toByte)),
+          SessionId(Array.fill(32)(2.toByte)),
+          None,
+          testUserAgentId,
+          UserAgentData(None, testUserId, UserAgentDetails.parse(None)),
+        )
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          _ <- env.userRepository.findByCredential.succeedsWith(None)
+          _ <- env.configService.getAcrVocabulary.succeedsWith(Map.empty)
+          _ <- env.otpConversationService.finish.succeedsWith(completeResult)
+          (result, _) <- env.router.submit(authId, PhoneSubmission(phone, "test-csrf"), None, None)
+        yield assertTrue(result == completeResult)
+      },
+    ),
+    suite("advance additional branches")(
+      test("routes to passkey enrollment when no password change is required") {
+        val env = Env()
+        val flow =
+          loginFlow.copy(primary = loginFlow.primary.copy(factors = List(AuthFactor(`type` = AuthFactorType.passkeyEnroll, required = true))))
+        val record = loginRecord.copy(authFlow = flow, needsPasswordChange = false)
+        for
+          _ <- env.configService.getAcrVocabulary.succeedsWith(Map.empty)
+          _ <- env.otpConversationService.offerPasskeyEnroll.succeedsWith(conversationResult)
+          _ <- env.router.advance(authId, record)
+          offerTimes = env.otpConversationService.offerPasskeyEnroll.times
+        yield assertTrue(offerTimes == 1)
+      },
+    ),
+    suite("registration additional branches")(
+      test("continues directly to the next step without re-registering when the user is already resolved") {
+        val env = Env()
+        val pending = registrationRecord.copy(
+          credential = Some(Left(email)),
+          step = otp,
+          registrationStep = Some(0),
+          userId = Some(testUserId),
+        )
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(pending))
+          _ <- env.otpConversationService.checkOtp.succeedsWith(ConversationResult.StepPassed(pending))
+          _ <- env.otpConversationService.offerSetPassword.succeedsWith(conversationResult)
+          (result, _) <- env.router.submit(authId, OtpSubmission(otpCode, "test-csrf"), None, None)
+          registerTimes = env.otpConversationService.registerVerifiedUser.times
+        yield assertTrue(result == conversationResult, registerTimes == 0)
+      },
+      test("denies access when advancing to an account-bound step without a verified credential") {
+        val env = Env()
+        val pending = registrationRecord.copy(
+          credential = Some(Left(email)),
+          step = otp,
+          registrationStep = Some(0),
+          amr = Map.empty,
+        )
+        val accessDeniedResult = ConversationResult.RenderStep(ConversationStep.AccessDenied)
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(pending))
+          _ <- env.otpConversationService.checkOtp.succeedsWith(ConversationResult.StepPassed(pending))
+          _ <- env.otpConversationService.accessDenied.succeedsWith(accessDeniedResult)
+          (result, _) <- env.router.submit(authId, OtpSubmission(otpCode, "test-csrf"), None, None)
+          registerTimes = env.otpConversationService.registerVerifiedUser.times
+        yield assertTrue(result == accessDeniedResult, registerTimes == 0)
+      },
+      test("returns a write conflict when creating the account for the next registration step loses the race") {
+        val env = Env()
+        val pending = registrationRecord.copy(
+          credential = Some(Left(email)),
+          step = otp,
+          registrationStep = Some(0),
+          amr = Map(PassedAuthFactor.otp -> PassedFactorRecord(Instant.now(), Set(AuthMethodRef.otp))),
+        )
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(pending))
+          _ <- env.otpConversationService.checkOtp.succeedsWith(ConversationResult.StepPassed(pending))
+          _ <- env.otpConversationService.registerVerifiedUser.succeedsWith(ConversationResult.WriteConflict)
+          (result, _) <- env.router.submit(authId, OtpSubmission(otpCode, "test-csrf"), None, None)
+        yield assertTrue(result == ConversationResult.WriteConflict)
+      },
+      test("denies access when the entry credential is missing despite a verified factor") {
+        val env = Env()
+        val pending = registrationRecord.copy(credential = Some(Left(email)), step = otp, registrationStep = Some(0))
+        val updatedWithoutCredential = pending.copy(
+          credential = None,
+          amr = Map(PassedAuthFactor.otp -> PassedFactorRecord(Instant.now(), Set(AuthMethodRef.otp))),
+        )
+        val accessDeniedResult = ConversationResult.RenderStep(ConversationStep.AccessDenied)
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(pending))
+          _ <- env.otpConversationService.checkOtp.succeedsWith(ConversationResult.StepPassed(updatedWithoutCredential))
+          _ <- env.otpConversationService.accessDenied.succeedsWith(accessDeniedResult)
+          (result, _) <- env.router.submit(authId, OtpSubmission(otpCode, "test-csrf"), None, None)
+          registerTimes = env.otpConversationService.registerVerifiedUser.times
+        yield assertTrue(result == accessDeniedResult, registerTimes == 0)
+      },
+      test("offers passkey enrollment as the next registration step") {
+        val env = Env()
+        val flow = RegistrationFlow(RegistrationCredential.email, List(RegistrationStep.Otp(), RegistrationStep.PasskeyEnroll()), Set(roleId))
+        val pending = registrationRecord.copy(
+          credential = Some(Left(email)),
+          step = otp,
+          registrationStep = Some(0),
+          registrationFlow = Some(flow),
+          amr = Map(PassedAuthFactor.otp -> PassedFactorRecord(Instant.now(), Set(AuthMethodRef.otp))),
+        )
+        val registered = pending.copy(userId = Some(testUserId), registrationStep = Some(1))
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(pending))
+          _ <- env.otpConversationService.checkOtp.succeedsWith(ConversationResult.StepPassed(pending))
+          _ <- env.otpConversationService.registerVerifiedUser.succeedsWith(RegistrationEntry.Registering(registered))
+          _ <- env.otpConversationService.offerPasskeyEnroll.succeedsWith(conversationResult)
+          (result, _) <- env.router.submit(authId, OtpSubmission(otpCode, "test-csrf"), None, None)
+          offerTimes = env.otpConversationService.offerPasskeyEnroll.times
+        yield assertTrue(result == conversationResult, offerTimes == 1)
+      },
+      test("denies access when a subsequent registration OTP step has no credential to send to") {
+        val env = Env()
+        val twoOtpFlow = RegistrationFlow(RegistrationCredential.email, List(RegistrationStep.Otp(), RegistrationStep.Otp()), Set(roleId))
+        val pending = registrationRecord.copy(
+          credential = Some(Left(email)),
+          step = otp,
+          registrationStep = Some(0),
+          registrationFlow = Some(twoOtpFlow),
+        )
+        val updatedNoCredential = pending.copy(credential = None)
+        val accessDeniedResult = ConversationResult.RenderStep(ConversationStep.AccessDenied)
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(pending))
+          _ <- env.otpConversationService.checkOtp.succeedsWith(ConversationResult.StepPassed(updatedNoCredential))
+          _ <- env.otpConversationService.accessDenied.succeedsWith(accessDeniedResult)
+          (result, _) <- env.router.submit(authId, OtpSubmission(otpCode, "test-csrf"), None, None)
+        yield assertTrue(result == accessDeniedResult)
+      },
+    ),
+    suite("step mismatch metrics label every current step")(
+      test("labels a mismatch on the Otp step") {
+        val env = Env()
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(otpRecord))
+          (result, _) <- env.router.submit(authId, PasswordSubmission(password, "test-csrf"), None, None)
+        yield assertTrue(result == ConversationResult.BadRequest)
+      },
+      test("labels a mismatch on the Password step") {
+        val env = Env()
+        val passwordStep = ConversationStep.Password(timesSubmitted = 0, oldPasswordChangedAt = None, factorIndex = 0, rateLimitExceeded = false)
+        val record = initialRecord.copy(step = passwordStep)
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          (result, _) <- env.router.submit(authId, OtpSubmission(otpCode, "test-csrf"), None, None)
+        yield assertTrue(result == ConversationResult.BadRequest)
+      },
+      test("labels a mismatch on the SetPassword step") {
+        val env = Env()
+        val setPasswordStep = ConversationStep.SetPassword(factorIndex = 0, timesSubmitted = 0, rateLimitExceeded = false, passwordReused = false)
+        val record = initialRecord.copy(step = setPasswordStep)
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          (result, _) <- env.router.submit(authId, OtpSubmission(otpCode, "test-csrf"), None, None)
+        yield assertTrue(result == ConversationResult.BadRequest)
+      },
+      test("labels a mismatch on the PasskeyEnroll step") {
+        val env = Env()
+        val enrollStep = ConversationStep.PasskeyEnroll("req", "{}")
+        val record = initialRecord.copy(step = enrollStep)
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          (result, _) <- env.router.submit(authId, OtpSubmission(otpCode, "test-csrf"), None, None)
+        yield assertTrue(result == ConversationResult.BadRequest)
+      },
+      test("labels a mismatch on the Consent step") {
+        val env = Env()
+        val consentStep = ConversationStep.Consent(requestedScope = Set(ScopeToken.OpenId), allowPartial = false)
+        val record = initialRecord.copy(step = consentStep)
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          (result, _) <- env.router.submit(authId, OtpSubmission(otpCode, "test-csrf"), None, None)
+        yield assertTrue(result == ConversationResult.BadRequest)
+      },
+      test("labels a mismatch on the AccessDenied step") {
+        val env = Env()
+        val record = initialRecord.copy(step = ConversationStep.AccessDenied)
+        for
+          _ <- env.otpConversationService.find.succeedsWith(Some(record))
+          (result, _) <- env.router.submit(authId, OtpSubmission(otpCode, "test-csrf"), None, None)
+        yield assertTrue(result == ConversationResult.BadRequest)
       },
     ),
   )

--- a/central/src/test/scala/versola/central/configuration/challenges/OtpChallengeControllerSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/challenges/OtpChallengeControllerSpec.scala
@@ -2,10 +2,10 @@ package versola.central.configuration.challenges
 
 import io.opentelemetry.api
 import org.scalamock.stubs.{Stub, ZIOStubs}
-import versola.central.{CentralConfig, TestAdminAuth, TestCentralConfig}
 import versola.central.configuration.edges.EdgeService
 import versola.central.configuration.resources.ResourceService
 import versola.central.configuration.tenants.TenantId
+import versola.central.{CentralConfig, TestAdminAuth, TestCentralConfig}
 import versola.util.JWT
 import versola.util.http.Observability
 import zio.*
@@ -23,7 +23,32 @@ object OtpChallengeControllerSpec extends ZIOSpecDefault, ZIOStubs:
   private val tenantId = TenantId("tenant-a")
   private val secretKey = SecretKeySpec(Array.fill(32)(7.toByte), "AES")
 
-  private val template = OtpTemplateRecord("default", tenantId, Map("en" -> "Code: {{code}}"), purpose = OtpTemplatePurpose.otp, channel = OtpTemplateChannel.sms)
+  private val template =
+    OtpTemplateRecord("default", tenantId, Map("en" -> "Code: {{code}}"), purpose = OtpTemplatePurpose.otp, channel = OtpTemplateChannel.sms)
+
+  private def settings(
+      authConversationTtlSeconds: Int = 111,
+      sessionTtlSeconds: Int = 222,
+      sessionIdleTtlSeconds: Option[Int] = Some(333),
+      userAgentTtlSeconds: Int = 444,
+      acrVocabulary: Option[Map[String, List[String]]] = Some(Map("a" -> List("b"))),
+      postLogoutRedirectUris: List[String] = List("https://existing.example/logout"),
+  ): ChallengeSettingsRecord =
+    ChallengeSettingsRecord(
+      tenantId = tenantId,
+      allowedPrefixes = List("+1"),
+      submissionLimits = SubmissionLimits.empty,
+      otpLength = 6,
+      otpResendAfter = 30,
+      passkeySettings = PasskeySettings("rp", "RP Name", List("https://rp.example"), "preferred"),
+      authConversationTtlSeconds = authConversationTtlSeconds,
+      sessionTtlSeconds = sessionTtlSeconds,
+      sessionIdleTtlSeconds = sessionIdleTtlSeconds,
+      userAgentTtlSeconds = userAgentTtlSeconds,
+      ipHeader = "X-Forwarded-For",
+      acrVocabulary = acrVocabulary,
+      postLogoutRedirectUris = postLogoutRedirectUris,
+    )
 
   private val syncToken = Unsafe.unsafe { unsafe ?=>
     Runtime.default.unsafe
@@ -50,33 +75,37 @@ object OtpChallengeControllerSpec extends ZIOSpecDefault, ZIOStubs:
       expectedStatus: Status,
       setup: Stub[OtpChallengeService] => UIO[Unit] = _ => ZIO.unit,
       verify: (Response, Stub[OtpChallengeService]) => Task[TestResult] = (_, _) => ZIO.succeed(assertTrue(true)),
+      settingsSetup: Stub[ChallengeSettingsService] => UIO[Unit] = _ => ZIO.unit,
+      settingsVerify: (Response, Stub[ChallengeSettingsService]) => Task[TestResult] = (_, _) => ZIO.succeed(assertTrue(true)),
   ) =
     test(description) {
       for
-        client        <- ZIO.service[Client]
-        service       = stub[OtpChallengeService]
+        client <- ZIO.service[Client]
+        service = stub[OtpChallengeService]
         challengeSettingsService = stub[ChallengeSettingsService]
-        edgeService   = stub[EdgeService]
+        edgeService = stub[EdgeService]
         resourceService = stub[ResourceService]
-        tracing       <- tracingLayer.build
+        tracing <- tracingLayer.build
         _ <- TestClient.addRoutes(
           Observability.handleErrors(
             OtpChallengeController.routes.provideEnvironment(
               ZEnvironment[OtpChallengeService](service) ++
                 ZEnvironment[ChallengeSettingsService](challengeSettingsService) ++
                 tracing ++ ZEnvironment[CentralConfig](config) ++ ZEnvironment[EdgeService](edgeService) ++
-                ZEnvironment[ResourceService](resourceService)
-            )
-          )
+                ZEnvironment[ResourceService](resourceService),
+            ),
+          ),
         )
-        _            <- resourceService.verifySecret.succeedsWith(true)
-        _            <- setup(service)
+        _ <- resourceService.verifySecret.succeedsWith(true)
+        _ <- setup(service)
+        _ <- settingsSetup(challengeSettingsService)
         requestWithAuth = request.headers.header(Header.Authorization) match
           case None => request.addHeader(TestAdminAuth.basicAuthHeader)
-          case _    => request
-        response     <- client.batched(requestWithAuth.addHeader(Header.Accept(MediaType.application.json)))
+          case _ => request
+        response <- client.batched(requestWithAuth.addHeader(Header.Accept(MediaType.application.json)))
         verifyResult <- verify(response, service)
-      yield assertTrue(response.status == expectedStatus) && verifyResult
+        settingsVerifyResult <- settingsVerify(response, challengeSettingsService)
+      yield assertTrue(response.status == expectedStatus) && verifyResult && settingsVerifyResult
     }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging
 
   def spec = suite("OtpChallengeController")(
@@ -84,7 +113,7 @@ object OtpChallengeControllerSpec extends ZIOSpecDefault, ZIOStubs:
       description = "GET otp-templates returns tenant templates",
       request = Request.get(
         (URL.empty / "configuration" / "challenges" / "otp-templates")
-          .addQueryParam("tenantId", tenantId.toString)
+          .addQueryParam("tenantId", tenantId.toString),
       ),
       expectedStatus = Status.Ok,
       setup = service => service.getTemplates.succeedsWith(Vector(template)),
@@ -121,7 +150,8 @@ object OtpChallengeControllerSpec extends ZIOSpecDefault, ZIOStubs:
       request = Request(
         method = Method.PUT,
         url = URL.empty / "configuration" / "challenges" / "otp-templates",
-        body = Body.fromString(UpsertOtpTemplateRequest(template.id, template.tenantId, template.localizations, template.purpose, template.channel).toJson),
+        body =
+          Body.fromString(UpsertOtpTemplateRequest(template.id, template.tenantId, template.localizations, template.purpose, template.channel).toJson),
       ).addHeader(Header.ContentType(MediaType.application.json)),
       expectedStatus = Status.NoContent,
       setup = service => service.upsertTemplate.succeedsWith(()),
@@ -139,5 +169,150 @@ object OtpChallengeControllerSpec extends ZIOSpecDefault, ZIOStubs:
       setup = service => service.deleteTemplate.succeedsWith(()),
       verify = (_, service) =>
         ZIO.succeed(assertTrue(service.deleteTemplate.calls == List((template.id, template.tenantId, template.purpose, template.channel)))),
+    ),
+    controllerTestCase(
+      description = "GET challenge-settings returns the tenant's settings",
+      request = Request.get(
+        (URL.empty / "configuration" / "challenges" / "challenge-settings")
+          .addQueryParam("tenantId", tenantId.toString),
+      ),
+      expectedStatus = Status.Ok,
+      settingsSetup = service => service.getSettings.succeedsWith(Some(settings())),
+      settingsVerify = (response, service) =>
+        for payload <- response.body.asJson[GetChallengeSettingsResponse]
+        yield assertTrue(
+          service.getSettings.calls == List(tenantId),
+          payload == GetChallengeSettingsResponse(Some(settings())),
+        ),
+    ),
+    controllerTestCase(
+      description = "GET challenge-settings/sync returns all settings for authorized service token",
+      request = Request
+        .get(URL.empty / "configuration" / "challenges" / "challenge-settings" / "sync")
+        .addHeader(Header.Authorization.Bearer(syncToken)),
+      expectedStatus = Status.Ok,
+      settingsSetup = service => service.getAllSettings.succeedsWith(Vector(settings())),
+      settingsVerify = (response, service) =>
+        for payload <- response.body.asJson[GetAllChallengeSettingsResponse]
+        yield assertTrue(
+          service.getAllSettings.calls.length == 1,
+          payload == GetAllChallengeSettingsResponse(Vector(settings())),
+        ),
+    ),
+    controllerTestCase(
+      description = "reject challenge-settings/sync request without service token",
+      request = Request.get(URL.empty / "configuration" / "challenges" / "challenge-settings" / "sync"),
+      expectedStatus = Status.Unauthorized,
+      settingsVerify = (_, service) =>
+        ZIO.succeed(assertTrue(service.getAllSettings.calls.isEmpty)),
+    ),
+    controllerTestCase(
+      description = "PUT challenge-settings prefers request-provided optional fields over existing settings",
+      request = Request(
+        method = Method.PUT,
+        url = URL.empty / "configuration" / "challenges" / "challenge-settings",
+        body = Body.fromString(
+          UpsertChallengeSettingsRequest(
+            tenantId = tenantId,
+            allowedPrefixes = List("+1"),
+            submissionLimits = SubmissionLimits.empty,
+            otpLength = 6,
+            otpResendAfter = 30,
+            passkeySettings = PasskeySettings("rp", "RP Name", List("https://rp.example"), "preferred"),
+            authConversationTtlSeconds = Some(10),
+            sessionTtlSeconds = Some(20),
+            sessionIdleTtlSeconds = Some(30),
+            userAgentTtlSeconds = Some(40),
+            ipHeader = "X-Forwarded-For",
+            acrVocabulary = Some(Map("x" -> List("y"))),
+            postLogoutRedirectUris = Some(List("https://new.example/logout")),
+          ).toJson,
+        ),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.NoContent,
+      settingsSetup = service =>
+        service.getSettings.succeedsWith(Some(settings())) *> service.upsertSettings.succeedsWith(()),
+      settingsVerify = (_, service) =>
+        ZIO.succeed(assertTrue(
+          service.upsertSettings.calls == List(
+            settings(
+              authConversationTtlSeconds = 10,
+              sessionTtlSeconds = 20,
+              sessionIdleTtlSeconds = Some(30),
+              userAgentTtlSeconds = 40,
+              acrVocabulary = Some(Map("x" -> List("y"))),
+              postLogoutRedirectUris = List("https://new.example/logout"),
+            ),
+          ),
+        )),
+    ),
+    controllerTestCase(
+      description = "PUT challenge-settings falls back to existing settings when optional fields are omitted",
+      request = Request(
+        method = Method.PUT,
+        url = URL.empty / "configuration" / "challenges" / "challenge-settings",
+        body = Body.fromString(
+          UpsertChallengeSettingsRequest(
+            tenantId = tenantId,
+            allowedPrefixes = List("+1"),
+            submissionLimits = SubmissionLimits.empty,
+            otpLength = 6,
+            otpResendAfter = 30,
+            passkeySettings = PasskeySettings("rp", "RP Name", List("https://rp.example"), "preferred"),
+            authConversationTtlSeconds = None,
+            sessionTtlSeconds = None,
+            sessionIdleTtlSeconds = None,
+            userAgentTtlSeconds = None,
+            ipHeader = "X-Forwarded-For",
+            acrVocabulary = None,
+            postLogoutRedirectUris = None,
+          ).toJson,
+        ),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.NoContent,
+      settingsSetup = service =>
+        service.getSettings.succeedsWith(Some(settings())) *> service.upsertSettings.succeedsWith(()),
+      settingsVerify = (_, service) =>
+        ZIO.succeed(assertTrue(service.upsertSettings.calls == List(settings()))),
+    ),
+    controllerTestCase(
+      description = "PUT challenge-settings falls back to defaults when there are no existing settings and fields are omitted",
+      request = Request(
+        method = Method.PUT,
+        url = URL.empty / "configuration" / "challenges" / "challenge-settings",
+        body = Body.fromString(
+          UpsertChallengeSettingsRequest(
+            tenantId = tenantId,
+            allowedPrefixes = List("+1"),
+            submissionLimits = SubmissionLimits.empty,
+            otpLength = 6,
+            otpResendAfter = 30,
+            passkeySettings = PasskeySettings("rp", "RP Name", List("https://rp.example"), "preferred"),
+            authConversationTtlSeconds = None,
+            sessionTtlSeconds = None,
+            sessionIdleTtlSeconds = None,
+            userAgentTtlSeconds = None,
+            ipHeader = "X-Forwarded-For",
+            acrVocabulary = None,
+            postLogoutRedirectUris = None,
+          ).toJson,
+        ),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.NoContent,
+      settingsSetup = service =>
+        service.getSettings.succeedsWith(None) *> service.upsertSettings.succeedsWith(()),
+      settingsVerify = (_, service) =>
+        ZIO.succeed(assertTrue(
+          service.upsertSettings.calls == List(
+            settings(
+              authConversationTtlSeconds = 900,
+              sessionTtlSeconds = 86400,
+              sessionIdleTtlSeconds = None,
+              userAgentTtlSeconds = 15552000,
+              acrVocabulary = None,
+              postLogoutRedirectUris = Nil,
+            ),
+          ),
+        )),
     ),
   )

--- a/central/src/test/scala/versola/central/configuration/edges/EdgeControllerSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/edges/EdgeControllerSpec.scala
@@ -4,17 +4,32 @@ import io.opentelemetry.api
 import org.scalamock.stubs.{Stub, ZIOStubs}
 import versola.central.TestAdminAuth
 import versola.central.configuration.resources.ResourceService
+import versola.util.RsaKeyPair
 import versola.util.http.Observability
 import zio.*
 import zio.http.*
 import zio.json.*
+import zio.json.ast.Json
 import zio.telemetry.opentelemetry.OpenTelemetry
 import zio.telemetry.opentelemetry.tracing.Tracing
 import zio.test.*
 
+import java.security.KeyPairGenerator
+import java.security.interfaces.{RSAPrivateKey, RSAPublicKey}
+
 object EdgeControllerSpec extends ZIOSpecDefault, ZIOStubs:
 
   private val edgeId = EdgeId("edge-1")
+
+  private val testKeyPair: RsaKeyPair =
+    val gen = KeyPairGenerator.getInstance("RSA")
+    gen.initialize(2048)
+    val pair = gen.generateKeyPair()
+    RsaKeyPair(
+      keyId = "2026-04-29_18-30-00",
+      publicKey = pair.getPublic.asInstanceOf[RSAPublicKey],
+      privateKey = pair.getPrivate.asInstanceOf[RSAPrivateKey],
+    )
 
   private val tracingLayer: ULayer[Tracing] =
     ZLayer.make[Tracing](
@@ -28,6 +43,7 @@ object EdgeControllerSpec extends ZIOSpecDefault, ZIOStubs:
       request: Request,
       expectedStatus: Status,
       setup: Stub[EdgeService] => UIO[Unit] = _ => ZIO.unit,
+      verify: (Response, Stub[EdgeService]) => Task[TestResult] = (_, _) => ZIO.succeed(assertTrue(true)),
   ) =
     test(description) {
       for
@@ -40,14 +56,15 @@ object EdgeControllerSpec extends ZIOSpecDefault, ZIOStubs:
             EdgeController.routes.provideEnvironment(
               ZEnvironment[EdgeService](edgeService) ++
                 ZEnvironment[ResourceService](resourceService) ++
-                tracing
-            )
-          )
+                tracing,
+            ),
+          ),
         )
         _ <- resourceService.verifySecret.succeedsWith(true)
         _ <- setup(edgeService)
         response <- client.batched(request.addHeader(TestAdminAuth.basicAuthHeader))
-      yield assertTrue(response.status == expectedStatus)
+        verifyResult <- verify(response, edgeService)
+      yield assertTrue(response.status == expectedStatus) && verifyResult
     }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging
 
   def spec = suite("EdgeController")(
@@ -58,11 +75,75 @@ object EdgeControllerSpec extends ZIOSpecDefault, ZIOStubs:
       setup = service => service.getAllEdges.succeedsWith(Vector.empty),
     ),
     controllerTestCase(
+      description = "get all edges maps each record's id and old-key presence",
+      request = Request.get(URL.root / "configuration" / "edges"),
+      expectedStatus = Status.Ok,
+      setup = service =>
+        service.getAllEdges.succeedsWith(
+          Vector(
+            EdgeRecord(edgeId, Json.Obj(), oldPublicKey = None),
+            EdgeRecord(EdgeId("edge-2"), Json.Obj(), oldPublicKey = Some(Json.Obj())),
+          ),
+        ),
+      verify = (response, _) =>
+        for body <- response.body.asJson[GetAllEdgesResponse]
+        yield assertTrue(
+          body.edges == List(
+            EdgeResponse(edgeId, hasOldKey = false),
+            EdgeResponse(EdgeId("edge-2"), hasOldKey = true),
+          ),
+        ),
+    ),
+    controllerTestCase(
       description = "delete edge returns 204 No Content",
       request = Request.delete(
-        (URL.root / "configuration" / "edges").addQueryParam("edgeId", edgeId.toString)
+        (URL.root / "configuration" / "edges").addQueryParam("edgeId", edgeId.toString),
       ),
       expectedStatus = Status.NoContent,
       setup = service => service.deleteEdge.succeedsWith(()),
+      verify = (_, service) =>
+        ZIO.succeed(assertTrue(service.deleteEdge.calls == List(edgeId))),
+    ),
+    controllerTestCase(
+      description = "register edge returns 201 Created with the generated key pair",
+      request = Request(
+        method = Method.POST,
+        url = URL.root / "configuration" / "edges",
+        body = Body.fromString(RegisterEdgeRequest(edgeId).toJson),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.Created,
+      setup = service => service.registerEdge.succeedsWith(testKeyPair),
+      verify = (response, service) =>
+        for body <- response.body.asJson[versola.central.configuration.edges.ServiceKeyResponse]
+        yield assertTrue(
+          service.registerEdge.calls == List(edgeId),
+          body.keyId == testKeyPair.keyId,
+        ),
+    ),
+    controllerTestCase(
+      description = "rotate edge key returns 200 OK with the rotated key pair",
+      request = Request(
+        method = Method.POST,
+        url = (URL.root / "configuration" / "edges" / "rotate-key").addQueryParam("edgeId", edgeId.toString),
+      ),
+      expectedStatus = Status.Ok,
+      setup = service => service.rotateEdgeKey.succeedsWith(testKeyPair),
+      verify = (response, service) =>
+        for body <- response.body.asJson[versola.central.configuration.edges.ServiceKeyResponse]
+        yield assertTrue(
+          service.rotateEdgeKey.calls == List(edgeId),
+          body.keyId == testKeyPair.keyId,
+        ),
+    ),
+    controllerTestCase(
+      description = "delete old edge key returns 204 No Content",
+      request = Request(
+        method = Method.DELETE,
+        url = (URL.root / "configuration" / "edges" / "old-key").addQueryParam("edgeId", edgeId.toString),
+      ),
+      expectedStatus = Status.NoContent,
+      setup = service => service.deleteOldEdgeKey.succeedsWith(()),
+      verify = (_, service) =>
+        ZIO.succeed(assertTrue(service.deleteOldEdgeKey.calls == List(edgeId))),
     ),
   )

--- a/central/src/test/scala/versola/central/configuration/forms/FormControllerSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/forms/FormControllerSpec.scala
@@ -2,13 +2,15 @@ package versola.central.configuration.forms
 
 import io.opentelemetry.api
 import org.scalamock.stubs.{Stub, ZIOStubs}
-import versola.central.{CentralConfig, TestAdminAuth, TestCentralConfig}
 import versola.central.configuration.edges.EdgeService
 import versola.central.configuration.resources.ResourceService
+import versola.central.{CentralConfig, TestAdminAuth, TestCentralConfig}
+import versola.util.JWT
 import versola.util.http.Observability
 import zio.*
 import zio.http.*
 import zio.json.*
+import zio.json.ast.Json
 import zio.telemetry.opentelemetry.OpenTelemetry
 import zio.telemetry.opentelemetry.tracing.Tracing
 import zio.test.*
@@ -25,6 +27,27 @@ object FormControllerSpec extends ZIOSpecDefault, ZIOStubs:
       ZLayer.succeed(api.OpenTelemetry.noop().getTracer("test")),
     )
 
+  private val syncToken = Unsafe.unsafe { unsafe ?=>
+    Runtime.default.unsafe
+      .run(
+        JWT.serialize(
+          JWT.Claims("a", "b", List("c"), Json.Obj()),
+          1.minute,
+          JWT.Signature.Symmetric(config.secretKey),
+        ),
+      )
+      .getOrThrowFiberFailure()
+  }
+
+  private val updateFormRequest = UpdateFormRequest(
+    id = form.id,
+    style = "new-style",
+    jsSource = Some("new-src"),
+    jsCompiled = Some("new-compiled"),
+    localizations = Map("en" -> Map("title" -> "Hello")),
+    properties = Vector.empty,
+  )
+
   private def controllerTestCase(
       description: String,
       request: Request,
@@ -34,26 +57,26 @@ object FormControllerSpec extends ZIOSpecDefault, ZIOStubs:
   ) =
     test(description) {
       for
-        client     <- ZIO.service[Client]
-        service    = stub[FormService]
+        client <- ZIO.service[Client]
+        service = stub[FormService]
         edgeService = stub[EdgeService]
         resourceService = stub[ResourceService]
-        tracing    <- tracingLayer.build
+        tracing <- tracingLayer.build
         _ <- TestClient.addRoutes(
           Observability.handleErrors(
             FormController.routes.provideEnvironment(
               ZEnvironment[FormService](service) ++ tracing ++ ZEnvironment[CentralConfig](config) ++
-                ZEnvironment[EdgeService](edgeService) ++ ZEnvironment[ResourceService](resourceService)
-            )
-          )
+                ZEnvironment[EdgeService](edgeService) ++ ZEnvironment[ResourceService](resourceService),
+            ),
+          ),
         )
         _ <- resourceService.verifySecret.succeedsWith(true)
         _ <- setup(service)
         requestWithAuth = request.headers.header(Header.Authorization) match
           case None => request.addHeader(TestAdminAuth.basicAuthHeader)
-          case _    => request
-        response      <- client.batched(requestWithAuth.addHeader(Header.Accept(MediaType.application.json)))
-        verifyResult  <- verify(response, service)
+          case _ => request
+        response <- client.batched(requestWithAuth.addHeader(Header.Accept(MediaType.application.json)))
+        verifyResult <- verify(response, service)
       yield assertTrue(response.status == expectedStatus) && verifyResult
     }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging
 
@@ -71,5 +94,53 @@ object FormControllerSpec extends ZIOSpecDefault, ZIOStubs:
           service.getAllForms.calls.length == 1,
           payload == GetAllFormsResponse(Vector(form)),
         ),
+    ),
+    controllerTestCase(
+      description = "GET /configuration/forms/sync returns active forms for an authorized service token",
+      request = Request.get(URL.empty / "configuration" / "forms" / "sync")
+        .addHeader(Header.Authorization.Bearer(syncToken)),
+      expectedStatus = Status.Ok,
+      setup = service => service.getSyncForms.succeedsWith(Vector(form)),
+      verify = (response, service) =>
+        for
+          payload <- response.body.asJson[GetAllFormsResponse]
+        yield assertTrue(
+          service.getSyncForms.calls.length == 1,
+          payload == GetAllFormsResponse(Vector(form)),
+        ),
+    ),
+    controllerTestCase(
+      description = "PUT /configuration/forms updates a form without activating it",
+      request = Request(
+        method = Method.PUT,
+        url = URL.empty / "configuration" / "forms",
+        body = Body.fromString(updateFormRequest.toJson),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.NoContent,
+      setup = service => service.updateForm.succeedsWith(()),
+      verify = (_, service) =>
+        ZIO.succeed(assertTrue(
+          service.updateForm.calls == List((
+            updateFormRequest.id,
+            updateFormRequest.style,
+            updateFormRequest.jsSource,
+            updateFormRequest.jsCompiled,
+            updateFormRequest.localizations,
+            updateFormRequest.properties,
+            false,
+          )),
+        )),
+    ),
+    controllerTestCase(
+      description = "PUT /configuration/forms/active sets the active version",
+      request = Request(
+        method = Method.PUT,
+        url = URL.empty / "configuration" / "forms" / "active",
+        body = Body.fromString(SetActiveVersionRequest(form.id, 2).toJson),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.NoContent,
+      setup = service => service.setActiveVersion.succeedsWith(()),
+      verify = (_, service) =>
+        ZIO.succeed(assertTrue(service.setActiveVersion.calls == List((form.id, 2)))),
     ),
   )

--- a/central/src/test/scala/versola/central/configuration/forms/FormServiceSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/forms/FormServiceSpec.scala
@@ -2,16 +2,17 @@ package versola.central.configuration.forms
 
 import org.scalamock.stubs.ZIOStubs
 import versola.central.configuration.locales.{LocaleRecord, LocaleService}
+import versola.central.configuration.sync.SyncEvent
 import versola.util.ReloadingCache
 import zio.*
 import zio.test.*
 
 object FormServiceSpec extends ZIOSpecDefault, ZIOStubs:
   class Env(initialForms: Vector[FormRecord] = Vector.empty):
-    val cache         = ReloadingCache(Unsafe.unsafe(unsafe ?=> Ref.unsafe.make(initialForms)))
-    val repository    = stub[FormRepository]
+    val cache = ReloadingCache(Unsafe.unsafe(unsafe ?=> Ref.unsafe.make(initialForms)))
+    val repository = stub[FormRepository]
     val localeService = stub[LocaleService]
-    val service       = FormService.Impl(cache, repository, localeService)
+    val service = FormService.Impl(cache, repository, localeService)
 
   def spec = suite("FormService")(
     test("updateForm delegates to repository upsertForm and refreshes cache") {
@@ -30,7 +31,7 @@ object FormServiceSpec extends ZIOSpecDefault, ZIOStubs:
       )
     },
     test("getSyncForms excludes inactive forms") {
-      val activeForm   = FormRecord(FormId("a"), 1, true,  "style", None, None, Map("en" -> Map("k" -> "v")), Vector.empty)
+      val activeForm = FormRecord(FormId("a"), 1, true, "style", None, None, Map("en" -> Map("k" -> "v")), Vector.empty)
       val inactiveForm = FormRecord(FormId("b"), 1, false, "style", None, None, Map("en" -> Map("k" -> "v")), Vector.empty)
       val env = new Env(Vector(activeForm, inactiveForm))
 
@@ -41,7 +42,12 @@ object FormServiceSpec extends ZIOSpecDefault, ZIOStubs:
     },
     test("getSyncForms strips localizations of inactive locales") {
       val form = FormRecord(
-        FormId("f"), 1, true, "style", None, None,
+        FormId("f"),
+        1,
+        true,
+        "style",
+        None,
+        None,
         Map("en" -> Map("title" -> "Hello"), "fr" -> Map("title" -> "Bonjour")),
         Vector.empty,
       )
@@ -51,5 +57,65 @@ object FormServiceSpec extends ZIOSpecDefault, ZIOStubs:
         _ <- env.localeService.getActive.succeedsWith(Vector(LocaleRecord("en", "English", isDefault = true, active = true)))
         result <- env.service.getSyncForms
       yield assertTrue(result.head.localizations == Map("en" -> Map("title" -> "Hello")))
+    },
+    test("getAllForms returns all forms sorted by id") {
+      val formB = FormRecord(FormId("b"), 1, true, "style", None, None, Map.empty, Vector.empty)
+      val formA = FormRecord(FormId("a"), 1, true, "style", None, None, Map.empty, Vector.empty)
+      val env = new Env(Vector(formB, formA))
+
+      for result <- env.service.getAllForms
+      yield assertTrue(result == Vector(formA, formB))
+    },
+    test("setActiveVersion delegates to repository and refreshes cache") {
+      val env = new Env()
+      val formId = FormId("test")
+      val record = FormRecord(formId, 2, true, "style", None, None, Map.empty, Vector.empty)
+
+      for
+        _ <- env.repository.setActiveVersion.succeedsWith(())
+        _ <- env.repository.getAll.succeedsWith(Vector(record))
+        _ <- env.service.setActiveVersion(formId, 2)
+        cached <- env.cache.get
+      yield assertTrue(
+        env.repository.setActiveVersion.calls == List((formId, 2)),
+        cached == Vector(record),
+      )
+    },
+    test("sync removes cached form on delete event") {
+      val formA = FormRecord(FormId("a"), 1, true, "style", None, None, Map.empty, Vector.empty)
+      val formB = FormRecord(FormId("b"), 1, true, "style", None, None, Map.empty, Vector.empty)
+      val env = new Env(Vector(formA, formB))
+
+      for
+        _ <- env.service.sync(SyncEvent.FormsUpdated(formA.id, formA.version, SyncEvent.Op.DELETE))
+        cached <- env.cache.get
+      yield assertTrue(cached == Vector(formB))
+    },
+    test("sync upserts fetched form for non-delete event") {
+      val formA = FormRecord(FormId("a"), 1, true, "style", None, None, Map.empty, Vector.empty)
+      val env = new Env(Vector(formA))
+      val updatedForm = formA.copy(active = false)
+
+      for
+        _ <- env.repository.find.succeedsWith(Some(updatedForm))
+        _ <- env.service.sync(SyncEvent.FormsUpdated(formA.id, formA.version, SyncEvent.Op.UPDATE))
+        cached <- env.cache.get
+      yield assertTrue(
+        env.repository.find.calls == List((formA.id, formA.version)),
+        cached == Vector(updatedForm),
+      )
+    },
+    test("sync removes cached form when record is missing on non-delete event") {
+      val formA = FormRecord(FormId("a"), 1, true, "style", None, None, Map.empty, Vector.empty)
+      val env = new Env(Vector(formA))
+
+      for
+        _ <- env.repository.find.succeedsWith(None)
+        _ <- env.service.sync(SyncEvent.FormsUpdated(formA.id, formA.version, SyncEvent.Op.UPDATE))
+        cached <- env.cache.get
+      yield assertTrue(
+        env.repository.find.calls == List((formA.id, formA.version)),
+        cached == Vector.empty,
+      )
     },
   )

--- a/central/src/test/scala/versola/central/configuration/metadata/ServerMetadataServiceSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/metadata/ServerMetadataServiceSpec.scala
@@ -54,8 +54,68 @@ object ServerMetadataServiceSpec extends ZIOSpecDefault, ZIOStubs:
           metadata(
             "issuer" -> Json.Str("https://issuer.example"),
             metadataKey -> Json.Arr(),
-          )
-        )
+          ),
+        ),
       )
+    },
+    test("adds the first type when no metadata has been stored yet") {
+      val env = new Env(None)
+
+      for
+        _ <- env.repository.get.succeedsWith(None)
+        _ <- env.repository.upsert.succeedsWith(())
+        _ <- env.service.updateAuthorizationDetailType("account", SyncEvent.Op.INSERT)
+      yield assertTrue(
+        env.repository.upsert.calls == List(metadata(metadataKey -> Json.Arr(Json.Str("account")))),
+      )
+    },
+    test("adds a type when the existing metadata has no configured types yet") {
+      val existing = metadata("issuer" -> Json.Str("https://issuer.example"))
+      val env = new Env(Some(ServerMetadataRecord("default", existing)))
+
+      for
+        _ <- env.repository.get.succeedsWith(Some(ServerMetadataRecord("default", existing)))
+        _ <- env.repository.upsert.succeedsWith(())
+        _ <- env.service.updateAuthorizationDetailType("account", SyncEvent.Op.INSERT)
+      yield assertTrue(
+        env.repository.upsert.calls == List(
+          metadata(
+            "issuer" -> Json.Str("https://issuer.example"),
+            metadataKey -> Json.Arr(Json.Str("account")),
+          ),
+        ),
+      )
+    },
+    test("getMetadata returns the cached metadata") {
+      val existing = metadata("issuer" -> Json.Str("https://issuer.example"))
+      val env = new Env(Some(ServerMetadataRecord("default", existing)))
+
+      for result <- env.service.getMetadata
+      yield assertTrue(result.contains(existing))
+    },
+    test("getMetadata returns None when nothing is cached") {
+      val env = new Env(None)
+
+      for result <- env.service.getMetadata
+      yield assertTrue(result.isEmpty)
+    },
+    test("upsertMetadata delegates to repository") {
+      val env = new Env(None)
+      val newMetadata = metadata("issuer" -> Json.Str("https://issuer.example"))
+
+      for
+        _ <- env.repository.upsert.succeedsWith(())
+        _ <- env.service.upsertMetadata(newMetadata)
+      yield assertTrue(env.repository.upsert.calls == List(newMetadata))
+    },
+    test("sync reloads the cache from the repository") {
+      val env = new Env(None)
+      val record = ServerMetadataRecord("default", metadata("issuer" -> Json.Str("https://issuer.example")))
+
+      for
+        _ <- env.repository.get.succeedsWith(Some(record))
+        _ <- env.service.sync()
+        cached <- env.cache.get
+      yield assertTrue(cached.contains(record))
     },
   )

--- a/central/src/test/scala/versola/central/configuration/permissions/PermissionServiceSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/permissions/PermissionServiceSpec.scala
@@ -1,13 +1,14 @@
 package versola.central.configuration.permissions
 
 import org.scalamock.stubs.{Stub, ZIOStubs}
+import versola.central.configuration.edges.EdgeId
 import versola.central.configuration.resources.ResourceEndpointId
 import versola.central.configuration.sync.SyncEvent
-import versola.central.configuration.tenants.{TenantId, TenantRepository}
+import versola.central.configuration.tenants.{TenantId, TenantRecord, TenantRepository}
 import versola.central.configuration.{CreatePermissionRequest, PatchDescription, UpdatePermissionRequest}
 import versola.util.ReloadingCache
-import zio.prelude.EqualOps
 import zio.*
+import zio.prelude.EqualOps
 import zio.test.*
 
 import java.util.UUID
@@ -22,7 +23,8 @@ object PermissionServiceSpec extends ZIOSpecDefault, ZIOStubs:
   private val readManagedEndpointId = endpointId("018f0f2a-1c7b-7000-8000-000000000103")
   private val writeUpdateEndpointId = endpointId("018f0f2a-1c7b-7000-8000-000000000201")
   private val tenantPermission = PermissionRecord(tenantId, Permission("users:read"), Map("en" -> "Read users"), Set(readListEndpointId))
-  private val otherTenantPermission = PermissionRecord(otherTenantId, Permission("users:write"), Map("en" -> "Write users"), Set(writeUpdateEndpointId))
+  private val otherTenantPermission =
+    PermissionRecord(otherTenantId, Permission("users:write"), Map("en" -> "Write users"), Set(writeUpdateEndpointId))
 
   private val createRequest = CreatePermissionRequest(
     tenantId = tenantId,
@@ -66,7 +68,7 @@ object PermissionServiceSpec extends ZIOSpecDefault, ZIOStubs:
         _ <- env.repository.createPermission.succeedsWith(())
         _ <- env.service.createPermission(createRequest)
       yield assertTrue(
-        env.repository.createPermission.calls === List((tenantId, tenantPermission.id, tenantPermission.description, tenantPermission.endpointIds))
+        env.repository.createPermission.calls === List((tenantId, tenantPermission.id, tenantPermission.description, tenantPermission.endpointIds)),
       )
     },
     test("updatePermission delegates request fields to repository") {
@@ -76,7 +78,7 @@ object PermissionServiceSpec extends ZIOSpecDefault, ZIOStubs:
         _ <- env.repository.updatePermission.succeedsWith(())
         _ <- env.service.updatePermission(updateRequest)
       yield assertTrue(
-        env.repository.updatePermission.calls == List((tenantId, tenantPermission.id, updateRequest.description, updateRequest.endpointIds))
+        env.repository.updatePermission.calls == List((tenantId, tenantPermission.id, updateRequest.description, updateRequest.endpointIds)),
       )
     },
     test("deletePermission delegates tenant and permission to repository") {
@@ -86,6 +88,33 @@ object PermissionServiceSpec extends ZIOSpecDefault, ZIOStubs:
         _ <- env.repository.deletePermission.succeedsWith(())
         _ <- env.service.deletePermission(tenantId, tenantPermission.id)
       yield assertTrue(env.repository.deletePermission.calls === List((tenantId, tenantPermission.id)))
+    },
+    test("getPermissionsForSync returns all cached permissions when no edge is specified") {
+      val env = new Env(Vector(tenantPermission, otherTenantPermission))
+
+      for result <- env.service.getPermissionsForSync(None)
+      yield assertTrue(result === Vector(tenantPermission, otherTenantPermission))
+    },
+    test("getPermissionsForSync filters permissions to tenants routed through the given edge") {
+      val env = new Env(Vector(tenantPermission, otherTenantPermission))
+      val edgeId = EdgeId("edge-1")
+      val routedTenant = TenantRecord(tenantId, "Tenant A", Some(edgeId))
+      val unroutedTenant = TenantRecord(otherTenantId, "Tenant B", None)
+
+      for
+        _ <- env.tenantRepository.getAll.succeedsWith(Vector(routedTenant, unroutedTenant))
+        result <- env.service.getPermissionsForSync(Some(edgeId))
+      yield assertTrue(result === Vector(tenantPermission))
+    },
+    test("getPermissionsForSync returns empty when no tenant is routed through the given edge") {
+      val env = new Env(Vector(tenantPermission, otherTenantPermission))
+      val edgeId = EdgeId("edge-1")
+      val unroutedTenant = TenantRecord(tenantId, "Tenant A", None)
+
+      for
+        _ <- env.tenantRepository.getAll.succeedsWith(Vector(unroutedTenant))
+        result <- env.service.getPermissionsForSync(Some(edgeId))
+      yield assertTrue(result.isEmpty)
     },
     test("sync removes cached permission on delete event") {
       val env = new Env(Vector(tenantPermission, otherTenantPermission))

--- a/central/src/test/scala/versola/central/configuration/roles/RoleServiceSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/roles/RoleServiceSpec.scala
@@ -1,13 +1,14 @@
 package versola.central.configuration.roles
 
 import org.scalamock.stubs.{Stub, ZIOStubs}
+import versola.central.configuration.edges.EdgeId
 import versola.central.configuration.permissions.Permission
 import versola.central.configuration.sync.SyncEvent
-import versola.central.configuration.tenants.{TenantId, TenantRepository}
+import versola.central.configuration.tenants.{TenantId, TenantRecord, TenantRepository}
 import versola.central.configuration.{CreateRoleRequest, PatchDescription, PatchPermissions, UpdateRoleRequest}
 import versola.util.ReloadingCache
-import zio.prelude.EqualOps
 import zio.*
+import zio.prelude.EqualOps
 import zio.test.*
 
 object RoleServiceSpec extends ZIOSpecDefault, ZIOStubs:
@@ -64,7 +65,7 @@ object RoleServiceSpec extends ZIOSpecDefault, ZIOStubs:
         _ <- env.repository.createRole.succeedsWith(())
         _ <- env.service.createRole(createRequest)
       yield assertTrue(
-        env.repository.createRole.calls === List((tenantId, adminRoleId, createRequest.description, createRequest.permissions.toList))
+        env.repository.createRole.calls === List((tenantId, adminRoleId, createRequest.description, createRequest.permissions.toList)),
       )
     },
     test("updateRole delegates request fields to repository") {
@@ -74,7 +75,7 @@ object RoleServiceSpec extends ZIOSpecDefault, ZIOStubs:
         _ <- env.repository.updateRole.succeedsWith(())
         _ <- env.service.updateRole(updateRequest)
       yield assertTrue(
-        env.repository.updateRole.calls == List((tenantId, adminRoleId, updateRequest.description, updateRequest.permissions))
+        env.repository.updateRole.calls == List((tenantId, adminRoleId, updateRequest.description, updateRequest.permissions)),
       )
     },
     test("markRoleInactive delegates tenant and id to repository") {
@@ -152,6 +153,41 @@ object RoleServiceSpec extends ZIOSpecDefault, ZIOStubs:
 
       for
         result <- env.service.getPermissionsForRoles(tenantId, Set.empty)
+      yield assertTrue(result.isEmpty)
+    },
+    test("getRolesForSync returns all cached roles when no edge is specified") {
+      val env = new Env(Vector(adminRole, otherTenantRole))
+
+      for
+        result <- env.service.getRolesForSync(None)
+      yield assertTrue(result === Vector(adminRole, otherTenantRole))
+    },
+    test("getRolesForSync filters roles to tenants assigned to the given edge") {
+      val edgeId = EdgeId("edge-1")
+      val env = new Env(Vector(adminRole, otherTenantRole))
+
+      for
+        _ <- env.tenantRepository.getAll.succeedsWith(
+          Vector(
+            TenantRecord(tenantId, "Tenant A", Some(edgeId)),
+            TenantRecord(otherTenantId, "Tenant B", None),
+          ),
+        )
+        result <- env.service.getRolesForSync(Some(edgeId))
+      yield assertTrue(result === Vector(adminRole))
+    },
+    test("getRolesForSync excludes all roles when no tenant is assigned to the given edge") {
+      val edgeId = EdgeId("edge-1")
+      val env = new Env(Vector(adminRole, otherTenantRole))
+
+      for
+        _ <- env.tenantRepository.getAll.succeedsWith(
+          Vector(
+            TenantRecord(tenantId, "Tenant A", None),
+            TenantRecord(otherTenantId, "Tenant B", None),
+          ),
+        )
+        result <- env.service.getRolesForSync(Some(edgeId))
       yield assertTrue(result.isEmpty)
     },
   )

--- a/central/src/test/scala/versola/central/configuration/themes/ThemeControllerSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/themes/ThemeControllerSpec.scala
@@ -2,15 +2,17 @@ package versola.central.configuration.themes
 
 import io.opentelemetry.api
 import org.scalamock.stubs.{Stub, ZIOStubs}
-import versola.central.{CentralConfig, TestAdminAuth}
 import versola.central.TestCentralConfig
 import versola.central.configuration.edges.EdgeService
 import versola.central.configuration.resources.ResourceService
 import versola.central.configuration.tenants.TenantId
+import versola.central.{CentralConfig, TestAdminAuth}
+import versola.util.JWT
 import versola.util.http.Observability
 import zio.*
 import zio.http.*
 import zio.json.*
+import zio.json.ast.Json
 import zio.telemetry.opentelemetry.OpenTelemetry
 import zio.telemetry.opentelemetry.tracing.Tracing
 import zio.test.*
@@ -18,7 +20,7 @@ import zio.test.*
 object ThemeControllerSpec extends ZIOSpecDefault, ZIOStubs:
 
   private val tenantId = TenantId("t1")
-  private val themeId  = "theme-1"
+  private val themeId = "theme-1"
   private val themeRecord = ThemeRecord(themeId, "body { color: red; }", Some(tenantId))
 
   private val tracingLayer: ULayer[Tracing] =
@@ -28,41 +30,60 @@ object ThemeControllerSpec extends ZIOSpecDefault, ZIOStubs:
       ZLayer.succeed(api.OpenTelemetry.noop().getTracer("test")),
     )
 
+  private val config = TestCentralConfig.config
+
+  private val syncToken = Unsafe.unsafe { unsafe ?=>
+    Runtime.default.unsafe
+      .run(
+        JWT.serialize(
+          JWT.Claims("a", "b", List("c"), Json.Obj()),
+          1.minute,
+          JWT.Signature.Symmetric(config.secretKey),
+        ),
+      )
+      .getOrThrowFiberFailure()
+  }
+
   private def controllerTestCase(
       description: String,
       request: Request,
       expectedStatus: Status,
       setup: Stub[ThemeService] => UIO[Unit] = _ => ZIO.unit,
+      verify: (Response, Stub[ThemeService]) => Task[TestResult] = (_, _) => ZIO.succeed(assertTrue(true)),
   ) =
     test(description) {
       for
-        client             <- ZIO.service[Client]
-        themeService        = stub[ThemeService]
-        resourceService  = stub[ResourceService]
-        edgeService         = stub[EdgeService]
-        tracing            <- tracingLayer.build
+        client <- ZIO.service[Client]
+        themeService = stub[ThemeService]
+        resourceService = stub[ResourceService]
+        edgeService = stub[EdgeService]
+        tracing <- tracingLayer.build
         _ <- TestClient.addRoutes(
           Observability.handleErrors(
             ThemeController.routes.provideEnvironment(
               ZEnvironment[ThemeService](themeService) ++
                 ZEnvironment[ResourceService](resourceService) ++
                 ZEnvironment[EdgeService](edgeService) ++
-                ZEnvironment[CentralConfig](TestCentralConfig.config) ++
-                tracing
-            )
-          )
+                ZEnvironment[CentralConfig](config) ++
+                tracing,
+            ),
+          ),
         )
         _ <- resourceService.verifySecret.succeedsWith(true)
         _ <- setup(themeService)
-        response <- client.batched(request.addHeader(TestAdminAuth.basicAuthHeader))
-      yield assertTrue(response.status == expectedStatus)
+        requestWithAuth = request.headers.header(Header.Authorization) match
+          case None => request.addHeader(TestAdminAuth.basicAuthHeader)
+          case _ => request
+        response <- client.batched(requestWithAuth)
+        verifyResult <- verify(response, themeService)
+      yield assertTrue(response.status == expectedStatus) && verifyResult
     }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging
 
   def spec = suite("ThemeController")(
     controllerTestCase(
       description = "get themes returns 200 OK",
       request = Request.get(
-        (URL.root / "configuration" / "themes").addQueryParam("tenantId", tenantId.toString)
+        (URL.root / "configuration" / "themes").addQueryParam("tenantId", tenantId.toString),
       ),
       expectedStatus = Status.Ok,
       setup = service => service.getThemes.succeedsWith(Vector(themeRecord)),
@@ -70,9 +91,66 @@ object ThemeControllerSpec extends ZIOSpecDefault, ZIOStubs:
     controllerTestCase(
       description = "delete theme returns 204 No Content",
       request = Request.delete(
-        (URL.root / "configuration" / "themes").addQueryParam("id", themeId)
+        (URL.root / "configuration" / "themes").addQueryParam("id", themeId),
       ),
       expectedStatus = Status.NoContent,
       setup = service => service.deleteTheme.succeedsWith(()),
+    ),
+    controllerTestCase(
+      description = "delete theme returns 409 Conflict when the theme is in use",
+      request = Request.delete(
+        (URL.root / "configuration" / "themes").addQueryParam("id", themeId),
+      ),
+      expectedStatus = Status.Conflict,
+      setup = service => service.deleteTheme.failsWith(new ThemeService.ThemeInUseError),
+    ),
+    controllerTestCase(
+      description = "delete theme returns 400 Bad Request when deleting the default theme",
+      request = Request.delete(
+        (URL.root / "configuration" / "themes").addQueryParam("id", ThemeService.DefaultThemeId),
+      ),
+      expectedStatus = Status.BadRequest,
+      setup = service => service.deleteTheme.failsWith(new IllegalArgumentException("Cannot delete the default theme")),
+    ),
+    controllerTestCase(
+      description = "create theme returns 201 Created",
+      request = Request(
+        method = Method.POST,
+        url = URL.root / "configuration" / "themes",
+        body = Body.fromString(CreateThemeRequest(themeId, "body { color: green; }", Some(tenantId)).toJson),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.Created,
+      setup = service => service.createTheme.succeedsWith(()),
+      verify = (_, service) =>
+        ZIO.succeed(assertTrue(
+          service.createTheme.calls == List(ThemeRecord(themeId, "body { color: green; }", Some(tenantId))),
+        )),
+    ),
+    controllerTestCase(
+      description = "update theme returns 204 No Content",
+      request = Request(
+        method = Method.PUT,
+        url = URL.root / "configuration" / "themes",
+        body = Body.fromString(UpdateThemeRequest(themeId, "body { color: yellow; }").toJson),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.NoContent,
+      setup = service => service.updateTheme.succeedsWith(()),
+      verify = (_, service) =>
+        ZIO.succeed(assertTrue(
+          service.updateTheme.calls == List(ThemeRecord(themeId, "body { color: yellow; }", None)),
+        )),
+    ),
+    controllerTestCase(
+      description = "sync themes returns 200 OK for an authorized service token",
+      request = Request.get(URL.root / "configuration" / "themes" / "sync")
+        .addHeader(Header.Authorization.Bearer(syncToken)),
+      expectedStatus = Status.Ok,
+      setup = service => service.getAllThemes.succeedsWith(Vector(themeRecord)),
+      verify = (response, service) =>
+        for payload <- response.body.asJson[GetAllThemesResponse]
+        yield assertTrue(
+          service.getAllThemes.calls.length == 1,
+          payload == GetAllThemesResponse(Vector(themeRecord)),
+        ),
     ),
   )

--- a/central/src/test/scala/versola/central/configuration/themes/ThemeServiceSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/themes/ThemeServiceSpec.scala
@@ -5,17 +5,19 @@ import versola.util.{ReloadingCache, UnitSpecBase}
 import zio.*
 import zio.test.*
 
+import java.sql.SQLException
+
 object ThemeServiceSpec extends UnitSpecBase:
 
-  private val tenantId  = TenantId("t1")
-  private val themeId   = "theme-1"
+  private val tenantId = TenantId("t1")
+  private val themeId = "theme-1"
   private val globalTheme = ThemeRecord(themeId, "body { color: red; }", None)
   private val tenantTheme = ThemeRecord("tenant-theme", "body { color: blue; }", Some(tenantId))
 
   class Env(initial: Vector[ThemeRecord] = Vector.empty):
-    val cache      = ReloadingCache(Unsafe.unsafe(unsafe ?=> Ref.unsafe.make(initial)))
+    val cache = ReloadingCache(Unsafe.unsafe(unsafe ?=> Ref.unsafe.make(initial)))
     val repository = stub[ThemeRepository]
-    val service    = ThemeService.Impl(cache, repository)
+    val service = ThemeService.Impl(cache, repository)
 
   def spec = suite("ThemeService")(
     test("getAllThemes returns all themes sorted by id") {
@@ -47,5 +49,54 @@ object ThemeServiceSpec extends UnitSpecBase:
         _ <- env.repository.delete.succeedsWith(())
         _ <- env.service.deleteTheme(themeId)
       yield assertTrue(env.repository.delete.calls == List(themeId))
+    },
+    test("updateTheme delegates to repository") {
+      val env = Env()
+      for
+        _ <- env.repository.update.succeedsWith(())
+        _ <- env.service.updateTheme(globalTheme)
+      yield assertTrue(env.repository.update.calls == List(globalTheme))
+    },
+    test("deleteTheme rejects deleting the default theme without calling the repository") {
+      val env = Env()
+      for result <- env.service.deleteTheme(ThemeService.DefaultThemeId).either
+      yield assertTrue(
+        result.swap.exists(_.isInstanceOf[IllegalArgumentException]),
+        result.swap.exists(_.getMessage == "Cannot delete the default theme"),
+        env.repository.delete.calls.isEmpty,
+      )
+    },
+    test("deleteTheme maps a foreign key violation to ThemeInUseError") {
+      val env = Env()
+      val sqlException = new SQLException("fk violation", "23503")
+      for
+        _ <- env.repository.delete.failsWith(sqlException)
+        result <- env.service.deleteTheme(themeId).either
+      yield assertTrue(result.swap.exists(_.isInstanceOf[ThemeService.ThemeInUseError]))
+    },
+    test("deleteTheme maps a foreign key violation wrapped in another exception to ThemeInUseError") {
+      val env = Env()
+      val sqlException = new SQLException("fk violation", "23503")
+      val wrapped = new RuntimeException("wrapped", sqlException)
+      for
+        _ <- env.repository.delete.failsWith(wrapped)
+        result <- env.service.deleteTheme(themeId).either
+      yield assertTrue(result.swap.exists(_.isInstanceOf[ThemeService.ThemeInUseError]))
+    },
+    test("deleteTheme propagates non-foreign-key repository errors unchanged") {
+      val env = Env()
+      val error = new RuntimeException("boom")
+      for
+        _ <- env.repository.delete.failsWith(error)
+        result <- env.service.deleteTheme(themeId).either
+      yield assertTrue(result == Left(error))
+    },
+    test("sync refreshes the cache from the repository") {
+      val env = Env(Vector(globalTheme))
+      for
+        _ <- env.repository.getAll.succeedsWith(Vector(tenantTheme))
+        _ <- env.service.sync()
+        cached <- env.cache.get
+      yield assertTrue(cached == Vector(tenantTheme))
     },
   )

--- a/central/src/test/scala/versola/central/users/UserServiceSpec.scala
+++ b/central/src/test/scala/versola/central/users/UserServiceSpec.scala
@@ -3,7 +3,7 @@ package versola.central.users
 import versola.central.configuration.clients.{AuthFlow, ClientId, OAuthClientRecord, OAuthClientService}
 import versola.central.configuration.roles.RoleId
 import versola.central.configuration.tenants.TenantId
-import versola.util.{Email, RedirectUri, SecureRandom, UnitSpecBase}
+import versola.util.{Email, Patch, Phone, RedirectUri, SecureRandom, UnitSpecBase}
 import zio.*
 import zio.durationInt
 import zio.json.ast.Json
@@ -14,17 +14,17 @@ import java.util.UUID
 
 object UserServiceSpec extends UnitSpecBase:
 
-  private val userId   = UserId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+  private val userId = UserId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
   private val tenantId = TenantId("t1")
-  private val email    = Email("user@example.com")
+  private val email = Email("user@example.com")
   private val indexRecord = UserIndexRecord(userId, Some(email), None, None)
 
   class Env:
-    val userRepository     = stub[UserRepository]
-    val authClient         = stub[AuthClient]
+    val userRepository = stub[UserRepository]
+    val authClient = stub[AuthClient]
     val oAuthClientService = stub[OAuthClientService]
-    val secureRandom       = stub[SecureRandom]
-    val service            = UserService.Impl(userRepository, authClient, oAuthClientService, secureRandom)
+    val secureRandom = stub[SecureRandom]
+    val service = UserService.Impl(userRepository, authClient, oAuthClientService, secureRandom)
 
   def spec = suite("UserService")(
     test("findById returns enriched record when user found") {
@@ -163,5 +163,169 @@ object UserServiceSpec extends UnitSpecBase:
       yield assertTrue(
         result.head.clients.map(_.clientId) == List(clientIdB, clientIdA),
       )
+    },
+    test("findByEmail returns enriched record when user found") {
+      val env = Env()
+      for
+        _ <- env.userRepository.findByEmail.succeedsWith(Some(indexRecord))
+        _ <- env.authClient.getUserClaims.succeedsWith(Some(Json.Obj()))
+        result <- env.service.findByEmail(email)
+      yield assertTrue(result.map(_.id).contains(userId))
+    },
+    test("findByPhone returns enriched record when user found") {
+      val env = Env()
+      val phone = Phone("+16502530000")
+      val record = UserIndexRecord(userId, None, Some(phone), None)
+      for
+        _ <- env.userRepository.findByPhone.succeedsWith(Some(record))
+        _ <- env.authClient.getUserClaims.succeedsWith(Some(Json.Obj()))
+        result <- env.service.findByPhone(phone)
+      yield assertTrue(result.map(_.id).contains(userId))
+    },
+    test("findByLogin returns enriched record when user found") {
+      val env = Env()
+      val login = Login("jdoe")
+      val record = UserIndexRecord(userId, None, None, Some(login))
+      for
+        _ <- env.userRepository.findByLogin.succeedsWith(Some(record))
+        _ <- env.authClient.getUserClaims.succeedsWith(Some(Json.Obj()))
+        result <- env.service.findByLogin(login)
+      yield assertTrue(result.map(_.id).contains(userId))
+    },
+    test("findById defaults to an empty claims object when auth has none for the user") {
+      val env = Env()
+      for
+        _ <- env.userRepository.findById.succeedsWith(Some(indexRecord))
+        _ <- env.authClient.getUserClaims.succeedsWith(None)
+        result <- env.service.findById(userId)
+      yield assertTrue(result.map(_.claims).contains(Json.Obj()))
+    },
+    test("invalidateSession delegates to authClient") {
+      val env = Env()
+      for
+        _ <- env.authClient.invalidateSession.succeedsWith(())
+        _ <- env.service.invalidateSession(userId)
+      yield assertTrue(env.authClient.invalidateSession.calls == List(userId))
+    },
+    test("create fails with UserConflict when repository reports a conflict") {
+      val env = Env()
+      val newId = UUID.fromString("00000000-0000-0000-0000-000000000003")
+      for
+        _ <- env.secureRandom.nextUUIDv7.succeedsWith(newId)
+        _ <- env.userRepository.create.failsWith(UserConflict)
+        result <- env.service.create(CreateUserRequest(Some(email), None, None)).either
+      yield assertTrue(result == Left(UserConflict))
+    },
+    test("indexRegistered fails with UserIndexConflict when credentials resolve to multiple users") {
+      val env = Env()
+      val request = RegisteredUserRequest(Some(email), None, None)
+      for
+        _ <- env.userRepository.indexFromAuth.failsWith(UserIndexConflict)
+        result <- env.service.indexRegistered(request).either
+      yield assertTrue(result == Left(UserIndexConflict))
+    },
+    test("patch delegates request fields to repository") {
+      val env = Env()
+      val request = PatchUserRequest(userId, Some(Patch.Modified(email)), None, None)
+      for
+        _ <- env.userRepository.patch.succeedsWith(())
+        _ <- env.service.patch(request)
+      yield assertTrue(
+        env.userRepository.patch.calls == List((userId, Some(Patch.Modified(email)), None, None)),
+      )
+    },
+    test("patchClaims delegates to authClient") {
+      val env = Env()
+      val patch = Json.Obj("test" -> Json.Bool(true))
+      for
+        _ <- env.authClient.patchUserClaims.succeedsWith(())
+        _ <- env.service.patchClaims(userId, patch)
+      yield assertTrue(env.authClient.patchUserClaims.calls == List((userId, patch)))
+    },
+    test("delete delegates to repository") {
+      val env = Env()
+      for
+        _ <- env.userRepository.delete.succeedsWith(())
+        _ <- env.service.delete(userId)
+      yield assertTrue(env.userRepository.delete.calls == List(userId))
+    },
+    test("updateRoles enqueues a role update via repository") {
+      val env = Env()
+      val request = UpdateUserRolesRequest(userId, tenantId, Set(RoleId("admin")), Set(RoleId("viewer")))
+      for
+        _ <- env.userRepository.enqueueRoleUpdate.succeedsWith(())
+        _ <- env.service.updateRoles(request)
+      yield assertTrue(
+        env.userRepository.enqueueRoleUpdate.calls ==
+          List((userId, tenantId, Set(RoleId("admin")), Set(RoleId("viewer")))),
+      )
+    },
+    test("resetLimits delegates request fields to authClient") {
+      val env = Env()
+      val request = ResetUserLimitsRequest(userId, tenantId, Some(email), None)
+      for
+        _ <- env.authClient.resetUserLimits.succeedsWith(())
+        _ <- env.service.resetLimits(request)
+      yield assertTrue(
+        env.authClient.resetUserLimits.calls == List((userId, tenantId, Some(email), None)),
+      )
+    },
+    test("listPasskeys delegates to authClient") {
+      val env = Env()
+      val passkey = PasskeyInfo(
+        id = "cred-1",
+        name = Some("Phone"),
+        deviceType = "MultiDevice",
+        transports = List("internal"),
+        backedUp = true,
+        backupEligible = true,
+        lastUsedAt = None,
+        createdAt = "2024-01-01T00:00:00Z",
+      )
+      for
+        _ <- env.authClient.listPasskeys.succeedsWith(List(passkey))
+        result <- env.service.listPasskeys(userId)
+      yield assertTrue(result == List(passkey))
+    },
+    test("renamePasskey delegates request fields to authClient") {
+      val env = Env()
+      val request = RenamePasskeyRequest(userId, "cred-1", Some("New name"))
+      for
+        _ <- env.authClient.renamePasskey.succeedsWith(())
+        _ <- env.service.renamePasskey(request)
+      yield assertTrue(env.authClient.renamePasskey.calls == List((userId, "cred-1", Some("New name"))))
+    },
+    test("deletePasskey delegates to authClient") {
+      val env = Env()
+      for
+        _ <- env.authClient.deletePasskey.succeedsWith(())
+        _ <- env.service.deletePasskey(userId, "cred-1")
+      yield assertTrue(env.authClient.deletePasskey.calls == List((userId, "cred-1")))
+    },
+    test("resetPassword returns the plaintext password when authClient provides one") {
+      val env = Env()
+      val request = ResetPasswordRequest(userId, 43200L, Some(DeliveryChannel.show))
+      for
+        _ <- env.authClient.resetPassword.succeedsWith(Some("Temp1234!"))
+        result <- env.service.resetPassword(request)
+      yield assertTrue(
+        result.contains("Temp1234!"),
+        env.authClient.resetPassword.calls == List((userId, 43200L, Some(DeliveryChannel.show))),
+      )
+    },
+    test("resetPassword returns None when the password is delivered out of band") {
+      val env = Env()
+      val request = ResetPasswordRequest(userId, 43200L, Some(DeliveryChannel.email))
+      for
+        _ <- env.authClient.resetPassword.succeedsWith(None)
+        result <- env.service.resetPassword(request)
+      yield assertTrue(result.isEmpty)
+    },
+    test("setPassword delegates to authClient") {
+      val env = Env()
+      for
+        _ <- env.authClient.setPassword.succeedsWith(())
+        _ <- env.service.setPassword(userId, "Secret123!")
+      yield assertTrue(env.authClient.setPassword.calls == List((userId, "Secret123!")))
     },
   )


### PR DESCRIPTION
Follow-up to the conversation-subsystem Phase 2 PR (#247). Targets the three biggest remaining statement-coverage gaps in `auth` plus the weakest-covered files in the central admin CRUD layer, as identified from a full repo-wide coverage sweep.

## auth/src/test/scala/versola/oauth/conversation/ConversationRouterSpec.scala
38 new tests: `startPasskeyOptions` (previously untested method) full branch set, `submit`'s dispatch branches for OTP/password/passkey-assertion/passkey-enroll/passkey-skip/set-password outcomes, `afterAuthenticationCredential` routing branches, `advance`'s passkeyEnroll factor routing, registration edge cases (already-resolved user, unverified credential, write-conflict, missing credential fallback), and `stepName`'s metrics-label branches.

**`ConversationRouter.scala`: 62.0% -> 88.1% statement coverage.**

## auth/src/test/scala/versola/oauth/conversation/ConversationRenderServiceSpec.scala
17 new tests: Password/SetPassword/PasskeyEnroll/AccessDenied step rendering (previously untested step types), all `stepErrorKey` branches, phone-credential/inlinePassword branches, `useFragment` fragment-URI branch, `renderTerminal`/`renderAccount` 404 branches, and a full new `renderLogoutConfirm` suite (had zero prior coverage).

**`ConversationRenderService.scala`: 73.6% -> 96.8% statement coverage.**

## auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
16 new tests covering the `/authorize` entry point: `ConflictingHints`, `IdTokenHintInvalid` (malformed JWT, missing/array `aud` claim), `UnmetAuthenticationRequirements`/`AccessDenied` session+ACR combinations, registration-flag propagation, user-agent header sanitization, idle-session prolongation, `ui_locales` negotiation (success + `UnsupportedUiLocales`), and full hybrid silent-auth id_token issuance (previously never exercised).

**`AuthorizeEndpointService.scala`: 76.5% -> 96.1% statement coverage.**

## Central admin CRUD layer (10 spec files extended)
`ThemeService`/`-Controller`, `FormService`/`-Controller`, `PermissionService`, `UserService`, `EdgeController`, `OtpChallengeController`, `RoleService`, `ServerMetadataService`.

Added tests for previously-untested `sync()` methods, `getXForSync` edge/tenant-routing branches, CRUD error paths (conflict/not-found/FK-violation), and controller endpoints that had no test at all (`registerEdge`, `rotateEdgeKey`, `deleteOldEdgeKey`, challenge-settings sync).

**central module: 83.5% -> 89.5% statement coverage; `ThemeController`, `FormController`, and `OtpChallengeController` now at 100%.**

## Known remaining gaps (not chased further)
All fall into previously-documented categories:
- `*.live` ZLayer DI-wiring lines in object companions (`ThemeService`, `FormService`, `PermissionService`, `RoleService`, `ServerMetadataService`, `ConversationRouter`) -- the same false-positive pattern already noted for `ConversationController`/`ConversationService` in #247.
- A couple of single-call-site default-parameter initializers in `ConversationRenderService.formFor` that never execute because the sole call site always supplies both arguments explicitly.
- One likely-unreachable `stepName` branch (`LogoutConfirm => "confirm-logout"`) in `ConversationRenderService`, given the current call graph.

## Results
- **auth module: 1087 -> 1159 tests (+72), 91.86% statement / 91.60% branch coverage** (up from 87.9%/83.2%).
- **central module: 426 -> 485 tests (+59), 89.54% statement / 89.51% branch coverage** (up from 83.5%).
- 0 failures. No production source files touched.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M1R187HGTGCA8J95BYK714XK&panel=chat)