### PR TITLE
test(e2e): cover the OAuth 2.0 refresh_token grant at /token

### DIFF
--- a/e2e/src/test/scala/versola/e2e/flows/basic/RefreshTokenFlowSpec.scala
+++ b/e2e/src/test/scala/versola/e2e/flows/basic/RefreshTokenFlowSpec.scala
@@ -1,0 +1,326 @@
+package versola.e2e.flows.basic
+
+import versola.e2e.support.{*, given}
+import zio.*
+import zio.http.Status
+import zio.json.*
+import zio.test.*
+
+/** OAuth 2.0 refresh token grant (RFC 6749 §6) at `/token`.
+  *
+  * The grant rotates: [[versola.oauth.session.SessionRepository.createRefreshToken]] deletes the
+  * presented token in the same transaction that inserts its successor, so every redemption both
+  * hands back a new refresh token and kills the one that bought it.
+  */
+object RefreshTokenFlowSpec extends E2ESpec:
+
+  // In non-prod the OTP is always the first N digits of "1234567890"; default length is 6.
+  private val fixedOtp = "123456"
+
+  private val offlineScope = "openid email offline_access"
+
+  /** A login through the shared email+OTP client, carrying the SSO_SESSION cookie the
+    * conversation ended with so re-auth tests can continue from it.
+    */
+  private case class Login(tokens: TokenResult.Success, sessionCookie: String)
+
+  private def login(
+      s: Flows.Setup,
+      auth: OAuthClient,
+      scope: String = offlineScope,
+      email: Option[String] = None,
+  ): Task[Login] =
+    for
+      authorize <- auth.authorize(
+        scope = scope,
+        clientId = Some(s.clientId),
+        redirectUri = Some(s.redirectUri),
+      ).assertChallengeRedirect
+      cookie = authorize.conversationCookie.get
+      credential <- auth.getChallenge(cookie).assertStep(ConversationStep.Credential)
+      _ <- auth.submitEmail(cookie, email.getOrElse(s.email.get), credential.csrf)
+      otp <- auth.getChallenge(cookie).assertStep(ConversationStep.Otp)
+      submit <- auth.submitOtp(cookie, fixedOtp, otp.csrf)
+      code <- submit.assertRedirect
+      sessionCookie <- ZIO.fromOption(submit.sessionCookie)
+        .orElseFail(RuntimeException("No SSO_SESSION cookie after the OTP submission"))
+      tokens <- auth.token(
+        code,
+        authorize.verifier,
+        clientId = Some(s.clientId),
+        clientSecret = Some(s.clientSecret),
+        redirectUri = Some(s.redirectUri),
+      ).success
+    yield Login(tokens, sessionCookie)
+
+  private def refreshTokenOf(tokens: TokenResult.Success): Task[String] =
+    ZIO.fromOption(tokens.refreshToken)
+      .orElseFail(RuntimeException("Expected a refresh token for the offline_access scope"))
+
+  /** RFC 6749 §5.2 error body, of which only the code is asserted on. */
+  private case class OAuthError(error: String) derives JsonDecoder
+
+  /** The `error` code of a rejected `/token` call, together with the status it came back with. */
+  private def rejection(result: TokenResult): Task[(Status, String)] =
+    result match
+      case s: TokenResult.Success =>
+        ZIO.fail(RuntimeException(s"Expected /token to reject the request, got ${s.response.status}"))
+      case TokenResult.Failure(response, body) =>
+        ZIO.fromEither(body.fromJson[OAuthError])
+          .mapBoth(
+            err => RuntimeException(s"Unparsable /token error body [$err]: $body"),
+            parsed => response.status -> parsed.error,
+          )
+
+  /** A syntactically valid but unissued refresh token: the endpoint decodes it as base64url
+    * before it ever looks it up, so an unparsable string would be rejected as a malformed
+    * request rather than as an unknown grant.
+    */
+  private def unissuedRefreshToken: String =
+    val bytes = Array.fill(32)(0.toByte)
+    scala.util.Random.nextBytes(bytes)
+    java.util.Base64.getUrlEncoder.withoutPadding.encodeToString(bytes)
+
+  def spec = suite("Refresh token grant")(
+
+    test("redeeming a refresh token issues a new access token that works") {
+      for
+        (s, auth) <- setup(Flows.Id.EmailOtp)
+        first <- login(s, auth)
+        refreshToken <- refreshTokenOf(first.tokens)
+        refreshed <- auth.refresh(
+          refreshToken,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+        ).success
+        rotated <- refreshTokenOf(refreshed)
+        userinfo <- auth.userinfo(refreshed.accessToken).success
+        // Access-token introspection is scoped to resources this client does not hold, so the
+        // grant's liveness is read off the refresh token the rotation handed back.
+        introspected <- auth.introspect(
+          rotated,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+        ).success
+        spent <- auth.introspect(
+          refreshToken,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+        ).success
+      yield assertTrue(refreshed.tokenType.toLowerCase == "bearer")
+        .label("the refreshed token_type must be 'bearer'") &&
+        assertTrue(userinfo.sub == s.userId)
+          .label(s"the refreshed access token must resolve to ${s.userId} at /userinfo, got ${userinfo.sub}") &&
+        assertTrue(introspected.active)
+          .label("the rotated refresh token must introspect as active") &&
+        assertTrue(!spent.active)
+          .label("the refresh token that was spent must introspect as inactive")
+    },
+
+    test("the refreshed access token is a new one and keeps the original subject") {
+      for
+        (s, auth) <- setup(Flows.Id.EmailOtp)
+        first <- login(s, auth)
+        refreshToken <- refreshTokenOf(first.tokens)
+        original <- auth.userinfo(first.tokens.accessToken).success
+        refreshed <- auth.refresh(
+          refreshToken,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+        ).success
+        rotated <- refreshTokenOf(refreshed)
+        userinfo <- auth.userinfo(refreshed.accessToken).success
+      yield assertTrue(refreshed.accessToken != first.tokens.accessToken)
+        .label("the refresh must mint a new access token, not hand back the old one") &&
+        assertTrue(rotated != refreshToken)
+          .label("the refresh must hand back a rotated refresh token, not the one presented") &&
+        assertTrue(userinfo.sub == original.sub)
+          .label(s"'sub' must survive the refresh: expected ${original.sub}, got ${userinfo.sub}")
+    },
+
+    test("a refresh token is single-use: the second redemption is rejected") {
+      for
+        (s, auth) <- setup(Flows.Id.EmailOtp)
+        first <- login(s, auth)
+        refreshToken <- refreshTokenOf(first.tokens)
+        refreshed <- auth.refresh(
+          refreshToken,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+        ).success
+        rotated <- refreshTokenOf(refreshed)
+        replay <- auth.refresh(
+          refreshToken,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+        )
+        (status, error) <- rejection(replay)
+        // The rotated token is the live one, so the replay must not have taken it down with it.
+        again <- auth.refresh(
+          rotated,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+        ).success
+      yield assertTrue(status == Status.BadRequest && error == "invalid_grant")
+        .label(s"replaying a spent refresh token must be 400 invalid_grant, got $status/$error") &&
+        assertTrue(again.accessToken.nonEmpty)
+          .label("the rotated refresh token must still be redeemable after the replay was refused")
+    },
+
+    test("a refresh may narrow the granted scope") {
+      for
+        (s, auth) <- setup(Flows.Id.EmailOtp)
+        first <- login(s, auth)
+        refreshToken <- refreshTokenOf(first.tokens)
+        refreshed <- auth.refresh(
+          refreshToken,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+          scope = Some("openid offline_access"),
+        ).success
+        userinfo <- auth.userinfo(refreshed.accessToken).success
+        granted = refreshed.scope.map(_.split(" ").toSet).getOrElse(Set.empty)
+      yield assertTrue(granted == Set("openid", "offline_access"))
+        .label(s"the narrowed grant must be echoed back, got ${refreshed.scope}") &&
+        assertTrue(userinfo.email.isEmpty)
+          .label("dropping 'email' from the scope must drop the email claim from /userinfo")
+    },
+
+    test("a refresh may not widen the granted scope") {
+      for
+        (s, auth) <- setup(Flows.Id.EmailOtp)
+        first <- login(s, auth)
+        refreshToken <- refreshTokenOf(first.tokens)
+        widened <- auth.refresh(
+          refreshToken,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+          scope = Some("openid email offline_access profile"),
+        )
+        (status, error) <- rejection(widened)
+      yield assertTrue(status == Status.BadRequest && error == "invalid_scope")
+        .label(s"asking for a scope the grant never carried must be 400 invalid_scope, got $status/$error")
+    },
+
+    test("a refresh token invalidated by re-auth without offline_access is rejected at /token") {
+      for
+        (s, auth) <- setup(Flows.Id.EmailOtp)
+        // A fresh user, so that killing this session cannot disturb the shared one.
+        uid = java.util.UUID.randomUUID().toString.take(8)
+        email = s"refresh-invalidated-$uid@example.test"
+        _ <- auth.registerUser(email = Some(email))
+        _ <- auth.flushUserOutbox()
+        first <- login(s, auth, email = Some(email))
+        refreshToken <- refreshTokenOf(first.tokens)
+
+        // Re-auth WITHOUT offline_access takes the Invalidate path: the prior session and every
+        // refresh token hanging off it expire.
+        authorize <- auth.authorizeRaw(
+          clientId = s.clientId,
+          redirectUri = s.redirectUri,
+          scope = Some("openid email"),
+          prompt = Some("login"),
+          sessionCookie = Some(first.sessionCookie),
+        ).assertChallengeRedirect
+        cookie = authorize.conversationCookie.get
+        credential <- auth.getChallenge(cookie).assertStep(ConversationStep.Credential)
+        _ <- auth.submitEmail(cookie, email, credential.csrf)
+        otp <- auth.getChallenge(cookie).assertStep(ConversationStep.Otp)
+        code <- auth.submitOtp(cookie, fixedOtp, otp.csrf).assertRedirect
+        _ <- auth.token(
+          code,
+          authorize.verifier,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+          redirectUri = Some(s.redirectUri),
+        ).success
+
+        result <- auth.refresh(
+          refreshToken,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+        )
+        (status, error) <- rejection(result)
+      yield assertTrue(status == Status.BadRequest && error == "invalid_grant")
+        .label(s"an invalidated refresh token must be refused by /token, got $status/$error")
+    },
+
+    test("a refresh token revoked at /revoke is rejected at /token") {
+      for
+        (s, auth) <- setup(Flows.Id.EmailOtp)
+        first <- login(s, auth)
+        refreshToken <- refreshTokenOf(first.tokens)
+        revoked <- auth.revoke(refreshToken, s.clientId, s.clientSecret, tokenTypeHint = Some("refresh_token"))
+        result <- auth.refresh(
+          refreshToken,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+        )
+        (status, error) <- rejection(result)
+      yield assertTrue(revoked.status == Status.Ok)
+        .label(s"/revoke must answer 200, got ${revoked.status}") &&
+        assertTrue(status == Status.BadRequest && error == "invalid_grant")
+          .label(s"a revoked refresh token must be refused by /token, got $status/$error")
+    },
+
+    test("an unissued refresh token is rejected as an invalid grant") {
+      for
+        (s, auth) <- setup(Flows.Id.EmailOtp)
+        result <- auth.refresh(
+          unissuedRefreshToken,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+        )
+        (status, error) <- rejection(result)
+      yield assertTrue(status == Status.BadRequest && error == "invalid_grant")
+        .label(s"a refresh token that was never issued must be 400 invalid_grant, got $status/$error")
+    },
+
+    test("another client's refresh token is rejected as an invalid grant") {
+      for
+        (s, auth) <- setup(Flows.Id.EmailOtp)
+        (other, _) <- setup(Flows.Id.PhoneOtp)
+        first <- login(s, auth)
+        refreshToken <- refreshTokenOf(first.tokens)
+        result <- auth.refresh(
+          refreshToken,
+          clientId = Some(other.clientId),
+          clientSecret = Some(other.clientSecret),
+        )
+        (status, error) <- rejection(result)
+      yield assertTrue(status == Status.BadRequest && error == "invalid_grant")
+        .label(s"a refresh token belonging to another client must be 400 invalid_grant, got $status/$error")
+    },
+
+    test("a refresh with the wrong client secret is rejected as an invalid client") {
+      for
+        (s, auth) <- setup(Flows.Id.EmailOtp)
+        first <- login(s, auth)
+        refreshToken <- refreshTokenOf(first.tokens)
+        result <- auth.refresh(
+          refreshToken,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret + "-wrong"),
+        )
+        (status, error) <- rejection(result)
+        // The rejection must be about the credentials alone: the grant itself is untouched.
+        after <- auth.refresh(
+          refreshToken,
+          clientId = Some(s.clientId),
+          clientSecret = Some(s.clientSecret),
+        ).success
+      yield assertTrue(status == Status.Unauthorized && error == "invalid_client")
+        .label(s"a wrong client secret must be 401 invalid_client, got $status/$error") &&
+        assertTrue(after.accessToken.nonEmpty)
+          .label("a failed client authentication must not spend the refresh token")
+    },
+
+    test("a login without offline_access yields no refresh token") {
+      for
+        (s, auth) <- setup(Flows.Id.EmailOtp)
+        first <- login(s, auth, scope = "openid email")
+      yield assertTrue(first.tokens.refreshToken.isEmpty)
+        .label(s"no offline_access means no refresh token, got ${first.tokens.refreshToken.isDefined}")
+    },
+
+  ) @@ TestAspect.sequential @@ TestAspect.timeout(120.seconds)


