### PR TITLE
loadgen: config tree + protocol contracts (Phase 0 / W1)

### DIFF
--- a/loadgen/src/main/scala/versola/loadgen/config/LoadgenConfig.scala
+++ b/loadgen/src/main/scala/versola/loadgen/config/LoadgenConfig.scala
@@ -1,0 +1,168 @@
+package versola.loadgen.config
+
+import zio.Config
+import zio.Duration
+import zio.config.magnolia.DeriveConfig
+
+/** Root configuration tree for `loadgen`, decoded from HOCON via `VersolaApp.parseConfig`
+  * (see versola-loadgen-dev-spec.md §5). One process, one file, one binary: `role` picks which
+  * half runs; `shard` is present only when `role = driver`.
+  *
+  * Deviates from the dev spec in one respect: the spec's HOCON sketch uses `actions` for two
+  * unrelated things (`session.actions` -- the NegBinomial action-count distribution -- and a
+  * top-level `actions` list -- the ten business action definitions). Renamed the former to
+  * `session.action-count` / [[ActionCountConfig]] here to remove the collision; the field
+  * still means exactly what §5 describes.
+  */
+case class LoadgenConfig(
+    role: LoadgenRole,
+    shard: Option[ShardConfig],
+    targets: TargetsConfig,
+    coordinator: CoordinatorClientConfig,
+    store: StoreConfig,
+    population: PopulationConfig,
+    session: SessionConfig,
+    campaign: CampaignConfig,
+    actions: List[BusinessActionConfig],
+)
+
+/** Which half of the `loadgen` binary this process runs. Same binary and image serve all four --
+  * see versola-loadgen-dev-spec.md §12 (coordinator) and §7 (driver). `Seed`/`Provision` are the
+  * one-shot `loadgen seed` / `loadgen provision` subcommands (§10, §4's `AdminClient`).
+  */
+enum LoadgenRole(val configValue: String):
+  case Coordinator extends LoadgenRole("coordinator")
+  case Driver extends LoadgenRole("driver")
+  case Seed extends LoadgenRole("seed")
+  case Provision extends LoadgenRole("provision")
+
+object LoadgenRole:
+  private val byValue: Map[String, LoadgenRole] = values.map(r => r.configValue -> r).toMap
+
+  def fromConfigString(value: String): Either[String, LoadgenRole] =
+    byValue.get(value)
+      .toRight(s"Unknown loadgen role '$value' (expected one of: ${values.map(_.configValue).mkString(", ")})")
+
+  // Same idiom as EnvName/Email/... in PostgresOAuthApp and EdgeConfigSpec: a plain string in
+  // HOCON, validated and lifted into the enum at decode time rather than relying on
+  // zio-config-magnolia's sealed-trait coproduct support (a discriminator-keyed shape that
+  // doesn't match a plain `role = "driver"` string).
+  given DeriveConfig[LoadgenRole] = DeriveConfig[String]
+    .mapOrFail(str => fromConfigString(str).left.map(message => Config.Error.InvalidData(message = message)))
+
+/** Which slice of the virtual-user population this driver owns: `shard = id % count`
+  * (versola-loadgen-dev-spec.md §7.1). Optional because a coordinator/seed/provision process has
+  * no shard to own -- their config files omit the block entirely, and requiring it here would
+  * fail their decode before role dispatch ever runs. Role dispatch asserts it is present for
+  * `driver`.
+  */
+case class ShardConfig(index: Int, count: Int)
+
+/** The SUT and the mock backend this campaign is driven against. */
+case class TargetsConfig(
+    authUrl: String,
+    edgeUrl: String,
+    centralUrl: String,
+    mockUrl: String,
+    /** WebAuthn `rp.origin` the software authenticator signs against (§4, §8.3). */
+    origin: String,
+)
+
+case class CoordinatorClientConfig(url: String, pollInterval: Duration)
+
+case class WriteBehindConfig(flushInterval: Duration, batchSize: Int)
+
+/** The emulator's own Postgres -- its bookkeeping, never the SUT's (§6). */
+case class StoreConfig(
+    url: String,
+    maximumPoolSize: Int,
+    writeBehind: WriteBehindConfig,
+)
+
+case class PopulationClassConfig(
+    name: String,
+    share: Double,
+    activeProbability: Double,
+    sessions: Int,
+)
+
+case class PlatformMixConfig(mobile: Double, web: Double)
+
+case class CredentialMixConfig(otp: Double, otpPassword: Double, passkey: Double)
+
+case class RoleMixConfig(retailUser: Double, retailBasic: Double)
+
+case class PopulationConfig(
+    target: Long,
+    classes: List[PopulationClassConfig],
+    platform: PlatformMixConfig,
+    credentials: CredentialMixConfig,
+    roles: RoleMixConfig,
+)
+
+case class FullLoginProbabilityConfig(mobile: Double, web: Double)
+
+/** NegBinomial parameters for actions-per-session. Named `action-count` in HOCON, not
+  * `actions`, to avoid colliding with the top-level business-action list -- see this file's
+  * top comment.
+  */
+case class ActionCountConfig(mobileMean: Double, webMean: Double, dispersion: Double)
+
+case class ThinkTimeConfig(median: Duration, sigma: Double)
+
+case class LogoutProbabilityConfig(mobile: Double, web: Double)
+
+case class SessionConfig(
+    fullLoginProbability: FullLoginProbabilityConfig,
+    actionCount: ActionCountConfig,
+    thinkTime: ThinkTimeConfig,
+    paymentProbability: Double,
+    extraRefreshProbability: Double,
+    logoutProbability: LogoutProbabilityConfig,
+    accessTokenTtl: Duration,
+)
+
+/** One phase of the campaign's arrival-rate envelope (§7.3). `scale` is used by flat phases
+  * (`warmup`, `steady`, `spike`, `recover`); `scaleFrom`/`scaleTo` by the linear `ramp` phase.
+  * All three are optional and mutually informative rather than mutually exclusive in the
+  * schema -- the scheduler (track D) decides which apply per phase `name`.
+  */
+case class CampaignPhaseConfig(
+    name: String,
+    duration: Duration,
+    scale: Option[Double],
+    scaleFrom: Option[Double],
+    scaleTo: Option[Double],
+)
+
+case class DiurnalConfig(
+    enabled: Boolean,
+    peakFactor: Double,
+    peakHour: Int,
+    timezone: String,
+)
+
+case class RegistrationConfig(
+    enabled: Boolean,
+    target: Long,
+    duration: Duration,
+)
+
+case class CampaignConfig(
+    name: String,
+    phases: List[CampaignPhaseConfig],
+    diurnal: DiurnalConfig,
+    registration: RegistrationConfig,
+)
+
+/** One of the ten protected-resource actions of versola-load-emulator-design.md §3: a relative
+  * weight, the HTTP method/path against edge, and the ACR it requires (`None` for actions with
+  * no step-up requirement).
+  */
+case class BusinessActionConfig(
+    name: String,
+    weight: Double,
+    method: String,
+    path: String,
+    acr: Option[String],
+)

