### PR TITLE
feat(auth): DPoP proof-of-possession token binding (RFC 9449)

### DIFF
--- a/auth/implementations/postgres/migrations/V0014__dpop_proofs_table.sql
+++ b/auth/implementations/postgres/migrations/V0014__dpop_proofs_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE dpop_proofs (
+    jkt TEXT NOT NULL,
+    jti TEXT NOT NULL,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    PRIMARY KEY (jkt, jti)
+);
+
+CREATE INDEX dpop_proofs_expires_at_idx
+    ON dpop_proofs (expires_at);

--- a/auth/implementations/postgres/migrations/V0015__refresh_tokens_cnf_jkt.sql
+++ b/auth/implementations/postgres/migrations/V0015__refresh_tokens_cnf_jkt.sql
@@ -1,0 +1,2 @@
+-- RFC 9449 §5: the JWK thumbprint the token is bound to, NULL for unbound (bearer) grants.
+ALTER TABLE refresh_tokens ADD COLUMN cnf_jkt TEXT;

--- a/auth/implementations/postgres/src/main/scala/versola/PostgresOAuthApp.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/PostgresOAuthApp.scala
@@ -9,6 +9,7 @@ import versola.oauth.challenge.passkey.{PasskeyRepository, PostgresPasskeyReposi
 import versola.oauth.challenge.password.{PasswordRepository, PasswordService, PostgresPasswordRepository}
 import versola.oauth.client.{ServiceController, OAuthClientSyncClient, OAuthConfigurationService, OAuthScopeSyncClient}
 import versola.oauth.consent.{ConsentRepository, ConsentService, PostgresConsentRepository}
+import versola.oauth.dpop.{DpopNonceService, DpopProofRepository, DpopService, PostgresDpopProofRepository}
 import versola.oauth.conversation.otp.{EmailOtpProvider, SmsOtpProvider, OtpGenerationService, OtpService}
 import versola.oauth.conversation.limit.{ChallengeThrottleRepository, PostgresChallengeThrottleRepository, SubmissionLimiter}
 import versola.oauth.conversation.{ConversationController, ConversationRenderService, ConversationRepository, ConversationRouter, ConversationService, PostgresConversationRepository}
@@ -43,6 +44,9 @@ object PostgresOAuthApp extends VersolaApp("auth"):
 
   type Dependencies =
     CoreConfig &
+      DpopProofRepository &
+      DpopNonceService &
+      DpopService &
       UserRepository &
       UserService &
       OAuthConfigurationService &
@@ -110,6 +114,7 @@ object PostgresOAuthApp extends VersolaApp("auth"):
       PostgresConsentRepository.live >+>
       PostgresAuthorizationCodeRepository.live >+>
       PostgresPushedAuthorizationRepository.live >+>
+      PostgresDpopProofRepository.live >+>
       PostgresSessionRepository.live >+>
       PostgresUserAgentRepository.live >+>
       PostgresPasswordRepository.live >+>
@@ -131,6 +136,8 @@ object PostgresOAuthApp extends VersolaApp("auth"):
       parseConfig[CoreConfig] >+>
       SecureRandom.live >+>
       securityService >+>
+      DpopNonceService.live >+>
+      DpopService.live >+>
       JsonSchemaValidator.live >+>
       OAuthConfigurationService.live >+>
       CentralSyncTokenService.live >+>
@@ -186,6 +193,11 @@ object PostgresOAuthApp extends VersolaApp("auth"):
     .mapOrFail(URL.decode(_).left.map(ex => zio.Config.Error.InvalidData(message = ex.getMessage)))
 
   given DeriveConfig[Method] = DeriveConfig[String].map(Method.fromString)
+
+  given DeriveConfig[Dpop.Algorithm] = DeriveConfig[String]
+    .mapOrFail: str =>
+      Dpop.Algorithm.values.find(_.toString == str)
+        .toRight(zio.Config.Error.InvalidData(message = s"Unknown DPoP signing algorithm: '$str'"))
 
   given DeriveConfig[Email] = DeriveConfig[String]
     .mapOrFail(Email.from(_).left.map(message => zio.Config.Error.InvalidData(message = message)))

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/dpop/PostgresDpopProofRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/dpop/PostgresDpopProofRepository.scala
@@ -1,0 +1,29 @@
+package versola.oauth.dpop
+
+import com.augustnagro.magnum.*
+import com.augustnagro.magnum.magzio.TransactorZIO
+import versola.util.postgres.BasicCodecs
+import zio.{Clock, Duration, Task, ZLayer}
+
+class PostgresDpopProofRepository(xa: TransactorZIO) extends DpopProofRepository, BasicCodecs:
+
+  override def recordIfAbsent(jkt: String, jti: String, ttl: Duration): Task[Boolean] =
+    Clock.instant.flatMap: now =>
+      xa.connectMeasured("record-dpop-proof-if-absent"):
+        // A row surviving past its own `expires_at` (cleanup hasn't reaped it yet) must not be
+        // treated as a live replay guard -- the UPDATE branch only fires, and only overwrites
+        // it, when it's already expired, so a still-valid row's INSERT keeps losing the
+        // conflict and reports a replay exactly as before.
+        sql"""
+          INSERT INTO dpop_proofs (jkt, jti, expires_at)
+          VALUES ($jkt, $jti, ${now.plusSeconds(ttl.toSeconds)})
+          ON CONFLICT (jkt, jti) DO UPDATE
+            SET expires_at = excluded.expires_at
+            WHERE dpop_proofs.expires_at <= $now
+          RETURNING dpop_proofs.jkt
+        """.query[String].run()
+          .nonEmpty
+
+object PostgresDpopProofRepository:
+  def live: ZLayer[TransactorZIO, Throwable, DpopProofRepository] =
+    ZLayer.fromFunction(PostgresDpopProofRepository(_))

--- a/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
+++ b/auth/implementations/postgres/src/main/scala/versola/oauth/session/PostgresSessionRepository.scala
@@ -247,7 +247,8 @@ class PostgresSessionRepository(xa: TransactorZIO)
           nonce,
           amr,
           auth_time,
-          acr
+          acr,
+          cnf_jkt
         )
         VALUES (
           $refreshToken,
@@ -267,7 +268,8 @@ class PostgresSessionRepository(xa: TransactorZIO)
           ${record.nonce},
           ${record.amr},
           ${record.authTime},
-          ${record.acr}
+          ${record.acr},
+          ${record.cnfJkt}
         )
         """.update.run()
       ()
@@ -284,7 +286,7 @@ class PostgresSessionRepository(xa: TransactorZIO)
           SELECT session_id, public_session_id, access_token, user_id, client_id,
                  audience, authorization_details, scope, issued_at,
                  expires_at, requested_claims, ui_locales, nonce, previous_id,
-                 amr, auth_time, acr
+                 amr, auth_time, acr, cnf_jkt
           FROM refresh_tokens
           WHERE id = $token AND expires_at > $now"""
           .query[RefreshTokenRecord]

--- a/auth/implementations/postgres/src/test/scala/versola/oauth/dpop/PostgresDpopProofRepositorySpec.scala
+++ b/auth/implementations/postgres/src/test/scala/versola/oauth/dpop/PostgresDpopProofRepositorySpec.scala
@@ -1,0 +1,20 @@
+package versola.oauth.dpop
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import com.augustnagro.magnum.sql
+import versola.util.postgres.PostgresSpec
+import zio.{ZIO, ZLayer}
+
+object PostgresDpopProofRepositorySpec extends PostgresSpec, DpopProofRepositorySpec:
+
+  override lazy val environment =
+    ZLayer:
+      for
+        xa <- ZIO.service[TransactorZIO]
+      yield DpopProofRepositorySpec.Env(PostgresDpopProofRepository(xa))
+
+  override def beforeEach(env: DpopProofRepositorySpec.Env) =
+    for
+      xa <- ZIO.service[TransactorZIO]
+      _ <- xa.connect(sql"TRUNCATE TABLE dpop_proofs".update.run())
+    yield ()

--- a/auth/src/main/scala/versola/oauth/dpop/DpopNonceService.scala
+++ b/auth/src/main/scala/versola/oauth/dpop/DpopNonceService.scala
@@ -1,0 +1,63 @@
+package versola.oauth.dpop
+
+import org.apache.commons.codec.digest.Blake3
+import versola.util.{Base64, CoreConfig}
+import zio.{Clock, IO, UIO, ZIO, ZLayer}
+
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.time.Instant
+
+/** RFC 9449 \u00a78: server-provided nonces a client must echo back in a fresh proof, so a proof
+  * captured once can't be replayed indefinitely -- each use requires a new, server-attested
+  * `iat`/signature.
+  *
+  * Stateless: a nonce is `<issuedAtSeconds>.<mac>`, where `mac` authenticates
+  * `issuedAtSeconds` under [[CoreConfig.Security.dpopNoncesSecret]] -- the same signed-cookie
+  * shape used elsewhere (see `versola.oauth.model.cookies`). Validity needs no lookup, only
+  * recomputing the MAC and checking [[CoreConfig.DpopConfig.nonceTtl]] hasn't elapsed.
+  */
+trait DpopNonceService:
+  def issue: UIO[String]
+  def verify(nonce: String, now: Instant): IO[DpopNonceService.Error, Unit]
+
+object DpopNonceService:
+  enum Error:
+    case Malformed
+    case Expired
+
+  def live: ZLayer[CoreConfig, Nothing, DpopNonceService] =
+    ZLayer.fromFunction(Impl(_))
+
+  private val Separator = '.'
+
+  class Impl(config: CoreConfig) extends DpopNonceService:
+
+    override def issue: UIO[String] =
+      Clock.instant.map(encode)
+
+    override def verify(nonce: String, now: Instant): IO[Error, Unit] =
+      nonce.split(Separator) match
+        case Array(issuedAtStr, sigB64) =>
+          for
+            issuedAtSeconds <- ZIO.attempt(issuedAtStr.toLong).orElseFail(Error.Malformed)
+            sigBytes <- ZIO.attempt(Base64.urlDecode(sigB64)).orElseFail(Error.Malformed)
+            issuedAt = Instant.ofEpochSecond(issuedAtSeconds)
+            _ <- ZIO.fail(Error.Malformed)
+              .unless(MessageDigest.isEqual(mac(issuedAtSeconds), sigBytes))
+            _ <- ZIO.fail(Error.Expired)
+              .unless(!issuedAt.isAfter(now) && !issuedAt.isBefore(now.minus(config.dpopOrDefault.nonceTtl)))
+          yield ()
+        case _ =>
+          ZIO.fail(Error.Malformed)
+
+    private def encode(issuedAt: Instant): String =
+      val issuedAtSeconds = issuedAt.getEpochSecond
+      s"$issuedAtSeconds$Separator${Base64.urlEncode(mac(issuedAtSeconds))}"
+
+    private def mac(issuedAtSeconds: Long): Array[Byte] =
+      val digest = Array.ofDim[Byte](32)
+      Blake3.initKeyedHash(config.security.dpopNoncesSecret)
+        .update(issuedAtSeconds.toString.getBytes(StandardCharsets.UTF_8))
+        .doFinalize(digest)
+      digest

--- a/auth/src/main/scala/versola/oauth/dpop/DpopProofRepository.scala
+++ b/auth/src/main/scala/versola/oauth/dpop/DpopProofRepository.scala
@@ -1,0 +1,16 @@
+package versola.oauth.dpop
+
+import zio.{Duration, Task}
+
+/** Replay protection for DPoP proofs (RFC 9449 \u00a711.1): a proof's `jti` must not be accepted
+  * twice. Scoped by `jkt` too, so an accidental `jti` collision between two unrelated keys can't
+  * cause a legitimate proof to be rejected as a replay.
+  */
+trait DpopProofRepository:
+
+  /** Atomically records a proof's `(jkt, jti)` pair, kept for `ttl`.
+    *
+    * @return true if this is the first time the pair has been seen and it is now recorded,
+    *   false if it was already recorded -- a replay.
+    */
+  def recordIfAbsent(jkt: String, jti: String, ttl: Duration): Task[Boolean]

