### PR TITLE
fix(auth): give the hybrid silent-authorization test spec a nonce

### DIFF
--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
@@ -25,7 +25,7 @@ import versola.oauth.client.model.{
 import versola.oauth.consent.{ConsentDecision, ConsentService}
 import versola.oauth.conversation.{ConversationRepository, ConversationResult, ConversationRouter, EmailSubmission, PhoneSubmission}
 import versola.oauth.jwks.JwksService
-import versola.oauth.model.{AccessToken, AuthorizationCode, CodeChallenge, CodeChallengeMethod, State}
+import versola.oauth.model.{AccessToken, AuthorizationCode, CodeChallenge, CodeChallengeMethod, Nonce, State}
 import versola.oauth.session.SessionService
 import versola.oauth.session.model.{ClientEntry, PublicSessionId, SessionId, SessionInfo, SessionRecord, UserAgentId}
 import versola.oauth.token.AuthorizationCodeRepository
@@ -1513,6 +1513,9 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
       val hybridRequest = baseRequest.copy(
         sessionId = Some(rawSessionId),
         responseType = NonEmptySet(ResponseTypeEntry.Code, ResponseTypeEntry.IdToken),
+        // OIDC requires nonce whenever response_type includes id_token; a hybrid request
+        // without one is not spec-compliant, so it shouldn't be what this success case models.
+        nonce = Some(Nonce("test-nonce")),
       )
       for
         _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))


### PR DESCRIPTION
Fixes the review comment on #248: https://github.com/versolauth/versola/pull/248#discussion_r3944651577

`AuthorizeEndpointServiceSpec`'s "issue a signed id_token for a hybrid silent authorization" test built its `hybridRequest` from `baseRequest.copy(...)` without overriding `nonce`, so it inherited `nonce = None` while still asserting successful front-channel ID-token issuance. OIDC requires `nonce` whenever `response_type` includes `id_token`, so this codified an invalid, replay-prone request as the case proving hybrid issuance works, and wouldn't catch a real endpoint-contract violation around nonce handling.

## Fix
Give the hybrid request an explicit `nonce = Some(Nonce("test-nonce"))` so the test models a spec-compliant request.

## Validation
- `sbt "auth/testOnly versola.oauth.authorize.AuthorizeEndpointServiceSpec"` -- 61 tests pass, 0 failures.
- `sbt auth/test central/test` -- 1644 tests pass, 0 failures (no regressions elsewhere).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M1VSPSGCN8AA2ZPWZ5QACZ0M&panel=chat)