### PR TITLE
fix(auth): require nonce for hybrid authorization requests

### DIFF
--- a/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/AuthorizeRequestParser.scala
@@ -186,9 +186,11 @@ object AuthorizeRequestParser:
               ZIO.none
           }
 
+        // OIDC Core §3.1.2.1: nonce is REQUIRED when the response type includes id_token.
         nonce <- getParam(params, "nonce")
           .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "nonce", useFragment = useFragment))
           .map(_.map(Nonce(_)))
+          .filterOrFail(_.isDefined || !responseTypeEntries.contains(ResponseTypeEntry.IdToken))(Error.NonceMissing(redirectUri, state, useFragment = useFragment))
 
         prompt <- getParam(params, "prompt")
           .orElseFail(Error.MultipleValuesProvided(redirectUri, state, "prompt", useFragment = useFragment))

--- a/auth/src/main/scala/versola/oauth/authorize/model/Error.scala
+++ b/auth/src/main/scala/versola/oauth/authorize/model/Error.scala
@@ -70,6 +70,12 @@ private[authorize] object Error:
       errorUri = Some("https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1#name-authorization-request"),
     )
 
+  case class NonceMissing(uri: URL, state: Option[State], useFragment: Boolean) extends RedirectError(
+      error = ErrorCode.InvalidRequest,
+      errorDescription = "Missing required parameter - nonce",
+      errorUri = Some("https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest"),
+    )
+
   case class CodeChallengeMethodMissing(uri: URL, state: Option[State], useFragment: Boolean) extends RedirectError(
       error = ErrorCode.InvalidRequest,
       errorDescription = "Missing required parameter - code_challenge_method",

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeEndpointServiceSpec.scala
@@ -315,6 +315,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
       val hybridRequest = baseRequest.copy(
         sessionId = Some(rawSessionId),
         responseType = NonEmptySet(ResponseTypeEntry.Code, ResponseTypeEntry.IdToken),
+        nonce = Some(Nonce("test-nonce")),
       )
       for
         _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
@@ -1191,6 +1192,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
       val hybridRequest = baseRequest.copy(
         prompt = Set(Prompt.none),
         responseType = NonEmptySet(ResponseTypeEntry.Code, ResponseTypeEntry.IdToken),
+        nonce = Some(Nonce("test-nonce")),
       )
       for
         _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
@@ -1205,6 +1207,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         sessionId = Some(rawSessionId),
         prompt = Set(Prompt.none),
         responseType = NonEmptySet(ResponseTypeEntry.Code, ResponseTypeEntry.IdToken),
+        nonce = Some(Nonce("test-nonce")),
       )
       for
         _ <- env.configurationService.find.succeedsWith(Some(clientWithOtpFlow))
@@ -1221,6 +1224,7 @@ object AuthorizeEndpointServiceSpec extends UnitSpecBase:
         sessionId = Some(rawSessionId),
         prompt = Set(Prompt.none),
         responseType = NonEmptySet(ResponseTypeEntry.Code, ResponseTypeEntry.IdToken),
+        nonce = Some(Nonce("test-nonce")),
       )
       for
         _ <- env.configurationService.find.succeedsWith(Some(clientWithConsent))

--- a/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
+++ b/auth/src/test/scala/versola/oauth/authorize/AuthorizeRequestParserSpec.scala
@@ -821,7 +821,7 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
     suite("response_type")(
       test("accepts code id_token") {
         val env = Env()
-        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("response_type" -> "code id_token")))
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("response_type" -> "code id_token", "nonce" -> "abc123")))
         for
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request)
@@ -880,6 +880,22 @@ object AuthorizeRequestParserSpec extends UnitSpecBase:
           _ <- env.configuration.find.succeedsWith(Some(clientRecord))
           result <- env.parser.parse(request)
         yield assertTrue(result.nonce == Some(Nonce("abc123")))
+      },
+      test("rejects a hybrid request without a nonce, reporting the error in the fragment") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams ++ Map("response_type" -> "code id_token")))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request).either
+        yield assertTrue(result == Left(Error.NonceMissing(redirectUri, Some(State("test-state")), useFragment = true)))
+      },
+      test("accepts a code flow request without a nonce") {
+        val env = Env()
+        val request = Request.get(URL.root.addQueryParams(validParams))
+        for
+          _ <- env.configuration.find.succeedsWith(Some(clientRecord))
+          result <- env.parser.parse(request)
+        yield assertTrue(result.nonce.isEmpty)
       },
     ),
     suite("prompt")(

--- a/e2e/src/test/scala/versola/e2e/flows/basic/AuthorizeNegativeSpec.scala
+++ b/e2e/src/test/scala/versola/e2e/flows/basic/AuthorizeNegativeSpec.scala
@@ -91,6 +91,7 @@ object AuthorizeNegativeSpec extends E2ESpec:
           clientId = s.clientId,
           redirectUri = s.redirectUri,
           responseType = Some("code id_token"),
+          nonce = Some("e2e-nonce"),
           prompt = Some("none"),
         ).assertFragmentErrorRedirect("login_required")
       yield assertCompletes

--- a/e2e/src/test/scala/versola/e2e/flows/basic/HybridFlowSpec.scala
+++ b/e2e/src/test/scala/versola/e2e/flows/basic/HybridFlowSpec.scala
@@ -22,11 +22,10 @@ import java.util.UUID
   * registered client may request either supported value, so a "client not registered
   * for hybrid" rejection does not exist in this implementation and is not tested here.
   *