--- a/loadgen/src/main/scala/versola/loadgen/model/DeviceSession.scala
+++ b/loadgen/src/main/scala/versola/loadgen/model/DeviceSession.scala
@@ -1,0 +1,20 @@
+package versola.loadgen.model
+
+/** Which protocol surface a session was established through -- a mobile bearer token
+  * (`AuthClient`) or an edge cookie session (`EdgeClient`). See §8.1-8.4.
+  */
+enum SessionKind:
+  case MobileToken, WebCookie
+
+/** One row of `vu_sessions` (§6, migration L0002). `generation` is bumped before every refresh
+  * exchange, not after -- see §7.4's refresh discipline -- so a crash between the bump and the
+  * exchange retires the session on restart instead of replaying it into reuse detection.
+  */
+case class DeviceSession(
+    id: Long,
+    userId: Long,
+    kind: SessionKind,
+    clientId: String,
+    generation: Int,
+    shard: Int,
+)

--- a/loadgen/src/main/scala/versola/loadgen/model/VirtualUser.scala
+++ b/loadgen/src/main/scala/versola/loadgen/model/VirtualUser.scala
@@ -1,0 +1,40 @@
+package versola.loadgen.model
+
+import java.util.UUID
+
+/** Cohort a virtual user belongs to (versola-loadgen-dev-spec.md §5's `population.classes`,
+  * design doc §2). Drives how often the user shows up at all, independent of platform/credential.
+  */
+enum ActivityClass:
+  case Heavy, Regular, Light, Dormant
+
+/** Which client family a user's sessions authenticate through -- `mobile-*` clients vs the
+  * edge/cookie path (§8.1-8.4).
+  */
+enum Platform:
+  case Mobile, Web
+
+/** Which conversation shape a user's login takes (§8.1-8.3). */
+enum CredentialKind:
+  case Otp, OtpPassword, Passkey
+
+/** Central role assignment -- `retail-basic` is what exercises the 403 path on step-up-gated
+  * actions (§4's `ProtocolError.Forbidden`).
+  */
+enum UserRole:
+  case RetailUser, RetailBasic
+
+/** One row of `vu_users` (§6, migration L0001). `id` is the dense shard key -- `shard = id %
+  * shardCount` (§7.1) -- deliberately not `sutUserId`, which stays `None` until the user is
+  * seeded or registers for real.
+  */
+case class VirtualUser(
+    id: Long,
+    sutUserId: Option[UUID],
+    phone: String,
+    activityClass: ActivityClass,
+    platform: Platform,
+    credential: CredentialKind,
+    role: UserRole,
+    shard: Int,
+)

