### PR TITLE
test(central): cover ClientController sync/error branches and ResourceService gaps

### DIFF
--- a/central/src/test/scala/versola/central/configuration/clients/ClientControllerSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/clients/ClientControllerSpec.scala
@@ -4,11 +4,12 @@ import io.opentelemetry.api
 import org.scalamock.stubs.{Stub, ZIOStubs}
 import versola.central.{CentralConfig, TestAdminAuth, TestCentralConfig}
 import versola.central.configuration.*
+import versola.central.configuration.edges.{EdgeId, EdgeRecord, EdgeService}
 import versola.central.configuration.permissions.Permission
 import versola.central.configuration.scopes.ScopeToken
 import versola.central.configuration.tenants.TenantId
 import versola.util.http.Observability
-import versola.util.{Base64, Base64Url, JWT, Patch, RedirectUri, Secret, SecurityService}
+import versola.util.{Base64, Base64Url, JWT, Patch, RedirectUri, RsaKeyPair, Secret, SecurityService}
 import zio.*
 import zio.http.*
 import zio.json.*
@@ -17,6 +18,8 @@ import zio.telemetry.opentelemetry.OpenTelemetry
 import zio.telemetry.opentelemetry.tracing.Tracing
 import zio.test.*
 
+import java.security.KeyPairGenerator
+import java.security.interfaces.RSAPublicKey
 import javax.crypto.spec.SecretKeySpec
 
 object ClientControllerSpec extends ZIOSpecDefault, ZIOStubs:
@@ -32,6 +35,17 @@ object ClientControllerSpec extends ZIOSpecDefault, ZIOStubs:
   private val previousSecret = Secret(Array.fill(48)(2.toByte))
   private val rotatedSecret = Secret(Array.fill(32)(3.toByte))
   private val secretKey = SecretKeySpec(Array.fill(32)(7.toByte), "AES")
+  private val edgeId = EdgeId("edge-1")
+  private val edgeKeyPair =
+    val generator = KeyPairGenerator.getInstance("RSA")
+    generator.initialize(2048)
+    val pair = generator.generateKeyPair()
+    RsaKeyPair(
+      keyId = "client-controller-edge-key",
+      publicKey = pair.getPublic.asInstanceOf[RSAPublicKey],
+      privateKey = pair.getPrivate.asInstanceOf[java.security.interfaces.RSAPrivateKey],
+    )
+  private val edgeRecord = EdgeRecord(edgeId, edgeKeyPair.toPublicJwk, None)
 
   private val config = TestCentralConfig.config
   private val syncToken = Unsafe.unsafe { unsafe ?=>
@@ -363,6 +377,54 @@ object ClientControllerSpec extends ZIOSpecDefault, ZIOStubs:
       verify = (_, service, _) =>
         ZIO.succeed(assertTrue(service.getClientsForSync.calls.isEmpty)),
     ),
