### PR TITLE
feat(migrate-tool): add --dry-run and --service to the migrate tool

### DIFF
--- a/docker/versola-tools/entrypoint.sh
+++ b/docker/versola-tools/entrypoint.sh
@@ -12,7 +12,13 @@ set -eu
 # genEnv below) -- see Dockerfile.tools' own comment on why the two jar
 # sets are kept apart instead of merged onto one classpath.
 if [ "${1:-}" = "migrate" ]; then
-  exec java -cp 'migrate-lib/*' versola.migrate.MigrateTool
+  # Shift the dispatch token itself off before exec'ing -- MigrateTool's own
+  # `main` reads argv looking for `--dry-run`/`--service <name>` (see its own
+  # doc comment); without this shift, those would always be one position off
+  # (argv(0) == "migrate", not the first real flag), and MigrateTool would
+  # never see them at all.
+  shift
+  exec java -cp 'migrate-lib/*' versola.migrate.MigrateTool "$@"
 fi
 
 OUT_DIR="${OUT_DIR:-/out}"

--- a/migrate-tool/src/main/scala/versola/migrate/MigrateTool.scala
+++ b/migrate-tool/src/main/scala/versola/migrate/MigrateTool.scala
@@ -17,6 +17,14 @@ import java.io.File
   * files the real services will start from means there is no way for what this applies to drift
   * from what they expect to find already there.
   *
+  * Two optional args, forwarded here by entrypoint.sh's own "migrate" dispatch branch (which
+  * shifts argv[0] off before exec'ing this): `--dry-run` reports each target's pending migrations
+  * via Flyway's own `info()` without applying anything, and `--service <name>` restricts either
+  * mode to one of "auth"/"central"/"edge" instead of all three. Both back versola-cli's own
+  * `--dry-run`/`--service` flags on `versola migrate` -- see its own comment for why a CI
+  * pipeline needs both (checking what WOULD apply without a human in the loop, and being able to
+  * fail on just one service's migrations rather than all three at once).
+  *
   * A plain synchronous `main`, not a ZIO app, and Flyway is handed a raw JDBC URL/user/password
   * rather than going through `PostgresHikariDataSource`/HikariCP (see build.sbt's `migrateTool`
   * project for the full reasoning) -- this runs once, sequentially, applying at most a handful of
@@ -72,11 +80,14 @@ object MigrateTool:
       password = conf.getString("postgres.password"),
     )
 
-  private def migrate(target: Target): Unit =
-    println(s"${target.serviceName}: applying migrations from ${target.configPath}")
+  /** Builds the one Flyway instance both `migrate` and `checkPending` need --
+    * identical configuration either way, since a dry run has to validate
+    * against the exact same migration history and connection a real one
+    * would, or "what would apply" stops meaning anything.
+    */
+  private def buildFlyway(target: Target): Flyway =
     val connection = readConnection(target.configPath)
-
-    val flyway = Flyway
+    Flyway
       .configure()
       .locations(target.migrationsLocation)
       .dataSource(connection.url, connection.user, connection.password)
@@ -100,11 +111,54 @@ object MigrateTool:
       .outOfOrder(true)
       .load()
 
+  private def migrate(target: Target): Unit =
+    println(s"${target.serviceName}: applying migrations from ${target.configPath}")
+    val flyway = buildFlyway(target)
     flyway.migrate()
     println(s"${target.serviceName}: migrations complete")
 
