### PR TITLE
test(auth): cover ConversationService/WebAuthnService/LogoutController gaps

### DIFF
--- a/auth/src/test/scala/versola/oauth/challenge/passkey/WebAuthnServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/challenge/passkey/WebAuthnServiceSpec.scala
@@ -107,12 +107,18 @@ object VirtualAuthenticator:
       challenge: String,
       credentialId: Array[Byte],
       pub: ECPublicKey,
+      // Non-empty to make the fabricated response report authenticator transports, so tests can
+      // reach WebAuthnService.Impl.fromYubico's per-transport mapping.
+      transports: List[String] = Nil,
   ): String =
     val clientData = s"""{"type":"webauthn.create","challenge":"$challenge","origin":"$origin"}"""
     val authData = authenticatorData(rpId, credentialId, pub, attested = true)
+    val transportsJson =
+      if transports.isEmpty then ""
+      else s""","transports":[${transports.map(t => s"\"$t\"").mkString(",")}]"""
     s"""{"id":"${b64Url(credentialId)}","rawId":"${b64Url(credentialId)}","response":{"clientDataJSON":"${b64Url(
         clientData.getBytes("UTF-8"),
-      )}","attestationObject":"${b64Url(attestationObject(authData))}"},"type":"public-key","clientExtensionResults":{}}"""
+      )}","attestationObject":"${b64Url(attestationObject(authData))}"$transportsJson},"type":"public-key","clientExtensionResults":{}}"""
 
   /** Builds a `response` JSON accepted by `PublicKeyCredential.parseAssertionResponseJson`,
     * simulating an authenticator asserting `credentialId`, signed with its private key.
@@ -461,5 +467,187 @@ object WebAuthnServiceSpec extends UnitSpecBase:
         _ <- repository.updateUsage.succeedsWith(false)
         result <- service.finishAssertion(settings, ceremony.request, response).exit
       yield assert(result)(fails(equalTo(WebAuthnError.AssertionFailed)))
+    },
+
+    // Covers WebAuthnService.Impl.fromYubico (every explicit case plus the INTERNAL default):
+    // reached only when the authenticator's response reports transports, which none of the
+    // other tests' fabricated responses do.
+    test("finishRegistration maps every reported transport back from the Yubico transport type") {
+      val repository = stub[PasskeyRepository]
+      val configService = stub[OAuthConfigurationService]
+      val credentialId = "test-credential-5".getBytes("UTF-8")
+      val keyPair = VirtualAuthenticator.keyPair()
+
+      for
+        service <- ZIO.service[WebAuthnService].provide(
+          ZLayer.succeed(repository),
+          ZLayer.succeed(configService),
+          WebAuthnService.live,
+        )
+        _ <- repository.listByUser.succeedsWith(Vector.empty)
+        ceremony <- service.startRegistration(settings, userId, "Test User")
+        challenge = VirtualAuthenticator.extractChallenge(ceremony.publicKeyOptions)
+        response = VirtualAuthenticator.registrationResponse(
+          rpId = settings.rpId,
+          origin = settings.origins.head,
+          challenge = challenge,
+          credentialId = credentialId,
+          pub = keyPair.getPublic.asInstanceOf[java.security.interfaces.ECPublicKey],
+          transports = List("ble", "hybrid", "nfc", "usb", "internal"),
+        )
+        _ <- configService.getPasskeySettings.succeedsWith(Some(settings))
+        _ <- repository.findByCredentialId.succeedsWith(Vector.empty)
+        _ <- repository.insert.succeedsWith(())
+        record <- service.finishRegistration(clientId, userId, ceremony.request, response, None)
+      yield assertTrue(
+        record.transports.toSet == Set(
+          AuthenticatorTransport.Ble,
+          AuthenticatorTransport.Hybrid,
+          AuthenticatorTransport.Nfc,
+          AuthenticatorTransport.Usb,
+          AuthenticatorTransport.Internal,
+        ),
+      )
+    },
+
+    // Covers startRegistration's own `.mapError`: the ceremony-building step can throw before
+    // any repository call happens (an invalid identity here), independent of a repository failure.
+    test("startRegistration fails with CeremonyFailed when the user identity cannot be built") {
+      val repository = stub[PasskeyRepository]
+      val configService = stub[OAuthConfigurationService]
+      for
+        service <- ZIO.service[WebAuthnService].provide(
+          ZLayer.succeed(repository),
+          ZLayer.succeed(configService),
+          WebAuthnService.live,
+        )
+        result <- service.startRegistration(settings, userId, null).exit
+      yield assert(result)(fails(isSubtype[WebAuthnError.CeremonyFailed](anything)))
+    },
+
+    // Covers startAssertion's own `.mapError`, the mirror of the above for the assertion ceremony.
+    test("startAssertion fails with CeremonyFailed when the relying party identity is invalid") {
+      val repository = stub[PasskeyRepository]
+      val configService = stub[OAuthConfigurationService]
+      for
+        service <- ZIO.service[WebAuthnService].provide(
+          ZLayer.succeed(repository),
+          ZLayer.succeed(configService),
+          WebAuthnService.live,
+        )
+        result <- service.startAssertion(settings.copy(rpId = null)).exit
+      yield assert(result)(fails(isSubtype[WebAuthnError.CeremonyFailed](anything)))
+    },
+
+    // Covers the `.mapError` on the `updateUsage` call itself: a genuine repository failure (not
+    // just "no row updated") must surface as CeremonyFailed.
+    test("finishAssertion fails with CeremonyFailed when updateUsage fails") {
+      val repository = stub[PasskeyRepository]
+      val configService = stub[OAuthConfigurationService]
+      val keyPair = VirtualAuthenticator.keyPair()
+      val pub = keyPair.getPublic.asInstanceOf[java.security.interfaces.ECPublicKey]
+      val priv = keyPair.getPrivate.asInstanceOf[java.security.interfaces.ECPrivateKey]
+      val credId = CredentialId("test-credential-6".getBytes("UTF-8"))
+      val record = passkeyRecord(credId, userId).copy(publicKey = VirtualAuthenticator.publicKeyCose(pub))
+
+      for
+        service <- ZIO.service[WebAuthnService].provide(
+          ZLayer.succeed(repository),
+          ZLayer.succeed(configService),
+          WebAuthnService.live,
+        )
+        ceremony <- service.startAssertion(settings)
+        challenge = VirtualAuthenticator.extractChallenge(ceremony.publicKeyOptions)
+        response = VirtualAuthenticator.assertionResponse(
+          rpId = settings.rpId,
+          origin = settings.origins.head,
+          challenge = challenge,
+          credentialId = credId,
+          userHandle = VirtualAuthenticator.userHandle(userId),
+          pub = pub,
+          priv = priv,
+        )
+        _ <- repository.findByCredentialId.succeedsWith(Vector(record))
+        _ <- repository.findByCredentialIdAndUser.succeedsWith(Some(record))
+        _ <- repository.updateUsage.failsWith(new RuntimeException("db unavailable"))
+        result <- service.finishAssertion(settings, ceremony.request, response).exit
+      yield assert(result)(fails(isSubtype[WebAuthnError.CeremonyFailed](anything)))
+    },
+
+    // repository.findByCredentialIdAndUser also backs the RP's own signature-verification lookup
+    // (call #1, which must keep succeeding for the ceremony to verify at all); only the fallback
+    // call after `updateUsage` reports no row (call #2) is made to fail here, to reach the
+    // `.mapError` guarding that specific lookup.
+    test("finishAssertion fails with CeremonyFailed when the post-updateUsage lookup fails") {
+      val repository = stub[PasskeyRepository]
+      val configService = stub[OAuthConfigurationService]
+      val keyPair = VirtualAuthenticator.keyPair()
+      val pub = keyPair.getPublic.asInstanceOf[java.security.interfaces.ECPublicKey]
+      val priv = keyPair.getPrivate.asInstanceOf[java.security.interfaces.ECPrivateKey]
+      val credId = CredentialId("test-credential-7".getBytes("UTF-8"))
+      val record = passkeyRecord(credId, userId).copy(publicKey = VirtualAuthenticator.publicKeyCose(pub))
+
+      for
+        service <- ZIO.service[WebAuthnService].provide(
+          ZLayer.succeed(repository),
+          ZLayer.succeed(configService),
+          WebAuthnService.live,
+        )
+        ceremony <- service.startAssertion(settings)
+        challenge = VirtualAuthenticator.extractChallenge(ceremony.publicKeyOptions)
+        response = VirtualAuthenticator.assertionResponse(
+          rpId = settings.rpId,
+          origin = settings.origins.head,
+          challenge = challenge,
+          credentialId = credId,
+          userHandle = VirtualAuthenticator.userHandle(userId),
+          pub = pub,
+          priv = priv,
+        )
+        _ <- repository.findByCredentialId.succeedsWith(Vector(record))
+        _ <- repository.findByCredentialIdAndUser.returnsZIOOnCall:
+          case 1 => ZIO.succeed(Some(record))
+          case _ => ZIO.fail(new RuntimeException("db unavailable"))
+        _ <- repository.updateUsage.succeedsWith(false)
+        result <- service.finishAssertion(settings, ceremony.request, response).exit
+      yield assert(result)(fails(isSubtype[WebAuthnError.CeremonyFailed](anything)))
+    },
+
+    // Mirrors the test above, but the fallback lookup succeeds with no record: the passkey was
+    // deleted between the signature check and here, so this must fail typed as CredentialNotFound
+    // rather than the generic AssertionFailed used when the record is still present.
+    test("finishAssertion fails with CredentialNotFound when the record vanished after updateUsage reported no row") {
+      val repository = stub[PasskeyRepository]
+      val configService = stub[OAuthConfigurationService]
+      val keyPair = VirtualAuthenticator.keyPair()
+      val pub = keyPair.getPublic.asInstanceOf[java.security.interfaces.ECPublicKey]
+      val priv = keyPair.getPrivate.asInstanceOf[java.security.interfaces.ECPrivateKey]
+      val credId = CredentialId("test-credential-8".getBytes("UTF-8"))
+      val record = passkeyRecord(credId, userId).copy(publicKey = VirtualAuthenticator.publicKeyCose(pub))
+
+      for
+        service <- ZIO.service[WebAuthnService].provide(
+          ZLayer.succeed(repository),
+          ZLayer.succeed(configService),
+          WebAuthnService.live,
+        )
+        ceremony <- service.startAssertion(settings)
+        challenge = VirtualAuthenticator.extractChallenge(ceremony.publicKeyOptions)
+        response = VirtualAuthenticator.assertionResponse(
+          rpId = settings.rpId,
+          origin = settings.origins.head,
+          challenge = challenge,
+          credentialId = credId,
+          userHandle = VirtualAuthenticator.userHandle(userId),
+          pub = pub,
+          priv = priv,
+        )
+        _ <- repository.findByCredentialId.succeedsWith(Vector(record))
+        _ <- repository.findByCredentialIdAndUser.returnsZIOOnCall:
+          case 1 => ZIO.succeed(Some(record))
+          case _ => ZIO.succeed(None)
+        _ <- repository.updateUsage.succeedsWith(false)
+        result <- service.finishAssertion(settings, ceremony.request, response).exit
+      yield assert(result)(fails(equalTo(WebAuthnError.CredentialNotFound)))
     },
   )

--- a/auth/src/test/scala/versola/oauth/conversation/ConversationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/conversation/ConversationServiceSpec.scala
@@ -197,6 +197,39 @@ object ConversationServiceSpec extends UnitSpecBase:
     yield ()
 
   def spec = suite("ConversationService")(
+    // Covers ConversationService.live (the ZLayer.fromFunction wiring): every other test builds
+    // Impl directly, so nothing else exercises the layer construction itself.
+    suite("live")(
+      test("wires Impl from its dependencies and delegates find") {
+        val env = Env()
+        for
+          service <- ZIO.service[ConversationService].provide(
+            ZLayer.succeed(env.otpService),
+            ZLayer.succeed(env.passwordService),
+            ZLayer.succeed(env.conversationRepository),
+            ZLayer.succeed(env.userRepository),
+            ZLayer.succeed(env.authorizationCodeRepository),
+            ZLayer.succeed(env.sessionRepository),
+            ZLayer.succeed(env.authPropertyGenerator),
+            ZLayer.succeed(env.securityService),
+            ZLayer.succeed(env.userInfoService),
+            ZLayer.succeed(TestEnvConfig.coreConfig),
+            ZLayer.succeed(env.submissionLimiter),
+            ZLayer.succeed(env.webAuthnService),
+            ZLayer.succeed(env.passkeyRepository),
+            ZLayer.succeed(env.configService),
+            ZLayer.succeed(env.acrResolver),
+            ZLayer.succeed(env.userAgentRepository),
+            ZLayer.succeed(env.secureRandom),
+            ZLayer.succeed(env.userService),
+            ZLayer.succeed(env.consentService),
+            ConversationService.live,
+          )
+          _ <- env.conversationRepository.find.succeedsWith(Some(conversationRecord))
+          result <- service.find(authId)
+        yield assertTrue(result == Some(conversationRecord))
+      },
+    ),
     suite("find")(
       test("delegates to the conversation repository") {
         val env = Env()

--- a/auth/src/test/scala/versola/oauth/logout/LogoutControllerSpec.scala
+++ b/auth/src/test/scala/versola/oauth/logout/LogoutControllerSpec.scala
@@ -385,4 +385,80 @@ object LogoutControllerSpec extends UnitSpecBase:
           logoutService.logout.calls === List((Right(rawSessionId), None, None)),
         )),
     ),
+    controllerTestCase(
+      description = "POST /logout with a valid csrf_token but an unknown session still logs out and clears the cookie",
+      // Also carries post_logout_redirect_uri so this exercises the same-branch URL.decode(...)
+      // call, not just the case None => performLogout(...) match arm.
+      request = Request.post(
+        URL.root / "logout",
+        Body.fromURLEncodedForm(Form.fromStrings(
+          "csrf_token" -> csrfToken(rawSessionId, Some(redirectUri.encode)),
+          "post_logout_redirect_uri" -> redirectUri.encode,
+        )),
+      ).addHeader(sessionCookieHeader()),
+      expectedStatus = Status.Ok,
+      setup = (logoutService, renderService, sessionService) =>
+        sessionService.find.succeedsWith(None) *>
+          logoutService.logout.succeedsWith(logoutResult) *>
+          renderService.renderLogout.succeedsWith(Response.text("<html>logout</html>")),
+      verify = (response, logoutService, _, sessionService) =>
+        ZIO.succeed(assertTrue(
+          sessionService.find.calls === List(rawSessionId),
+          logoutService.logout.calls === List((Right(rawSessionId), Some(redirectUri), None)),
+          response.headers.get(Header.SetCookie).exists { h =>
+            h.renderedValue.contains(SessionCookie.name) && h.renderedValue.contains("Max-Age=0")
+          },
+        )),
+    ),
+    controllerTestCase(
+      description = "POST /logout with a session cookie and a matching id_token_hint logs out immediately without csrf",
+      request = Request.post((URL.root / "logout").addQueryParam("id_token_hint", idTokenHint(sid = publicSessionId)), Body.empty)
+        .addHeader(sessionCookieHeader()),
+      expectedStatus = Status.Ok,
+      setup = (logoutService, renderService, sessionService) =>
+        sessionService.find.succeedsWith(Some(sessionInfo)) *>
+          logoutService.logout.succeedsWith(logoutResult) *>
+          renderService.renderLogout.succeedsWith(Response.text("<html>logout</html>")),
+      verify = (_, logoutService, _, sessionService) =>
+        ZIO.succeed(assertTrue(
+          sessionService.find.calls === List(rawSessionId),
+          logoutService.logout.calls === List((Right(rawSessionId), None, None)),
+        )),
+    ),
+    controllerTestCase(
+      description = "POST /logout with a session cookie and a mismatched id_token_hint does not log out immediately",
+      request = Request.post((URL.root / "logout").addQueryParam("id_token_hint", idTokenHint(sid = "other-sid")), Body.empty)
+        .addHeader(sessionCookieHeader()),
+      expectedStatus = Status.Ok,
+      setup = (_, renderService, sessionService) =>
+        sessionService.find.succeedsWith(Some(sessionInfo)) *>
+          renderService.renderLogout.succeedsWith(Response.text("<html>logout</html>")),
+      verify = (response, logoutService, renderService, _) =>
+        ZIO.succeed(assertTrue(
+          logoutService.logout.calls.isEmpty,
+          renderService.renderLogout.calls === List((Nil, None, None)),
+          response.headers.get(Header.SetCookie).isEmpty,
+        )),
+    ),
+    controllerTestCase(
+      description = "POST /logout resolves identifier from id_token_hint when no session cookie is present",
+      request = Request.post((URL.root / "logout").addQueryParam("id_token_hint", idTokenHint()), Body.empty),
+      expectedStatus = Status.Ok,
+      setup = (logoutService, renderService, _) =>
+        logoutService.logout.succeedsWith(logoutResult) *>
+          renderService.renderLogout.succeedsWith(Response.text("<html>logout</html>")),
+      verify = (_, logoutService, _, _) =>
+        ZIO.succeed(assertTrue(logoutService.logout.calls === List((Left(publicSessionId), None, None)))),
+    ),
+    controllerTestCase(
+      description = "POST /logout returns 200 OK without calling LogoutService when no identifier is present",
+      request = Request.post(URL.root / "logout", Body.empty),
+      expectedStatus = Status.Ok,
+      setup = (_, renderService, _) => renderService.renderLogout.succeedsWith(Response.text("<html>logout</html>")),
+      verify = (_, logoutService, renderService, _) =>
+        ZIO.succeed(assertTrue(
+          logoutService.logout.calls.isEmpty,
+          renderService.renderLogout.calls == List((Nil, None, None)),
+        )),
+    ),
   )


### PR DESCRIPTION
Adds targeted unit tests to close statement-coverage gaps in the `auth` module. No production code changed.

## ConversationServiceSpec
- New "live" suite building `ConversationService.live` end-to-end via `ZLayer.succeed` for all dependencies, exercising the `ZLayer.fromFunction` wiring that no other test reached (every other test constructs `Impl` directly).
- Note: `worstStatus` (private, unused) and `decideConsent`'s defensive `None` branch (unreachable given its single call site already filters `None`) are genuinely dead/unreachable code, left untouched rather than forcing artificial coverage.

## WebAuthnServiceSpec (+6 tests)
- `finishRegistration` maps every reported transport back from the Yubico transport type (full match)
- `startRegistration` fails with `CeremonyFailed` when the user identity can't be built (null displayName)
- `startAssertion` fails with `CeremonyFailed` when the relying party identity is invalid (null rpId)
- `finishAssertion` fails with `CeremonyFailed` when `updateUsage` fails, and separately when the post-`updateUsage` lookup fails
- `finishAssertion` fails with `CredentialNotFound` when the record vanished after `updateUsage` reported no row
- (A few remaining uncovered lines are confirmed unreachable given the java-webauthn-server 2.7.0 library's actual call patterns -- documented in the PR discussion if needed.)

## LogoutControllerSpec (+5 test cases)
- POST /logout: valid csrf_token + unknown session (with `post_logout_redirect_uri` so `URL.decode` itself executes), matching `id_token_hint` + session cookie, mismatched `id_token_hint` + session cookie, `id_token_hint` only (no cookie), neither cookie nor hint.
- Fully closes all originally-targeted uncovered lines.

## Validation
- Each spec passes individually: WebAuthnServiceSpec 19/19, ConversationServiceSpec 32/32, LogoutControllerSpec 22/22
- `sbt coverage auth/test coverageReport`: statement coverage 91.86% -> 92.58%, branch coverage 91.60% -> 93.05%
- Full `sbt auth/test` (no instrumentation): 1171 tests passed, 0 failed, 0 ignored -- no regressions

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M1VSPSGCN8AA2ZPWZ5QACZ0M&panel=chat)