-  * `nonce` is parsed as optional (`AuthorizeRequestParser`) and is never required:
-  * `UserInfoService.getUserInfoInternal` simply omits the `nonce` claim when none was
-  * supplied (`auth/.../UserInfoService.scala`). This is the same gap the unit-test
-  * analog (`AuthorizeEndpointServiceSpec`) recently had to correct for — hybrid requests
-  * without a nonce are OIDC-non-compliant, but the server does not reject them.
+  * `nonce` is REQUIRED whenever the response type includes `id_token` (OIDC Core
+  * §3.1.2.1): `AuthorizeRequestParser` rejects a hybrid request without one with
+  * `invalid_request`, delivered in the fragment like every other hybrid error. It stays
+  * optional for the plain `code` flow.
   */
 object HybridFlowSpec extends E2ESpec:
 
@@ -86,22 +85,15 @@ object HybridFlowSpec extends E2ESpec:
           .label("the code exchanged at /token must resolve to the same 'sub' as the fragment id_token")
     },
 
-    test("hybrid without nonce is accepted but the id_token omits the nonce claim") {
+    test("hybrid without nonce is rejected with invalid_request in the fragment") {
       for
         (s, auth) <- setup(Flows.Id.LoginPassword)
-        authorize <- auth.authorizeRaw(
+        _ <- auth.authorizeRaw(
           clientId = s.clientId,
           redirectUri = s.redirectUri,
           responseType = Some("code id_token"),
-        ).assertChallengeRedirect
-        cookie = authorize.conversationCookie.get
-        challenge <- auth.getChallenge(cookie).assertStep(ConversationStep.Credential)
-        (_, idToken) <- auth.submitLoginPassword(cookie, s.login.get, s.password, challenge.csrf)
-          .assertFragmentRedirect
-        claims <- ZIO.fromEither(decodeJwtPayload(idToken).fromJson[HybridIdTokenClaims])
-          .mapError(error => RuntimeException(s"Could not decode hybrid id_token claims [$error]"))
-      yield assertTrue(claims.nonce.isEmpty)
-        .label(s"a hybrid request with no nonce must not fabricate one; got ${claims.nonce}")
+        ).assertFragmentErrorRedirect("invalid_request")
+      yield assertCompletes
     },
 
     test("a protocol error during a hybrid request is returned in the fragment, never the query") {


### PR DESCRIPTION
Closes an OIDC compliance gap surfaced while reviewing PR #259: `nonce` was not enforced for the hybrid flow (`response_type=code id_token`), even though OIDC Core §3.1.2.1 makes it REQUIRED whenever the response type includes `id_token`. Before this change, a hybrid request with no `nonce` was accepted and the issued id_token simply omitted the `nonce` claim — replayable, and non-compliant.

**Stacked on `test/e2e-hybrid-flow` (#259)** because that branch adds `HybridFlowSpec`, which contained a test documenting the old lenient behavior; this PR updates that test as part of the fix. This PR's base will need to be retargeted to `main` once #259 merges.

## Change

- Added `Error.NonceMissing` (`auth/.../authorize/model/Error.scala`), matching the existing `CodeChallengeMissing` pattern: `invalid_request`, error URI pointing at OIDC Core §3.1.2.1.
- `AuthorizeRequestParser` now requires `nonce` when `responseTypeEntries` includes `id_token` (i.e., hybrid only — the plain `code` flow is unaffected, since the spec doesn't require nonce there and making it mandatory would be a breaking change).
- Delivered in the fragment via the existing `useFragment` mechanism, consistent with other hybrid-flow errors.
- Verified the PAR path needs no separate change: `PushedAuthorizationService.push` and `resolvePushedRequest` both route through the same `parser.validate`, so push and redemption are both covered.

## Tests

- New unit tests in `AuthorizeRequestParserSpec`: hybrid request without nonce → rejected with `NonceMissing` in the fragment; code flow without nonce → still accepted (pins the non-breaking half).
- Updated `AuthorizeEndpointServiceSpec` and `AuthorizeRequestParserSpec` hybrid fixtures to supply a nonce (they were exercising non-compliant requests).
- Updated e2e `AuthorizeNegativeSpec` hybrid fixture to supply a nonce so the test still exercises its intended `login_required` case rather than failing earlier on `invalid_request`.
- Rewrote e2e `HybridFlowSpec`'s "hybrid without nonce is accepted but omits the nonce claim" test → renamed to assert the request is now rejected with `invalid_request` in the fragment; updated the file's scaladoc accordingly.

## Verification

- `sbt auth/test`: 1173 passed, 0 failed.
- `sbt e2e/test`: 97 passed, 0 failed (matches baseline on `test/e2e-hybrid-flow`, since this rewrites a test rather than adding one).
- Mutation check: reverting the parser guard makes exactly the new/rewritten tests fail (1 unit, 1 e2e); restored and green again.
- `git diff test/e2e-hybrid-flow --stat`: 6 files, +38/−17.

## Deliberately not changed

- `AuthorizeRequest.nonce` stays `Option[Nonce]` — tightening it would ripple through `AuthorizeEndpointService`, `ConversationRecord`, `AuthorizationCodeRecord` and their postgres codecs for no runtime benefit, since the parser is the only construction site reaching the endpoint.
- `scripts/gen-env.scala`'s discovery metadata (`response_types_supported: ["code", "code id_token"]`) — still accurate, no change needed.
- `central-ui` authorization presets only store a `responseType` string, no nonce handling — unaffected.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M1VSPSGCN8AA2ZPWZ5QACZ0M&panel=chat)