### PR TITLE
loadgen/mockapi: sbt module skeleton (Phase 0 / W0)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -37,6 +37,14 @@ target/
 !migrate-tool/target/universal
 !migrate-tool/target/universal/stage
 !migrate-tool/target/universal/stage/**
+!loadgen/target
+!loadgen/target/universal
+!loadgen/target/universal/stage
+!loadgen/target/universal/stage/**
+!mockapi/target
+!mockapi/target/universal
+!mockapi/target/universal/stage
+!mockapi/target/universal/stage/**
 
 # Dockerfile.gateway needs the built SPA in its build context -- everything
 # else (Dockerfile.central, which only needs central-ui's separately-built

--- a/build.sbt
+++ b/build.sbt
@@ -213,6 +213,77 @@ lazy val tools = project
     Compile / mainClass := Some("genEnv"),
   )
 
+// versola-loadgen: coordinator + driver for the load emulator (see
+// versola-loadgen-dev-spec.md). Depends on `util`/`util-postgres` for `VersolaApp` (diagnostics
+// port, `/liveness`, `/readiness`, graceful shutdown) and `PostgresHikariDataSource` -- the
+// emulator's own state store, not the SUT's. Not part of `root`'s aggregate, same reasoning as
+// `e2e`/`tools` above: staged explicitly (`sbt loadgen/stage`), not part of the default
+// `sbt compile`/`sbt test` loop. ci-cd.yml does NOT yet compile or stage this project -- that
+// change to the "Compile" step needs the `workflow` token scope, tracked on #268; until it lands
+// nothing here is validated by CI (the same gap `tools` closed for itself by naming itself in
+// that step).
+lazy val loadgen = project
+  .in(file("loadgen"))
+  .enablePlugins(JavaAppPackaging)
+  .settings(
+    name := "loadgen",
+    commonSettings,
+    libraryDependencies ++= Dependencies.http ++ Dependencies.database.postgres ++ Seq(
+      "org.hdrhistogram" % "HdrHistogram" % Versions.hdrHistogram,
+    ),
+    Compile / mainClass := Some("versola.loadgen.Main"),
+    // Not aggregated by root, so `sbt coverage test coverageReport coverageAggregate`
+    // (the "Run tests with coverage" CI step) never touches this project anyway -- explicit
+    // here so that stays true even if someone runs `loadgen/coverage loadgen/test` directly.
+    coverageEnabled := false,
+  )
+  .dependsOn(
+    util % CompileTest,
+    `util-postgres` % CompileTest,
+  )
+
+// versola-mockapi: the load emulator's mock protected-resource backend (see
+// versola-loadgen-dev-spec.md §9). Deliberately does NOT depend on `util` and deliberately does
+// NOT use `commonSettings` -- both pull in `Dependencies.core` regardless of `dependsOn` (see
+// `migrateTool`'s comment above for the same reasoning), none of which a pure delay generator has
+// any use for. Measured, not assumed: staging with `Dependencies.http` alone gives 89 jars, and
+// drops BouncyCastle, the WebAuthn server, nimbus-jose-jwt, Flyway, HikariCP, magnum, the
+// Postgres driver, CEL, json-schema-validator, libphonenumber and angus-mail. Note what it does
+// NOT drop: `Dependencies.http` carries the OpenTelemetry SDK and the OTLP exporter itself, so
+// okhttp/okio are on this classpath either way -- the win here is that no middleware uses them
+// per request, not that they're absent.
+//
+// The classpath is only half of it: depending on `util` is what makes `VersolaApp` available, and
+// `VersolaApp` mounts `Observability.middleware` in front of every route -- a span, the RED
+// counters, request/response serialisation and one unfiltered `receive-http` JSON log line per
+// request. At ~8,400 rps that is a constant latency bias on the process the whole campaign's
+// latency numbers are measured against, so `mockapi` owns its own (much smaller) boot sequence
+// instead. The cost of that choice is real and worth stating: no tracing, no `/metrics`, no
+// shared graceful-shutdown behaviour, and a `/liveness`+`/readiness` surface that has to stay
+// correct here on its own. Not part of `root`'s aggregate, and -- like `loadgen` above -- not yet
+// named in ci-cd.yml's "Compile" step either; see that comment.
+lazy val mockapi = project
+  .in(file("mockapi"))
+  .enablePlugins(JavaAppPackaging)
+  .settings(
+    name := "mockapi",
+    scalaVersion := "3.8.1",
+    scalacOptions ++= Seq(
+      "-deprecation",
+      "-source:future",
+      "-new-syntax",
+      "-indent",
+    ),
+    libraryDependencies ++= Dependencies.http ++ Seq(
+      "dev.zio" %% "zio-test" % Versions.zio % Test,
+      "dev.zio" %% "zio-test-sbt" % Versions.zio % Test,
+    ),
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    Compile / mainClass := Some("versola.mockapi.Main"),
+    // Same reasoning as loadgen's coverageEnabled above.
+    coverageEnabled := false,
+  )
+
 lazy val sbtForkSettings = Seq(
   fork := true,
   run / baseDirectory := (ThisBuild / baseDirectory).value,

--- a/docker/Dockerfile.loadgen
+++ b/docker/Dockerfile.loadgen
@@ -1,0 +1,31 @@
+# versola-loadgen: no sbt in this image. Expects the staged tree `sbt loadgen/stage` produces,
+# downloaded as an artifact before this Dockerfile ever runs -- same shape as Dockerfile.auth.
+# The CI job that stages and uploads it does not exist yet (see build.sbt's comment on the
+# `loadgen` project); until it does, this image is buildable only from a local `sbt loadgen/stage`.
+# Runs as either the coordinator or a driver shard; role is selected entirely by config
+# (see versola-loadgen-dev-spec.md §5), not by a build-time or entrypoint switch.
+#
+# Pinned by digest, not just `:25-jre` -- see Dockerfile.auth's comment for why.
+FROM eclipse-temurin:25-jre@sha256:f19dbf0a22d0b3658fda48ce7d7181df05ad14bda151dd5ad12cc09d1451c70e
+
+WORKDIR /app
+
+# Staged application (see ci-cd.yml) -- carved back out of .dockerignore's blanket `target/`
+# exclusion for exactly this path.
+COPY loadgen/target/universal/stage /app
+
+# See Dockerfile.auth's comment: actions/upload-artifact normalizes file modes on upload,
+# losing bin/loadgen's executable bit along the way.
+RUN chmod +x /app/bin/*
+
+# Flyway migrations for the emulator's own Postgres (its bookkeeping, not the SUT's).
+COPY loadgen/migrations /app/loadgen/migrations
+
+# Application port, diagnostics port (/liveness, /readiness, /metrics), coordinator API port.
+EXPOSE 8080 8081 8100
+
+# See Dockerfile.auth's comment on both flags.
+ENV JAVA_OPTS="-XX:+UseG1GC -XX:MaxRAMPercentage=75.0 -XX:+UseCompactObjectHeaders --enable-native-access=ALL-UNNAMED"
+ENV CONFIG_PATH="/app/config/env.conf"
+
+ENTRYPOINT ["/bin/sh", "-c", "/app/bin/loadgen -Denv.path=$CONFIG_PATH $JAVA_OPTS"]

--- a/docker/Dockerfile.mockapi
+++ b/docker/Dockerfile.mockapi
@@ -1,0 +1,30 @@
+# versola-mockapi: no sbt in this image. Expects the staged tree `sbt mockapi/stage` produces,
+# downloaded as an artifact before this Dockerfile ever runs -- same shape as Dockerfile.auth.
+# The CI job that stages and uploads it does not exist yet (see build.sbt's comment on the
+# `mockapi` project); until it does, this image is buildable only from a local `sbt mockapi/stage`.
+#
+# Deliberately the plainest image in docker/: mockapi has no config file, no migrations, no
+# database -- it is a pure delay generator with its own minimal boot sequence rather than
+# `VersolaApp`'s (see build.sbt's comment on the `mockapi` project and
+# versola-loadgen-dev-spec.md §9). PORT/DPORT/BIND_HOST are read directly from the environment.
+#
+# Pinned by digest, not just `:25-jre` -- see Dockerfile.auth's comment for why.
+FROM eclipse-temurin:25-jre@sha256:f19dbf0a22d0b3658fda48ce7d7181df05ad14bda151dd5ad12cc09d1451c70e
+
+WORKDIR /app
+
+# Staged application (see ci-cd.yml) -- carved back out of .dockerignore's blanket `target/`
+# exclusion for exactly this path.
+COPY mockapi/target/universal/stage /app
+
+# See Dockerfile.auth's comment: actions/upload-artifact normalizes file modes on upload,
+# losing bin/mockapi's executable bit along the way.
+RUN chmod +x /app/bin/*
+
+# Application port, diagnostics port (/liveness, /readiness -- no /metrics on this service,
+# which is not a VersolaApp).
+EXPOSE 8100 8101
+
+ENV JAVA_OPTS="-XX:+UseG1GC -XX:MaxRAMPercentage=75.0 -XX:+UseCompactObjectHeaders --enable-native-access=ALL-UNNAMED"
+
+ENTRYPOINT ["/bin/sh", "-c", "/app/bin/mockapi $JAVA_OPTS"]

--- a/loadgen/migrations/.gitkeep
+++ b/loadgen/migrations/.gitkeep
@@ -1,0 +1,3 @@
+Flyway migrations for the emulator's own Postgres state store (vu_users, vu_sessions, vu_events
+-- see versola-loadgen-dev-spec.md §6). Land with the `store` track (C); this placeholder keeps
+the directory present so Dockerfile.loadgen's COPY has something to copy from the start.

--- a/loadgen/src/main/scala/versola/loadgen/Main.scala
+++ b/loadgen/src/main/scala/versola/loadgen/Main.scala
@@ -1,0 +1,33 @@
+package versola.loadgen
+
+import versola.util.EnvName
+import versola.util.http.VersolaApp
+import zio.*
+import zio.http.*
+import zio.telemetry.opentelemetry.tracing.Tracing
+
+/** Entry point for both the coordinator and driver roles (see `versola-loadgen-dev-spec.md`
+  * §2, §12) -- which one this process plays is a config value (`role = coordinator | driver`),
+  * not a build-time or CLI switch, so the same staged jar and image serve both.
+  *
+  * This is the skeleton commit only: it wires `loadgen` into the build and proves out
+  * `VersolaApp`'s boot sequence (diagnostics port, `/liveness`, `/readiness`, graceful shutdown)
+  * for the module. Role dispatch, the full `LoadgenConfig` tree, and the real routes land with
+  * the `config`/`protocol`/`coordinator`/`driver` packages.
+  */
+object Main extends VersolaApp("loadgen"):
+  val environmentTag = Tag[Environment]
+
+  override type Dependencies = Any
+
+  override given Tag[Dependencies] = Tag[Dependencies]
+
+  override val dependencies: ZLayer[Scope & EnvName & ConfigProvider & Tracing & Client, Throwable, Dependencies] =
+    ZLayer.succeed(())
+
+  override def routes: Routes[Dependencies & Tracing & EnvName, Throwable] =
+    Routes(
+      Method.GET / "" -> handler { (_: Request) =>
+        ZIO.succeed(Response.text("loadgen"))
+      },
+    )