--- a/loadgen/src/main/scala/versola/loadgen/protocol/Acr.scala
+++ b/loadgen/src/main/scala/versola/loadgen/protocol/Acr.scala
@@ -1,0 +1,16 @@
+package versola.loadgen.protocol
+
+/** Known ACR (Authentication Context Class Reference) values, provisioned by track E
+  * (`AdminClient.upsertAuthRequestPresets`/challenge settings) and asserted against by every
+  * step-up flow (§7.4). Copied verbatim from `e2e/.../support/Acr.scala` -- see
+  * versola-loadgen-dev-spec.md §3.1, "Copy verbatim".
+  */
+object Acr:
+  /** Satisfied by an OTP factor. */
+  val OtpLevel = "otp-level"
+
+  /** Satisfied by a password factor. */
+  val PasswordLevel = "password-level"
+
+  /** Satisfied by a passkey factor. */
+  val PasskeyLevel = "passkey-level"

--- a/loadgen/src/main/scala/versola/loadgen/protocol/AdminClient.scala
+++ b/loadgen/src/main/scala/versola/loadgen/protocol/AdminClient.scala
@@ -1,0 +1,27 @@
+package versola.loadgen.protocol
+
+import zio.Task
+import zio.json.ast.Json
+
+/** Bootstraps and administers the SUT's configuration -- clients, resources, roles,
+  * permissions, auth-request presets, challenge settings -- plus the sync/outbox calls a
+  * campaign needs before traffic starts. Used only by `loadgen provision` and `loadgen seed`
+  * (§10); never wired into a driver, which is why this lives on its own trait rather than
+  * folded into [[AuthClient]].
+  *
+  * Request/response shapes are `Json.Obj` placeholders for now, not the ~55 concrete admin
+  * payloads e2e's `OAuthClient`/`Flows.scala` already encode. Track E replaces every one of
+  * these with a typed request built from the shared flow resource files under `flows`
+  * (§3.4) once it ports them; the point of this trait for now is the set of admin operations
+  * a campaign needs, not their exact wire shape.
+  */
+trait AdminClient:
+  def registerClient(spec: Json.Obj): Task[ClientCreds]
+  def registerResource(spec: Json.Obj): Task[Unit]
+  def upsertRoles(spec: Json.Obj): Task[Unit]
+  def upsertPermissions(spec: Json.Obj): Task[Unit]
+  def upsertAuthRequestPresets(spec: Json.Obj): Task[Unit]
+  def upsertChallengeSettings(spec: Json.Obj): Task[Unit]
+  def syncConfiguration(): Task[Unit]
+  def syncEdgeConfiguration(): Task[Unit]
+  def flushUserOutbox(): Task[Unit]

--- a/loadgen/src/main/scala/versola/loadgen/protocol/AuthClient.scala
+++ b/loadgen/src/main/scala/versola/loadgen/protocol/AuthClient.scala
@@ -1,0 +1,52 @@
+package versola.loadgen.protocol
+
+import zio.IO
+
+/** Everything a virtual user's device can do against auth directly -- the `mobile-*` clients of
+  * §8.1-8.3. No admin calls, no assertions: a driver never has more surface than a real client
+  * app would (see versola-loadgen-dev-spec.md §4).
+  *
+  * Every method here keeps the exact URL, form fields, header set and cookie names the e2e
+  * `OAuthClient` uses -- that is the hard-won protocol knowledge (§3.2). Implementations land
+  * with track B; this is the interface every other track (scenario engine, calibration harness)
+  * compiles against in the meantime.
+  */
+trait AuthClient:
+  def authorize(
+      scope: String,
+      clientId: Option[String],
+      acrValues: Option[List[String]],
+  ): IO[ProtocolError, AuthorizeStarted]
+
+  def challenge(conversation: ConversationCookie): IO[ProtocolError, ChallengePage]
+
+  def submitPhone(conversation: ConversationCookie, phone: String, csrf: Csrf): IO[ProtocolError, SubmitOutcome]
+
+  def submitOtp(conversation: ConversationCookie, code: String, csrf: Csrf): IO[ProtocolError, SubmitOutcome]
+
+  def submitSetPassword(
+      conversation: ConversationCookie,
+      password: String,
+      csrf: Csrf,
+  ): IO[ProtocolError, SubmitOutcome]
+
+  def submitLoginPassword(
+      conversation: ConversationCookie,
+      login: String,
+      password: String,
+      csrf: Csrf,
+  ): IO[ProtocolError, SubmitOutcome]
+
+  def passkeyOptions(conversation: ConversationCookie): IO[ProtocolError, String]
+
+  def submitPasskeyAssertion(
+      conversation: ConversationCookie,
+      assertionJson: String,
+      csrf: Csrf,
+  ): IO[ProtocolError, SubmitOutcome]
+
+  def exchangeCode(code: AuthCode, verifier: CodeVerifier, client: ClientCreds): IO[ProtocolError, Tokens]
+
+  def exchangeRefresh(token: RefreshToken, client: ClientCreds): IO[ProtocolError, Tokens]
+
+  def logout(idToken: IdToken): IO[ProtocolError, Unit]