+    // Gap: getAllClientsSyncEndpoint's edgeId match { case Some(id) => ... } branch (RSA transport
+    // encryption for edge-issued tokens) was never exercised; every other sync test uses a
+    // central-signed token, which takes the `None` (AES) branch.
+    test("return synced tenant clients encrypted via edge RSA key when request is signed by an edge") {
+      val edgeSecurity = new SecurityService:
+        override def encryptAes256(data: Array[Byte], key: javax.crypto.SecretKey) = ZIO.succeed(data)
+        override def decryptAes256(data: Array[Byte], key: javax.crypto.SecretKey) = ZIO.succeed(data)
+        override def encryptRsa(data: Array[Byte], key: java.security.PublicKey) = ZIO.succeed(data)
+        override def decryptRsa(data: Array[Byte], key: java.security.PrivateKey) = ZIO.dieMessage("Unused in test")
+        override def mac(secret: versola.util.Secret, key: Array[Byte]) = ZIO.dieMessage("Unused in test")
+        override def hashPassword(password: versola.util.Secret, salt: versola.util.Salt, pepper: versola.util.Secret.Bytes16) = ZIO.dieMessage("Unused in test")
+        override def generateRsaKeyPair = ZIO.dieMessage("Unused in test")
+      for
+        client <- ZIO.service[Client]
+        service = stub[OAuthClientService]
+        resourceService = stub[versola.central.configuration.resources.ResourceService]
+        edgeService = stub[EdgeService]
+        tracing <- tracingLayer.build
+        token <- JWT.serialize(
+          JWT.Claims("edge", "edge", List("central"), Json.Obj()),
+          1.minute,
+          JWT.Signature.Asymmetric(JWT.Algorithm.RS256, edgeKeyPair.keyId, edgeKeyPair.privateKey),
+          headers = Map("edge_id" -> edgeId.toString),
+        )
+        _ <- edgeService.find.succeedsWith(Some(edgeRecord))
+        _ <- service.getClientsForSync.succeedsWith(Vector(clients.head))
+        _ <- TestClient.addRoutes(
+          Observability.handleErrors(
+            ClientController.routes.provideEnvironment(
+              ZEnvironment[OAuthClientService](service) ++ ZEnvironment[versola.central.configuration.resources.ResourceService](resourceService) ++ ZEnvironment[CentralConfig](config) ++ tracing ++
+                ZEnvironment[SecurityService](edgeSecurity) ++ ZEnvironment[EdgeService](edgeService),
+            ),
+          ),
+        )
+        response <- client.batched(
+          Request.get((URL.empty / "configuration" / "clients" / "sync").addQueryParam("tenantId", tenantId.toString))
+            .addHeader(Header.Authorization.Bearer(token)),
+        )
+        payload <- response.body.asJson[GetOAuthClientsSyncResponse]
+      yield assertTrue(
+        response.status == Status.Ok,
+        // authorizeInternal verifies the token's issuing edge, then the sync endpoint looks
+        // up the edge again to pick its RSA public key for transport encryption.
+        edgeService.find.calls == List(edgeId, edgeId),
+        service.getClientsForSync.calls == List(Some(edgeId)),
+        payload.clients.head.secret.isDefined,
+      )
+    }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
     controllerTestCase(
       description = "create client and return encoded secret",
       request = Request(
@@ -396,6 +458,56 @@ object ClientControllerSpec extends ZIOSpecDefault, ZIOStubs:
         ZIO.succeed(
           assertTrue(service.registerClient.calls.isEmpty),
         ),
+    ),
+    controllerTestCase(
+      description = "create client returns 409 when the client id already exists",
+      request = Request(
+        method = Method.POST,
+        url = URL.empty / "configuration" / "clients",
+        body = Body.fromString(createRequest.toJson),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.Conflict,
+      setup = service =>
+        service.registerClient.failsWith(ClientAlreadyExists(clientId)),
+    ),
+    controllerTestCase(
+      description = "create client returns 400 when the consent screen URI is invalid",
+      request = Request(
+        method = Method.POST,
+        url = URL.empty / "configuration" / "clients",
+        body = Body.fromString(createRequest.toJson),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.BadRequest,
+      setup = service =>
+        service.registerClient.failsWith(InvalidConsentUri("policyUri", "must be an absolute https URL")),
+      verify = (response, _, _) =>
+        for body <- response.body.asString
+        yield assertTrue(body == "Invalid policyUri: must be an absolute https URL"),
+    ),
+    controllerTestCase(
+      description = "create client returns 400 when the registration configuration is invalid",
+      request = Request(
+        method = Method.POST,
+        url = URL.empty / "configuration" / "clients",
+        body = Body.fromString(createRequest.toJson),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.BadRequest,
+      setup = service =>
+        service.registerClient.failsWith(InvalidRegistrationConfiguration(clientId, "registration must start with OTP verification")),
+      verify = (response, _, _) =>
+        for body <- response.body.asString
+        yield assertTrue(body == "Invalid registration configuration: registration must start with OTP verification"),
+    ),
+    controllerTestCase(
+      description = "create client surfaces an unexpected failure as 500 Internal Server Error",
+      request = Request(
+        method = Method.POST,
+        url = URL.empty / "configuration" / "clients",
+        body = Body.fromString(createRequest.toJson),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.InternalServerError,
+      setup = service =>
+        service.registerClient.failsWith(RuntimeException("boom")),
     ),
     controllerTestCase(
       description = "update client and return no content",
@@ -471,6 +583,65 @@ object ClientControllerSpec extends ZIOSpecDefault, ZIOStubs:
         ZIO.succeed(
           assertTrue(service.updateClient.calls.nonEmpty),
         ),
+    ),
+    // Gap: isSettingValue's `case Patch.Deleted => false` branch is only reached when a logout
+    // URI patch is explicitly nulled out; every other test either omits the field or sets it
+    // to a value (Patch.Modified).
+    controllerTestCase(
+      description = "update client succeeds when clearing a single logout URI via null patch",
+      request = Request(
+        method = Method.PUT,
+        url = URL.empty / "configuration" / "clients",
+        body = Body.fromString(updateRequest.copy(
+          frontChannelLogoutUri = Some(Patch.Deleted),
+        ).toJson),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.NoContent,
+      setup = service =>
+        service.updateClient.succeedsWith(()),
+      verify = (_, service, _) =>
+        ZIO.succeed(
+          assertTrue(service.updateClient.calls == List(updateRequest.copy(frontChannelLogoutUri = Some(Patch.Deleted)))),
+        ),
+    ),
+    controllerTestCase(
+      description = "update client returns 400 when the consent screen URI is invalid",
+      request = Request(
+        method = Method.PUT,
+        url = URL.empty / "configuration" / "clients",
+        body = Body.fromString(updateRequest.toJson),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.BadRequest,
+      setup = service =>
+        service.updateClient.failsWith(InvalidConsentUri("policyUri", "must be an absolute https URL")),
+      verify = (response, _, _) =>
+        for body <- response.body.asString
+        yield assertTrue(body == "Invalid policyUri: must be an absolute https URL"),
+    ),
+    controllerTestCase(
+      description = "update client returns 400 when the registration configuration is invalid",
+      request = Request(
+        method = Method.PUT,
+        url = URL.empty / "configuration" / "clients",
+        body = Body.fromString(updateRequest.toJson),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.BadRequest,
+      setup = service =>
+        service.updateClient.failsWith(InvalidRegistrationConfiguration(clientId, "registration must start with OTP verification")),
+      verify = (response, _, _) =>
+        for body <- response.body.asString
+        yield assertTrue(body == "Invalid registration configuration: registration must start with OTP verification"),
+    ),
+    controllerTestCase(
+      description = "update client surfaces an unexpected failure as 500 Internal Server Error",
+      request = Request(
+        method = Method.PUT,
+        url = URL.empty / "configuration" / "clients",
+        body = Body.fromString(updateRequest.toJson),
+      ).addHeader(Header.ContentType(MediaType.application.json)),
+      expectedStatus = Status.InternalServerError,
+      setup = service =>
+        service.updateClient.failsWith(RuntimeException("boom")),
     ),
     controllerTestCase(
       description = "rotate client secret and return encoded value",

--- a/central/src/test/scala/versola/central/configuration/clients/ClientControllerSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/clients/ClientControllerSpec.scala
@@ -9,7 +9,7 @@ import versola.central.configuration.permissions.Permission
 import versola.central.configuration.scopes.ScopeToken
 import versola.central.configuration.tenants.TenantId
 import versola.util.http.Observability
-import versola.util.{Base64, Base64Url, JWT, Patch, RedirectUri, RsaKeyPair, Secret, SecurityService}
+import versola.util.{Base64, Base64Url, JWT, Patch, RedirectUri, RsaKeyPair, Secret, SecureRandom, SecurityService}
 import zio.*
 import zio.http.*
 import zio.json.*
@@ -381,16 +381,24 @@ object ClientControllerSpec extends ZIOSpecDefault, ZIOStubs:
     // encryption for edge-issued tokens) was never exercised; every other sync test uses a
     // central-signed token, which takes the `None` (AES) branch.
     test("return synced tenant clients encrypted via edge RSA key when request is signed by an edge") {
-      val edgeSecurity = new SecurityService:
-        override def encryptAes256(data: Array[Byte], key: javax.crypto.SecretKey) = ZIO.succeed(data)
+      // Delegates to the real RSA implementation, so the emitted secret is genuine ciphertext
+      // that only the edge's private key can open, and records which public key was used.
+      // The AES path dies: for an edge-issued token it must not be taken at all.
+      def edgeSecurity(realSecurity: SecurityService, rsaKeys: Ref[Vector[java.security.PublicKey]]) = new SecurityService:
+        override def encryptAes256(data: Array[Byte], key: javax.crypto.SecretKey) =
+          ZIO.dieMessage("AES transport encryption must not be used for an edge-issued token")
         override def decryptAes256(data: Array[Byte], key: javax.crypto.SecretKey) = ZIO.succeed(data)
-        override def encryptRsa(data: Array[Byte], key: java.security.PublicKey) = ZIO.succeed(data)
-        override def decryptRsa(data: Array[Byte], key: java.security.PrivateKey) = ZIO.dieMessage("Unused in test")
+        override def encryptRsa(data: Array[Byte], key: java.security.PublicKey) =
+          rsaKeys.update(_ :+ key) *> realSecurity.encryptRsa(data, key)
+        override def decryptRsa(data: Array[Byte], key: java.security.PrivateKey) = realSecurity.decryptRsa(data, key)
         override def mac(secret: versola.util.Secret, key: Array[Byte]) = ZIO.dieMessage("Unused in test")
         override def hashPassword(password: versola.util.Secret, salt: versola.util.Salt, pepper: versola.util.Secret.Bytes16) = ZIO.dieMessage("Unused in test")
         override def generateRsaKeyPair = ZIO.dieMessage("Unused in test")
       for
         client <- ZIO.service[Client]
+        security <- (SecureRandom.live >>> SecurityService.live).build
+        realSecurity = security.get[SecurityService]
+        rsaKeys <- Ref.make(Vector.empty[java.security.PublicKey])
         service = stub[OAuthClientService]
         resourceService = stub[versola.central.configuration.resources.ResourceService]
         edgeService = stub[EdgeService]
@@ -407,7 +415,7 @@ object ClientControllerSpec extends ZIOSpecDefault, ZIOStubs:
           Observability.handleErrors(
             ClientController.routes.provideEnvironment(
               ZEnvironment[OAuthClientService](service) ++ ZEnvironment[versola.central.configuration.resources.ResourceService](resourceService) ++ ZEnvironment[CentralConfig](config) ++ tracing ++
-                ZEnvironment[SecurityService](edgeSecurity) ++ ZEnvironment[EdgeService](edgeService),
+                ZEnvironment[SecurityService](edgeSecurity(realSecurity, rsaKeys)) ++ ZEnvironment[EdgeService](edgeService),
             ),
           ),
         )
@@ -416,13 +424,19 @@ object ClientControllerSpec extends ZIOSpecDefault, ZIOStubs:
             .addHeader(Header.Authorization.Bearer(token)),
         )
         payload <- response.body.asJson[GetOAuthClientsSyncResponse]
+        rsaKeysUsed <- rsaKeys.get
+        wireSecret = payload.clients.head.secret
+        recovered <- ZIO.foreach(wireSecret)(s => realSecurity.decryptRsa(Base64.urlDecode(s), edgeKeyPair.privateKey))
+        plaintext = clients.head.secret
       yield assertTrue(
         response.status == Status.Ok,
         // authorizeInternal verifies the token's issuing edge, then the sync endpoint looks
         // up the edge again to pick its RSA public key for transport encryption.
         edgeService.find.calls == List(edgeId, edgeId),
         service.getClientsForSync.calls == List(Some(edgeId)),
-        payload.clients.head.secret.isDefined,
+        rsaKeysUsed == Vector(edgeRecord.activeRsaPublicKey),
+        wireSecret.exists(_ != Base64Url.encode(plaintext.get)),
+        recovered.map(_.toVector) == plaintext.map(_.toVector),
       )
     }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging,
     controllerTestCase(

--- a/central/src/test/scala/versola/central/configuration/resources/ResourceServiceSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/resources/ResourceServiceSpec.scala
@@ -3,7 +3,8 @@ package versola.central.configuration.resources
 import org.scalamock.stubs.ZIOStubs
 import versola.central.{CentralConfig, TestCentralConfig}
 import versola.central.configuration.clients.ClientId
-import versola.central.configuration.tenants.TenantId
+import versola.central.configuration.edges.EdgeId
+import versola.central.configuration.tenants.{TenantId, TenantRecord, TenantRepository}
 import versola.central.configuration.sync.SyncEvent
 import versola.central.configuration.{CreateResourceEndpointRequest, CreateResourceRequest, InjectRule, InjectTarget, ResourceUri, UpdateResourceRequest}
 import versola.util.{ReloadingCache, SecureRandom, Secret, SecurityService}
@@ -81,6 +82,27 @@ object ResourceServiceSpec extends ZIOSpecDefault, ZIOStubs:
     val config = TestCentralConfig.config
     val service = ResourceService.Impl(cache, repository, tenantRepository, celEvaluator, secureRandom, securityService, config)
 
+  /** Builds a [[ResourceService]] through [[ResourceService.live]] itself, rather than
+    * constructing [[ResourceService.Impl]] directly like [[Env]] does, so the wiring in
+    * `live` (the reloading cache backed by the secret-decrypting CacheSource) is exercised.
+    */
+  private def liveResourceService(
+      repository: ResourceRepository,
+      tenantRepository: TenantRepository,
+      secureRandom: SecureRandom,
+      securityService: SecurityService,
+  ) =
+    ZLayer.make[ResourceService](
+      ZLayer.succeed(repository),
+      ZLayer.succeed(tenantRepository),
+      ZLayer.succeed(CelEvaluator.Impl(Unsafe.unsafe(unsafe ?=> Ref.unsafe.make(Map.empty)))),
+      ZLayer.succeed(secureRandom),
+      ZLayer.succeed(securityService),
+      ZLayer.succeed(TestCentralConfig.config),
+      Scope.default,
+      ResourceService.live,
+    )
+
   def spec = suite("ResourceService")(
     test("verifySecret accepts current and previous central resource secrets") {
       val env = new Env(Vector(centralResource))
@@ -104,6 +126,48 @@ object ResourceServiceSpec extends ZIOSpecDefault, ZIOStubs:
 
       for result <- env.service.getTenantResources(tenantId, offset = 1, limit = Some(1))
       yield assertTrue(result == Vector(pagedResource))
+    },
+    // Gap: getResourcesForSync had no coverage at all (neither branch).
+    test("getResourcesForSync returns every cached resource when no edge is specified") {
+      val env = new Env(Vector(resource, otherTenantResource))
+
+      for result <- env.service.getResourcesForSync(None)
+      yield assertTrue(result == Vector(resource, otherTenantResource))
+    },
+    test("getResourcesForSync filters resources to tenants assigned to the given edge") {
+      val syncEdgeId = EdgeId("edge-1")
+      val env = new Env(Vector(resource, otherTenantResource))
+
+      for
+        _ <- env.tenantRepository.getAll.succeedsWith(Vector(
+          TenantRecord(tenantId, "tenant a", Some(syncEdgeId)),
+          TenantRecord(otherTenantId, "tenant b", None),
+        ))
+        result <- env.service.getResourcesForSync(Some(syncEdgeId))
+      yield assertTrue(result == Vector(resource))
+    },
+    // Gap: ResourceService.live's ZLayer wiring (the reloading cache and the
+    // secret-decrypting CacheSource built on top of the repository) was never built by any
+    // test; Env instantiates Impl directly with a hand-made cache instead.
+    test("live decrypts resource secrets loaded from the repository through the reloading cache") {
+      val liveRepository = stub[ResourceRepository]
+      val liveTenantRepository = stub[TenantRepository]
+      val liveSecureRandom = stub[SecureRandom]
+      val liveSecurityService = stub[SecurityService]
+      val encryptedSecret = Array.fill(32)(9.toByte)
+      val decryptedSecret = Secret(Array.fill(32)(5.toByte))
+      // Both current and previous secret are set so decryptSecrets' foreach over each one
+      // (two independent closures) is actually invoked, not just skipped as None.
+      val storedResource = resource.copy(secret = Some(Secret(encryptedSecret)), previousSecret = Some(Secret(encryptedSecret)))
+
+      for
+        _ <- liveRepository.getAll.succeedsWith(Vector(storedResource))
+        _ <- liveSecurityService.decryptAes256.succeedsWith(decryptedSecret)
+        result <- (for
+          service   <- ZIO.service[ResourceService]
+          resources <- service.getTenantResources(tenantId, 0, None)
+        yield resources).provide(liveResourceService(liveRepository, liveTenantRepository, liveSecureRandom, liveSecurityService))
+      yield assertTrue(result == Vector(storedResource.copy(secret = Some(decryptedSecret), previousSecret = Some(decryptedSecret))))
     },
     test("createResource delegates resource and endpoint records to repository") {
       val env = new Env
@@ -176,6 +240,23 @@ object ResourceServiceSpec extends ZIOSpecDefault, ZIOStubs:
         result.isLeft,
         result.swap.exists(_.isInstanceOf[ResourceValidationError.InvalidAllowExpression]),
         env.repository.createResource.calls.isEmpty,
+      )
+    },
+    // Gap: pathSegments' `case "" => Vector.empty` branch (the root path, stripped of its
+    // leading slash) was never reached; every other endpoint path test has segments after "/".
+    test("createResource accepts the root path as a valid endpoint") {
+      val env = new Env
+      val request = createRequest.copy(
+        endpoints = Vector(
+          CreateResourceEndpointRequest(existingEndpointId, "/", "GET", false, None, Vector.empty, stepUpCondition = None, stepUpAcr = None, maxAge = None),
+        ),
+      )
+      for
+        _ <- env.repository.createResource.succeedsWith(())
+        result <- env.service.createResource(request)
+      yield assertTrue(
+        result == Right((resourceId, None)),
+        env.repository.createResource.calls.nonEmpty,
       )
     },
     test("createResource accepts endpoint paths with named path parameters") {
@@ -290,6 +371,23 @@ object ResourceServiceSpec extends ZIOSpecDefault, ZIOStubs:
         env.repository.createResource.calls.isEmpty,
       )
     },
+    // Gap: validateEndpoints' fold short-circuit (`case (Some(err), _) => ...`, skipping
+    // validation once an earlier endpoint already failed) was never reached because every
+    // existing invalid-endpoint test used a single-endpoint request.
+    test("createResource stops validating endpoints once an earlier one already failed") {
+      val env = new Env
+      val badRequest = createRequest.copy(
+        endpoints = Vector(
+          CreateResourceEndpointRequest(existingEndpointId, "/users/{}", "GET", false, None, Vector.empty, stepUpCondition = None, stepUpAcr = None, maxAge = None),
+          CreateResourceEndpointRequest(createdEndpointId, "/users", "POST", false, None, Vector.empty, stepUpCondition = None, stepUpAcr = None, maxAge = None),
+        ),
+      )
+      for result <- env.service.createResource(badRequest)
+      yield assertTrue(
+        result == Left(ResourceValidationError.InvalidEndpointPath(existingEndpointId)),
+        env.repository.createResource.calls.isEmpty,
+      )
+    },
     test("createResource returns error when inject expression is invalid CEL") {
       val env = new Env
       val badRequest = createRequest.copy(
@@ -307,6 +405,29 @@ object ResourceServiceSpec extends ZIOSpecDefault, ZIOStubs:
       for
         _ <- env.repository.createResource.succeedsWith(())
         result <- env.service.createResource(badRequest)
+      yield assertTrue(
+        result.isLeft,
+        result.swap.exists(_.isInstanceOf[ResourceValidationError.InvalidInjectExpression]),
+        env.repository.createResource.calls.isEmpty,
+      )
+    },
+    // Gap: same fold short-circuit as above, but for inject rules within a single endpoint
+    // (`injectCheck`'s `case (Some(err), _) => ...`) - needs 2+ inject rules, first invalid.
+    test("createResource stops validating inject rules once an earlier one already failed") {
+      val env = new Env
+      val badRequest = createRequest.copy(
+        endpoints = Vector(
+          CreateResourceEndpointRequest(
+            existingEndpointId, "/users", "GET", false, None,
+            Vector(InjectRule(InjectTarget.header, "x-bad", "(unterminated"), InjectRule(InjectTarget.header, "x-user", "token.sub")),
+            stepUpCondition = None,
+            stepUpAcr = None,
+            maxAge = None,
+          ),
+        ),
+      )
+
+      for result <- env.service.createResource(badRequest)
       yield assertTrue(
         result.isLeft,
         result.swap.exists(_.isInstanceOf[ResourceValidationError.InvalidInjectExpression]),
@@ -359,6 +480,30 @@ object ResourceServiceSpec extends ZIOSpecDefault, ZIOStubs:
         env.repository.createResource.calls.isEmpty,
       )
     },
+    // Gap: every stepUpCondition test above exercises only the error paths of the validate
+    // call; the success path (`.as(Option.empty[ResourceValidationError])`) was never hit.
+    test("createResource accepts endpoint with a valid boolean stepUpCondition expression") {
+      val env = new Env
+      val request = createRequest.copy(
+        endpoints = Vector(
+          CreateResourceEndpointRequest(
+            existingEndpointId, "/users", "GET", false, None,
+            Vector.empty,
+            stepUpCondition = Some("true"),
+            stepUpAcr = None,
+            maxAge = None,
+          ),
+        ),
+      )
+
+      for
+        _ <- env.repository.createResource.succeedsWith(())
+        result <- env.service.createResource(request)
+      yield assertTrue(
+        result == Right((resourceId, None)),
+        env.repository.createResource.calls.nonEmpty,
+      )
+    },
     test("updateResource delegates patches and endpoint replacements to repository") {
       val env = new Env
 
@@ -375,6 +520,47 @@ object ResourceServiceSpec extends ZIOSpecDefault, ZIOStubs:
           Vector(updatedEndpoint, createdEndpoint),
           Set(removedEndpointId),
         )),
+      )
+    },
+    // Gap: updateResource's own `validateEndpoints(...).flatMap { case Some(error) => ... }`
+    // branch was never reached; existing update tests either succeed outright or fail via
+    // findAmbiguousEndpoint (which runs only once validateEndpoints returns None).
+    test("updateResource returns error when a submitted endpoint fails validation") {
+      val env = new Env
+      val badRequest = updateRequest.copy(
+        createEndpoints = Vector(
+          CreateResourceEndpointRequest(createdEndpointId, "/users/{}", "GET", false, None, Vector.empty, stepUpCondition = None, stepUpAcr = None, maxAge = None),
+        ),
+      )
+
+      for result <- env.service.updateResource(badRequest)
+      yield assertTrue(
+        result == Left(ResourceValidationError.InvalidEndpointPath(createdEndpointId)),
+        env.repository.findResource.calls.isEmpty,
+        env.repository.updateResource.calls.isEmpty,
+      )
+    },
+    // Gap: finalEndpointRefs' `existing.fold(Vector.empty[...])(...)` "missing resource" branch
+    // was never reached; every other update test stubs findResource to return Some(...).
+    test("updateResource treats a missing existing resource as having no retained endpoints") {
+      val env = new Env
+      val request = UpdateResourceRequest(
+        resourceId = resourceId,
+        resource = None,
+        audience = None,
+        deleteEndpoints = Set.empty,
+        createEndpoints = Vector(
+          CreateResourceEndpointRequest(createdEndpointId, "/users", "GET", false, None, Vector.empty, stepUpCondition = None, stepUpAcr = None, maxAge = None),
+        ),
+      )
+
+      for
+        _ <- env.repository.findResource.succeedsWith(None)
+        _ <- env.repository.updateResource.succeedsWith(())
+        result <- env.service.updateResource(request)
+      yield assertTrue(
+        result == Right(()),
+        env.repository.updateResource.calls.nonEmpty,
       )
     },
     test("updateResource returns error when a submitted endpoint is ambiguous with one retained from the existing resource") {


### PR DESCRIPTION
Adds targeted unit tests to close statement-coverage gaps identified in the `central` module. No production code changed.

## ClientControllerSpec (+9 tests)
- Sync endpoint's edge-issued-token branch (RSA-encrypted transport, `edge_id` header path)
- create/update `catchAll` error branches: `ClientAlreadyExists` -> 409, `InvalidConsentUri` -> 400, `InvalidRegistrationConfiguration` -> 400, generic `Throwable` -> 500
- `isSettingValue`'s `Patch.Deleted` branch (explicit JSON `null` on a logout URI)

## ResourceServiceSpec (+9 tests)
- `getResourcesForSync` both branches (`None` and `Some(edgeId)`)
- `ResourceService.live` ZLayer wiring, including secret-decrypting cache source (mirrors existing `JwksServiceSpec` pattern)
- `validateEndpoints`/inject-rule fold short-circuit branches
- `stepUpCondition` CEL-validate success path
- `updateResource`'s validateEndpoints-error branch and `finalEndpointRefs`'s missing-resource fold default
- `pathSegments`'s root-path (`"/"`) branch

## Validation
- `sbt "central/testOnly versola.central.configuration.clients.ClientControllerSpec versola.central.configuration.resources.ResourceServiceSpec"` -- all pass
- `sbt central/test` -- 503 tests passed, 0 failed (baseline ~485, +18 new tests)
- `sbt coverage central/test coverageAggregate` -- all originally-listed uncovered lines in both files now covered; overall project statement coverage 72.22% -> 72.30%

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M1VSPSGCN8AA2ZPWZ5QACZ0M&panel=chat)