### PR TITLE
edge: precompile CEL rules when the resource cache loads, not on first request

### DIFF
--- a/edge/implementations/postgres/src/main/scala/versola/PostgresEdgeApp.scala
+++ b/edge/implementations/postgres/src/main/scala/versola/PostgresEdgeApp.scala
@@ -69,6 +69,7 @@ object PostgresEdgeApp extends VersolaApp("edge"):
       CentralSyncTokenService.live >+>
       AuthorizationPresetsSyncClient.live >+>
       OAuthClientsSyncClient.live >+>
+      CelEvaluator.live >+>
       ResourcesSyncClient.live >+>
       RolesSyncClient.live >+>
       PermissionsSyncClient.live >+>
@@ -78,7 +79,6 @@ object PostgresEdgeApp extends VersolaApp("edge"):
       PermissionService.live >+>
       JwksService.live >+>
       TokenRevocationService.live >+>
-      CelEvaluator.live >+>
       SSOClient.live >+>
       EdgeService.live
 

--- a/edge/src/main/scala/versola/edge/ResourcesSyncClient.scala
+++ b/edge/src/main/scala/versola/edge/ResourcesSyncClient.scala
@@ -3,6 +3,7 @@ package versola.edge
 import versola.edge.model.Resource.given
 import versola.edge.model.{Resource, ResourceEndpoint, ResourceId}
 import versola.util.{Base64, CacheSource, Secret, SecurityService}
+import versola.util.cel.CelEvaluator
 import zio.http.{Client, Header, Request}
 import zio.json.JsonCodec
 import zio.schema.codec.JsonCodec.zioJsonBinaryCodec
@@ -12,14 +13,15 @@ trait ResourcesSyncClient extends CacheSource[Map[ResourceId, Resource]]:
   def getAll: Task[Map[ResourceId, Resource]]
 
 object ResourcesSyncClient:
-  val live: URLayer[Client & EdgeConfig & SecurityService & CentralSyncTokenService, ResourcesSyncClient] =
-    ZLayer.fromFunction(Impl(_, _, _, _))
+  val live: URLayer[Client & EdgeConfig & SecurityService & CentralSyncTokenService & CelEvaluator, ResourcesSyncClient] =
+    ZLayer.fromFunction(Impl(_, _, _, _, _))
 
   class Impl(
       httpClient: Client,
       config: EdgeConfig,
       securityService: SecurityService,
       centralSyncTokenService: CentralSyncTokenService,
+      celEvaluator: CelEvaluator,
   ) extends ResourcesSyncClient:
     private val ResourcesURL = config.central.url / "configuration" / "resources" / "sync"
 
@@ -34,7 +36,21 @@ object ResourcesSyncClient:
             Resource(resource.resourceId, resource.resource, resource.endpoints, secret)
           }
         }
+        _ <- precompileRules(resources)
       yield resources.map(x => x.resourceId -> x).toMap
+
+    /** Warms `celEvaluator`'s compile cache for every rule this sync just fetched, so the
+      * compile happens here, on load and on every refresh, rather than on whichever request
+      * happens to hit an endpoint's rule first. `compile` is keyed by expression string and
+      * never fails, so calling it again for an expression already cached, or for one that
+      * turns out not to compile, is a cheap no-op / one-time warning, not a request-path risk.
+      */
+    private def precompileRules(resources: Vector[Resource]): Task[Unit] =
+      ZIO.foreachDiscard(resources): resource =>
+        ZIO.foreachDiscard(resource.endpoints): endpoint =>
+          ZIO.foreachDiscard(endpoint.allow.filter(_.trim.nonEmpty))(celEvaluator.compile) *>
+            ZIO.foreachDiscard(endpoint.stepUpCondition)(celEvaluator.compile) *>
+            ZIO.foreachDiscard(endpoint.inject)(rule => celEvaluator.compile(rule.expression))
 
     private def decryptSecret(value: String): Task[Secret] =
       for

--- a/edge/src/test/scala/versola/edge/ResourcesSyncClientSpec.scala
+++ b/edge/src/test/scala/versola/edge/ResourcesSyncClientSpec.scala
@@ -1,6 +1,7 @@
 package versola.edge
 
-import versola.edge.model.{EdgeId, ResourceId}
+import versola.edge.model.{EdgeId, ResourceEndpointId, ResourceId}
+import versola.util.cel.CelEvaluator
 import versola.util.{Base64, Secret, SecurityService}
 import zio.*
 import zio.http.*
@@ -43,6 +44,20 @@ object ResourcesSyncClientSpec extends ZIOSpecDefault:
   private val centralSyncTokenService = new CentralSyncTokenService:
     override def getToken: UIO[String] = ZIO.succeed(token)
 