--- a/loadgen/src/main/scala/versola/loadgen/protocol/ConversationStep.scala
+++ b/loadgen/src/main/scala/versola/loadgen/protocol/ConversationStep.scala
@@ -1,0 +1,31 @@
+package versola.loadgen.protocol
+
+/** Open enum of known conversation step identifiers carried by
+  * `<meta name="versola-step" content="...">` in the challenge HTML.
+  *
+  * Ported from `e2e/.../support/ConversationStep.scala` with the one fix
+  * versola-loadgen-dev-spec.md §3.1/§3.3 calls out: the extraction regex is a top-level `val`
+  * here, not recompiled on every page (the e2e original compiles it inside `fromHtml`, once per
+  * call -- fine at test volume, a measurable cost at load).
+  */
+enum ConversationStep(val value: String):
+  case Credential extends ConversationStep("credential")
+  case Password extends ConversationStep("password")
+  case SetPassword extends ConversationStep("set-password")
+  case Otp extends ConversationStep("otp")
+  case PasskeyEnroll extends ConversationStep("passkey-enroll")
+  case Consent extends ConversationStep("consent")
+  case AccessDenied extends ConversationStep("access-denied")
+  case Unknown(override val value: String) extends ConversationStep(value)
+
+object ConversationStep:
+  private val known: List[ConversationStep] =
+    List(Credential, Password, SetPassword, Otp, PasskeyEnroll, Consent, AccessDenied)
+
+  private val stepMetaTag = """<meta name="versola-step" content="([^"]+)"""".r
+
+  def fromString(s: String): ConversationStep =
+    known.find(_.value == s).getOrElse(Unknown(s))
+
+  def fromHtml(html: String): Option[ConversationStep] =
+    stepMetaTag.findFirstMatchIn(html).map(m => fromString(m.group(1)))

--- a/loadgen/src/main/scala/versola/loadgen/protocol/EdgeClient.scala
+++ b/loadgen/src/main/scala/versola/loadgen/protocol/EdgeClient.scala
@@ -1,0 +1,19 @@
+package versola.loadgen.protocol
+
+import zio.IO
+
+/** The web/cookie path through edge (§8.4) -- entirely new code, not covered by the e2e client
+  * (which never exercises `/login/{presetId}` -> `/complete`). Implementation lands with track G.
+  */
+trait EdgeClient:
+  def login(preset: PresetId, acrValues: Option[List[String]]): IO[ProtocolError, EdgeLoginStarted]
+
+  def complete(state: String, code: AuthCode): IO[ProtocolError, EdgeSession]
+
+  /** [[EdgeCredential.Cookie]] drives the web path, [[EdgeCredential.Bearer]] the mobile one.
+    * Edge rotates the cookie on refresh; callers must adopt [[ActionOutcome.rotatedSession]]
+    * whenever it is set (§8.4).
+    */
+  def call(credential: EdgeCredential, action: ActionCall): IO[ProtocolError, ActionOutcome]
+
+  def logout(preset: PresetId, session: EdgeSession): IO[ProtocolError, Unit]