### PR DESCRIPTION
Adds end-to-end coverage for the `refresh_token` grant at `/token`, which previously had no e2e coverage — `OAuthClient.refresh` existed in the harness but no spec called it, and `StepUpFlowSpec` only checked a stale refresh token through `/introspect` rather than actually redeeming one.

## What's covered (11 new tests, all in `RefreshTokenFlowSpec`)
1. redeeming a refresh token issues a new access token that works (`/userinfo`, rotated RT introspects active, spent RT introspects inactive)
2. the refreshed access token is new; original subject is preserved
3. single-use enforcement: second redemption of the same refresh token is rejected (`invalid_grant`)
4. scope may narrow on refresh (compared against the granted scope, not client registration)
5. scope may not widen on refresh (`invalid_scope`)
6. a refresh token invalidated by re-auth without `offline_access` is rejected at `/token`, not just "inactive" at `/introspect`
7. a refresh token revoked via `/revoke` is rejected at `/token`
8. an unissued/garbage refresh token is rejected as `invalid_grant`
9. another client's refresh token is rejected as `invalid_grant`
10. wrong client secret on refresh → `invalid_client`, and the token is not spent
11. login without `offline_access` yields no refresh token

## Rotation semantics (verified against the implementation, not assumed)
Refresh tokens **rotate and are single-use**, enforced by two independent mechanisms:
- `OAuthTokenService.refreshAccessToken` deletes the presented token's row in the same transaction as inserting its successor (`previousRefreshToken`).
- `previous_id BYTEA UNIQUE` in the schema catches a concurrent replay even if the delete were skipped.