--- a/mockapi/src/main/scala/versola/mockapi/Main.scala
+++ b/mockapi/src/main/scala/versola/mockapi/Main.scala
@@ -1,0 +1,78 @@
+package versola.mockapi
+
+import zio.*
+import zio.http.*
+
+/** Entry point for the load emulator's mock protected-resource backend (see
+  * `versola-loadgen-dev-spec.md` §9). Deliberately does not extend `VersolaApp` or depend on
+  * `util`: `VersolaApp` puts `Observability.middleware` in front of every route, which costs a
+  * span, the RED counters, request/response serialisation and one unfiltered `receive-http` JSON
+  * log line per request. At this service's ~8,400 rps that is a constant latency bias on the one
+  * process whose entire purpose is to not distort the measurement -- and a bias the track L
+  * calibration gate would then have to unpick. See build.sbt's comment on the `mockapi` project
+  * for what that costs in exchange (this file, rather than `VersolaApp`, owns the boot sequence).
+  *
+  * This is the skeleton commit only: it wires `mockapi` into the build with a plain
+  * liveness/readiness surface. The ten business routes and `DelaySampler` land with Phase 1
+  * track A.
+  */
+object Main extends ZIOAppDefault:
+
+  // 8100/8101 is where the dev spec (§5's `targets.mock-url`) and Dockerfile.mockapi's EXPOSE
+  // both put mockapi -- deliberately not VersolaApp's 8080/8081, which auth already holds in the
+  // docker-local topology.
+  private def port: Int =
+    Option(java.lang.System.getenv("PORT")).flatMap(_.toIntOption).getOrElse(8100)
+
+  private def diagnosticsPort: Int =
+    Option(java.lang.System.getenv("DPORT")).flatMap(_.toIntOption).getOrElse(8101)
+
+  // Same default as VersolaApp's bindHost -- see that class's comment on why 0.0.0.0.
+  private def bindHost: String =
+    Option(java.lang.System.getenv("BIND_HOST")).getOrElse("0.0.0.0")
+
+  private val routes: Routes[Any, Nothing] =
+    Routes(
+      Method.GET / "" -> handler { (_: Request) =>
+        ZIO.succeed(Response.text("mockapi"))
+      },
+    )
+
+  /** `/readiness` answers 503 until the application listener is actually installed, matching what
+    * `VersolaApp` does: a probe that reported ready earlier than that would route traffic at a
+    * port nothing is bound to yet.
+    */
+  private def diagnosticsRoutes(ready: Ref[Boolean]): Routes[Any, Nothing] =
+    Routes(
+      Method.GET / "liveness" -> handler { (_: Request) => ZIO.succeed(Response.ok) },
+      Method.GET / "readiness" -> handler { (_: Request) =>
+        ready.get.map(if _ then Response.ok else Response.status(Status.ServiceUnavailable))
+      },
+    )
+
+  private def serve(
+      name: String,
+      boundPort: Int,
+      serverRoutes: Routes[Any, Nothing],
+      onInstalled: UIO[Unit],
+  ): ZIO[Any, Throwable, Nothing] =
+    (
+      Server.install(serverRoutes) *>
+        ZIO.logInfo(s"mockapi $name server started on port $boundPort") *>
+        onInstalled *>
+        ZIO.never
+    ).provide(
+      Server.live,
+      ZLayer.succeed(Server.Config.default.binding(bindHost, boundPort)),
+    )
+
+  // `zipPar`, not `fork`: a bind failure on either port has to take the process down. Forking the
+  // diagnostics server and dropping its fiber would leave a live application server with no
+  // liveness or readiness surface at all -- a pod that never gets restarted and never gets
+  // traffic, which during a campaign reads as capacity that silently isn't there.
+  override val run: ZIO[Any, Throwable, Unit] =
+    for
+      ready <- Ref.make(false)
+      _ <- serve("diagnostics", diagnosticsPort, diagnosticsRoutes(ready), ZIO.unit)
+        .zipPar(serve("application", port, routes, ready.set(true)))
+    yield ()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,6 +28,7 @@ object Versions {
   val cel = "0.12.0"
   val jsonSchemaValidator = "2.0.4"
   val typesafeConfig = "1.4.3"
+  val hdrHistogram = "2.2.2"
 }
 
 object Dependencies {


### PR DESCRIPTION
Closes #268. Part of #267 (load emulator tracking issue).

First PR of the load emulator build-out (see `versola-loadgen-dev-spec.md` / `versola-load-emulator-design.md`). This is **W0** in the decomposition graph — pure skeleton, no behavior yet. Everything else (protocol client, store, scheduler, scenario engine, ...) branches off this once it's in.

**Update:** installed JDK 25 (Temurin, matching `docker/Dockerfile.auth`'s pinned runtime) and sbt, and actually compiled/tested/staged/booted both binaries locally before pushing. Found and fixed real bugs the first version had (see below) — none of which CI would have caught as configured (see "Needs a manual follow-up").

**Update 2 (superseded):** `mockapi` briefly used `VersolaApp` too. Reverted — see Update 3.

**Update 3:** `mockapi` keeps its own entry point. `VersolaApp` mounts `Observability.middleware` in front of every route, which costs a span, the RED counters, request/response serialisation and one unfiltered `receive-http` JSON log line per request. At `mockapi`'s ~8,400 rps that is a constant latency bias on the one process the whole campaign's latency numbers are measured against, and exactly the kind of bias the track L calibration gate would then have to unpick. Discussed on #270; `loadgen` still uses `VersolaApp` and is unaffected.

The tradeoff is stated in build.sbt rather than left implicit: `mockapi` has no tracing, no `/metrics`, no shared graceful-shutdown behaviour, and a `/liveness`+`/readiness` surface that has to stay correct on its own. The classpath saving is also stated accurately now, measured from the staged tree — 89 jars, dropping BouncyCastle, the WebAuthn server, nimbus-jose-jwt, Flyway, HikariCP, magnum, the Postgres driver, CEL, json-schema-validator, libphonenumber and angus-mail. It does **not** drop the OpenTelemetry SDK or the OTLP exporter, which live in `Dependencies.http` itself, so okhttp/okio are on the classpath either way; the win is that nothing touches them per request.

## What this adds

- **`loadgen`** sbt module (coordinator + driver binary, role TBD by config in W1). Depends on `util`/`util-postgres` for `VersolaApp` — diagnostics port, `/liveness`, `/readiness`, graceful shutdown — for free. `Main.scala` is a boot-sequence proof only: `Dependencies = Any`, one placeholder route.
- **`mockapi`** sbt module (mock protected-resource backend). Its own `ZIOAppDefault` with a minimal two-server boot sequence: application on 8100, diagnostics on 8101, `/readiness` gated on the application listener, both servers under `zipPar` so a bind failure on either port fails the process.
- `docker/Dockerfile.loadgen`, `docker/Dockerfile.mockapi` — same shape as `Dockerfile.auth` (copy staged `sbt <module>/stage` output onto a bare JRE). `mockapi`'s needs no config file; `loadgen`'s takes the usual `CONFIG_PATH`/`-Denv.path`.
- `.dockerignore` carve-outs for both modules' staged output.
- `project/Dependencies.scala`: pins `HdrHistogram`'s version (needed starting with the metrics track; declared now since it's a one-line addition).
- `loadgen/migrations/.gitkeep` — placeholder so `Dockerfile.loadgen`'s `COPY` has something to copy before the `store` track lands real Flyway migrations.
- Both projects get `coverageEnabled := false` — neither is aggregated by `root`, so `sbt coverage test coverageReport coverageAggregate` never touches them anyway, but this makes that explicit rather than incidental.

Neither module joins `root`'s aggregate, following the existing `e2e`/`tools`/`migrateTool` convention (staged explicitly, not part of the default `sbt compile`/`test` loop).

## Bugs found by actually compiling and booting this (all fixed, all verified locally)

1. **`loadgen/Main.scala` didn't compile at all**: `VersolaApp` (a `ZIOApp`) needs an explicit `val environmentTag = Tag[Environment]` and `override given Tag[Dependencies] = Tag[Dependencies]` in every subclass — izumi-reflect can't auto-derive a `Tag` for the app's full environment intersection type. Copied the exact two lines `PostgresOAuthApp` already uses for this.
2. A doc-comment bug in the W1 PR's `AdminClient.scala` (`flows/*.json` inside a `/** */` comment opens a *nested* comment — Scala block comments nest — which ate the real closing `*/` and broke compilation of everything after it). Fixed there; noting it here since it's the same "actually compile before pushing" lesson.
3. **`mockapi` reported readiness before its application listener existed**, and **discarded its diagnostics fiber** so a `DPORT` bind failure left a live process with no probe surface at all. Both from review; both fixed in the current hand-rolled entry point (`Ref` set only after `Server.install` returns; `zipPar` instead of `fork`) and verified by holding each port in turn — `liveness=200 readiness=503` when the application port is taken, exit 1 when either port is taken.
4. **`Dockerfile.mockapi` exposed 8100/8101 while the app served 8080/8081** — briefly true while `mockapi` extended `VersolaApp`, whose defaults are 8080/8081, with nothing setting `PORT`/`DPORT` in the image. The container would have exposed two dead ports and collided with auth locally.
5. **build.sbt claimed CI compiles and stages these modules.** It doesn't (see below), and the Dockerfiles made the matching claim about a CI artifact with no producer. All four comments corrected.

Verified locally end to end: `sbt loadgen/compile loadgen/Test/compile loadgen/test mockapi/compile mockapi/Test/compile mockapi/stage loadgen/stage` all succeed, and both staged binaries actually **boot and serve traffic** — `loadgen` through the full `VersolaApp` lifecycle, `mockapi` through its own (8100 serves, 8101 answers both probes with no config file and no env vars set). Also reran the whole existing repo (`sbt compile "tools/compile"`) to confirm nothing else broke.

## The CI "build" job failure you'll see on this branch is pre-existing, not from this PR

Checked: `main`'s own latest commit (`c84e8d3`) is currently red with the exact same failure — a duplicate-key race (`refresh_tokens_previous_id_key`) in the e2e refresh-token test, unrelated to anything here.

## Needs a manual follow-up (permissions)

I can't push a change to `.github/workflows/ci-cd.yml` — the configured git credential (confirmed: same one `github-api`/`git push` both use, `X-OAuth-Scopes: repo` only) lacks the `workflow` scope GitHub requires to touch `.github/workflows/*`, for both `git push` and the Contents API. Only someone with `workflow` scope can land this one-line change:

```diff
       - name: Compile
-        run: sbt compile "tools/compile"
+        run: sbt compile "tools/compile" "loadgen/compile" "loadgen/Test/compile" "mockapi/compile" "mockapi/Test/compile"
```

Until it lands, **nothing in either module is validated by CI at all** — which is how five of the bugs above were found, and is not a substitute for having it. Deliberately `Test/compile`, not `loadgen/test`/`mockapi/test`: that catches a break in test *code* without requiring CI to execute either suite yet. I run the real tests locally before every push instead.

## Not in this PR

Config decoding (`LoadgenConfig`), the `protocol` traits, the emulator's real routes, and the actual Flyway migrations under `loadgen/migrations/` — those are W1 (#269) and the parallel Phase 1 tracks: A (#270), B (#271), C (#272), D (#273), E (#274), F (#275).