--- a/auth/src/main/scala/versola/oauth/dpop/DpopService.scala
+++ b/auth/src/main/scala/versola/oauth/dpop/DpopService.scala
@@ -1,0 +1,87 @@
+package versola.oauth.dpop
+
+import versola.util.{CoreConfig, Dpop}
+import zio.http.Method
+import zio.{Clock, IO, ZIO, ZLayer}
+
+import java.time.Instant
+
+/** Orchestrates RFC 9449 DPoP proof validation for a single request: delegates the proof's
+  * self-contained checks to [[Dpop.verify]], then enforces replay protection via
+  * [[DpopProofRepository]] and, when the caller requires it, a fresh server nonce via
+  * [[DpopNonceService]].
+  */
+trait DpopService:
+  /**
+   * @param token the raw `DPoP` request header value
+   * @param method the current request's HTTP method
+   * @param uri the current request's URI, scheme+host+path only (see [[Dpop.verify]])
+   * @param requireNonce RFC 9449 \u00a79: when true, a request without a valid, fresh nonce
+   *   fails with [[DpopService.Error.NonceRequired]] carrying a freshly issued one for the
+   *   caller to return via the `DPoP-Nonce` response header.
+   */
+  def verify(
+      token: String,
+      method: Method,
+      uri: String,
+      requireNonce: Boolean,
+  ): IO[Throwable | DpopService.Error, Dpop.Proof]
+
+object DpopService:
+  enum Error:
+    case InvalidProof(reason: Dpop.Error)
+    case Replayed
+    case NonceRequired(nonce: String)
+
+  def live: ZLayer[DpopProofRepository & DpopNonceService & CoreConfig, Nothing, DpopService] =
+    ZLayer.fromFunction(Impl(_, _, _))
+
+  class Impl(
+      proofRepository: DpopProofRepository,
+      nonceService: DpopNonceService,
+      config: CoreConfig,
+  ) extends DpopService:
+
+    override def verify(
+        token: String,
+        method: Method,
+        uri: String,
+        requireNonce: Boolean,
+    ): IO[Throwable | Error, Dpop.Proof] =
+      val dpopConfig = config.dpopOrDefault
+      for
+        now <- Clock.instant
+
+        proof <- Dpop.verify(
+          token = token,
+          allowedAlgorithms = dpopConfig.allowedAlgorithms,
+          expectedMethod = method,
+          expectedUri = uri,
+          now = now,
+          iatLeeway = dpopConfig.iatLeeway,
+        ).mapError(Error.InvalidProof.apply)
+
+        _ <- checkNonce(proof, requireNonce, now)
+
+        fresh <- proofRepository.recordIfAbsent(proof.jkt, proof.jti, dpopConfig.proofRetention)
+        _ <- ZIO.fail(Error.Replayed).unless(fresh)
+      yield proof
+
+    private def checkNonce(
+        proof: Dpop.Proof,
+        requireNonce: Boolean,
+        now: Instant,
+    ): IO[Throwable | Error, Unit] =
+      proof.nonce match
+        case Some(nonce) =>
+          nonceService.verify(nonce, now).foldZIO(
+            _ => freshNonceRequired,
+            _ => ZIO.unit,
+          )
+        case None if requireNonce =>
+          freshNonceRequired
+        case None =>
+          ZIO.unit
+
+    private def freshNonceRequired: IO[Throwable | Error, Nothing] =
+      nonceService.issue.flatMap(nonce => ZIO.fail(Error.NonceRequired(nonce)))

--- a/auth/src/main/scala/versola/oauth/model/AccessTokenPayload.scala
+++ b/auth/src/main/scala/versola/oauth/model/AccessTokenPayload.scala
@@ -27,9 +27,18 @@ case class AccessTokenPayload(
     /** The session this token was issued under, absent for grants that have none
       * (client_credentials). Same value as the id token's `sid`. */
     @jsonField("sid") sessionId: Option[PublicSessionId],
+    /** RFC 9449 §6 confirmation claim, present only on a DPoP-bound token. A resource server
+      * must check the accompanying proof's thumbprint against `cnf.jkt`. */
+    @jsonField("cnf") confirmation: Option[Confirmation],
 ):
   /** Parse userId from subject if it's a valid UUID, otherwise None (for client_credentials tokens) */
   def userId: Option[UserId] = UserId.parse(subject).toOption
+
+/** RFC 7800 confirmation claim; only the RFC 9449 `jkt` member is used. */
+case class Confirmation(jkt: String)
+
+object Confirmation:
+  given JsonDecoder[Confirmation] = DeriveJsonDecoder.gen[Confirmation]
 
 object AccessTokenPayload:
 

--- a/auth/src/main/scala/versola/oauth/session/model/RefreshTokenRecord.scala
+++ b/auth/src/main/scala/versola/oauth/session/model/RefreshTokenRecord.scala
@@ -35,4 +35,7 @@ case class RefreshTokenRecord(
     amr: Set[AuthMethodRef],
     authTime: Instant,
     acr: Option[Acr],
+    /** RFC 9449 §5: the JWK thumbprint this grant is bound to, `None` for a bearer grant.
+      * A bound grant may only be refreshed by a proof carrying the same thumbprint. */
+    cnfJkt: Option[String],
 ) derives CanEqual, Equal

--- a/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
+++ b/auth/src/main/scala/versola/oauth/token/OAuthTokenService.scala
@@ -15,19 +15,24 @@ import zio.{Duration, IO, Task, ZIO, ZLayer}
 
 trait OAuthTokenService:
 
+  /** @param dpopJkt thumbprint of the key that proved possession on this request, `None` when
+    *   the request carried no DPoP proof and the issued tokens are therefore bearer tokens. */
   def exchangeAuthorizationCode(
       codeExchangeRequest: CodeExchangeRequest,
       tokenCredentials: ClientCredentials,
+      dpopJkt: Option[String],
   ): IO[Throwable | TokenEndpointError, IssuedTokens]
 
   def refreshAccessToken(
       refreshTokenRequest: RefreshTokenRequest,
       tokenCredentials: ClientCredentials,
+      dpopJkt: Option[String],
   ): IO[Throwable | TokenEndpointError, IssuedTokens]
 
   def clientCredentials(
       clientCredentialsRequest: ClientCredentialsRequest,
       tokenCredentials: ClientCredentials,
+      dpopJkt: Option[String],
   ): IO[Throwable | TokenEndpointError, IssuedTokens]
 
 object OAuthTokenService:
@@ -54,6 +59,7 @@ object OAuthTokenService:
     override def exchangeAuthorizationCode(
         codeExchangeRequest: CodeExchangeRequest,
         tokenCredentials: ClientCredentials,
+        dpopJkt: Option[String],
     ): IO[Throwable | TokenEndpointError, IssuedTokens] =
       import codeExchangeRequest.{code, codeVerifier, redirectUri}
       for
@@ -117,6 +123,7 @@ object OAuthTokenService:
             amr = codeRecord.amr,
             authTime = codeRecord.authTime,
             acr = codeRecord.acr,
+            cnfJkt = dpopJkt,
           ),
           accessTokenAudience = codeRecord.resources,
           accessTokenAuthorizationDetails = codeRecord.authorizationDetails.getOrElse(Nil),
@@ -132,6 +139,7 @@ object OAuthTokenService:
     override def refreshAccessToken(
         refreshTokenRequest: RefreshTokenRequest,
         tokenCredentials: ClientCredentials,
+        dpopJkt: Option[String],
     ): IO[Throwable | TokenEndpointError, IssuedTokens] =
       import refreshTokenRequest.{authorizationDetails, refreshToken, resources, scope}
       for
@@ -151,6 +159,13 @@ object OAuthTokenService:
 
         _ <- Observability.setSessionId(tokenRecord.publicSessionId)
         _ <- Observability.setUserId(tokenRecord.userId.toString)
+
+        // RFC 9449 §5: a bound grant stays bound to the key it was issued to, so the proof on
+        // this request has to carry that same thumbprint. The binding is fixed at issuance and
+        // never re-derived from the current proof -- otherwise presenting a stolen unbound
+        // refresh token with any key of one's own would "upgrade" it into a bound one.
+        _ <- ZIO.fail(TokenEndpointError.InvalidGrant)
+          .when(tokenRecord.cnfJkt.exists(!dpopJkt.contains(_)))
 
         // RFC 6749 §6: the request may narrow the underlying grant but never widen it, so the
         // comparison is against what was granted, not against the client's registration —
@@ -242,6 +257,7 @@ object OAuthTokenService:
     override def clientCredentials(
         request: ClientCredentialsRequest,
         tokenCredentials: ClientCredentials,
+        dpopJkt: Option[String],
     ): IO[Throwable | TokenEndpointError, IssuedTokens] =
       for
         client <- tokenCredentials match
@@ -294,6 +310,7 @@ object OAuthTokenService:
         amr = Set.empty,
         authTime = None,
         acr = None,
+        cnfJkt = dpopJkt,
       )
 
     /** Orchestrates token issuance for a specific authentication session.
@@ -344,4 +361,5 @@ object OAuthTokenService:
         amr = record.amr,
         authTime = Some(record.authTime),
         acr = record.acr,
+        cnfJkt = record.cnfJkt,
       )

--- a/auth/src/main/scala/versola/oauth/token/TokenEndpointController.scala
+++ b/auth/src/main/scala/versola/oauth/token/TokenEndpointController.scala
@@ -5,6 +5,7 @@ import com.nimbusds.jose.{JOSEObjectType, JWSAlgorithm, JWSHeader}
 import com.nimbusds.jwt.{JWTClaimsSet, SignedJWT}
 import versola.oauth.client.OAuthConfigurationService
 import versola.oauth.client.model.{AuthMethodRef, AuthorizationDetail, ResourceUri, ScopeToken}
+import versola.oauth.dpop.DpopService
 import versola.oauth.jwks.JwksService
 import versola.oauth.model.{AccessToken, AuthorizationCode, CodeVerifier, RefreshToken}
 import versola.oauth.token.model.{ClientCredentialsRequest, CodeExchangeRequest, IssuedTokens, RefreshTokenRequest, TokenEndpointError, TokenErrorResponse, TokenRequest, TokenResponse}
@@ -23,7 +24,16 @@ import java.time.Instant
 import java.util.Date
 
 object TokenEndpointController extends Controller:
-  type Env = Tracing & OAuthTokenService & OAuthConfigurationService & UserInfoService & JwksService & CoreConfig
+  type Env = Tracing & OAuthTokenService & OAuthConfigurationService & UserInfoService & JwksService & DpopService & CoreConfig
+
+  private val DpopHeader = "DPoP"
+  private val DpopNonceHeader = "DPoP-Nonce"
+
+  /** RFC 9449 §4.3 compares a proof's `htu` against the endpoint's own URI. It is derived from
+    * the configured issuer rather than from the inbound request, so a forwarded host header
+    * can't be used to make a proof minted for some other origin validate here. */
+  private def tokenEndpointUri(config: CoreConfig): String =
+    s"${config.jwt.issuer.stripSuffix("/")}/token"
 
   def routes: Routes[Env, Throwable] = Routes(
     tokenEndpoint,
@@ -38,29 +48,64 @@ object TokenEndpointController extends Controller:
         form <- request.body.asURLEncodedForm.orElseFail(TokenEndpointError.InvalidRequest)
         tokenRequest <- parseRequest(form)
         credentials <- request.extractCredentials(form).orElseFail(TokenEndpointError.InvalidClient)
+        dpopJkt <- verifyDpopProof(request, config)
         issuedTokens <- tokenRequest match
           case codeExchangeRequest: CodeExchangeRequest =>
-            oauthTokenService.exchangeAuthorizationCode(codeExchangeRequest, credentials)
+            oauthTokenService.exchangeAuthorizationCode(codeExchangeRequest, credentials, dpopJkt)
           case refreshTokenRequest: RefreshTokenRequest =>
-            oauthTokenService.refreshAccessToken(refreshTokenRequest, credentials)
+            oauthTokenService.refreshAccessToken(refreshTokenRequest, credentials, dpopJkt)
           case clientCredentialsRequest: ClientCredentialsRequest =>
-            oauthTokenService.clientCredentials(clientCredentialsRequest, credentials)
+            oauthTokenService.clientCredentials(clientCredentialsRequest, credentials, dpopJkt)
         response <- toTokenResponse(issuedTokens, config, signingKey)
       yield Response.json(response.toJson))
         .catchAll {
           case error: TokenEndpointError =>
             Observability.setError(error.error, error.errorDescription).as:
               val errorResponse = TokenErrorResponse.from(error)
-              Response
+              val response = Response
                 .json(errorResponse.toJson)
                 .status(error.status)
                 .addHeader(Header.CacheControl.NoStore)
                 .addHeader(Header.Pragma.NoCache)
+              error match
+                case TokenEndpointError.UseDpopNonce(nonce) =>
+                  response.addHeader(Header.Custom(DpopNonceHeader, nonce))
+                case _ => response
 
           case error: Throwable =>
             ZIO.fail(error)
         }
     }
+
+  /** RFC 9449 §5: DPoP is opt-in per request here -- a request without a proof still yields
+    * bearer tokens. Whether a given client is *required* to use DPoP is a separate, per-client
+    * policy decision that isn't wired up yet.
+    */
+  private def verifyDpopProof(
+      request: Request,
+      config: CoreConfig,
+  ): ZIO[DpopService, Throwable | TokenEndpointError, Option[String]] =
+    request.headers.get(DpopHeader) match
+      case None =>
+        ZIO.none
+      case Some(proof) =>
+        ZIO.serviceWithZIO[DpopService](
+          _.verify(
+            token = proof,
+            method = Method.POST,
+            uri = tokenEndpointUri(config),
+            requireNonce = false,
+          ),
+        )
+          .mapBoth(
+            {
+              case DpopService.Error.InvalidProof(reason) => TokenEndpointError.InvalidDpopProof(reason.toString)
+              case DpopService.Error.Replayed => TokenEndpointError.InvalidDpopProof("proof has already been used")
+              case DpopService.Error.NonceRequired(nonce) => TokenEndpointError.UseDpopNonce(nonce)
+              case error: Throwable => error
+            },
+            verified => Some(verified.jkt),
+          )
 
   private def toTokenResponse(
       tokens: IssuedTokens,
@@ -79,6 +124,7 @@ object TokenEndpointController extends Controller:
         "tenant_id" -> Json.Str(tokens.tenantId),
       ) ++
         tokens.sessionId.map(sid => "sid" -> Json.Str(sid)) ++
