### PR TITLE
fix(versola-tools): give migrate service every service's secrets, not just central's

### DIFF
--- a/docker/versola-tools/compose.fragment.vps.yml.template
+++ b/docker/versola-tools/compose.fragment.vps.yml.template
@@ -67,16 +67,22 @@ services:
     # No `platform:` pin, same reasoning as central/auth/edge below.
     network_mode: host
     command: ["migrate"]
-    # auth.conf/central.conf/edge.conf's postgres.password field is an
-    # OpenBao-resolved ${POSTGRES_PASSWORD} placeholder here (unlike
-    # docker-local's literal value -- see gen-env.scala's secretField call
-    # on that field), so it needs env_file the same way central's own
-    # service does below. All three services' passwords are the one value
-    # gen-env.scala generates and reuses (see pgPassDefault), so any one of
-    # the three secrets files would do; central.secrets.env is picked
-    # because central is already the first service this file starts.
+    # This one container mounts all three services' config files below and
+    # resolves each in turn (see MigrateTool.readConnection) -- and Typesafe
+    # Config's own resolve() requires every ${VAR} substitution in a config
+    # document to resolve, not just the ones a given code path actually
+    # reads. That means this needs every secret any of the three configs
+    # placeholders out, not just postgres.password (the one field that's
+    # the same value shared across all three, and the only one this used to
+    # list a secrets file for -- auth.conf's and edge.conf's OWN secrets,
+    # e.g. AUTH_CODES_SECRET, EDGE_PRIVATE_KEY, aren't in central.secrets.env
+    # and were left unresolved by that, which is exactly what broke the
+    # first real `versola migrate vps` run: ConfigException.
+    # UnresolvedSubstitution on auth.conf's AUTH_CODES_SECRET).
     env_file:
+      - ./auth.secrets.env
       - ./central.secrets.env
+      - ./edge.secrets.env
     volumes:
       - ./auth.conf:/opt/versola-tools/config/auth.conf:ro
       - ./central.conf:/opt/versola-tools/config/central.conf:ro

--- a/docker/versola-tools/compose.fragment.yml.template
+++ b/docker/versola-tools/compose.fragment.yml.template
@@ -115,9 +115,22 @@ services:
     # Postgres user/password are fixed, non-secret literals (matching
     # postgres's own POSTGRES_USER/POSTGRES_PASSWORD above and what's
     # already written literally into auth.conf/central.conf/edge.conf's own
-    # postgres blocks for this target) -- no OpenBao resolution needed here,
-    # unlike vps's counterpart in compose.fragment.vps.yml.template.
+    # postgres blocks for this target) -- that part needs no OpenBao
+    # resolution, unlike vps's counterpart. But every OTHER secret field
+    # (JWT_PRIVATE_KEY, AUTH_CODES_SECRET, EDGE_PRIVATE_KEY, ...) IS an
+    # OpenBao-resolved placeholder here too (gen-env.scala's useOpenBao is
+    # true for docker-local, not just vps) -- and this container mounts all
+    # three services' config files below, resolving each one whole
+    # (Typesafe Config's resolve() requires every ${VAR} in the document to
+    # resolve, not just the ones actually read). Without env_file here, the
+    # first real `migrate` run on a fresh docker-local deployment hits the
+    # same ConfigException.UnresolvedSubstitution vps's did before this was
+    # added (see compose.fragment.vps.yml.template's own comment).
     command: ["migrate"]
+    env_file:
+      - ./auth.secrets.env
+      - ./central.secrets.env
+      - ./edge.secrets.env
     volumes:
       - ./auth.conf:/opt/versola-tools/config/auth.conf:ro
       - ./central.conf:/opt/versola-tools/config/central.conf:ro


### PR DESCRIPTION
The migrate service mounts auth.conf/central.conf/edge.conf all into one container and resolves each in turn (MigrateTool.readConnection). Typesafe Config's resolve() requires every ${VAR} substitution in a config document to resolve, not just the ones a given code path actually reads -- so migrate needs every secret any of the three configs placeholders out, not just postgres.password (the one field shared across all three, and the only one env_file previously covered for vps; docker-local's migrate had no env_file at all).

Reproduced on the first real `versola migrate vps` run against a live VPS deploy (0.5.0): ConfigException.UnresolvedSubstitution on auth.conf's AUTH_CODES_SECRET, because central.secrets.env (migrate's only env_file) doesn't have it. docker-local's migrate would hit the same failure the first time someone runs it standalone against a real generated deployment, for the same reason -- fixed there too even though it hasn't been reported yet.

Worked around by hand-patching the generated compose.yml on the VPS for this deploy (see VPS-DEPLOY-LOG.md); this is the real fix so the next `configure` doesn't regenerate the broken version.