--- a/loadgen/src/main/scala/versola/loadgen/protocol/ProtocolError.scala
+++ b/loadgen/src/main/scala/versola/loadgen/protocol/ProtocolError.scala
@@ -1,0 +1,35 @@
+package versola.loadgen.protocol
+
+import zio.http.Status
+
+/** Why a refresh exchange was rejected. Reuse detection (`RefreshRejected(AlreadyExchanged)`)
+  * is the one that must stay at ~0 for the whole campaign -- see §7.4 and
+  * `loadgen_refresh_rejected_total` in §11. Any sustained non-zero value means either a
+  * scheduling bug (two fibers touching one session) or a real SUT defect, and either way the
+  * campaign's numbers past that point are not trustworthy.
+  */
+enum RefreshRejection:
+  case AlreadyExchanged
+  case SessionRevoked
+  case Expired
+  case Unknown(detail: String)
+
+/** Every way a protocol call can end up not returning the happy-path result. Deliberately not
+  * just `Throwable`: `StepUpRequired`/`Forbidden`/`Unauthorized` are *expected outcomes* the
+  * scenario engine branches on (§4, §7.4), not failures, and keeping them out of a generic
+  * error channel is what stops them from being miscounted as SUT errors in the report (§11).
+  */
+enum ProtocolError:
+  /** Connect/read/timeout -- infrastructure, not the SUT under test. */
+  case Transport(cause: Throwable)
+  case UnexpectedStatus(expected: Set[Status], got: Status, endpoint: String)
+  case MalformedResponse(endpoint: String, detail: String)
+  /** `401 WWW-Authenticate: ...insufficient_user_authentication, acr_values="..."` -- expected,
+    * drives the step-up re-authentication flow (§7.4).
+    */
+  case StepUpRequired(acrValues: List[String], endpoint: String)
+  /** Expected for `retail-basic` users on actions their role doesn't cover. */
+  case Forbidden(endpoint: String)
+  /** Expected once an access token's TTL (§5's `session.access-token-ttl`) has elapsed. */
+  case Unauthorized(endpoint: String)
+  case RefreshRejected(reason: RefreshRejection)

--- a/loadgen/src/main/scala/versola/loadgen/protocol/Types.scala
+++ b/loadgen/src/main/scala/versola/loadgen/protocol/Types.scala
@@ -1,0 +1,116 @@
+package versola.loadgen.protocol
+
+import zio.http.{Method, Status}
+
+// Opaque wrappers over the handful of protocol-level strings that must never be interchanged by
+// accident (a CSRF token passed where a conversation cookie was expected fails silently as a
+// wrong-parameter bug, not a compile error, without this). Kept to plain `String` underneath --
+// no validation here, that belongs to whatever produced the value (auth's response, or
+// `PkceHelper`/`SoftAuthenticator` once track B ports them).
+
+opaque type ConversationCookie = String
+object ConversationCookie:
+  def apply(value: String): ConversationCookie = value
+  extension (c: ConversationCookie) def value: String = c
+
+opaque type Csrf = String
+object Csrf:
+  def apply(value: String): Csrf = value
+  extension (c: Csrf) def value: String = c
+
+opaque type AuthCode = String
+object AuthCode:
+  def apply(value: String): AuthCode = value
+  extension (c: AuthCode) def value: String = c
+
+opaque type CodeVerifier = String
+object CodeVerifier:
+  def apply(value: String): CodeVerifier = value
+  extension (c: CodeVerifier) def value: String = c
+
+opaque type RefreshToken = String
+object RefreshToken:
+  def apply(value: String): RefreshToken = value
+  extension (t: RefreshToken) def value: String = t
+
+opaque type IdToken = String
+object IdToken:
+  def apply(value: String): IdToken = value
+  extension (t: IdToken) def value: String = t
+
+opaque type AccessToken = String
+object AccessToken:
+  def apply(value: String): AccessToken = value
+  extension (t: AccessToken) def value: String = t
+
+opaque type PresetId = String
+object PresetId:
+  def apply(value: String): PresetId = value
+  extension (p: PresetId) def value: String = p
+
+/** The edge cookie session (`EDGE_SESSION`, §8.4). Edge rotates this on refresh -- the driver
+  * must adopt every `Set-Cookie` on every response, or the session dies mid-run and looks like a
+  * phantom SUT failure (§8.4's warning).
+  */
+opaque type EdgeSession = String
+object EdgeSession:
+  def apply(value: String): EdgeSession = value
+  extension (s: EdgeSession) def value: String = s
+
+case class ClientCreds(clientId: String, clientSecret: Option[String])
+
+case class Tokens(
+    accessToken: AccessToken,
+    refreshToken: Option[RefreshToken],
+    idToken: Option[IdToken],
+    expiresInSeconds: Long,
+)
+
+/** Result of the `authorize` convenience call (§4): generates PKCE + state, starts a new
+  * conversation, and returns everything the caller needs for the rest of the flow.
+  */
+case class AuthorizeStarted(
+    conversation: ConversationCookie,
+    codeVerifier: CodeVerifier,
+    state: String,
+)
+
+/** A fetched challenge page. `step`/`csrf` are `None` when the page carries neither (e.g. an
+  * error page) -- callers that require one assert on it explicitly rather than this type
+  * throwing, unlike the e2e original's `ChallengeResult.csrf` (§3.2).
+  */
+case class ChallengePage(
+    conversation: ConversationCookie,
+    html: String,
+    step: Option[ConversationStep],
+    csrf: Option[Csrf],
+)
+
+/** Outcome of a challenge submission: either the conversation advanced to another page, or it
+  * redirected out (to the code redirect URI, an error redirect, or -- mid-flow -- to
+  * `/challenge` again for the next step, which `Redirected` alone deliberately does not
+  * distinguish; the caller re-fetches via `challenge` to see which).
+  */
+enum SubmitOutcome:
+  case Redirected(location: String)
+  case Rendered(page: ChallengePage)
+
+case class EdgeLoginStarted(conversation: ConversationCookie, codeVerifier: CodeVerifier, state: String)
+
+case class ActionCall(method: Method, path: String, body: Option[String])
+
+/** What a business action is authenticated with. An ADT rather than two `Option`s on
+  * [[EdgeClient.call]]: the web and mobile paths are mutually exclusive, and edge gives a bearer
+  * token precedence over the cookie when both arrive, so a caller that sent both would silently
+  * exercise the mobile path while believing it measured the web one.
+  */
+enum EdgeCredential:
+  case Cookie(session: EdgeSession)
+  case Bearer(token: AccessToken)
+
+/** `rotatedSession` carries the `EDGE_SESSION` edge issued on this response, when it issued one
+  * (a refresh happened, or it simply re-set the cookie) -- the caller must adopt it for its next
+  * call or the session dies mid-run and reads as a phantom SUT failure (§8.4). Always `None` on
+  * the bearer path, which has no cookie to rotate.
+  */
+case class ActionOutcome(status: Status, body: String, rotatedSession: Option[EdgeSession])