+        tokens.cnfJkt.map(jkt => "cnf" -> Json.Obj("jkt" -> Json.Str(jkt))) ++
         tokens.requestedClaims.map(rc => "requested_claims" -> rc.toJsonAST.toOption.get) ++
         authorizationDetailsClaim(tokens).map("authorization_details" -> _) ++
         AuthMethodRef.idTokenClaims(tokens.amr, tokens.authTime, tokens.acr)
@@ -105,7 +151,8 @@ object TokenEndpointController extends Controller:
       idToken <- generateIdToken(tokens, config, signingKey, serializedAT)
     yield TokenResponse(
       accessToken = serializedAT,
-      tokenType = "Bearer",
+      // RFC 9449 §5: a bound token is presented with the `DPoP` scheme, not `Bearer`.
+      tokenType = if tokens.cnfJkt.isDefined then "DPoP" else "Bearer",
       expiresIn = tokens.accessTokenTtl.toSeconds,
       refreshToken = tokens.refreshToken.map(Base64.urlEncode),
       scope = Option.when(tokens.scope.nonEmpty)(tokens.scope.mkString(" ")),

--- a/auth/src/main/scala/versola/oauth/token/model/ErrorCode.scala
+++ b/auth/src/main/scala/versola/oauth/token/model/ErrorCode.scala
@@ -35,3 +35,9 @@ object ErrorCode:
     /** The requested RFC 9396 authorization details are invalid, unknown, or exceed the grant */
     val InvalidAuthorizationDetails: ErrorCode = "invalid_authorization_details"
 
+  /** The RFC 9449 DPoP proof accompanying the request is missing, malformed, or replayed */
+  val InvalidDpopProof: ErrorCode = "invalid_dpop_proof"
+
+  /** The request needs to be retried carrying the server-supplied RFC 9449 DPoP nonce */
+  val UseDpopNonce: ErrorCode = "use_dpop_nonce"
+

--- a/auth/src/main/scala/versola/oauth/token/model/IssuedTokens.scala
+++ b/auth/src/main/scala/versola/oauth/token/model/IssuedTokens.scala
@@ -31,4 +31,7 @@ case class IssuedTokens(
     amr: Set[AuthMethodRef],
     authTime: Option[Instant], // None for client_credentials grant
     acr: Option[Acr],
+    /** RFC 9449 §6: the JWK thumbprint the access token is bound to, carried as its `cnf.jkt`
+      * claim; `None` for a bearer token. */
+    cnfJkt: Option[String],
 )

--- a/auth/src/main/scala/versola/oauth/token/model/TokenEndpointError.scala
+++ b/auth/src/main/scala/versola/oauth/token/model/TokenEndpointError.scala
@@ -53,3 +53,17 @@ object TokenEndpointError:
     val error = ErrorCode.InvalidAuthorizationDetails
     val errorDescription = Some(s"The requested authorization details are invalid or exceed the grant: $reason")
     val errorUri = Some("https://datatracker.ietf.org/doc/html/rfc9396#section-6")
+
+  case class InvalidDpopProof(reason: String) extends TokenEndpointError:
+    val status = Status.BadRequest
+    val error = ErrorCode.InvalidDpopProof
+    val errorDescription = Some(s"The DPoP proof is invalid: $reason")
+    val errorUri = Some("https://datatracker.ietf.org/doc/html/rfc9449#section-5")
+
+  /** RFC 9449 §8: the accompanying `nonce` is served in the response's `DPoP-Nonce` header,
+    * which the client echoes in its next proof. */
+  case class UseDpopNonce(nonce: String) extends TokenEndpointError:
+    val status = Status.BadRequest
+    val error = ErrorCode.UseDpopNonce
+    val errorDescription = Some("Authorization server requires a nonce in the DPoP proof")
+    val errorUri = Some("https://datatracker.ietf.org/doc/html/rfc9449#section-8")

--- a/auth/src/main/scala/versola/util/CoreConfig.scala
+++ b/auth/src/main/scala/versola/util/CoreConfig.scala
@@ -15,9 +15,12 @@ case class CoreConfig(
     smtp: Option[CoreConfig.SmtpConfig],
     configurationCacheRefreshInterval: Duration,
     par: Option[CoreConfig.ParConfig],
+    dpop: Option[CoreConfig.DpopConfig],
     argon2: Option[Argon2Config],
 ):
   def parOrDefault: CoreConfig.ParConfig = par.getOrElse(CoreConfig.ParConfig.default)
+
+  def dpopOrDefault: CoreConfig.DpopConfig = dpop.getOrElse(CoreConfig.DpopConfig.default)
 
   def argon2OrDefault: Argon2Config = argon2.getOrElse(Argon2Config.default)
 
@@ -66,6 +69,7 @@ object CoreConfig:
     sessionCookieSecret: Secret.Bytes32,
     userAgentCookieSecret: Secret.Bytes32,
     parRequestsSecret: Secret.Bytes32,
+    dpopNoncesSecret: Secret.Bytes32,
 )
 
   /** RFC 9126 pushed authorization request endpoint settings. */
@@ -77,3 +81,33 @@ object CoreConfig:
   object ParConfig:
     /** RFC 9126 §2.2 suggests a short lifetime, typically between 5 and 600 seconds. */
     val default: ParConfig = ParConfig(requestUriTtl = Duration.fromSeconds(60), maxRequestSize = 8192)
+
+  /** RFC 9449 DPoP proof validation settings.
+    *
+    * @param allowedAlgorithms signing algorithms an incoming proof's `alg` may use
+    *   (`dpop_signing_alg_values_supported`); the client picks based on the key it holds, so
+    *   this is independent of [[JwtConfig]] / this server's own signing algorithm.
+    * @param iatLeeway maximum allowed distance between a proof's `iat` and the time it's
+    *   checked, in either direction.
+    * @param proofRetention how long a proof's `(jkt, jti)` pair is kept for replay detection.
+    *   Must be at least `2 * iatLeeway`, otherwise a proof could be replayed once its `jti`
+    *   record has been forgotten but before it would fail the `iat` window check on its own.
+    * @param nonceTtl how long a server-issued `DPoP-Nonce` remains acceptable.
+    */
+  case class DpopConfig(
+      allowedAlgorithms: Set[Dpop.Algorithm],
+      iatLeeway: Duration,
+      proofRetention: Duration,
+      nonceTtl: Duration,
+  )
+
+  object DpopConfig:
+    /** RFC 9449 §5 mandates `ES256`; `PS256` is included for FAPI 2.0 deployments. `RS256` is
+      * supported by [[Dpop.verify]] but left out of the default allow-list -- FAPI disallows it
+      * outright, and non-FAPI deployments can opt back in explicitly. */
+    val default: DpopConfig = DpopConfig(
+      allowedAlgorithms = Set(Dpop.Algorithm.ES256, Dpop.Algorithm.PS256),
+      iatLeeway = Duration.fromSeconds(60),
+      proofRetention = Duration.fromSeconds(300),
+      nonceTtl = Duration.fromSeconds(300),
+    )

--- a/auth/src/test/scala/versola/auth/TestEnvConfig.scala
+++ b/auth/src/test/scala/versola/auth/TestEnvConfig.scala
@@ -77,6 +77,7 @@ object TestEnvConfig:
       sessionCookieSecret      = Secret.Bytes32(Array.fill(32)(0.toByte)),
       userAgentCookieSecret    = Secret.Bytes32(Array.fill(32)(0.toByte)),
       parRequestsSecret        = Secret.Bytes32(Array.fill(32)(0.toByte)),
+      dpopNoncesSecret         = Secret.Bytes32(Array.fill(32)(0.toByte)),
     ),
     jwt = jwtConfig,
     central = CoreConfig.CentralSyncConfig(
@@ -106,5 +107,6 @@ object TestEnvConfig:
     ),
     configurationCacheRefreshInterval = 5.minutes,
     par = None,
+    dpop = None,
     argon2 = None,
   )

--- a/auth/src/test/scala/versola/oauth/dpop/DpopNonceServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/dpop/DpopNonceServiceSpec.scala
@@ -1,0 +1,75 @@
+package versola.oauth.dpop
+
+import versola.auth.TestEnvConfig
+import versola.util.UnitSpecBase
+import zio.*
+import zio.test.*
+
+object DpopNonceServiceSpec extends UnitSpecBase:
+
+  private val config = TestEnvConfig.coreConfig
+  private val service = DpopNonceService.Impl(config)
+
+  def spec = suite("DpopNonceService")(
+    test("a freshly issued nonce verifies against the time it was issued") {
+      for
+        now <- Clock.instant
+        nonce <- service.issue
+        result <- service.verify(nonce, now).either
+      yield assertTrue(result == Right(()))
+    },
+    test("verifies right up to the edge of the configured ttl") {
+      for
+        now <- Clock.instant
+        nonce <- service.issue
+        result <- service.verify(nonce, now.plus(config.dpopOrDefault.nonceTtl)).either
+      yield assertTrue(result == Right(()))
+    },
+    test("fails once the ttl has elapsed") {
+      for
+        now <- Clock.instant
+        nonce <- service.issue
+        result <- service.verify(nonce, now.plus(config.dpopOrDefault.nonceTtl).plusSeconds(1)).either
+      yield assertTrue(result == Left(DpopNonceService.Error.Expired))
+    },
+    test("fails for a nonce issued in the future relative to now (clock skew guard)") {
+      for
+        now <- Clock.instant
+        nonce <- service.issue
+        result <- service.verify(nonce, now.minusSeconds(1)).either
+      yield assertTrue(result == Left(DpopNonceService.Error.Expired))
+    },
+    test("fails for a nonce with the right shape but a forged mac") {
+      for
+        now <- Clock.instant
+        nonce <- service.issue
+        tampered = nonce.split('.').nn.updated(1, "forged").mkString(".")
+        result <- service.verify(tampered, now).either
+      yield assertTrue(result == Left(DpopNonceService.Error.Malformed))
+    },
+    test("fails for a nonce with an unparseable timestamp") {
+      for
+        now <- Clock.instant
+        result <- service.verify("not-a-number.abc", now).either
+      yield assertTrue(result == Left(DpopNonceService.Error.Malformed))
+    },
+    test("fails for a nonce with no separator at all") {
+      for
+        now <- Clock.instant
+        result <- service.verify("garbage", now).either
+      yield assertTrue(result == Left(DpopNonceService.Error.Malformed))
+    },
+    test("fails when a mac is spliced onto a different nonce's timestamp") {
+      for
+        now <- Clock.instant
+        nonceA <- service.issue
+        _ <- TestClock.adjust(5.seconds)
+        nonceB <- service.issue
+        laterNow <- Clock.instant
+        macOfA = nonceA.split('.').nn(1)
+        timestampOfB = nonceB.split('.').nn(0)
+        spliced = s"$timestampOfB.$macOfA"
+        result <- service.verify(spliced, laterNow).either
+      yield assertTrue(nonceA != nonceB, result == Left(DpopNonceService.Error.Malformed))
+    },
+  )

--- a/auth/src/test/scala/versola/oauth/dpop/DpopProofRepositorySpec.scala
+++ b/auth/src/test/scala/versola/oauth/dpop/DpopProofRepositorySpec.scala
@@ -1,0 +1,52 @@
+package versola.oauth.dpop
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import versola.util.DatabaseSpecBase
+import zio.*
+import zio.test.*
+
+trait DpopProofRepositorySpec extends DatabaseSpecBase[DpopProofRepositorySpec.Env]:
+  self: ZIOSpec[TransactorZIO] =>
+
+  val ttl = 60.seconds
+
+  def testCases(env: DpopProofRepositorySpec.Env): List[Spec[DpopProofRepositorySpec.Env & Scope, Any]] =
+    List(
+      test("records a new (jkt, jti) pair and reports it as fresh") {
+        for fresh <- env.repository.recordIfAbsent("jkt-1", "jti-1", ttl)
+        yield assertTrue(fresh)
+      },
+      test("reports a replay for the same (jkt, jti) pair recorded twice") {
+        for
+          first <- env.repository.recordIfAbsent("jkt-1", "jti-1", ttl)
+          second <- env.repository.recordIfAbsent("jkt-1", "jti-1", ttl)
+        yield assertTrue(first, !second)
+      },
+      test("treats the same jti under a different jkt as a distinct, fresh pair") {
+        for
+          first <- env.repository.recordIfAbsent("jkt-1", "jti-1", ttl)
+          second <- env.repository.recordIfAbsent("jkt-2", "jti-1", ttl)
+        yield assertTrue(first, second)
+      },
+      test("treats a different jti under the same jkt as a distinct, fresh pair") {
+        for
+          first <- env.repository.recordIfAbsent("jkt-1", "jti-1", ttl)
+          second <- env.repository.recordIfAbsent("jkt-1", "jti-2", ttl)
+        yield assertTrue(first, second)
+      },
+      test("an expired record no longer counts as a replay") {
+        for
+          _ <- env.repository.recordIfAbsent("jkt-1", "jti-1", 0.seconds)
+          _ <- TestClock.adjust(1.second)
+          fresh <- env.repository.recordIfAbsent("jkt-1", "jti-1", ttl)
+        yield assertTrue(fresh)
+      },
+      test("concurrent attempts to record the same pair -- only one should see it as fresh") {
+        for
+          results <- ZIO.collectAllPar(List.fill(10)(env.repository.recordIfAbsent("jkt-1", "jti-1", ttl)))
+        yield assertTrue(results.count(identity) == 1)
+      },
+    )
+
+object DpopProofRepositorySpec:
+  case class Env(repository: DpopProofRepository)