+  private val dummyProgram: CelEvaluator.Program = new CelEvaluator.Program:
+    override def evaluateBoolean(context: Map[String, AnyRef]) = ZIO.succeed(true)
+    override def evaluateString(context: Map[String, AnyRef]) = ZIO.succeed(None)
+
+  /** Records every expression handed to `compile`, so a test can assert precompilation reached
+    * every rule on a synced endpoint without depending on `CelEvaluator`'s own compile cache. */
+  private def trackingEvaluator(compiled: Ref[Vector[String]]): CelEvaluator = new CelEvaluator:
+    override def compile(expression: String): UIO[CelEvaluator.Program] =
+      compiled.update(_ :+ expression).as(dummyProgram)
+    override def validate(expression: String, expectedType: Option[dev.cel.common.types.CelType]) =
+      ZIO.succeed(dummyProgram)
+
+  private val celEvaluator = CelEvaluator.Impl(Unsafe.unsafe(unsafe ?=> Ref.unsafe.make(Map.empty)))
+
   def spec = suite("ResourcesSyncClient")(
     test("decrypts synced resource secrets") {
       for
@@ -57,7 +72,7 @@ object ResourcesSyncClientSpec extends ZIOSpecDefault:
           }.toRoutes
         )
         client <- ZIO.service[Client]
-        service = ResourcesSyncClient.Impl(client, config, securityService, centralSyncTokenService)
+        service = ResourcesSyncClient.Impl(client, config, securityService, centralSyncTokenService, celEvaluator)
         resources <- service.getAll
         request <- seen.get.someOrFail(RuntimeException("Central sync request was not captured"))
       yield assertTrue(
@@ -65,6 +80,32 @@ object ResourcesSyncClientSpec extends ZIOSpecDefault:
         request.url.encode.contains("configuration/resources/sync"),
         request.header(Header.Authorization).contains(Header.Authorization.Bearer(token)),
         resources(ResourceId("central")).secret.exists(_.sameElements(decryptedSecret)),
+      )
+    },
+    test("precompiles allow, step-up and inject expressions from every synced endpoint") {
+      val endpointId = ResourceEndpointId(java.util.UUID.fromString("018f0f2a-1c7b-7000-8000-000000000001"))
+      for
+        compiled <- Ref.make(Vector.empty[String])
+        _ <- TestClient.addRoutes(
+          Handler.fromFunctionZIO[Request] { _ =>
+            ZIO.succeed(
+              Response.json(
+                s"""{"resources":[{"resourceId":"central","resource":"https://central.example","endpoints":[
+                  |{"id":"$endpointId","method":"GET","path":"/orders","fetchUserInfo":false,
+                  |"allow":"request.body.total <= 50000",
+                  |"inject":[{"target":"header","name":"X-User","expression":"token.sub"}],
+                  |"stepUpCondition":"user.subscription == 'premium'",
+                  |"stepUpAcr":null,"maxAge":null}],"secret":null}]}""".stripMargin,
+              )
+            )
+          }.toRoutes
+        )
+        client <- ZIO.service[Client]
+        service = ResourcesSyncClient.Impl(client, config, securityService, centralSyncTokenService, trackingEvaluator(compiled))
+        _ <- service.getAll
+        expressions <- compiled.get
+      yield assertTrue(
+        expressions.toSet == Set("request.body.total <= 50000", "user.subscription == 'premium'", "token.sub"),
       )
     },
   ).provide(TestClient.layer)


### PR DESCRIPTION
## What

Follow-up to #236. `ResourcesSyncClient.getAll` now warms `CelEvaluator`'s compile cache for every `allow`, `stepUpCondition` and inject-rule expression on every synced resource endpoint, right after fetching them from central.

`ReloadingCache.make` calls `getAll` both on initial load and on every periodic refresh, so this covers both cases with no new caching mechanism: a freshly started edge, and a rule added or changed via the admin console mid-flight, both get compiled ahead of whichever request happens to reach them first.

`CelEvaluator.compile` itself is unchanged — still keyed by expression string, still never fails. Calling it here is a cache warm, not a new code path: the request-time compile calls in `EdgeService` (`checkRules`, `checkStepUp`, `evaluateAll`) now just hit an already-warm cache instead of compiling cold on whichever request gets there first.

## Files
- `edge/src/main/scala/versola/edge/ResourcesSyncClient.scala` — precompile step
- `edge/implementations/postgres/src/main/scala/versola/PostgresEdgeApp.scala` — moved `CelEvaluator.live` earlier in the layer chain so `ResourcesSyncClient` can depend on it
- `edge/src/test/scala/versola/edge/ResourcesSyncClientSpec.scala` — updated the existing constructor call; added a test asserting all three rule kinds get compiled on sync

Note: couldn't run a local Scala compile in this environment (no sbt/JDK available) — relying on CI for that.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M1R05DC803KEZ85ZWTCD17WM&panel=chat)