### PR TITLE
feat: add PS256 and ES256 JWT signing algorithm support

### DIFF
--- a/auth/src/test/scala/versola/oauth/client/OAuthClientSyncClientSpec.scala
+++ b/auth/src/test/scala/versola/oauth/client/OAuthClientSyncClientSpec.scala
@@ -65,6 +65,7 @@ object OAuthClientSyncClientSpec extends ZIOSpecDefault:
     override def mac(secret: Secret, key: Array[Byte]) = ZIO.dieMessage("Unused in test")
     override def hashPassword(password: Secret, salt: versola.util.Salt, pepper: Secret.Bytes16) = ZIO.dieMessage("Unused in test")
     override def generateRsaKeyPair = ZIO.dieMessage("Unused in test")
+    override def generateEcKeyPair: UIO[EcKeyPair] = ZIO.dieMessage("not used in test")
   )
 
   def spec = suite("OAuthClientsClient")(

--- a/auth/src/test/scala/versola/oauth/client/ResourceSyncClientSpec.scala
+++ b/auth/src/test/scala/versola/oauth/client/ResourceSyncClientSpec.scala
@@ -2,7 +2,7 @@ package versola.oauth.client
 
 import versola.auth.TestEnvConfig
 import versola.oauth.client.model.{ClientId, ResourceId, ResourceUri, TenantId}
-import versola.util.{Base64, Secret, SecurityService}
+import versola.util.{Base64, EcKeyPair, Secret, SecurityService}
 import zio.*
 import zio.http.*
 import zio.json.*
@@ -24,6 +24,7 @@ object ResourceSyncClientSpec extends ZIOSpecDefault:
     override def hashPassword(pw: Secret, salt: versola.util.Salt, pepper: Secret.Bytes16) =
       ZIO.dieMessage("Unused in test")
     override def generateRsaKeyPair = ZIO.dieMessage("Unused in test")
+    override def generateEcKeyPair: UIO[EcKeyPair] = ZIO.dieMessage("not used in test")
 
   private case class RegistryEntryMirror(
       resourceId: ResourceId,

--- a/central/implementations/postgres/migrations/V1001__tenants_table.sql
+++ b/central/implementations/postgres/migrations/V1001__tenants_table.sql
@@ -1,6 +1,7 @@
 CREATE TABLE tenants (
     id   TEXT PRIMARY KEY,
-    description TEXT NOT NULL
+    description TEXT NOT NULL,
+    signing_algorithm TEXT NOT NULL DEFAULT 'RS256'
 );
 
 -- INSERT INTO tenants (id, description) VALUES ('default', 'Default');

--- a/central/implementations/postgres/src/main/scala/versola/configuration/tenants/PostgresTenantRepository.scala
+++ b/central/implementations/postgres/src/main/scala/versola/configuration/tenants/PostgresTenantRepository.scala
@@ -15,7 +15,7 @@ class PostgresTenantRepository(xa: TransactorZIO) extends TenantRepository, Basi
 
   override def getAll: Task[Vector[TenantRecord]] =
     xa.connectMeasured("get-all-tenants"):
-      sql"""SELECT id, description, edge_id FROM tenants ORDER BY id"""
+      sql"""SELECT id, description, edge_id, signing_algorithm FROM tenants ORDER BY id"""
         .query[TenantRecord]
         .run()
 

--- a/central/src/main/scala/versola/central/configuration/jwks/JwksController.scala
+++ b/central/src/main/scala/versola/central/configuration/jwks/JwksController.scala
@@ -8,6 +8,7 @@ import zio.http.{Method, Request, Response, Routes, Status, handler}
 import zio.json.EncoderOps
 import zio.json.ast.Json
 import zio.{Task, ZIO}
+import versola.util.JWT
 
 /** Endpoints for the central-owned JWKS.
   *
@@ -26,6 +27,7 @@ object JwksController extends Controller:
     updateJwkEndpoint,
     deleteJwkEndpoint,
     getJwksSyncEndpoint,
+    generateJwkEndpoint,
   )
 
   val getJwksEndpoint =
@@ -76,6 +78,21 @@ object JwksController extends Controller:
         service <- ZIO.service[JwksService]
         jwks <- service.getRaw
       yield Response.json(jwks.toJson)
+    }
+
+  val generateJwkEndpoint =
+    Method.POST / "configuration" / "jwks" / "generate" -> handler { (request: Request) =>
+      for
+        _ <- authorizeBasic(request)
+        service <- ZIO.service[JwksService]
+        algorithmStr <- request.url.queryZIO[String]("algorithm")
+        algorithm <- algorithmStr match
+          case "RS256" => ZIO.succeed(JWT.Algorithm.RS256)
+          case "PS256" => ZIO.succeed(JWT.Algorithm.PS256)
+          case "ES256" => ZIO.succeed(JWT.Algorithm.ES256)
+          case other   => ZIO.fail(new IllegalArgumentException(s"Unsupported algorithm: $other"))
+        _ <- service.generateKey(algorithm)
+      yield Response.status(Status.Created)
     }
 
   /** Parses the request body as a JWK and extracts its `kid`, replying with

--- a/central/src/main/scala/versola/central/configuration/jwks/JwksService.scala
+++ b/central/src/main/scala/versola/central/configuration/jwks/JwksService.scala
@@ -1,7 +1,7 @@
 package versola.central.configuration.jwks
 
 import versola.central.CentralConfig
-import versola.util.{JWT, ReloadingCache}
+import versola.util.{JWT, ReloadingCache, SecurityService}
 import zio.json.ast.Json
 import zio.{Schedule, Scope, Task, UIO, ZIO, ZLayer}
 
@@ -20,15 +20,16 @@ trait JwksService:
   def createKey(kid: String, jwk: Json.Obj): Task[Unit]
   def updateKey(kid: String, jwk: Json.Obj): Task[Unit]
   def deleteKey(kid: String): Task[Unit]
+  def generateKey(algorithm: JWT.Algorithm): Task[Unit]
 
 object JwksService:
-  def live: ZLayer[JwksRepository & Scope & CentralConfig, Throwable, JwksService] =
+  def live: ZLayer[JwksRepository & SecurityService & Scope & CentralConfig, Throwable, JwksService] =
     (ZLayer.fromZIO:
       ZIO.serviceWithZIO[CentralConfig](config =>
         ReloadingCache.make[Vector[JwksRecord]](config.configurationCacheRefreshInterval),
       )
     )
-      >>> ZLayer.fromFunction(Impl(_, _))
+      >>> ZLayer.fromFunction(Impl(_, _, _))
 
   private def toJwks(records: Vector[JwksRecord]): Json.Obj =
     Json.Obj("keys" -> Json.Arr(records.map(_.jwk)*))
@@ -36,6 +37,7 @@ object JwksService:
   case class Impl(
       cache: ReloadingCache[Vector[JwksRecord]],
       repository: JwksRepository,
+      security: SecurityService,
   ) extends JwksService:
     override def getPublicKeys: UIO[JWT.PublicKeys] =
       cache.get.map(records => JWT.PublicKeys.fromJson(toJwks(records)))
@@ -54,3 +56,16 @@ object JwksService:
 
     override def deleteKey(kid: String): Task[Unit] =
       repository.delete(kid)
+
+    override def generateKey(algorithm: JWT.Algorithm): Task[Unit] =
+      algorithm match
+        case JWT.Algorithm.RS256 | JWT.Algorithm.PS256 =>
+          security.generateRsaKeyPair.flatMap(pair =>
+            repository.create(pair.keyId, pair.toPublicJwk)
+          )
+        case JWT.Algorithm.ES256 =>
+          security.generateEcKeyPair.flatMap(pair =>
+            repository.create(pair.keyId, pair.toPublicJwk)
+          )
+        case JWT.Algorithm.HS256 =>
+          ZIO.fail(new IllegalArgumentException("HS256 is symmetric and not stored in JWKS"))

--- a/central/src/main/scala/versola/central/configuration/tenants/TenantRecord.scala
+++ b/central/src/main/scala/versola/central/configuration/tenants/TenantRecord.scala
@@ -7,6 +7,7 @@ case class TenantRecord(
     id: TenantId,
     description: String,
     edgeId: Option[EdgeId],
+    signingAlgorithm: String = "RS256",
 )
 
 object TenantRecord:

--- a/central/src/test/scala/versola/central/configuration/clients/ClientControllerSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/clients/ClientControllerSpec.scala
@@ -9,7 +9,7 @@ import versola.central.configuration.permissions.Permission
 import versola.central.configuration.scopes.ScopeToken
 import versola.central.configuration.tenants.TenantId
 import versola.util.http.Observability
-import versola.util.{Base64, Base64Url, JWT, Patch, RedirectUri, RsaKeyPair, Secret, SecureRandom, SecurityService}
+import versola.util.{Base64, Base64Url, EcKeyPair, JWT, Patch, RedirectUri, RsaKeyPair, Secret, SecureRandom, SecurityService}
 import zio.*
 import zio.http.*
 import zio.json.*
@@ -169,6 +169,7 @@ object ClientControllerSpec extends ZIOSpecDefault, ZIOStubs:
       override def mac(secret: versola.util.Secret, key: Array[Byte]) = ZIO.dieMessage("Unused in test")
       override def hashPassword(password: versola.util.Secret, salt: versola.util.Salt, pepper: versola.util.Secret.Bytes16) = ZIO.dieMessage("Unused in test")
       override def generateRsaKeyPair = ZIO.dieMessage("Unused in test")
+      override def generateEcKeyPair: UIO[EcKeyPair] = ZIO.dieMessage("Unused in test")
     )
 
   private def controllerTestCase(
@@ -394,6 +395,7 @@ object ClientControllerSpec extends ZIOSpecDefault, ZIOStubs:
         override def mac(secret: versola.util.Secret, key: Array[Byte]) = ZIO.dieMessage("Unused in test")
         override def hashPassword(password: versola.util.Secret, salt: versola.util.Salt, pepper: versola.util.Secret.Bytes16) = ZIO.dieMessage("Unused in test")
         override def generateRsaKeyPair = ZIO.dieMessage("Unused in test")
+        override def generateEcKeyPair: UIO[EcKeyPair] = ZIO.dieMessage("Unused in test")
       for
         client <- ZIO.service[Client]
         security <- (SecureRandom.live >>> SecurityService.live).build

--- a/central/src/test/scala/versola/central/configuration/jwks/JwksServiceSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/jwks/JwksServiceSpec.scala
@@ -7,6 +7,9 @@ import zio.*
 import zio.json.*
 import zio.json.ast.Json
 import zio.test.*
+import versola.util.{EcKeyPair, MAC, RsaKeyPair, Secret, Salt, SecurityService}
+import java.security.{PrivateKey, PublicKey}
+import javax.crypto.SecretKey as JSecretKey
 
 import java.security.KeyPairGenerator
 import java.security.interfaces.RSAPublicKey
@@ -38,12 +41,25 @@ object JwksServiceSpec extends ZIOSpecDefault:
       def update(kid: String, jwk: Json.Obj): Task[Unit] = ZIO.unit
       def delete(kid: String): Task[Unit]                = ZIO.unit
     )
+    
+  private val stubSecurity: ULayer[SecurityService] =
+    ZLayer.succeed(new SecurityService:
+      def encryptAes256(data: Array[Byte], key: JSecretKey): Task[Array[Byte]]         = ZIO.dieMessage("not used")
+      def decryptAes256(data: Array[Byte], key: JSecretKey): Task[Array[Byte]]         = ZIO.dieMessage("not used")
+      def encryptRsa(data: Array[Byte], key: PublicKey): Task[Array[Byte]]             = ZIO.dieMessage("not used")
+      def decryptRsa(data: Array[Byte], key: PrivateKey): Task[Array[Byte]]            = ZIO.dieMessage("not used")
+      def mac(secret: Secret, key: Array[Byte]): Task[MAC]                             = ZIO.dieMessage("not used")
+      def hashPassword(p: Secret, s: Salt, pepper: Secret.Bytes16): Task[MAC]          = ZIO.dieMessage("not used")
+      def generateRsaKeyPair: UIO[RsaKeyPair]                                          = ZIO.dieMessage("not used")
+      def generateEcKeyPair: UIO[EcKeyPair]                                            = ZIO.dieMessage("not used")
+    )
 
   private def serviceFrom(records: Vector[JwksRecord]) =
     ZLayer.make[JwksService](
       inMemoryRepo(records),
       Scope.default,
       ZLayer.succeed(TestCentralConfig.config),
+      stubSecurity,
       JwksService.live,
     )
 

--- a/central/src/test/scala/versola/central/configuration/resources/ResourceControllerSpec.scala
+++ b/central/src/test/scala/versola/central/configuration/resources/ResourceControllerSpec.scala
@@ -7,7 +7,7 @@ import versola.central.configuration.edges.{EdgeId, EdgeRecord, EdgeService}
 import versola.central.configuration.clients.ClientId
 import versola.central.configuration.tenants.TenantId
 import versola.central.configuration.*
-import versola.util.{Base64Url, JWT, RsaKeyPair, Secret, SecurityService}
+import versola.util.{Base64Url, EcKeyPair, JWT, RsaKeyPair, Secret, SecurityService}
 import versola.util.http.Observability
 import zio.*
 import zio.http.*
@@ -110,6 +110,7 @@ object ResourceControllerSpec extends ZIOSpecDefault, ZIOStubs:
       override def mac(secret: versola.util.Secret, key: Array[Byte]) = ZIO.dieMessage("Unused in test")
       override def hashPassword(password: versola.util.Secret, salt: versola.util.Salt, pepper: versola.util.Secret.Bytes16) = ZIO.dieMessage("Unused in test")
       override def generateRsaKeyPair = ZIO.dieMessage("Unused in test")
+      override def generateEcKeyPair: UIO[EcKeyPair] = ZIO.dieMessage("Unused in test")
     )
 
   private def controllerTestCase(

--- a/edge/src/test/scala/versola/edge/OAuthClientsSyncClientSpec.scala
+++ b/edge/src/test/scala/versola/edge/OAuthClientsSyncClientSpec.scala
@@ -1,7 +1,7 @@
 package versola.edge
 
 import versola.edge.model.{ClientId, EdgeId, PermissionId}
-import versola.util.{Base64, Secret, SecurityService}
+import versola.util.{Base64, EcKeyPair, Secret, SecurityService}
 import zio.*
 import zio.http.*
 import zio.json.*
@@ -42,6 +42,7 @@ object OAuthClientsSyncClientSpec extends ZIOSpecDefault:
       override def hashPassword(pw: Secret, salt: versola.util.Salt, pepper: Secret.Bytes16) =
         ZIO.dieMessage("Unused in test")
       override def generateRsaKeyPair = ZIO.dieMessage("Unused in test")
+      override def generateEcKeyPair: UIO[EcKeyPair] = ZIO.dieMessage("not used in test")
 
   private val centralSyncTokenService = new CentralSyncTokenService:
     override def getToken: UIO[String] = ZIO.succeed(syncToken)

--- a/edge/src/test/scala/versola/edge/ResourcesSyncClientSpec.scala
+++ b/edge/src/test/scala/versola/edge/ResourcesSyncClientSpec.scala
@@ -2,7 +2,7 @@ package versola.edge
 
 import versola.edge.model.{EdgeId, ResourceEndpointId, ResourceId}
 import versola.util.cel.CelEvaluator
-import versola.util.{Base64, Secret, SecurityService}
+import versola.util.{Base64, EcKeyPair, Secret, SecurityService}
 import zio.*
 import zio.http.*
 import zio.test.*
@@ -40,6 +40,7 @@ object ResourcesSyncClientSpec extends ZIOSpecDefault:
     override def mac(secret: Secret, key: Array[Byte]) = ZIO.dieMessage("Unused in test")
     override def hashPassword(password: Secret, salt: versola.util.Salt, pepper: Secret.Bytes16) = ZIO.dieMessage("Unused in test")
     override def generateRsaKeyPair = ZIO.dieMessage("Unused in test")
+    override def generateEcKeyPair: UIO[EcKeyPair] = ZIO.dieMessage("not used in test")
 
   private val centralSyncTokenService = new CentralSyncTokenService:
     override def getToken: UIO[String] = ZIO.succeed(token)

--- a/util/src/main/scala/versola/util/EcKeyPair.scala
+++ b/util/src/main/scala/versola/util/EcKeyPair.scala
@@ -1,0 +1,23 @@
+package versola.util
+
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.jwk.{Curve, ECKey, KeyUse}
+import zio.json.ast.Json
+import zio.json.DecoderOps
+
+import java.security.interfaces.{ECPrivateKey, ECPublicKey}
+
+case class EcKeyPair(
+    keyId: String,
+    publicKey: ECPublicKey,
+    privateKey: ECPrivateKey,
+):
+  def toPublicJwk: Json.Obj =
+    val jwk = new ECKey.Builder(Curve.P_256, publicKey)
+      .keyID(keyId)
+      .algorithm(JWSAlgorithm.ES256)
+      .keyUse(KeyUse.SIGNATURE)
+      .build()
+
+    jwk.toJSONString.fromJson[Json.Obj]
+      .getOrElse(throw new IllegalStateException("Failed to encode JWK as JSON object"))

--- a/util/src/main/scala/versola/util/JWT.scala
+++ b/util/src/main/scala/versola/util/JWT.scala
@@ -1,6 +1,6 @@
 package versola.util
 
-import com.nimbusds.jose.crypto.{ECDSAVerifier, MACSigner, MACVerifier, RSASSASigner, RSASSAVerifier}
+import com.nimbusds.jose.crypto.{ECDSASigner, ECDSAVerifier, MACSigner, MACVerifier, RSASSASigner, RSASSAVerifier}
 import com.nimbusds.jose.jwk.*
 import com.nimbusds.jose.{JOSEObjectType, JWSAlgorithm, JWSHeader, JWSSigner}
 import com.nimbusds.jwt.{JWTClaimsSet, SignedJWT}
@@ -55,8 +55,11 @@ object JWT:
 
         val jwt = new com.nimbusds.jwt.SignedJWT(header, claimsSet)
         val signer = signature match {
-          case Signature.Asymmetric(_, _, privateKey) if signature.algorithm == Algorithm.RS256 =>
+          case Signature.Asymmetric(_, _, privateKey)
+              if signature.algorithm == Algorithm.RS256 || signature.algorithm == Algorithm.PS256 =>
             new RSASSASigner(privateKey)
+          case Signature.Asymmetric(_, _, privateKey) if signature.algorithm == Algorithm.ES256 =>
+            new ECDSASigner(privateKey.asInstanceOf[java.security.interfaces.ECPrivateKey])
           case Signature.Symmetric(key) =>
             new MACSigner(key)
           case _ =>
@@ -73,7 +76,7 @@ object JWT:
     */
   def leftHalfHash(value: String, algorithm: Algorithm): String =
     val digestName = algorithm match
-      case Algorithm.RS256 | Algorithm.HS256 => "SHA-256"
+      case Algorithm.RS256 | Algorithm.HS256 | Algorithm.PS256 | Algorithm.ES256 => "SHA-256"
     val digest = java.security.MessageDigest.getInstance(digestName)
       .digest(value.getBytes(StandardCharsets.UTF_8))
     Base64.urlEncode(digest.take(digest.length / 2))
@@ -114,6 +117,8 @@ object JWT:
   enum Algorithm(val jwsAlgorithm: JWSAlgorithm):
     case RS256 extends Algorithm(JWSAlgorithm.RS256)
     case HS256 extends Algorithm(JWSAlgorithm.HS256)
+    case PS256 extends Algorithm(JWSAlgorithm.PS256)
+    case ES256 extends Algorithm(JWSAlgorithm.ES256)
 
   case class PublicKeys(keys: JWKSet):
     def active: PublicKey = PublicKey(keys.getKeys.get(0))
@@ -130,6 +135,8 @@ object JWT:
     def id: String = key.getKeyID
     def algorithm: Algorithm = key.getAlgorithm.getName match
       case "RS256" => Algorithm.RS256
+      case "PS256" => Algorithm.PS256
+      case "ES256" => Algorithm.ES256
 
   case class Header(header: JWSHeader):
     def get(name: String): Option[String] =

--- a/util/src/main/scala/versola/util/SecurityService.scala
+++ b/util/src/main/scala/versola/util/SecurityService.scala
@@ -6,7 +6,8 @@ import org.bouncycastle.crypto.params.Argon2Parameters
 import zio.{Clock, Semaphore, Task, UIO, URLayer, ZIO, ZLayer}
 
 import java.security.{KeyPairGenerator, PrivateKey, PublicKey}
-import java.security.interfaces.{RSAPrivateKey, RSAPublicKey}
+import java.security.interfaces.{ECPrivateKey, ECPublicKey, RSAPrivateKey, RSAPublicKey}
+import java.security.spec.ECGenParameterSpec
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import javax.crypto.spec.GCMParameterSpec
@@ -24,6 +25,7 @@ trait SecurityService:
   def hashPassword(password: Secret, salt: Salt, pepper: Secret.Bytes16): Task[MAC]
 
   def generateRsaKeyPair: UIO[RsaKeyPair]
+  def generateEcKeyPair: UIO[EcKeyPair]
 
 object SecurityService:
   /** Used by services that never hash passwords (central, edge); auth passes its configured
@@ -139,11 +141,30 @@ object SecurityService:
         val publicKey = keyPair.getPublic.asInstanceOf[RSAPublicKey]
         val privateKey = keyPair.getPrivate.asInstanceOf[RSAPrivateKey]
 
-        // Format timestamp as YYYY-MM-DD_HH-MM-SS (up to seconds precision)
         val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss")
         val keyId = formatter.format(now.atZone(ZoneOffset.UTC))
 
         RsaKeyPair(
+          keyId = keyId,
+          publicKey = publicKey,
+          privateKey = privateKey,
+        )
+
+    override def generateEcKeyPair: UIO[EcKeyPair] =
+      for
+        now <- Clock.instant
+        keyPair <- ZIO.succeedBlocking:
+          val gen = KeyPairGenerator.getInstance("EC")
+          gen.initialize(new ECGenParameterSpec("secp256r1"))
+          gen.generateKeyPair()
+      yield
+        val publicKey = keyPair.getPublic.asInstanceOf[ECPublicKey]
+        val privateKey = keyPair.getPrivate.asInstanceOf[ECPrivateKey]
+
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss")
+        val keyId = formatter.format(now.atZone(ZoneOffset.UTC))
+
+        EcKeyPair(
           keyId = keyId,
           publicKey = publicKey,
           privateKey = privateKey,


### PR DESCRIPTION
Closes #192 

- Add PS256 and ES256 cases to JWT.Algorithm enum
- Add ECDSASigner support in JWT.serialize
- Add EcKeyPair model with toPublicJwk
- Add generateEcKeyPair to SecurityService trait and Impl
- Extend JwksService with generateKey(algorithm) method
- Add POST /configuration/jwks/generate HTTP endpoint
- Add signingAlgorithm field to TenantRecord (default RS256)
- Add signing_algorithm column to tenants migration
- Update PostgresTenantRepository SELECT to include signing_algorithm
- Update SecurityService stubs in all affected test files