--- a/auth/src/test/scala/versola/oauth/dpop/DpopServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/dpop/DpopServiceSpec.scala
@@ -1,0 +1,123 @@
+package versola.oauth.dpop
+
+import com.nimbusds.jose.crypto.ECDSASigner
+import com.nimbusds.jose.jwk.{Curve, ECKey}
+import com.nimbusds.jose.{JWSAlgorithm, JWSHeader}
+import com.nimbusds.jwt.{JWTClaimsSet, SignedJWT}
+import versola.auth.TestEnvConfig
+import versola.util.{Dpop, UnitSpecBase}
+import zio.*
+import zio.http.Method
+import zio.test.*
+
+import java.security.KeyPairGenerator
+import java.security.interfaces.{ECPrivateKey, ECPublicKey}
+import java.time.Instant
+import java.util.Date
+
+object DpopServiceSpec extends UnitSpecBase:
+
+  private val config = TestEnvConfig.coreConfig
+
+  private val ecKeyPairGenerator = KeyPairGenerator.getInstance("EC")
+  ecKeyPairGenerator.initialize(Curve.P_256.toECParameterSpec)
+  private val ecKeyPair = ecKeyPairGenerator.generateKeyPair()
+  private val ecPrivateKey = ecKeyPair.getPrivate.asInstanceOf[ECPrivateKey]
+  private val ecPublicKey = ecKeyPair.getPublic.asInstanceOf[ECPublicKey]
+  private val ecJwk = ECKey.Builder(Curve.P_256, ecPublicKey).build()
+
+  private val Htm = Method.POST
+  private val Htu = "https://auth.example.com/token"
+
+  private def proof(
+      htm: String = Htm.name,
+      htu: String = Htu,
+      jti: String = "jti-1",
+      iat: Instant = Instant.now,
+      nonce: Option[String] = None,
+  ): String =
+    val header = JWSHeader.Builder(JWSAlgorithm.ES256).`type`(Dpop.JwtType).jwk(ecJwk).build()
+    val claimsBuilder = JWTClaimsSet.Builder()
+      .claim("htm", htm)
+      .claim("htu", htu)
+      .jwtID(jti)
+      .issueTime(Date.from(iat))
+    nonce.foreach(claimsBuilder.claim("nonce", _))
+    val jwt = SignedJWT(header, claimsBuilder.build())
+    jwt.sign(ECDSASigner(ecPrivateKey))
+    jwt.serialize()
+
+  private class Env:
+    val proofRepository = stub[DpopProofRepository]
+    val nonceService = stub[DpopNonceService]
+
+    val service: DpopService = DpopService.Impl(proofRepository, nonceService, config)
+
+  def spec = suite("DpopService")(
+    test("returns the validated proof when it's fresh and no nonce is required") {
+      val env = Env()
+      for
+        now <- Clock.instant
+        _ <- env.proofRepository.recordIfAbsent.succeedsWith(true)
+        result <- env.service.verify(proof(iat = now), Htm, Htu, requireNonce = false).either
+      yield assertTrue(result.map(_.jti) == Right("jti-1"))
+    },
+    test("fails with InvalidProof when the proof itself doesn't validate (e.g. wrong htm)") {
+      val env = Env()
+      for
+        now <- Clock.instant
+        result <- env.service.verify(proof(htm = "GET", iat = now), Htm, Htu, requireNonce = false).either
+      yield assertTrue(result == Left(DpopService.Error.InvalidProof(Dpop.Error.MethodMismatch)))
+    },
+    test("fails with Replayed when the (jkt, jti) pair was already recorded") {
+      val env = Env()
+      for
+        now <- Clock.instant
+        _ <- env.proofRepository.recordIfAbsent.succeedsWith(false)
+        result <- env.service.verify(proof(iat = now), Htm, Htu, requireNonce = false).either
+      yield assertTrue(result == Left(DpopService.Error.Replayed))
+    },
+    test("fails with NonceRequired carrying a fresh nonce when one is required but absent") {
+      val env = Env()
+      for
+        now <- Clock.instant
+        _ <- env.nonceService.issue.succeedsWith("fresh-nonce")
+        result <- env.service.verify(proof(iat = now), Htm, Htu, requireNonce = true).either
+      yield assertTrue(result == Left(DpopService.Error.NonceRequired("fresh-nonce")))
+    },
+    test("does not consult the repository at all when a required nonce is missing") {
+      val env = Env()
+      for
+        now <- Clock.instant
+        _ <- env.nonceService.issue.succeedsWith("fresh-nonce")
+        _ <- env.service.verify(proof(iat = now), Htm, Htu, requireNonce = true).either
+      yield assertTrue(env.proofRepository.recordIfAbsent.calls.isEmpty)
+    },
+    test("proceeds past the nonce check when the proof carries a valid nonce") {
+      val env = Env()
+      for
+        now <- Clock.instant
+        _ <- env.nonceService.verify.succeedsWith(())
+        _ <- env.proofRepository.recordIfAbsent.succeedsWith(true)
+        result <- env.service.verify(proof(iat = now, nonce = Some("srv-nonce")), Htm, Htu, requireNonce = true).either
+      yield assertTrue(result.isRight)
+    },
+    test("fails with a fresh NonceRequired when the proof's nonce doesn't verify") {
+      val env = Env()
+      for
+        now <- Clock.instant
+        _ <- env.nonceService.verify.failsWith(DpopNonceService.Error.Expired)
+        _ <- env.nonceService.issue.succeedsWith("fresh-nonce")
+        result <- env.service.verify(proof(iat = now, nonce = Some("stale-nonce")), Htm, Htu, requireNonce = true).either
+      yield assertTrue(result == Left(DpopService.Error.NonceRequired("fresh-nonce")))
+    },
+    test("still validates a present nonce even when the endpoint doesn't require one") {
+      val env = Env()
+      for
+        now <- Clock.instant
+        _ <- env.nonceService.verify.succeedsWith(())
+        _ <- env.proofRepository.recordIfAbsent.succeedsWith(true)
+        result <- env.service.verify(proof(iat = now, nonce = Some("srv-nonce")), Htm, Htu, requireNonce = false).either
+      yield assertTrue(env.nonceService.verify.calls.nonEmpty, result.isRight)
+    },
+  )

--- a/auth/src/test/scala/versola/oauth/introspect/IntrospectionServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/introspect/IntrospectionServiceSpec.scala
@@ -76,6 +76,7 @@ object IntrospectionServiceSpec extends UnitSpecBase:
     amr = Set(AuthMethodRef.pwd),
     authTime = now,
     acr = None,
+    cnfJkt = None,
   )
 
   def accessTokenPayload(now: Instant, audience: Vector[ResourceUri] = Vector.empty) = AccessTokenPayload(
@@ -91,6 +92,7 @@ object IntrospectionServiceSpec extends UnitSpecBase:
     id = accessToken1,
     authorizationDetails = None,
     sessionId = None,
+    confirmation = None,
   )
 
   val paymentDetail = AuthorizationDetail.parse(

--- a/auth/src/test/scala/versola/oauth/revoke/RevocationServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/revoke/RevocationServiceSpec.scala
@@ -77,6 +77,7 @@ object RevocationServiceSpec extends UnitSpecBase:
     amr = Set(AuthMethodRef.pwd),
     authTime = now,
     acr = None,
+    cnfJkt = None,
   )
 
   def accessTokenPayload(now: Instant) = AccessTokenPayload(
@@ -92,6 +93,7 @@ object RevocationServiceSpec extends UnitSpecBase:
     id = accessToken1,
     authorizationDetails = None,
     sessionId = None,
+    confirmation = None,
   )
 
   class Env:

--- a/auth/src/test/scala/versola/oauth/session/RefreshTokenRepositorySpec.scala
+++ b/auth/src/test/scala/versola/oauth/session/RefreshTokenRepositorySpec.scala
@@ -64,6 +64,7 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
     amr = Set(AuthMethodRef.pwd),
     authTime = now,
     acr = None,
+    cnfJkt = None,
   )
 
   def tokenRecord2(now: Instant, ttl: Duration) = RefreshTokenRecord(
@@ -84,6 +85,7 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
     amr = Set(AuthMethodRef.pwd),
     authTime = now,
     acr = None,
+    cnfJkt = None,
   )
 
   def testCases(env: RefreshTokenRepositorySpec.Env): List[Spec[RefreshTokenRepositorySpec.Env & Scope, Any]] =
@@ -113,6 +115,23 @@ trait RefreshTokenRepositorySpec extends DatabaseSpecBase[RefreshTokenRepository
           _ <- env.repository.createRefreshToken(refreshToken1, record)
           found <- env.repository.findToken(refreshToken1)
         yield assertTrue(found.map(_.authorizationDetails) == Some(Some(List(detail))))
+      },
+      test("persist and retrieve the DPoP binding thumbprint") {
+        val jkt = "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I"
+        for
+          now <- Clock.instant
+          record = tokenRecord1(now, refreshTtl).copy(cnfJkt = Some(jkt))
+          _ <- env.repository.createRefreshToken(refreshToken1, record)
+          found <- env.repository.findToken(refreshToken1)
+        yield assertTrue(found.map(_.cnfJkt) == Some(Some(jkt)))
+      },
+      test("an unbound grant round-trips with no thumbprint") {
+        for
+          now <- Clock.instant
+          record = tokenRecord1(now, refreshTtl)
+          _ <- env.repository.createRefreshToken(refreshToken1, record)
+          found <- env.repository.findToken(refreshToken1)
+        yield assertTrue(found.map(_.cnfJkt) == Some(None))
       },
       test("find returns None for non-existent refresh token") {
         for

--- a/auth/src/test/scala/versola/oauth/session/SessionRepositorySpec.scala
+++ b/auth/src/test/scala/versola/oauth/session/SessionRepositorySpec.scala
@@ -212,6 +212,7 @@ trait SessionRepositorySpec extends DatabaseSpecBase[SessionRepositorySpec.Env]:
             amr                  = Set(AuthMethodRef.pwd),
             authTime             = now,
             acr                  = None,
+            cnfJkt               = None,
           )
           _            <- env.repository.create(atomicSessionId, session1, 5.minutes, None, None)
           _            <- env.repository.createRefreshToken(atomicTokenId, record)
@@ -259,6 +260,7 @@ trait SessionRepositorySpec extends DatabaseSpecBase[SessionRepositorySpec.Env]:
             amr                  = Set(AuthMethodRef.pwd),
             authTime             = now,
             acr                  = None,
+            cnfJkt               = None,
           )
           _          <- env.repository.create(atomicSessionId, session1, 5.minutes, None, None)
           _          <- env.repository.createRefreshToken(atomicTokenId, record)
@@ -322,6 +324,7 @@ trait SessionRepositorySpec extends DatabaseSpecBase[SessionRepositorySpec.Env]:
             amr                  = Set(AuthMethodRef.pwd),
             authTime             = now,
             acr                  = None,
+            cnfJkt               = None,
           )
           _          <- env.repository.create(atomicSessionId, session1.copy(publicId = atomicPublicId), 5.minutes, None, None)
           _          <- env.repository.createRefreshToken(atomicTokenId, record)

--- a/auth/src/test/scala/versola/oauth/token/OAuthTokenServiceSpec.scala
+++ b/auth/src/test/scala/versola/oauth/token/OAuthTokenServiceSpec.scala
@@ -141,6 +141,31 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
     authorizationDetails = None,
   )
 
+  val jkt1 = "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I"
+  val jkt2 = "R0NfNEZOWnR5LURXcHFxMzBqWnlKR0hUTjBkMkhnbEI"
+
+  /** A refresh token record bound to `cnfJkt`, or unbound when it is `None`. */
+  def boundRecord(now: Instant, cnfJkt: Option[String]) = RefreshTokenRecord(
+    sessionId = sessionId1,
+    publicSessionId = publicSessionId1,
+    accessToken = accessToken1,
+    userId = userId1,
+    clientId = clientId1,
+    audience = List.empty,
+    authorizationDetails = None,
+    scope = scope1,
+    issuedAt = now.minusSeconds(3600),
+    expiresAt = now.plusSeconds(testClient.refreshTokenTtl.toSeconds),
+    requestedClaims = None,
+    uiLocales = None,
+    nonce = None,
+    previousRefreshToken = None,
+    amr = amr1,
+    authTime = authTime1,
+    acr = None,
+    cnfJkt = cnfJkt,
+  )
+
   /** Runs a refresh with the given granted/requested authorization details. */
   def refresh(
       env: Env,
@@ -168,6 +193,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
         amr = amr1,
         authTime = authTime1,
         acr = None,
+        cnfJkt = None,
       )
 
       _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
