### PR TITLE
test(e2e): cover the client credentials grant

### DIFF
--- a/e2e/src/test/scala/versola/e2e/flows/basic/ClientCredentialsFlowSpec.scala
+++ b/e2e/src/test/scala/versola/e2e/flows/basic/ClientCredentialsFlowSpec.scala
@@ -1,0 +1,204 @@
+package versola.e2e.flows.basic
+
+import versola.e2e.support.{*, given}
+import zio.*
+import zio.http.Status
+import zio.json.*
+import zio.json.ast.Json
+import zio.test.*
+
+import java.util.UUID
+
+/** OAuth 2.0 client credentials grant (RFC 6749 §4.4) end-to-end coverage.
+  *
+  * The grant has no resource owner, so what it must get right is different from the
+  * authorization code flow: the client is the subject, nothing about a user may leak into
+  * the response, and every check that would otherwise happen at `/authorize` — scope,
+  * `resource` (RFC 8707), `authorization_details` (RFC 9396) — has to happen at `/token`.
+  */
+object ClientCredentialsFlowSpec extends E2ESpec:
+
+  /** A confidential client of its own, so that changing its scope or its resources cannot
+    * disturb the shared bootstrap fixtures other specs run against.
+    */
+  private def registerClient(
+      auth: OAuthClient,
+      scopes: Set[String] = Set("openid", "email", "offline_access"),
+  ): Task[(String, String)] =
+    val clientId = s"cc-client-${UUID.randomUUID().toString.replace("-", "").take(8)}"
+    for
+      result <- auth.registerClient(
+        clientId,
+        "Client Credentials Test Client",
+        Set("http://localhost:3000"),
+        allowedScopes = scopes,
+      ).success
+      _ <- auth.syncConfiguration()
+    yield (clientId, result.secret)
+
+  /** The access token is a JWT, and the claims it carries are the point of most of these
+    * assertions — the token response alone would not show `sub` or `aud`.
+    */
+  private def claims(accessToken: String): Task[Json.Obj] =
+    for
+      payload <- ZIO.attempt(String(java.util.Base64.getUrlDecoder.decode(accessToken.split('.')(1)), "UTF-8"))
+        .mapError(error => RuntimeException(s"Access token is not a JWT [$error]: $accessToken"))
+      json <- ZIO.fromEither(payload.fromJson[Json.Obj])
+        .mapError(error => RuntimeException(s"Access token payload is not a JSON object [$error]: $payload"))
+    yield json
+
+  private def claim(claims: Json.Obj, name: String): Option[String] =
+    claims.get(name).collect { case Json.Str(value) => value }
+
+  /** `aud` is a single string when the token names one resource and an array otherwise. */
+  private def audience(claims: Json.Obj): List[String] =
+    claims.get("aud").toList.flatMap:
+      case Json.Str(value) => List(value)
+      case Json.Arr(values) => values.collect { case Json.Str(value) => value }.toList
+      case _ => Nil
+
+  /** The `error` code of a rejected token request; `None` when the request succeeded. */
+  private def errorCode(result: TokenResult): Option[String] =
+    result match
+      case TokenResult.Failure(_, body) =>
+        body.fromJson[Json.Obj].toOption.flatMap(_.get("error")).collect { case Json.Str(code) => code }
+      case _: TokenResult.Success => None
+
+  def spec = suite("Client credentials (RFC 6749 §4.4)")(
+    test("a confidential client gets an access token for itself, and nothing about a user") {
+      for
+        (_, auth) <- setup(Flows.Id.LoginPassword)
+        (clientId, clientSecret) <- registerClient(auth)
+        token <- auth.clientCredentials(clientId, clientSecret).success
+        payload <- claims(token.accessToken)
+      yield assertTrue(token.tokenType == "Bearer") &&
+        assertTrue(claim(payload, "sub").contains(clientId))
+          .label(s"the client itself must be the subject, got sub=${claim(payload, "sub")}") &&
+        assertTrue(claim(payload, "client_id").contains(clientId)) &&
+        // There is no end user to describe, so an id_token would be a claim about nobody.
+        assertTrue(token.idToken.isEmpty)
+          .label(s"expected no id_token, got ${token.idToken}") &&
+        // RFC 6749 §4.4.3: no refresh token, even though the client may ask for
+        // `offline_access` — there is no consent to keep alive between requests.
+        assertTrue(token.refreshToken.isEmpty)
+          .label(s"expected no refresh token, got ${token.refreshToken}") &&
+        assertTrue(token.scope.map(_.split(' ').toSet).contains(Set("openid", "email", "offline_access")))
+          .label(s"an unrequested scope must default to the client's own, got ${token.scope}")
+    },
+
+    test("the granted scope narrows to the requested subset") {
+      for
+        (_, auth) <- setup(Flows.Id.LoginPassword)
+        (clientId, clientSecret) <- registerClient(auth)
+        token <- auth.clientCredentials(clientId, clientSecret, scope = Some("email")).success
+        payload <- claims(token.accessToken)
+      yield assertTrue(token.scope.contains("email")) &&
+        assertTrue(claim(payload, "scope").contains("email"))
+          .label(s"the access token must carry the narrowed scope, got ${claim(payload, "scope")}")
+    },
+
+    test("the issued token introspects as active and carries the requested audience") {
+      for
+        (_, auth) <- setup(Flows.Id.LoginPassword)
+        (clientId, clientSecret) <- registerClient(auth, scopes = Set("openid", "email"))
+        resource = s"https://$clientId.example.test"
+        _ <- auth.registerResource(s"res-$clientId", resource, audience = Set(clientId))
+        _ <- auth.syncConfiguration()
+
+        token <- auth.clientCredentials(
+          clientId,
+          clientSecret,
+          scope = Some("email"),
+          resources = Some(List(resource)),
+        ).success
+        payload <- claims(token.accessToken)
+        introspection <- auth.introspect(token.accessToken, Some(clientId), Some(clientSecret)).success
+      yield assertTrue(audience(payload) == List(resource))
+        .label(s"expected aud=[$resource], got ${audience(payload)}") &&
+        assertTrue(introspection.active)
+          .label("the resource server must see the token as active") &&
+        assertTrue(claim(payload, "scope").contains("email"))
+    },
+
+    test("a scope outside the client's registered scope is rejected") {
+      for
+        (_, auth) <- setup(Flows.Id.LoginPassword)
+        (clientId, clientSecret) <- registerClient(auth, scopes = Set("openid", "email"))
+        result <- auth.clientCredentials(clientId, clientSecret, scope = Some("openid profile"))
+      yield assertTrue(errorCode(result).contains("invalid_scope"))
+        .label(s"expected invalid_scope, got $result")
+    },
+
+    test("a wrong client secret is rejected") {
+      for
+        (_, auth) <- setup(Flows.Id.LoginPassword)
+        (clientId, clientSecret) <- registerClient(auth)
+        result <- auth.clientCredentials(clientId, clientSecret.reverse)
+      yield assertTrue(errorCode(result).contains("invalid_client"))
+        .label(s"expected invalid_client, got $result") &&
+        assertTrue(result.response.status == Status.Unauthorized)
+    },
+
+    test("a client that presents no secret at all is rejected") {
+      for
+        (_, auth) <- setup(Flows.Id.LoginPassword)
+        (clientId, _) <- registerClient(auth)
+        // The grant is only open to confidential clients, so identifying the client without
+        // authenticating it is not enough, however well-known the client id is.
+        result <- auth.clientCredentials(clientId, "")
+      yield assertTrue(errorCode(result).contains("invalid_client"))
+        .label(s"expected invalid_client, got $result")
+    },
+
+    test("an empty resource parameter is rejected") {
+      for
+        (_, auth) <- setup(Flows.Id.LoginPassword)
+        (clientId, clientSecret) <- registerClient(auth)
+        // Sending `resource=` is not the same as omitting it: it asks for a token for no
+        // resource at all, which is never what the client meant.
+        result <- auth.clientCredentials(clientId, clientSecret, resources = Some(Nil))
+      yield assertTrue(errorCode(result).contains("invalid_request"))
+        .label(s"expected invalid_request, got $result")
+    },
+
+    test("an empty authorization_details parameter is rejected") {
+      for
+        (_, auth) <- setup(Flows.Id.LoginPassword)
+        (clientId, clientSecret) <- registerClient(auth)
+        result <- auth.clientCredentials(clientId, clientSecret, authorizationDetails = Some("[]"))
+      yield assertTrue(errorCode(result).contains("invalid_request"))
+        .label(s"expected invalid_request, got $result")
+    },
+
+    test("a resource the client cannot reach is rejected with invalid_target") {
+      for
+        (_, auth) <- setup(Flows.Id.LoginPassword)
+        (clientId, clientSecret) <- registerClient(auth)
+        result <- auth.clientCredentials(
+          clientId,
+          clientSecret,
+          resources = Some(List("https://unregistered.example.test")),
+        )
+      yield assertTrue(errorCode(result).contains("invalid_target"))
+        .label(s"expected invalid_target, got $result")
+    },
+
+    test("a revoked token stops being accepted by the edge") {
+      // The bootstrap fixture is used here rather than a client of this spec's own: the edge
+      // only accepts security events for a client it already knows about, and `Flows.layer`
+      // has already made it learn about this one.
+      for
+        (s, auth) <- setup(Flows.Id.BackChannelLogout)
+        token <- auth.clientCredentials(s.clientId, s.clientSecret).success
+        before <- auth.edgePermissions(token.accessToken).map(_.status)
+        _ <- auth.revoke(token.accessToken, s.clientId, s.clientSecret)
+        after <- auth.edgePermissions(token.accessToken).map(_.status)
+          .repeat(Schedule.spaced(100.millis) && Schedule.recurUntil[Status](_ == Status.Unauthorized))
+          .map(_._2)
+      yield assertTrue(before == Status.Ok)
+        .label("the edge must accept the token before it is revoked") &&
+        assertTrue(after == Status.Unauthorized)
+          .label("the edge must reject the token once auth has revoked it")
+    },
+    // The revocation above is recorded against wall-clock expiry, so these need the live clock.
+  ) @@ TestAspect.sequential @@ TestAspect.withLiveClock @@ TestAspect.timeout(60.seconds)