--- a/loadgen/src/test/scala/versola/loadgen/config/LoadgenConfigSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/config/LoadgenConfigSpec.scala
@@ -1,0 +1,127 @@
+package versola.loadgen.config
+
+import zio.config.magnolia.deriveConfig
+import zio.config.typesafe.TypesafeConfigProvider
+import zio.test.*
+
+/** Pure config-parsing test for [[LoadgenConfig]], mirroring EdgeConfigSpec's pattern: a
+  * kebab-case [[zio.ConfigProvider]] over a raw HOCON string, loaded via
+  * `deriveConfig[LoadgenConfig]` -- the same mechanism `VersolaApp.parseConfig` uses in
+  * production.
+  *
+  * This is deliberately the first thing `loadgen` gets tested against: every parallel track
+  * (protocol, store, scheduler, scenario engine, ...) reads its settings out of this tree, so a
+  * decode failure here would otherwise only surface once all of them are wired together.
+  */
+object LoadgenConfigSpec extends ZIOSpecDefault:
+
+  private val loadgenConfigDescriptor = deriveConfig[LoadgenConfig]
+
+  private val hocon: String =
+    """role = driver
+      |shard { index = 0, count = 8 }
+      |
+      |targets {
+      |  auth-url    = "http://auth:8080"
+      |  edge-url    = "http://edge:8095"
+      |  central-url = "http://central:8090"
+      |  mock-url    = "http://mockapi:8100"
+      |  origin      = "https://bank.example.test"
+      |}
+      |
+      |coordinator { url = "http://loadgen-coordinator:8100", poll-interval = 10s }
+      |
+      |store {
+      |  url = "jdbc:postgresql://loadgen-db:5432/loadgen"
+      |  maximum-pool-size = 16
+      |  write-behind { flush-interval = 200ms, batch-size = 500 }
+      |}
+      |
+      |population {
+      |  target = 10000000
+      |  classes = [
+      |    { name = heavy,   share = 0.15, active-probability = 0.90, sessions = 4 },
+      |    { name = regular, share = 0.45, active-probability = 0.40, sessions = 2 },
+      |    { name = light,   share = 0.30, active-probability = 0.10, sessions = 1 },
+      |    { name = dormant, share = 0.10, active-probability = 0.01, sessions = 1 },
+      |  ]
+      |  platform { mobile = 0.88, web = 0.12 }
+      |  credentials { otp = 0.35, otp-password = 0.40, passkey = 0.25 }
+      |  roles { retail-user = 0.90, retail-basic = 0.10 }
+      |}
+      |
+      |session {
+      |  full-login-probability { mobile = 0.033, web = 0.85 }
+      |  action-count { mobile-mean = 6, web-mean = 10, dispersion = 0.6 }
+      |  think-time { median = 4s, sigma = 0.8 }
+      |  payment-probability = 0.25
+      |  extra-refresh-probability = 0.25
+      |  logout-probability { mobile = 0.05, web = 0.35 }
+      |  access-token-ttl = 15m
+      |}
+      |
+      |campaign {
+      |  name = "c3-10m-steady"
+      |  phases = [
+      |    { name = warmup,  duration = 15m, scale = 0.1 },
+      |    { name = ramp,    duration = 30m, scale-from = 0.1, scale-to = 1.0 },
+      |    { name = steady,  duration = 10h, scale = 1.0 },
+      |  ]
+      |  diurnal { enabled = true, peak-factor = 3.0, peak-hour = 20, timezone = "Asia/Almaty" }
+      |  registration { enabled = false, target = 1000000, duration = 72h }
+      |}
+      |
+      |actions = [
+      |  { name = balance, weight = 0.4, method = GET, path = "/accounts/balance" },
+      |  { name = pay,     weight = 0.1, method = POST, path = "/payments", acr = "password-level" },
+      |]
+      |""".stripMargin
+
+  def spec = suite("LoadgenConfig")(
+    suite("parsing")(
+      test("decodes a full campaign config") {
+        for config <- TypesafeConfigProvider
+            .fromHoconString(hocon)
+            .kebabCase
+            .load(loadgenConfigDescriptor)
+        yield assertTrue(
+          config.role == LoadgenRole.Driver,
+          config.shard == Some(ShardConfig(index = 0, count = 8)),
+          config.targets.mockUrl == "http://mockapi:8100",
+          config.store.writeBehind.batchSize == 500,
+          config.population.target == 10000000L,
+          config.population.classes.map(_.name) == List("heavy", "regular", "light", "dormant"),
+          config.session.actionCount.webMean == 10,
+          config.campaign.phases.map(_.name) == List("warmup", "ramp", "steady"),
+          config.campaign.phases(1).scaleFrom == Some(0.1),
+          config.campaign.phases(1).scale == None,
+          config.campaign.diurnal.timezone == "Asia/Almaty",
+          config.actions.map(_.name) == List("balance", "pay"),
+          config.actions(1).acr == Some("password-level"),
+          config.actions(0).acr == None,
+        )
+      },
+      test("decodes a coordinator config, which owns no shard") {
+        for config <- TypesafeConfigProvider
+            .fromHoconString(
+              hocon
+                .replaceFirst("role = driver", "role = coordinator")
+                .replaceFirst("shard \\{ index = 0, count = 8 \\}", ""),
+            )
+            .kebabCase
+            .load(loadgenConfigDescriptor)
+        yield assertTrue(
+          config.role == LoadgenRole.Coordinator,
+          config.shard == None,
+        )
+      },
+      test("rejects an unknown role") {
+        for exit <- TypesafeConfigProvider
+            .fromHoconString(hocon.replaceFirst("role = driver", "role = orchestrator"))
+            .kebabCase
+            .load(loadgenConfigDescriptor)
+            .exit
+        yield assertTrue(exit.isFailure)
+      },
+    ),
+  )