@@ -181,6 +207,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
       result <- env.service.refreshAccessToken(
         RefreshTokenRequest(refreshToken1, None, None, requested),
         ClientIdWithSecret(clientId1, Some(clientSecret1)),
+        None,
       ).either
     yield result
 
@@ -250,7 +277,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           )
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.exchangeAuthorizationCode(request, credentials)
+          result <- env.service.exchangeAuthorizationCode(request, credentials, None)
           createCalls = env.tokenRepo.createRefreshToken.calls
         yield assertTrue(
           result.accessToken == accessToken1,
@@ -303,7 +330,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = CodeExchangeRequest(authCode1, redirectUri1, codeVerifier1)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.exchangeAuthorizationCode(request, credentials)
+          result <- env.service.exchangeAuthorizationCode(request, credentials, None)
         yield assertTrue(
           result.accessToken == accessToken1,
           result.refreshToken.isEmpty,
@@ -318,7 +345,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = CodeExchangeRequest(authCode1, redirectUri1, codeVerifier1)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.exchangeAuthorizationCode(request, credentials).either
+          result <- env.service.exchangeAuthorizationCode(request, credentials, None).either
         yield assertTrue(
           result == Left(TokenEndpointError.InvalidClient),
         )
@@ -333,7 +360,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = CodeExchangeRequest(authCode1, redirectUri1, codeVerifier1)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.exchangeAuthorizationCode(request, credentials).either
+          result <- env.service.exchangeAuthorizationCode(request, credentials, None).either
         yield assertTrue(
           result == Left(TokenEndpointError.InvalidGrant),
         )
@@ -369,7 +396,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = CodeExchangeRequest(authCode1, wrongRedirectUri, codeVerifier1)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.exchangeAuthorizationCode(request, credentials).either
+          result <- env.service.exchangeAuthorizationCode(request, credentials, None).either
         yield assertTrue(
           result == Left(TokenEndpointError.InvalidGrant),
         )
@@ -408,7 +435,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
           now <- Clock.instant
-          result <- env.service.exchangeAuthorizationCode(request, credentials).either
+          result <- env.service.exchangeAuthorizationCode(request, credentials, None).either
         yield assertTrue(
           result == Left(TokenEndpointError.InvalidGrant),
           // The replayed code's token is not in hand, so its lifetime is bounded by the
@@ -453,7 +480,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = CodeExchangeRequest(authCode1, redirectUri1, codeVerifier1)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.exchangeAuthorizationCode(request, credentials)
+          result <- env.service.exchangeAuthorizationCode(request, credentials, None)
         yield assertTrue(
           result.accessToken == accessToken1,
           result.accessToken != freshAccessToken,
@@ -493,7 +520,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = CodeExchangeRequest(authCode1, redirectUri1, codeVerifier1)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.exchangeAuthorizationCode(request, credentials)
+          result <- env.service.exchangeAuthorizationCode(request, credentials, None)
         yield assertTrue(
           result.tenantId.contains("default"),
           result.roles.isEmpty,
@@ -534,7 +561,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = CodeExchangeRequest(authCode1, redirectUri1, codeVerifier1)
           credentials = ClientIdWithSecret(OAuthTokenService.centralAdminClientId, Some(clientSecret1))
 
-          result <- env.service.exchangeAuthorizationCode(request, credentials)
+          result <- env.service.exchangeAuthorizationCode(request, credentials, None)
         yield assertTrue(
           env.userRepo.findRolesByUserAndTenant.calls.nonEmpty,
           result.tenantId.contains("default"),
@@ -566,6 +593,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
             amr = amr1,
             authTime = authTime1,
             acr = None,
+            cnfJkt = None,
           )
 
           newRefreshToken = RefreshToken(Array.fill(32)(7.toByte))
@@ -588,7 +616,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           )
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.refreshAccessToken(request, credentials)
+          result <- env.service.refreshAccessToken(request, credentials, None)
 
           createCalls = env.tokenRepo.createRefreshToken.calls
         yield assertTrue(
@@ -628,6 +656,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
             amr = amr1,
             authTime = authTime1,
             acr = None,
+            cnfJkt = None,
           )
 
           newRefreshToken = RefreshToken(Array.fill(32)(9.toByte))
@@ -645,7 +674,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = RefreshTokenRequest(refreshToken1, Some(reducedScope), None, None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.refreshAccessToken(request, credentials)
+          result <- env.service.refreshAccessToken(request, credentials, None)
 
           createCalls = env.tokenRepo.createRefreshToken.calls
         yield assertTrue(
@@ -661,7 +690,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = RefreshTokenRequest(refreshToken1, None, None, None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.refreshAccessToken(request, credentials).either
+          result <- env.service.refreshAccessToken(request, credentials, None).either
         yield assertTrue(
           result == Left(TokenEndpointError.InvalidClient),
         )
@@ -676,7 +705,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = RefreshTokenRequest(refreshToken1, None, None, None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.refreshAccessToken(request, credentials).either
+          result <- env.service.refreshAccessToken(request, credentials, None).either
         yield assertTrue(
           result == Left(TokenEndpointError.InvalidGrant),
         )
@@ -705,6 +734,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
             amr = amr1,
             authTime = authTime1,
             acr = None,
+            cnfJkt = None,
           )
 
           _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
@@ -714,7 +744,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = RefreshTokenRequest(refreshToken1, Some(invalidScope), None, None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.refreshAccessToken(request, credentials).either
+          result <- env.service.refreshAccessToken(request, credentials, None).either
         yield assertTrue(
           result == Left(TokenEndpointError.InvalidScope),
         )
@@ -746,6 +776,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
             amr = amr1,
             authTime = authTime1,
             acr = None,
+            cnfJkt = None,
           )
 
           _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
@@ -755,7 +786,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = RefreshTokenRequest(refreshToken1, Some(widenedScope), None, None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.refreshAccessToken(request, credentials).either
+          result <- env.service.refreshAccessToken(request, credentials, None).either
         yield assertTrue(
           // `write` is registered for the client, so only the grant can reject it
           widenedScope.subsetOf(testClient.scope),
@@ -785,6 +816,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
             amr = amr1,
             authTime = authTime1,
             acr = None,
+            cnfJkt = None,
           )
 
           newRefreshToken = RefreshToken(Array.fill(32)(7.toByte))
@@ -801,7 +833,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = RefreshTokenRequest(refreshToken1, None, None, None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.refreshAccessToken(request, credentials).either
+          result <- env.service.refreshAccessToken(request, credentials, None).either
         yield assertTrue(
           result == Left(TokenEndpointError.InvalidGrant),
         )
@@ -817,7 +849,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = ClientCredentialsRequest(scope = None, resources = None, authorizationDetails = None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.clientCredentials(request, credentials)
+          result <- env.service.clientCredentials(request, credentials, None)
         yield assertTrue(
           result.accessToken == accessToken1,
           result.clientId == clientId1,
@@ -838,7 +870,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = ClientCredentialsRequest(scope = requestedScope, resources = None, authorizationDetails = None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.clientCredentials(request, credentials)
+          result <- env.service.clientCredentials(request, credentials, None)
         yield assertTrue(
           result.scope == scope2,
         )
@@ -858,6 +890,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
             result <- env.service.clientCredentials(
               ClientCredentialsRequest(scope = None, resources = None, authorizationDetails = None),
               ClientIdWithSecret(clientId1, Some(clientSecret1)),
+              None,
             )
           yield assertTrue(result.audience == List(publicResource, ResourceUri("resource://edge")))
         },
@@ -868,6 +901,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
             result <- env.service.clientCredentials(
               ClientCredentialsRequest(scope = None, resources = Some(Nil), authorizationDetails = None),
               ClientIdWithSecret(clientId1, Some(clientSecret1)),
+              None,
             ).either
           yield assertTrue(result == Left(TokenEndpointError.InvalidRequest))
         },
@@ -882,7 +916,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
 
             request = ClientCredentialsRequest(scope = None, resources = Some(List(publicResource, edgeResource)), authorizationDetails = None)
             credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
-            result <- env.service.clientCredentials(request, credentials)
+            result <- env.service.clientCredentials(request, credentials, None)
           yield assertTrue(
             result.audience == List(publicResource, edgeResource),
             env.clientService.findResource.calls == List((testClient.tenantId, publicResource)),
@@ -906,6 +940,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
             result <- env.service.clientCredentials(
               ClientCredentialsRequest(scope = None, resources = Some(List(internalResource)), authorizationDetails = None),
               ClientIdWithSecret(clientId1, Some(clientSecret1)),
+              None,
             )
           yield assertTrue(
             result.audience == List(internalResource),
@@ -923,6 +958,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
             result <- env.service.clientCredentials(
               ClientCredentialsRequest(scope = None, resources = Some(List(edgeResource, internalResource)), authorizationDetails = None),
               ClientIdWithSecret(clientId1, Some(clientSecret1)),
+              None,
             ).either
           yield assertTrue(result == Left(TokenEndpointError.InvalidTarget(edgeResource)))
         },
@@ -935,6 +971,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
             result <- env.service.clientCredentials(
               ClientCredentialsRequest(scope = None, resources = Some(List(resource)), authorizationDetails = None),
               ClientIdWithSecret(clientId1, Some(clientSecret1)),
+              None,
             ).either
           yield assertTrue(result == Left(TokenEndpointError.InvalidTarget(resource)))
         },
@@ -946,7 +983,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = ClientCredentialsRequest(scope = None, resources = None, authorizationDetails = None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.clientCredentials(request, credentials).either
+          result <- env.service.clientCredentials(request, credentials, None).either
         yield assertTrue(
           result == Left(TokenEndpointError.InvalidClient),
         )
@@ -959,7 +996,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = ClientCredentialsRequest(scope = None, resources = None, authorizationDetails = None)
           credentials = ClientIdWithSecret(publicClientId, None)
 
-          result <- env.service.clientCredentials(request, credentials).either
+          result <- env.service.clientCredentials(request, credentials, None).either
         yield assertTrue(
           result == Left(TokenEndpointError.InvalidClient),
         )
@@ -973,7 +1010,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           request = ClientCredentialsRequest(scope = invalidScope, resources = None, authorizationDetails = None)
           credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
 
-          result <- env.service.clientCredentials(request, credentials).either
+          result <- env.service.clientCredentials(request, credentials, None).either
         yield assertTrue(
           result == Left(TokenEndpointError.InvalidScope),
         )
@@ -996,6 +1033,7 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           result <- env.service.exchangeAuthorizationCode(
             CodeExchangeRequest(authCode1, redirectUri1, codeVerifier1),
             ClientIdWithSecret(clientId1, Some(clientSecret1)),
+            None,
           )
         yield assertTrue(result.authorizationDetails == List(paymentDetail))
       },
@@ -1044,10 +1082,144 @@ object OAuthTokenServiceSpec extends ZIOSpecDefault, ZIOStubs:
           result <- env.service.clientCredentials(
             ClientCredentialsRequest(scope = None, resources = None, authorizationDetails = Some(List(paymentDetail))),
             ClientIdWithSecret(clientId1, Some(clientSecret1)),
+            None,
           ).either
         yield assertTrue(result == Left(TokenEndpointError.InvalidAuthorizationDetails(
           "payment_initiation - unknown authorization details type",
         )))
+      },
+    ),
+    suite("DPoP binding")(
+      test("binds the issued tokens to the proof's thumbprint on the authorization_code grant") {
+        val env = new Env
+        for
+          _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
+          _ <- env.securityService.mac.succeedsWith(codeMac1)
+          _ <- env.authCodeRepo.find.succeedsWith(Some(authorizationCodeRecord.copy(scope = scope1)))
+          _ <- env.authCodeRepo.markAsUsed.succeedsWith(Right(()))
+          _ <- env.propertyGenerator.nextAccessToken.succeedsWith(accessToken1)
+          _ <- env.propertyGenerator.nextRefreshToken.succeedsWith(refreshToken1)
+          _ <- env.securityService.mac.succeedsWith(refreshTokenMac1)
+          _ <- env.tokenRepo.createRefreshToken.succeedsWith(())
+          _ <- env.userRepo.findRolesByUserAndTenant.succeedsWith(List.empty)
+
+          request = CodeExchangeRequest(authCode1, redirectUri1, codeVerifier1)
+          credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
+
+          result <- env.service.exchangeAuthorizationCode(request, credentials, Some(jkt1))
+        yield assertTrue(
+          result.cnfJkt.contains(jkt1),
+          env.tokenRepo.createRefreshToken.calls.head._2.cnfJkt.contains(jkt1),
+        )
+      },
+      test("leaves the grant unbound when the code exchange carries no proof") {
+        val env = new Env
+        for
+          _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
+          _ <- env.securityService.mac.succeedsWith(codeMac1)
+          _ <- env.authCodeRepo.find.succeedsWith(Some(authorizationCodeRecord.copy(scope = scope1)))
+          _ <- env.authCodeRepo.markAsUsed.succeedsWith(Right(()))
+          _ <- env.propertyGenerator.nextAccessToken.succeedsWith(accessToken1)
+          _ <- env.propertyGenerator.nextRefreshToken.succeedsWith(refreshToken1)
+          _ <- env.securityService.mac.succeedsWith(refreshTokenMac1)
+          _ <- env.tokenRepo.createRefreshToken.succeedsWith(())
+          _ <- env.userRepo.findRolesByUserAndTenant.succeedsWith(List.empty)
+
+          request = CodeExchangeRequest(authCode1, redirectUri1, codeVerifier1)
+          credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
+
+          result <- env.service.exchangeAuthorizationCode(request, credentials, None)
+        yield assertTrue(
+          result.cnfJkt.isEmpty,
+          env.tokenRepo.createRefreshToken.calls.head._2.cnfJkt.isEmpty,
+        )
+      },
+      test("refreshes a bound grant when the proof carries the same thumbprint") {
+        val env = new Env
+        for
+          now <- Clock.instant
+          _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
+          _ <- env.securityService.mac.succeedsWith(refreshTokenMac1)
+          _ <- env.securityService.mac.succeedsWith(MAC(Array.fill(32)(11.toByte)))
+          _ <- env.tokenRepo.findToken.succeedsWith(Some(boundRecord(now, Some(jkt1))))
+          _ <- env.propertyGenerator.nextAccessToken.succeedsWith(accessToken1)
+          _ <- env.propertyGenerator.nextRefreshToken.succeedsWith(refreshToken1)
+          _ <- env.tokenRepo.createRefreshToken.succeedsWith(())
+          _ <- env.userRepo.findRolesByUserAndTenant.succeedsWith(List.empty)
+
+          request = RefreshTokenRequest(refreshToken1, None, None, None)
+          credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
+
+          result <- env.service.refreshAccessToken(request, credentials, Some(jkt1))
+        yield assertTrue(
+          result.cnfJkt.contains(jkt1),
+          env.tokenRepo.createRefreshToken.calls.head._2.cnfJkt.contains(jkt1),
+        )
+      },
+      test("rejects a refresh whose proof carries a different thumbprint") {
+        val env = new Env
+        for
+          now <- Clock.instant
+          _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
+          _ <- env.securityService.mac.succeedsWith(refreshTokenMac1)
+          _ <- env.tokenRepo.findToken.succeedsWith(Some(boundRecord(now, Some(jkt1))))
+
+          request = RefreshTokenRequest(refreshToken1, None, None, None)
+          credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
+
+          result <- env.service.refreshAccessToken(request, credentials, Some(jkt2)).either
+        yield assertTrue(
+          result == Left(TokenEndpointError.InvalidGrant),
+          env.tokenRepo.createRefreshToken.calls.isEmpty,
+        )
+      },
+      test("rejects a refresh of a bound grant presented without any proof") {
+        val env = new Env
+        for
+          now <- Clock.instant
+          _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
+          _ <- env.securityService.mac.succeedsWith(refreshTokenMac1)
+          _ <- env.tokenRepo.findToken.succeedsWith(Some(boundRecord(now, Some(jkt1))))
+
+          request = RefreshTokenRequest(refreshToken1, None, None, None)
+          credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
+
+          result <- env.service.refreshAccessToken(request, credentials, None).either
+        yield assertTrue(result == Left(TokenEndpointError.InvalidGrant))
+      },
+      test("will not promote an unbound grant to a bound one just because a proof is presented") {
+        val env = new Env
+        for
+          now <- Clock.instant
+          _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
+          _ <- env.securityService.mac.succeedsWith(refreshTokenMac1)
+          _ <- env.securityService.mac.succeedsWith(MAC(Array.fill(32)(11.toByte)))
+          _ <- env.tokenRepo.findToken.succeedsWith(Some(boundRecord(now, None)))
+          _ <- env.propertyGenerator.nextAccessToken.succeedsWith(accessToken1)
+          _ <- env.propertyGenerator.nextRefreshToken.succeedsWith(refreshToken1)
+          _ <- env.tokenRepo.createRefreshToken.succeedsWith(())
+          _ <- env.userRepo.findRolesByUserAndTenant.succeedsWith(List.empty)
+
+          request = RefreshTokenRequest(refreshToken1, None, None, None)
+          credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
+
+          result <- env.service.refreshAccessToken(request, credentials, Some(jkt1))
+        yield assertTrue(
+          result.cnfJkt.isEmpty,
+          env.tokenRepo.createRefreshToken.calls.head._2.cnfJkt.isEmpty,
+        )
+      },
+      test("binds a client_credentials token to the proof's thumbprint") {
+        val env = new Env
+        for
+          _ <- env.clientService.verifySecret.succeedsWith(Some(testClient))
+          _ <- env.propertyGenerator.nextAccessToken.succeedsWith(accessToken1)
+
+          request = ClientCredentialsRequest(scope = None, resources = None, authorizationDetails = None)
+          credentials = ClientIdWithSecret(clientId1, Some(clientSecret1))
+
+          result <- env.service.clientCredentials(request, credentials, Some(jkt1))
+        yield assertTrue(result.cnfJkt.contains(jkt1))
       },
     ),
   ) 

--- a/auth/src/test/scala/versola/oauth/token/TokenEndpointControllerSpec.scala
+++ b/auth/src/test/scala/versola/oauth/token/TokenEndpointControllerSpec.scala
@@ -7,6 +7,8 @@ import com.nimbusds.jose.crypto.RSASSAVerifier
 import com.nimbusds.jose.jwk.{KeyUse, RSAKey}
 import com.nimbusds.jwt.SignedJWT
 import versola.oauth.client.OAuthConfigurationService
+import versola.oauth.dpop.DpopService
+import versola.util.Dpop
 import versola.oauth.jwks.JwksService
 import versola.oauth.client.model.{AuthMethodRef, ClientId, ClientIdWithSecret, ResourceUri, ScopeToken, TenantId}
 import versola.oauth.model.{AccessToken, AuthorizationCode, CodeVerifier, Nonce, RefreshToken}
@@ -56,15 +58,41 @@ object TokenEndpointControllerSpec extends UnitSpecBase:
     amr = Set(AuthMethodRef.pwd),
     authTime = Some(java.time.Instant.ofEpochSecond(1700000000)),
     acr = None,
+    cnfJkt = None,
+  )
+
+  val jkt1 = "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I"
+
+  val proof1 = Dpop.Proof(
+    jkt = jkt1,
+    jti = "jti-1",
+    iat = java.time.Instant.ofEpochSecond(1700000000),
+    nonce = None,
+    ath = None,
   )
 
   def authHeader(clientId: ClientId, secret: Option[Secret]): Header.Authorization =
     val secretStr = secret.map(s => Base64.urlEncode(s)).getOrElse("")
     Header.Authorization.Basic(clientId, secretStr)
 
+  val codeExchangeRequest = Request.post(
+    url = URL.empty / "token",
+    body = Body.fromURLEncodedForm(
+      Form.fromStrings(
+        "grant_type" -> "authorization_code",
+        "code" -> Base64.urlEncode(authCode1),
+        "redirect_uri" -> redirectUri,
+        "code_verifier" -> codeVerifier1,
+      ),
+    ),
+  ).addHeader(authHeader(clientId1, Some(clientSecret1)))
+
+  val dpopCodeExchangeRequest = codeExchangeRequest.addHeader(Header.Custom("DPoP", "a.b.c"))
+
   case class Services(
       oauthTokenService: Stub[OAuthTokenService],
       userInfoService: Stub[UserInfoService],
+      dpopService: Stub[DpopService],
   )
 
   def tokenEndpointTestCase(
@@ -73,6 +101,7 @@ object TokenEndpointControllerSpec extends UnitSpecBase:
       expectedStatus: Status,
       setup: Services => UIO[Unit] = _ => ZIO.unit,
       verify: Response => Task[TestResult] = _ => ZIO.succeed(assertTrue(true)),
+      verifyServices: Services => Task[TestResult] = _ => ZIO.succeed(assertTrue(true)),
   ) =
     test(description) {
       for
@@ -82,21 +111,23 @@ object TokenEndpointControllerSpec extends UnitSpecBase:
         userInfoService = stub[UserInfoService]
         config = TestEnvConfig.coreConfig
         jwksService = TestEnvConfig.jwksService
+        dpopService = stub[DpopService]
         tracing <- NoopTracing.layer.build
 
-        services = Services(tokenService, userInfoService)
+        services = Services(tokenService, userInfoService, dpopService)
 
         _ <- TestClient.addRoutes(
           Observability.handleErrors(
             TokenEndpointController.routes
-              .provideEnvironment(ZEnvironment(tokenService) ++ ZEnvironment(clientService) ++ ZEnvironment(userInfoService) ++ ZEnvironment(jwksService) ++ ZEnvironment(config) ++ tracing)
+              .provideEnvironment(ZEnvironment(tokenService) ++ ZEnvironment(clientService) ++ ZEnvironment(userInfoService) ++ ZEnvironment(jwksService) ++ ZEnvironment(config) ++ ZEnvironment(dpopService) ++ tracing)
           )
         )
         _ <- setup(services)
 
         response <- client.batched(request)
         verifyResult <- verify(response)
-      yield assertTrue(response.status == expectedStatus) && verifyResult
+        verifyServicesResult <- verifyServices(services)
+      yield assertTrue(response.status == expectedStatus) && verifyResult && verifyServicesResult
     }.provideSomeLayer(TestClient.layer) @@ TestAspect.silentLogging
 
   val spec = suite("TokenEndpointController")(
@@ -817,7 +848,7 @@ object TokenEndpointControllerSpec extends UnitSpecBase:
               TokenEndpointController.routes
                 .provideEnvironment(
                   ZEnvironment(tokenService) ++ ZEnvironment(clientService) ++ ZEnvironment(userInfoService) ++
-                    ZEnvironment(driftedJwksService) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ tracing,
+                    ZEnvironment(driftedJwksService) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(stub[DpopService]) ++ tracing,
                 )
             )
           )
@@ -868,7 +899,7 @@ object TokenEndpointControllerSpec extends UnitSpecBase:
               TokenEndpointController.routes
                 .provideEnvironment(
                   ZEnvironment(tokenService) ++ ZEnvironment(clientService) ++ ZEnvironment(userInfoService) ++
-                    ZEnvironment(noSigningKeyJwksService) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ tracing,
+                    ZEnvironment(noSigningKeyJwksService) ++ ZEnvironment(TestEnvConfig.coreConfig) ++ ZEnvironment(stub[DpopService]) ++ tracing,
                 )
             )
           )
@@ -920,6 +951,85 @@ object TokenEndpointControllerSpec extends UnitSpecBase:
         TokenEndpointController.refreshTokenRequestDecoder.decode(form).either.map: result =>
           assertTrue(result.isLeft)
       },
+    ),
+    suite("POST /token - DPoP")(
+      tokenEndpointTestCase(
+        description = "issues a DPoP-bound token and echoes the binding in cnf.jkt",
+        request = dpopCodeExchangeRequest,
+        expectedStatus = Status.Ok,
+        setup = services =>
+          services.dpopService.verify.succeedsWith(proof1) *>
+            services.oauthTokenService.exchangeAuthorizationCode.succeedsWith(
+              issuedTokens.copy(cnfJkt = Some(jkt1)),
+            ),
+        verify = response =>
+          for
+            body <- response.body.asString
+            tokenResponse <- ZIO.fromEither(body.fromJson[TokenResponse]).mapError(new RuntimeException(_))
+            claims = SignedJWT.parse(tokenResponse.accessToken).getJWTClaimsSet
+          yield assertTrue(
+            tokenResponse.tokenType == "DPoP",
+            claims.getJSONObjectClaim("cnf").get("jkt") == jkt1,
+          ),
+        verifyServices = services =>
+          ZIO.succeed(assertTrue(
+            services.oauthTokenService.exchangeAuthorizationCode.calls.head._3.contains(jkt1),
+          )),
+      ),
+      tokenEndpointTestCase(
+        description = "leaves a request without a proof as an unbound Bearer token",
+        request = codeExchangeRequest,
+        expectedStatus = Status.Ok,
+        setup = services =>
+          services.oauthTokenService.exchangeAuthorizationCode.succeedsWith(issuedTokens),
+        verify = response =>
+          for
+            body <- response.body.asString
+            tokenResponse <- ZIO.fromEither(body.fromJson[TokenResponse]).mapError(new RuntimeException(_))
+            claims = SignedJWT.parse(tokenResponse.accessToken).getJWTClaimsSet
+          yield assertTrue(
+            tokenResponse.tokenType == "Bearer",
+            claims.getJSONObjectClaim("cnf") == null,
+          ),
+        verifyServices = services =>
+          ZIO.succeed(assertTrue(
+            services.dpopService.verify.calls.isEmpty,
+            services.oauthTokenService.exchangeAuthorizationCode.calls.head._3.isEmpty,
+          )),
+      ),
+      tokenEndpointTestCase(
+        description = "rejects a proof that does not validate with invalid_dpop_proof",
+        request = dpopCodeExchangeRequest,
+        expectedStatus = Status.BadRequest,
+        setup = services =>
+          services.dpopService.verify.failsWith(DpopService.Error.InvalidProof(Dpop.Error.UriMismatch)),
+        verify = response =>
+          for body <- response.body.asString
+          yield assertTrue(body.contains("invalid_dpop_proof")),
+      ),
+      tokenEndpointTestCase(
+        description = "rejects a replayed proof with invalid_dpop_proof",
+        request = dpopCodeExchangeRequest,
+        expectedStatus = Status.BadRequest,
+        setup = services =>
+          services.dpopService.verify.failsWith(DpopService.Error.Replayed),
+        verify = response =>
+          for body <- response.body.asString
+          yield assertTrue(body.contains("invalid_dpop_proof")),
+      ),
+      tokenEndpointTestCase(
+        description = "answers a nonce challenge with use_dpop_nonce and serves the nonce in the DPoP-Nonce header",
+        request = dpopCodeExchangeRequest,
+        expectedStatus = Status.BadRequest,
+        setup = services =>
+          services.dpopService.verify.failsWith(DpopService.Error.NonceRequired("fresh-nonce")),
+        verify = response =>
+          for body <- response.body.asString
+          yield assertTrue(
+            body.contains("use_dpop_nonce"),
+            response.headers.get("DPoP-Nonce").contains("fresh-nonce"),
+          ),
+      ),
     ),
   )
 