+  /** `--dry-run`'s own path: validates the same way `migrate` would, then
+    * lists what Flyway's own history table says is still pending, via
+    * `info().pending()` -- standard OSS Flyway, not a Teams-only feature
+    * (unlike `dryRunOutput`, which generates SQL and IS Teams-only) --
+    * without ever calling `.migrate()`, so nothing here touches the schema.
+    */
+  private def checkPending(target: Target): Unit =
+    println(s"${target.serviceName}: checking pending migrations against ${target.configPath}")
+    val flyway = buildFlyway(target)
+    flyway.validate()
+    val pending = flyway.info().pending()
+    if pending.isEmpty then println(s"${target.serviceName}: up to date, nothing to apply")
+    else
+      println(s"${target.serviceName}: ${pending.length} pending migration(s):")
+      pending.foreach(m => println(s"  ${m.getVersion} - ${m.getDescription}"))
+
+  /** `--service <name>` restricts `targets` to just that one -- validated
+    * against the fixed list above rather than trusting the string, so a
+    * typo fails with a clear message instead of quietly matching nothing
+    * and reporting "0 targets" as if that were a success.
+    */
+  private def selectTargets(serviceArg: Option[String]): List[Target] =
+    serviceArg match
+      case None => targets
+      case Some(name) =>
+        targets.find(_.serviceName == name) match
+          case Some(t) => List(t)
+          case None =>
+            System.err.println(
+              s"versola-tools migrate: unknown --service '$name' (expected one of ${targets.map(_.serviceName).mkString(", ")})"
+            )
+            sys.exit(1)
+
   def main(args: Array[String]): Unit =
-    try targets.foreach(migrate)
+    val dryRun = args.contains("--dry-run")
+    val serviceIdx = args.indexOf("--service")
+    val serviceArg =
+      if serviceIdx >= 0 && serviceIdx + 1 < args.length then Some(args(serviceIdx + 1)) else None
+
+    val selected = selectTargets(serviceArg)
+
+    try selected.foreach(t => if dryRun then checkPending(t) else migrate(t))
     catch
       case t: Throwable =>
         System.err.println(s"versola-tools migrate: failed -- ${t.getMessage}")

--- a/migrate-tool/src/main/scala/versola/migrate/MigrateTool.scala
+++ b/migrate-tool/src/main/scala/versola/migrate/MigrateTool.scala
@@ -154,7 +154,19 @@ object MigrateTool:
     val dryRun = args.contains("--dry-run")
     val serviceIdx = args.indexOf("--service")
     val serviceArg =
-      if serviceIdx >= 0 && serviceIdx + 1 < args.length then Some(args(serviceIdx + 1)) else None
+      if serviceIdx < 0 then None
+      else if serviceIdx + 1 < args.length then Some(args(serviceIdx + 1))
+      else
+        // "--service" present with nothing after it (e.g. it's the last
+        // token) is a malformed command, not "no --service given" -- that
+        // distinction matters because None means "every target" (see
+        // selectTargets below). Falling through to None here would turn a
+        // typo'd/truncated production command into migrations against
+        // every schema instead of failing loudly, the same failure mode
+        // selectTargets' own unknown-name branch exists to avoid for a bad
+        // value.
+        System.err.println("versola-tools migrate: --service requires a value")
+        sys.exit(1)
 
     val selected = selectTargets(serviceArg)
 


### PR DESCRIPTION
Adds --dry-run and --service to versola-tools' migrate entrypoint, backing
the same flags on `versola migrate` in versola-cli (see
versolauth/versola-cli#<PR-номер>).

- --dry-run validates and lists pending migrations via Flyway's own
  info().pending() (standard OSS API, not dryRunOutput which is
  Teams-only) without ever calling .migrate().
- --service auth|central|edge restricts either mode to one target.
- entrypoint.sh's migrate dispatch wasn't forwarding argv at all before
  this — added the missing `shift` so MigrateTool actually sees the flags.

**Depends on https://github.com/versolauth/versola-cli/pull/10 — without
that fix, --dry-run on a real vps deployment fails on the same missing
secrets bug before this code ever runs (config loading happens before
dry-run/migrate branch). Please merge the fix first or review/test them
together.

## Testing
sbt migrateTool/compile and full sbt compile pass. No unit tests exist for
this module (plain synchronous main, no test dir) — testing is via the
companion versola-cli PR's smoke test.ted assumption, not a new behavior.