--- a/loadgen/src/test/scala/versola/loadgen/protocol/ConversationStepSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/protocol/ConversationStepSpec.scala
@@ -1,0 +1,19 @@
+package versola.loadgen.protocol
+
+import zio.test.*
+
+object ConversationStepSpec extends ZIOSpecDefault:
+
+  def spec = suite("ConversationStep")(
+    test("extracts a known step from the meta tag") {
+      val html = """<html><head><meta name="versola-step" content="otp"></head></html>"""
+      assertTrue(ConversationStep.fromHtml(html) == Some(ConversationStep.Otp))
+    },
+    test("wraps an unrecognized step value in Unknown rather than failing") {
+      val html = """<meta name="versola-step" content="future-step">"""
+      assertTrue(ConversationStep.fromHtml(html) == Some(ConversationStep.Unknown("future-step")))
+    },
+    test("returns None when the page carries no versola-step meta tag") {
+      assertTrue(ConversationStep.fromHtml("<html></html>") == None)
+    },
+  )


### PR DESCRIPTION
Closes #269. Part of #267 (load emulator tracking issue).

> Note: base branch is `feat/loadgen-skeleton`, not `main`, so GitHub will not auto-close #269 on merge — close it manually once #264 lands and this merges through to `main`.

**Stacked on #264** (W0). This is **W1** in the decomposition graph: the shared contracts every Phase 1 track (protocol client #271, store #272, scheduler #273, provision #274, metrics #275) compiles against. Traits and data only, no implementations.