--- a/scripts/gen-env.scala
+++ b/scripts/gen-env.scala
@@ -178,6 +178,7 @@ def writeGeneratedSecrets(dir: File, name: String, secrets: Seq[(String, String)
   val edgeSessionsSecret        = rand(rng, 32)
   val edgeInternalSecret        = rand(rng, 32) // authorizes edge's non-prod /service/configuration/sync
   val parRequestsSecret         = rand(rng, 32) // auth only: keys the stored request_uri references
+  val dpopNoncesSecret          = rand(rng, 32) // auth only: authenticates DPoP-Nonce values
   val accountResourceSecretGenerated = rand(rng, 32) // central: seeds the "auth" resource record; auth fetches it decrypted via registry sync
 
   // ── Environment ───────────────────────────────────────────────────────────────
@@ -536,6 +537,7 @@ def writeGeneratedSecrets(dir: File, name: String, secrets: Seq[(String, String)
        |  session-cookie-secret        = ${secretField(useOpenBao, sessionCookieSecret, "SESSION_COOKIE_SECRET")}
        |  user-agent-cookie-secret     = ${secretField(useOpenBao, userAgentCookieSecret, "USER_AGENT_COOKIE_SECRET")}
        |  par-requests-secret          = ${secretField(useOpenBao, parRequestsSecret, "PAR_REQUESTS_SECRET")}
+       |  dpop-nonces-secret           = ${secretField(useOpenBao, dpopNoncesSecret, "DPOP_NONCES_SECRET")}
        |}
        |
        |par {
@@ -594,6 +596,12 @@ def writeGeneratedSecrets(dir: File, name: String, secrets: Seq[(String, String)
        |      batch-size = 1000
        |      interval   = "5 minutes"
        |      key-column = "request_uri"
+       |    }
+       |    {
+       |      table-name = "dpop_proofs"
+       |      batch-size = 10000
+       |      interval   = "5 minutes"
+       |      key-column = "ctid"
        |    }
        |    {
        |      table-name = "refresh_tokens"
@@ -829,6 +837,7 @@ def writeGeneratedSecrets(dir: File, name: String, secrets: Seq[(String, String)
         "SESSION_COOKIE_SECRET"      -> sessionCookieSecret,
         "USER_AGENT_COOKIE_SECRET"   -> userAgentCookieSecret,
         "PAR_REQUESTS_SECRET"        -> parRequestsSecret,
+        "DPOP_NONCES_SECRET"         -> dpopNoncesSecret,
         "JWT_PRIVATE_KEY"            -> jwtKey.privateB64,
         "CENTRAL_SECRET_KEY"         -> centralSecretKey,
       ) ++ authExtras)

--- a/util/src/main/scala/versola/util/Dpop.scala
+++ b/util/src/main/scala/versola/util/Dpop.scala
@@ -1,0 +1,151 @@
+package versola.util
+
+import com.nimbusds.jose.crypto.{ECDSAVerifier, RSASSAVerifier}
+import com.nimbusds.jose.jwk.{ECKey, JWK, RSAKey}
+import com.nimbusds.jose.{JOSEObjectType, JWSAlgorithm}
+import com.nimbusds.jwt.SignedJWT
+import zio.http.Method
+import zio.{Duration, IO, ZIO}
+
+import java.time.Instant
+
+/** RFC 9449 DPoP proof JWTs.
+  *
+  * A DPoP proof is a JWS whose header carries the client's own public key (`jwk`) rather than a
+  * `kid` pointing at a key this server issued -- the server has never seen the key before and
+  * verifies the proof entirely against the key the proof itself carries. This object only
+  * performs those self-contained checks: JWS structure, `typ`, signature against the embedded
+  * key, and the `htm`/`htu`/`iat` binding to the current request. `jti` replay detection and
+  * `nonce` validity need persistence/secrets this module doesn't have access to, so they live in
+  * `versola.oauth.dpop.DpopService`.
+  */
+object Dpop:
+
+  /** The `typ` header RFC 9449 \u00a74.2 requires on every DPoP proof, distinguishing it from an
+    * ordinary JWT so one can't be replayed as the other.
+    */
+  val JwtType: JOSEObjectType = JOSEObjectType("dpop+jwt")
+
+  /** Signing algorithms a DPoP proof may use. Chosen by the client based on the key it holds, so
+    * this is independent of [[JWT.Algorithm]] (which governs this server's own token signing).
+    * RFC 9449 \u00a75 requires `ES256` support; `PS256` is included for FAPI 2.0 deployments.
+    * `RS256` is supported here too -- whether it's actually accepted is a deployment choice, see
+    * `CoreConfig.DpopConfig`.
+    */
+  enum Algorithm(val jwsAlgorithm: JWSAlgorithm):
+    case ES256 extends Algorithm(JWSAlgorithm.ES256)
+    case PS256 extends Algorithm(JWSAlgorithm.PS256)
+    case RS256 extends Algorithm(JWSAlgorithm.RS256)
+
+  object Algorithm:
+    def fromJws(alg: JWSAlgorithm): Option[Algorithm] = values.find(_.jwsAlgorithm == alg)
+
+  /** The proof's self-contained, already-validated claims.
+    *
+    * @param jkt RFC 7638 JWK thumbprint of the proof's embedded public key -- what an issued
+    *   access token's `cnf.jkt` gets bound to.
+    * @param jti still needs checking against server state by the caller (replay detection).
+    * @param nonce still needs checking against server state by the caller (freshness).
+    * @param ath base64url(SHA-256(access token)), present only on resource requests; the caller
+    *   is responsible for requiring and checking it there.
+    */
+  case class Proof(
+      jkt: String,
+      jti: String,
+      iat: Instant,
+      nonce: Option[String],
+      ath: Option[String],
+  )
+
+  enum Error:
+    case NotJWT
+    case InvalidType
+    case UnsupportedAlgorithm
+    case MissingJwk
+    case InvalidSignature
+    case MissingClaim(name: String)
+    case MethodMismatch
+    case UriMismatch
+    case IatOutOfWindow
+
+  /**
+   * Verifies a DPoP proof's self-contained properties against the current request: JWS
+   * structure and `typ`, signature against its own embedded public key, and the `htm`/`htu`/
+   * `iat` binding. Does not check `jti` replay or `nonce` validity -- see
+   * `versola.oauth.dpop.DpopService`.
+   *
+   * @param token the raw `DPoP` request header value
+   * @param allowedAlgorithms signing algorithms this deployment accepts
+   *   (`dpop_signing_alg_values_supported`)
+   * @param expectedMethod the current request's HTTP method (`htm`)
+   * @param expectedUri the current request's URI with no query or fragment, exactly as
+   *   advertised to clients (`htu`) -- RFC 9449 \u00a74.3
+   * @param now current time
+   * @param iatLeeway maximum allowed distance between `iat` and `now`, in either direction
+   */
+  def verify(
+      token: String,
+      allowedAlgorithms: Set[Algorithm],
+      expectedMethod: Method,
+      expectedUri: String,
+      now: Instant,
+      iatLeeway: Duration,
+  ): IO[Error, Proof] =
+    for
+      jwt <- ZIO.attempt(SignedJWT.parse(token)).orElseFail(Error.NotJWT)
+      _ <- verifyType(jwt)
+      _ <- verifyAlgorithm(jwt, allowedAlgorithms)
+      // Nimbus's own JWS header parsing already rejects a `jwk` carrying private/symmetric key
+      // material at the `SignedJWT.parse` call above (surfacing as `Error.NotJWT`), so by the
+      // time a header reaches here its embedded key is guaranteed public.
+      jwk <- ZIO.fromOption(Option(jwt.getHeader.getJWK)).orElseFail(Error.MissingJwk)
+      _ <- verifySignature(jwt, jwk)
+
+      claims = jwt.getJWTClaimsSet
+      htm <- requireClaim(claims.getStringClaim("htm"), "htm")
+      htu <- requireClaim(claims.getStringClaim("htu"), "htu")
+      jti <- requireClaim(claims.getStringClaim("jti"), "jti")
+      iatDate <- requireClaim(claims.getDateClaim("iat"), "iat")
+
+      _ <- ZIO.fail(Error.MethodMismatch).unless(htm == expectedMethod.name)
+      _ <- ZIO.fail(Error.UriMismatch).unless(htu == expectedUri)
+
+      iat = iatDate.toInstant
+      _ <- ZIO.fail(Error.IatOutOfWindow)
+        .unless(!iat.isBefore(now.minus(iatLeeway)) && !iat.isAfter(now.plus(iatLeeway)))
+
+      jkt <- ZIO.attempt(jwk.computeThumbprint().toString).orElseFail(Error.MissingJwk)
+    yield Proof(
+      jkt = jkt,
+      jti = jti,
+      iat = iat,
+      nonce = Option(claims.getStringClaim("nonce")),
+      ath = Option(claims.getStringClaim("ath")),
+    )
+
+  private def requireClaim[A](value: => A, name: String): IO[Error, A] =
+    ZIO.attempt(Option(value)).orElseFail(Error.MissingClaim(name)).someOrFail(Error.MissingClaim(name))
+
+  private def verifyType(jwt: SignedJWT): IO[Error, Unit] =
+    ZIO.attempt(Option(jwt.getHeader.getType))
+      .orElseFail(Error.InvalidType)
+      .someOrFail(Error.InvalidType)
+      .filterOrFail(_ == JwtType)(Error.InvalidType)
+      .unit
+
+  private def verifyAlgorithm(jwt: SignedJWT, allowedAlgorithms: Set[Algorithm]): IO[Error, Unit] =
+    ZIO.fromOption(Option(jwt.getHeader.getAlgorithm).flatMap(Algorithm.fromJws))
+      .orElseFail(Error.UnsupportedAlgorithm)
+      .filterOrFail(allowedAlgorithms.contains)(Error.UnsupportedAlgorithm)
+      .unit
+
+  private def verifySignature(jwt: SignedJWT, jwk: JWK): IO[Error, Unit] =
+    ZIO.attempt(
+      jwk match
+        case key: RSAKey => jwt.verify(RSASSAVerifier(key))
+        case key: ECKey => jwt.verify(ECDSAVerifier(key))
+        case _ => false,
+    )
+      .orElseFail(Error.InvalidSignature)
+      .filterOrFail(identity)(Error.InvalidSignature)
+      .unit

--- a/util/src/test/scala/versola/util/DpopSpec.scala
+++ b/util/src/test/scala/versola/util/DpopSpec.scala
@@ -1,0 +1,205 @@
+package versola.util
+
+import com.nimbusds.jose.crypto.{ECDSASigner, RSASSASigner}
+import com.nimbusds.jose.jwk.{Curve, ECKey, OctetKeyPair, RSAKey}
+import com.nimbusds.jose.util.Base64URL
+import com.nimbusds.jose.{JOSEObjectType, JWSAlgorithm, JWSHeader}
+import com.nimbusds.jwt.{JWTClaimsSet, SignedJWT}
+import zio.*
+import zio.http.Method
+import zio.test.*
+
+import java.security.KeyPairGenerator
+import java.security.interfaces.{ECPrivateKey, ECPublicKey, RSAPrivateKey, RSAPublicKey}
+import java.time.Instant
+import java.util.{Base64, Date}
+import javax.crypto.KeyGenerator
+
+object DpopSpec extends ZIOSpecDefault:
+
+  private val ecKeyPairGenerator = KeyPairGenerator.getInstance("EC")
+  ecKeyPairGenerator.initialize(Curve.P_256.toECParameterSpec)
+  private val ecKeyPair = ecKeyPairGenerator.generateKeyPair()
+  private val ecPrivateKey = ecKeyPair.getPrivate.asInstanceOf[ECPrivateKey]
+  private val ecPublicKey = ecKeyPair.getPublic.asInstanceOf[ECPublicKey]
+  private val ecJwk = ECKey.Builder(Curve.P_256, ecPublicKey).build()
+
+  private val otherEcKeyPair = ecKeyPairGenerator.generateKeyPair()
+  private val otherEcPrivateKey = otherEcKeyPair.getPrivate.asInstanceOf[ECPrivateKey]
+
+  private val rsaKeyPairGenerator = KeyPairGenerator.getInstance("RSA")
+  rsaKeyPairGenerator.initialize(2048)
+  private val rsaKeyPair = rsaKeyPairGenerator.generateKeyPair()
+  private val rsaPrivateKey = rsaKeyPair.getPrivate.asInstanceOf[RSAPrivateKey]
+  private val rsaPublicKey = rsaKeyPair.getPublic.asInstanceOf[RSAPublicKey]
+  private val rsaJwk = RSAKey.Builder(rsaPublicKey).build()
+
+  // A public key type Dpop.verifySignature doesn't special-case (neither RSAKey nor ECKey), to
+  // exercise its fallback branch. Ed25519 rather than a symmetric key: Nimbus's own JWS header
+  // parsing already refuses to round-trip a `jwk` carrying private/symmetric material (see the
+  // "embedded private/symmetric key" test below), so a public OKP key is the only way to reach
+  // that branch through `SignedJWT.parse` at all.
+  private val okpJwk = OctetKeyPair.Builder(Curve.Ed25519, Base64URL.encode(Array.fill[Byte](32)(9))).build()
+
+  private val Htm = Method.POST
+  private val Htu = "https://auth.example.com/token"
+  private val AllAlgorithms = Set(Dpop.Algorithm.ES256, Dpop.Algorithm.PS256, Dpop.Algorithm.RS256)
+
+  private def proof(
+      alg: JWSAlgorithm = JWSAlgorithm.ES256,
+      typ: JOSEObjectType = Dpop.JwtType,
+      jwk: Option[com.nimbusds.jose.jwk.JWK] = Some(ecJwk),
+      signer: com.nimbusds.jose.JWSSigner = ECDSASigner(ecPrivateKey),
+      htm: String = Htm.name,
+      htu: String = Htu,
+      jti: String = "jti-1",
+      iat: Instant = Instant.parse("2024-01-01T00:00:00Z"),
+      nonce: Option[String] = None,
+      ath: Option[String] = None,
+  ): String =
+    val headerBuilder = JWSHeader.Builder(alg).`type`(typ)
+    jwk.foreach(headerBuilder.jwk)
+    val claimsBuilder = JWTClaimsSet.Builder()
+      .claim("htm", htm)
+      .claim("htu", htu)
+      .jwtID(jti)
+      .issueTime(Date.from(iat))
+    nonce.foreach(claimsBuilder.claim("nonce", _))
+    ath.foreach(claimsBuilder.claim("ath", _))
+    val jwt = SignedJWT(headerBuilder.build(), claimsBuilder.build())
+    jwt.sign(signer)
+    jwt.serialize()
+
+  /** Hand-assembles a compact JWS from raw header/payload JSON, bypassing every Nimbus API that
+    * would otherwise refuse to build it -- the only way to see what `Dpop.verify` does with a
+    * proof whose header a well-behaved JOSE library could never produce in the first place.
+    */
+  private def rawEcToken(headerJson: String, claimsJson: String, signingKey: ECPrivateKey): String =
+    def b64(bytes: Array[Byte]) = Base64.getUrlEncoder.withoutPadding.encodeToString(bytes)
+    def b64s(s: String) = b64(s.getBytes("UTF-8"))
+    val signingInput = s"${b64s(headerJson)}.${b64s(claimsJson)}".getBytes("UTF-8")
+    val signature = java.security.Signature.getInstance("SHA256withECDSA")
+    signature.initSign(signingKey)
+    signature.update(signingInput)
+    val jwsSignature = com.nimbusds.jose.crypto.impl.ECDSA.transcodeSignatureToConcat(
+      signature.sign(),
+      com.nimbusds.jose.crypto.impl.ECDSA.getSignatureByteArrayLength(JWSAlgorithm.ES256),
+    )
+    s"${b64s(headerJson)}.${b64s(claimsJson)}.${b64(jwsSignature)}"
+
+  private val now = Instant.parse("2024-01-01T00:00:00Z")
+  private val leeway = 60.seconds
+
+  private def verify(token: String, allowed: Set[Dpop.Algorithm] = AllAlgorithms) =
+    Dpop.verify(token, allowed, Htm, Htu, now, leeway)
+
+  def spec = suite("Dpop")(
+    test("accepts a well-formed ES256 proof and returns its claims") {
+      for result <- verify(proof()).either
+      yield assertTrue(
+        result.map(_.jti) == Right("jti-1"),
+        result.map(_.iat) == Right(now),
+        result.toOption.exists(_.jkt == ecJwk.computeThumbprint().toString),
+        result.toOption.exists(_.nonce.isEmpty),
+        result.toOption.exists(_.ath.isEmpty),
+      )
+    },
+    test("accepts a well-formed PS256 proof") {
+      val token = proof(alg = JWSAlgorithm.PS256, jwk = Some(rsaJwk), signer = RSASSASigner(rsaPrivateKey))
+      for result <- verify(token).either
+      yield assertTrue(result.isRight)
+    },
+    test("accepts a well-formed RS256 proof") {
+      val token = proof(alg = JWSAlgorithm.RS256, jwk = Some(rsaJwk), signer = RSASSASigner(rsaPrivateKey))
+      for result <- verify(token).either
+      yield assertTrue(result.isRight)
+    },
+    test("carries nonce and ath through when present") {
+      val token = proof(nonce = Some("srv-nonce"), ath = Some("ath-value"))
+      for result <- verify(token).either
+      yield assertTrue(
+        result.toOption.flatMap(_.nonce) == Some("srv-nonce"),
+        result.toOption.flatMap(_.ath) == Some("ath-value"),
+      )
+    },
+    test("rejects a proof that isn't a JWT at all") {
+      for result <- verify("not-a-jwt").either
+      yield assertTrue(result == Left(Dpop.Error.NotJWT))
+    },
+    test("rejects the wrong typ header") {
+      val token = proof(typ = JOSEObjectType.JWT)
+      for result <- verify(token).either
+      yield assertTrue(result == Left(Dpop.Error.InvalidType))
+    },
+    test("rejects an algorithm outside the allowed set") {
+      val token = proof()
+      for result <- verify(token, allowed = Set(Dpop.Algorithm.PS256)).either
+      yield assertTrue(result == Left(Dpop.Error.UnsupportedAlgorithm))
+    },
+    test("rejects HS256, which isn't a DPoP algorithm at all") {
+      val hmacKey = KeyGenerator.getInstance("HmacSHA256").generateKey()
+      val token = proof(
+        alg = JWSAlgorithm.HS256,
+        jwk = None,
+        signer = com.nimbusds.jose.crypto.MACSigner(hmacKey),
+      )
+      for result <- verify(token).either
+      yield assertTrue(result == Left(Dpop.Error.UnsupportedAlgorithm))
+    },
+    test("rejects a proof whose header embeds a private/symmetric key -- Nimbus refuses to " +
+      "round-trip one, so this can only be hand-assembled, and surfaces as a parse failure") {
+      val privateEcJwk = ECKey.Builder(Curve.P_256, ecPublicKey).privateKey(ecPrivateKey).build()
+      val headerJson = s"""{"typ":"dpop+jwt","alg":"ES256","jwk":${privateEcJwk.toString}}"""
+      val claimsJson = s"""{"htm":"${Htm.name}","htu":"$Htu","jti":"jti-1","iat":${now.getEpochSecond}}"""
+      val token = rawEcToken(headerJson, claimsJson, ecPrivateKey)
+      for result <- verify(token).either
+      yield assertTrue(result == Left(Dpop.Error.NotJWT))
+    },
+    test("rejects a public key type it doesn't recognize as a DPoP signing key") {
+      val token = proof(jwk = Some(okpJwk))
+      for result <- verify(token).either
+      yield assertTrue(result == Left(Dpop.Error.InvalidSignature))
+    },
+    test("rejects a proof missing the htm claim") {
+      val header = JWSHeader.Builder(JWSAlgorithm.ES256).`type`(Dpop.JwtType).jwk(ecJwk).build()
+      val claims = JWTClaimsSet.Builder()
+        .claim("htu", Htu)
+        .jwtID("jti-1")
+        .issueTime(Date.from(now))
+        .build()
+      val jwt = SignedJWT(header, claims)
+      jwt.sign(ECDSASigner(ecPrivateKey))
+      for result <- verify(jwt.serialize()).either
+      yield assertTrue(result == Left(Dpop.Error.MissingClaim("htm")))
+    },
+    test("rejects a proof signed by a different key than the one it embeds (key confusion)") {
+      val token = proof(signer = ECDSASigner(otherEcPrivateKey))
+      for result <- verify(token).either
+      yield assertTrue(result == Left(Dpop.Error.InvalidSignature))
+    },
+    test("rejects a method (htm) that doesn't match the request") {
+      val token = proof(htm = "GET")
+      for result <- verify(token).either
+      yield assertTrue(result == Left(Dpop.Error.MethodMismatch))
+    },
+    test("rejects a uri (htu) that doesn't match the request") {
+      val token = proof(htu = "https://auth.example.com/other")
+      for result <- verify(token).either
+      yield assertTrue(result == Left(Dpop.Error.UriMismatch))
+    },
+    test("rejects an iat too far in the past") {
+      val token = proof(iat = now.minusSeconds(120))
+      for result <- verify(token).either
+      yield assertTrue(result == Left(Dpop.Error.IatOutOfWindow))
+    },
+    test("rejects an iat too far in the future") {
+      val token = proof(iat = now.plusSeconds(120))
+      for result <- verify(token).either
+      yield assertTrue(result == Left(Dpop.Error.IatOutOfWindow))
+    },
+    test("accepts an iat right at the edge of the leeway window") {
+      val token = proof(iat = now.minusSeconds(60))
+      for result <- verify(token).either
+      yield assertTrue(result.isRight)
+    },
+  )


### PR DESCRIPTION
## What

Binds access and refresh tokens to a client's DPoP key when a proof is presented on the token endpoint, and enforces replay protection on the proof itself (RFC 9449).

- `util`: `Dpop.verify` validates a proof's self-contained properties (JWS signature, `htm`/`htu`, `iat` window) against the current request.
- `auth`: `DpopService` orchestrates verification, replay protection via `DpopProofRepository` (`jkt`+`jti`, Postgres-backed, RFC 9449 §11.1), and server-issued nonces via `DpopNonceService` (§8/§9).
- `/token` reads the `DPoP` header, embeds `cnf.jkt` on issued access tokens, switches `token_type` to `DPoP`, and responds with `invalid_dpop_proof` / `use_dpop_nonce` (+ `DPoP-Nonce` header) on failure.
- `authorization_code` and `client_credentials` grants bind the issued refresh token's `cnf_jkt` to the presenting key. The binding is fixed at issuance: a bound refresh token's subsequent refresh requests must present a proof with the same thumbprint, and an unbound grant is never promoted to bound just because a proof shows up later.
- New Postgres tables: `dpop_proofs` (replay guard) and `refresh_tokens.cnf_jkt` (binding), both wired into the existing generic `CleanupManager` reaper. `dpop_proofs` batch-size set to 10000 (not the manager's usual 1000 default) after benchmarking: the cleanup delete's query plan flips from a cheap per-row Nested Loop to a full-table Hash Join past a table-size-dependent batch threshold, so this stays well clear of it.

## Tests

+12 in `OAuthTokenServiceSpec`/`TokenEndpointControllerSpec`, +2 Postgres round-trip tests, new `DpopSpec`/`DpopServiceSpec`/`DpopNonceServiceSpec`/`DpopProofRepositorySpec`/`PostgresDpopProofRepositorySpec`.

`util` 115, `auth` +12, `auth-postgres-impl` +2 — all green.

## Not covered here

- Resource-side enforcement (`ath` / `cnf.jkt` checks at `/userinfo` and the edge) — nothing consumes the binding yet, it's recorded but not enforced on resource requests.
- Per-client DPoP requirement (DPoP is opt-in per request today).
- The `dpop_jkt` authorization-request parameter (RFC 9449 §10), which binds the code itself.
- Discovery metadata (`dpop_signing_alg_values_supported`) comes from central, unchanged here.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M1VJCGN5DK4AS4MZJ7TCS4PS&panel=chat)