--- a/e2e/src/test/scala/versola/e2e/support/OAuthClient.scala
+++ b/e2e/src/test/scala/versola/e2e/support/OAuthClient.scala
@@ -656,6 +656,30 @@ final class OAuthClient(client: Client, config: E2EConfig):
       .addHeader(Header.ContentType(MediaType.application.`x-www-form-urlencoded`))
     Client.batched(req).provide(ZLayer.succeed(client)).flatMap(TokenResult.parse)
 
+  /** POST /token — obtains a token for the client itself (RFC 6749 §4.4).
+    *
+    * `resources` (RFC 8707) travel as a single comma-joined `resource` field, which is how
+    * zio-http presents repeated form fields to the server; pass `Some(Nil)` to send the
+    * parameter empty. `authorizationDetails` is the raw RFC 9396 JSON array.
+    */
+  def clientCredentials(
+      clientId: String,
+      clientSecret: String,
+      scope: Option[String] = None,
+      resources: Option[List[String]] = None,
+      authorizationDetails: Option[String] = None,
+  ): Task[TokenResult] =
+    val body = formBody(
+      Map("grant_type" -> "client_credentials")
+        ++ scope.map("scope" -> _)
+        ++ resources.map("resource" -> _.mkString(","))
+        ++ authorizationDetails.map("authorization_details" -> _),
+    )
+    val req = Request.post(s"${config.authUrl}/token", body)
+      .addHeader(Authorization.Basic(clientId, clientSecret))
+      .addHeader(Header.ContentType(MediaType.application.`x-www-form-urlencoded`))
+    Client.batched(req).provide(ZLayer.succeed(client)).flatMap(TokenResult.parse)
+
   /** POST /introspect — introspects a token (access or refresh) per RFC 7662. */
   def introspect(
       token: String,
@@ -899,6 +923,36 @@ final class OAuthClient(client: Client, config: E2EConfig):
       .addHeader(centralAuthorization)
       .addHeader(Header.ContentType(MediaType.application.json))
     Client.batched(req).provide(ZLayer.succeed(client)).flatMap(RegisterClientResult.parse)
+
+  /** POST /configuration/resources — registers a protected resource via the Central API, so
+    * that `resource` (RFC 8707) can name it and introspection can resolve it for `audience`.
+    * `resource` must be an absolute URI with no path, query or fragment.
+    */
+  def registerResource(
+      resourceId: String,
+      resource: String,
+      audience: Set[String],
+      tenantId: String = "default",
+      internal: Boolean = false,
+  ): Task[Unit] =
+    val body = Body.fromString(
+      Json.Obj(
+        "tenantId" -> Json.Str(tenantId),
+        "resourceId" -> Json.Str(resourceId),
+        "resource" -> Json.Str(resource),
+        "audience" -> Json.Arr(Chunk.fromIterable(audience.map(Json.Str(_)))),
+        "endpoints" -> Json.Arr(),
+        "internal" -> Json.Bool(internal),
+      ).toJson,
+    )
+    val req = Request.post(s"${config.centralUrl}/configuration/resources", body)
+      .addHeader(centralAuthorization)
+      .addHeader(Header.ContentType(MediaType.application.json))
+    Client.batched(req).provide(ZLayer.succeed(client)).flatMap: resp =>
+      if resp.status.isSuccess then ZIO.unit
+      else
+        resp.body.asString.flatMap: bodyStr =>
+          ZIO.fail(RuntimeException(s"registerResource failed: status=${resp.status} body=$bodyStr"))
 
   /** POST /configuration/authorization-detail-types — registers an RFC 9396 authorization detail
     * type via the Central API. `schema` is the raw JSON Schema (as a JSON string) that requested


### PR DESCRIPTION
Adds end-to-end coverage for the OAuth 2.0 `client_credentials` grant (RFC 6749 §4.4), which was fully implemented but had zero e2e coverage and no harness support.

## Harness additions to `OAuthClient.scala` (54 lines, purely additive)
- `clientCredentials(...)` — POST `/token` with Basic auth, optional `scope`/`resources`/`authorization_details`. Resources are comma-joined per how zio-http presents repeated form fields.
- `registerResource(...)` — POST `/configuration/resources` via Central, needed because without a resource whose `audience` contains the client, `IntrospectionService.resolveAudience` is always empty and `/introspect` would answer `active:false` for every client-credentials token, making "the token introspects as active" untestable otherwise.

No `Flows.Id` added; no existing code moved or reformatted.

## Tests added (10, `ClientCredentialsFlowSpec`)
1. happy path: `sub == clientId`, no `id_token`, no refresh token even though the client is registered for `offline_access`, unrequested scope defaults to the full registered scope
2. requested scope narrows the granted scope
3. the issued token introspects as active and carries the requested audience
4. a scope outside the client's registered scope → `invalid_scope`
5. wrong client secret → `invalid_client` (401)
6. no secret presented → `invalid_client`
7. empty `resource` → `invalid_request`
8. empty `authorization_details` → `invalid_request`
9. an unreachable resource → `invalid_target`
10. a revoked token stops being accepted by the edge (introspection is intentionally NOT the assertion here — see below)

## Two deliberate deviations from the original brief — please note for review
1. **"a public client → invalid_client" is not e2e-reachable.** `OAuthClientRecord.isPublic = !secret.nonEmpty`, but Central's `registerClient` always mints a secret and no route can null one out, so the `client.isPublic` branch in `OAuthTokenService.clientCredentials` is currently e2e-dead code. Test 6 instead covers the one *reachable* path to the same `invalid_client` outcome (confidential client, no secret presented, rejected in `verifySecret`), and is named accordingly rather than claiming to exercise `isPublic`.
2. **Revoked tokens do NOT stop introspecting as active, by design.** `AccessTokenRevocationService` has an explicit comment: introspection reports a revoked access token as active until expiry, since auth doesn't keep its own revocation record. Confirmed live (`revoke=200` then `/introspect` still `active:true`). Test 10 instead asserts the observable effect — the edge stops accepting the token after `/revoke` pushes to the back channel — mirroring `TokenRevocationFlowSpec`.

## Mutation checks (both reverted, production byte-identical to HEAD)
- Changed the id_token subject fallback to a hardcoded string → test 1 failed as expected (9/10 passed).
- Removed the `invalid_scope` guard in `OAuthTokenService.clientCredentials` → test 4 failed as expected (9/10 passed).

## Test results
`sbt e2e/test` run 3× against a live database: **104/104 passing** each time (94 pre-existing + 10 new), no flakiness.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M1VSPSGCN8AA2ZPWZ5QACZ0M&panel=chat)