**Updates since first opened:**
- Verified locally (JDK 25 + sbt installed, see #264) instead of just carefully reviewed. Found one real bug: the `AdminClient.scala` doc comment referenced `flows/*.json`, and since Scala block comments **nest**, that `/*` opened a second comment inside the `/** ... */` doc comment and ate the real closing `*/`, breaking compilation of the file. Fixed — reworded to avoid the literal `/*` sequence.
- Dropped every default parameter value the first version had — `CampaignPhaseConfig.{scale,scaleFrom,scaleTo}`, `BusinessActionConfig.acr`, `AuthClient.authorize`'s `scope`/`clientId`/`acrValues`, `EdgeClient.login`'s `acrValues`, `ActionCall.body`. This repo doesn't use defaults in case classes (or in migrations — noted on #267/#272 for track C). `Option[T]` fields stay required parameters; the caller passes `None` explicitly. Confirmed the config-decode test doesn't rely on any of these (it decodes from HOCON strings, never constructs the case classes positionally), so this was a pure signature tightening.
- Fixed a stale commit-message encoding bug (literal `\u00a7` instead of `§` in several places) from an earlier amend.

`sbt loadgen/compile loadgen/Test/compile loadgen/test` passes clean (5/5 tests) after all of the above, rebased onto #264's updated tip.

## What this adds

- **`config/LoadgenConfig.scala`** — the full HOCON tree from `versola-loadgen-dev-spec.md` §5, decoded via `zio-config-magnolia`, same mechanism `CoreConfig`/`EdgeConfig` already use (`VersolaApp.parseConfig`). One deviation from the dev spec, called out in the file's top comment: the spec used `session.actions` and a top-level `actions` list for two unrelated things (a NegBinomial count distribution vs. the ten business-action definitions) — renamed the former to `session.action-count` to remove the collision.
- **`LoadgenConfigSpec.scala`** — decodes a full example campaign config, mirroring `EdgeConfigSpec`'s exact pattern (`TypesafeConfigProvider.fromHoconString(...).kebabCase.load(deriveConfig[...])`). Flagged in the dev spec as *"the highest-value hour in the whole project"* — every other track reads its settings out of this tree. **Passes.**
- **`protocol/{AuthClient,EdgeClient,AdminClient}.scala`** — the three client traits (dev spec §4). `AdminClient`'s request/response shapes are `Json.Obj` placeholders for now, not e2e's ~55 concrete admin payloads — the point of the trait right now is *which* admin operations a campaign needs, not their exact wire shape (track E, #274, replaces these once it ports the real payloads).
- **`protocol/ProtocolError.scala`** — the error ADT. `StepUpRequired`/`Forbidden`/`Unauthorized` are kept out of the failure channel as documented *outcomes* a scenario branches on, not SUT errors (dev spec §4/§11).
- **`protocol/{Acr,ConversationStep}.scala`** — ported from `e2e/.../support/` per the dev spec §3.1 file-by-file verdict. `ConversationStep`'s meta-tag regex is a top-level `val` instead of being recompiled per page (§3.2/§3.3). Covered by `ConversationStepSpec.scala`. **Passes.**
- **`protocol/Types.scala`** — opaque wrappers (`ConversationCookie`, `Csrf`, `AuthCode`, `RefreshToken`, ...) so e.g. a CSRF token can't be passed where a conversation cookie is expected without a compile error, plus the small result types (`Tokens`, `ChallengePage`, `SubmitOutcome`, ...).
- **`model/{VirtualUser,DeviceSession}.scala`** — the driver-side shapes backing the `vu_users`/`vu_sessions` tables (dev spec §6).

## Deliberately not in this PR

Store repository traits. Per the decomposition graph, that's track C's own PR (#272) once its Flyway migrations exist to define what they actually persist — guessing at that shape here risked a confident-but-wrong interface two tracks would then build against.

## Verification

```
sbt loadgen/compile loadgen/Test/compile loadgen/test
...
+ LoadgenConfig
  + parsing
    + rejects an unknown role
    + decodes a full campaign config
+ ConversationStep
  + wraps an unrecognized step value in Unknown rather than failing
  + extracts a known step from the meta tag
  + returns None when the page carries no versola-step meta tag
5 tests passed. 0 tests failed. 0 tests ignored.
```

Same CI caveat as #264: the `.github/workflows/ci-cd.yml` "Compile" step edit that would cover this module in CI is blocked on `workflow` scope (see #264) — I'm compensating by actually running `sbt loadgen/compile loadgen/Test/compile loadgen/test` locally before every push instead of relying on CI to catch it.