Both were confirmed via mutation testing (see below) — disabling either alone is insufficient to make a replay succeed.

One correction made mid-flight: introspecting a *refreshed access token* returns `active=false` for these fixtures because `IntrospectionService` requires the requesting client's resources to intersect the token audience, which the test clients don't hold. Liveness of the access token is proven via `/userinfo` instead; introspection is used only for the refresh token itself.

## Mutation checks (both reverted, production code byte-identical to HEAD)
- Removed the `DELETE` of the spent refresh token → test 1 failed as expected (spent token no longer reported inactive).
- Set `previousRefreshToken = None` (disabling both guards) → tests 1 and 3 failed as expected (replay returned 200 instead of `invalid_grant`).

## Test results
`sbt e2e/test` run 3× against a live database: **105/105 passing** each time (94 pre-existing + 11 new), no cross-spec interference. The one test that mutates session state uses a throwaway per-test user to avoid disturbing shared fixtures.

## Shared-file impact
`OAuthClient.scala` and `Flows.scala` are untouched — this branch adds exactly one new file (`RefreshTokenFlowSpec.scala`), so there's no merge conflict surface with the other in-flight e2e branches (client_credentials, cross-client SSO, discovery+JWKS, hybrid flow).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M1VSPSGCN8AA2ZPWZ5QACZ0M&panel=chat)