### PR TITLE
loadgen: emulator state store, migrations and write-behind (Phase 1 / C)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -250,6 +250,10 @@ lazy val loadgen = project
     // (the "Run tests with coverage" CI step) never touches this project anyway -- explicit
     // here so that stays true even if someone runs `loadgen/coverage loadgen/test` directly.
     coverageEnabled := false,
+    // The store specs share one database (LoadgenPostgresSpec), each truncating its own table
+    // between tests, and each builds a pool that runs Flyway against it on first use. Same
+    // reasoning as the three *-postgres-impl projects above.
+    Test / parallelExecution := false,
   )
   .dependsOn(
     util % CompileTest,

--- a/loadgen/migrations/V0001__virtual_users.sql
+++ b/loadgen/migrations/V0001__virtual_users.sql
@@ -1,0 +1,53 @@
+-- The emulator's own bookkeeping, never the SUT's schema (dev spec §6). Everything here is
+-- reconstructible by a re-seed, which is what buys the two properties this store is tuned for:
+-- UNLOGGED tables (no WAL for the emulator's writes) and asynchronous commit. At 10M modelled
+-- users the write rate mirrors the refresh rate -- ~420 writes/s at peak -- and this store must
+-- never become the bottleneck that the campaign then attributes to the SUT (design doc §6.6).
+
+-- synchronous_commit belongs to the database rather than to a table, so it is set here rather
+-- than left to whoever writes the Helm values: a store deployed without it is not visibly
+-- different, it is just slower under load, which is exactly the failure that reads as a SUT
+-- regression. The EXCEPTION arm keeps the migration applicable by a role that does not own the
+-- database (a managed instance, or a shared dev box) -- the setting is then the deployment's
+-- job, and the warning says so instead of failing the boot.
+DO $$
+BEGIN
+    EXECUTE format('ALTER DATABASE %I SET synchronous_commit = off', current_database());
+EXCEPTION
+    WHEN insufficient_privilege THEN
+        RAISE WARNING 'Could not set synchronous_commit = off on %: not the database owner. '
+                      'Set it in the server/Helm configuration instead (dev spec §6).',
+                      current_database();
+END
+$$;
+
+-- No DEFAULT on any column (versolauth/versola#267): every insert into this schema comes from
+-- the seeder or a driver and supplies every value, so a field someone forgot to write fails at
+-- the call site instead of silently acquiring a value nobody chose.
+CREATE UNLOGGED TABLE vu_users (
+    id              BIGINT      NOT NULL PRIMARY KEY,   -- dense, not UUID: it is the shard key
+    sut_user_id     UUID,                               -- NULL until registered/seeded
+    phone           TEXT        NOT NULL UNIQUE,
+    password        TEXT,                               -- plaintext, test-only
+    activity_class  SMALLINT    NOT NULL,
+    platform        SMALLINT    NOT NULL,
+    credential      SMALLINT    NOT NULL,               -- otp | otp-password | passkey
+    role            SMALLINT    NOT NULL,
+    passkey_key     BYTEA,                              -- PKCS#8 P-256 private key
+    passkey_cred_id TEXT,
+    state           SMALLINT    NOT NULL,               -- planned | registered | broken
+    shard           SMALLINT    NOT NULL,
+    last_seen_at    TIMESTAMPTZ
+);
+
+-- Serves the driver's slice load: `WHERE shard = ? AND id > ? ORDER BY id LIMIT ?`, the keyset
+-- pagination in VirtualUserRepository.loadShardSlice. Leading `shard` makes one driver's users
+-- one contiguous stretch of this index even though `shard = id % count` scatters them across
+-- the heap, and the trailing `id` makes the paging a range scan with no sort.
+CREATE INDEX vu_users_shard_idx ON vu_users (shard, id);
+
+-- Serves the coordinator's population counts: `SELECT state, count(*) FROM vu_users GROUP BY
+-- state` every 60 s for the registration controller and `GET /status` (dev spec §12). Without
+-- it that is a full scan of 10-20M rows on a fixed timer, competing with the drivers' writes;
+-- with it the planner can take an index-only scan of a smallint btree.
+CREATE INDEX vu_users_state_idx ON vu_users (state);

--- a/loadgen/migrations/V0002__device_sessions.sql
+++ b/loadgen/migrations/V0002__device_sessions.sql
@@ -1,0 +1,32 @@
+-- One row per live device credential set: a mobile refresh token or an edge cookie session.
+-- Written on the critical path of every refresh exchange (§7.4), so it carries no foreign key
+-- to vu_users: the reference is guaranteed by construction (both tables are written by the same
+-- seeder, and a driver only ever touches its own shard), and the constraint would cost a
+-- referential lookup on every insert plus an ordering dependency on the re-seed.
+CREATE UNLOGGED TABLE vu_sessions (
+    id                 BIGINT      NOT NULL PRIMARY KEY,
+    user_id            BIGINT      NOT NULL,
+    kind               SMALLINT    NOT NULL,            -- mobile-token | web-cookie
+    client_id          TEXT        NOT NULL,
+    refresh_token      TEXT,
+    edge_cookie        TEXT,
+    access_expires_at  TIMESTAMPTZ,
+    refresh_expires_at TIMESTAMPTZ,
+    acr                TEXT,
+    auth_time          TIMESTAMPTZ,
+    -- Bumped before every refresh exchange, never after (§7.4). The dev spec writes this column
+    -- with `DEFAULT 0`; dropped per versolauth/versola#267 -- the generation of a new session is
+    -- a decision its creator makes, and a session inserted without one is a bug worth failing on.
+    generation         INT         NOT NULL,
+    shard              SMALLINT    NOT NULL
+);
+
+-- Serves `WHERE user_id = ?`: the scenario engine picking a user's sessions before deciding
+-- between a refresh and a full login (design doc §2.3).
+CREATE INDEX vu_sessions_user_idx ON vu_sessions (user_id);
+
+-- Serves the driver's startup load of its own live sessions:
+-- `WHERE shard = ? AND refresh_expires_at > now() ORDER BY refresh_expires_at LIMIT ?`.
+-- Leading `shard` keeps it to one driver's slice; the trailing expiry both filters the dead
+-- sessions inside the index and gives the scan its order.
+CREATE INDEX vu_sessions_shard_idx ON vu_sessions (shard, refresh_expires_at);

--- a/loadgen/migrations/V0002__device_sessions.sql
+++ b/loadgen/migrations/V0002__device_sessions.sql
@@ -10,6 +10,11 @@ CREATE UNLOGGED TABLE vu_sessions (
     client_id          TEXT        NOT NULL,
     refresh_token      TEXT,
     edge_cookie        TEXT,
+    -- The auth-side SSO_SESSION (§3.2, §7.4). Persisted beside the other credentials because a
+    -- session restored without it cannot re-run /authorize on its own SSO session: a silent
+    -- reauthorization degrades into a full credential login and an ACR step-up is impossible,
+    -- either of which changes the scenario mix the driver reports it ran.
+    sso_session        TEXT,
     access_expires_at  TIMESTAMPTZ,
     refresh_expires_at TIMESTAMPTZ,
     acr                TEXT,
@@ -26,7 +31,14 @@ CREATE UNLOGGED TABLE vu_sessions (
 CREATE INDEX vu_sessions_user_idx ON vu_sessions (user_id);
 
 -- Serves the driver's startup load of its own live sessions:
--- `WHERE shard = ? AND refresh_expires_at > now() ORDER BY refresh_expires_at LIMIT ?`.
+-- `WHERE shard = ? AND COALESCE(refresh_expires_at, access_expires_at) > now() ORDER BY 2 LIMIT ?`.
 -- Leading `shard` keeps it to one driver's slice; the trailing expiry both filters the dead
 -- sessions inside the index and gives the scan its order.
-CREATE INDEX vu_sessions_shard_idx ON vu_sessions (shard, refresh_expires_at);
+--
+-- The expiry is a COALESCE rather than refresh_expires_at alone because which credential bounds
+-- resumability depends on the kind: a mobile session outlives its access token for as long as
+-- its refresh token is valid, while a web-cookie session has no refresh token at all and lives
+-- exactly as long as its EDGE_SESSION, whose expiry is access_expires_at. Indexing the bare
+-- column would make every still-live web session invisible to the startup load (NULL > now() is
+-- NULL), sending its traffic to a fresh login instead of a resume.
+CREATE INDEX vu_sessions_shard_idx ON vu_sessions (shard, COALESCE(refresh_expires_at, access_expires_at));

--- a/loadgen/migrations/V0003__events.sql
+++ b/loadgen/migrations/V0003__events.sql
@@ -1,0 +1,16 @@
+-- A 1% sample of executed steps, for post-hoc forensics only (dev spec §6). The campaign's
+-- actual latency numbers come from the per-driver HdrHistograms (§11), never from here -- this
+-- table exists to answer "what did that one user's session actually do" after the run.
+--
+-- Deliberately unindexed and without a primary key: it is append-only on the write-behind path
+-- at ~5M rows/day (design doc §6.6), and nothing reads it while a campaign is running. Every
+-- index would be paid for on every insert to speed up a query that is run by hand, once, over a
+-- table small enough to scan. Add one when a forensic query proves too slow, not before.
+CREATE UNLOGGED TABLE vu_events (
+    at          TIMESTAMPTZ NOT NULL,
+    user_id     BIGINT      NOT NULL,
+    scenario    TEXT        NOT NULL,
+    step        TEXT        NOT NULL,
+    outcome     TEXT        NOT NULL,
+    latency_ms  INT         NOT NULL
+);

--- a/loadgen/migrations/V0004__metric_snapshots.sql
+++ b/loadgen/migrations/V0004__metric_snapshots.sql
@@ -1,0 +1,41 @@
+-- Per-driver HdrHistogram snapshots, written every 60 s and merged by the coordinator into the
+-- campaign report (dev spec §11, §12). §11 asks for these to be "written to the emulator DB" and
+-- names no table; this is that table.
+--
+-- The only LOGGED table in this schema, deliberately. Everything else here is reconstructible by
+-- a re-seed, which is what justifies UNLOGGED (§6) -- and UNLOGGED means *truncated* on crash
+-- recovery, not merely stale. These rows are not reconstructible by anything: they are the
+-- campaign's measured latency, accumulated over a run that takes hours, and the merged p99 is the
+-- whole deliverable. Losing them to a driver-unrelated Postgres restart would mean re-running the
+-- campaign. The database-wide `synchronous_commit = off` from V0001 still applies, so a commit
+-- here is fast; it is only the WAL that this table buys back.
+CREATE TABLE vu_metric_snapshots (
+    campaign      TEXT        NOT NULL,
+    driver_id     TEXT        NOT NULL,
+    captured_at   TIMESTAMPTZ NOT NULL,
+    -- Track F's wire-envelope version (DriverHistogramReport.version). Stored so a coordinator
+    -- from a later build refuses a payload it cannot read instead of decoding it into a
+    -- plausible-looking histogram of the wrong shape.
+    wire_version  INT         NOT NULL,
+    kind          SMALLINT    NOT NULL,   -- 0 = step, 1 = flow
+    -- NULL for a flow, which §11 labels on its own rather than inside a scenario. The one
+    -- nullable column in this schema that means "not applicable" rather than "not yet known".
+    scenario      TEXT,
+    name          TEXT        NOT NULL,   -- the step name, or the flow name when kind = 1
+    unit          TEXT        NOT NULL,
+    sample_count  BIGINT      NOT NULL,
+    -- HdrHistogram's own compressed encoding, base64url'd. Buckets, not quantiles: quantiles do
+    -- not add, and merging across drivers is the entire reason this table exists rather than a
+    -- Prometheus query.
+    histogram     TEXT        NOT NULL
+);
+
+-- Snapshot identity, for idempotency: a driver that retries a failed snapshot write must not
+-- double-count its buckets into the merge. An expression index rather than a primary key because
+-- `scenario` is nullable and NULLs are not comparable in a PK.
+CREATE UNIQUE INDEX vu_metric_snapshots_identity_idx
+    ON vu_metric_snapshots (campaign, driver_id, captured_at, kind, COALESCE(scenario, ''), name);
+
+-- Serves the report: every snapshot of one campaign, in interval order, across all drivers.
+CREATE INDEX vu_metric_snapshots_campaign_idx
+    ON vu_metric_snapshots (campaign, captured_at);

--- a/loadgen/src/main/scala/versola/loadgen/config/LoadgenConfig.scala
+++ b/loadgen/src/main/scala/versola/loadgen/config/LoadgenConfig.scala
@@ -1,5 +1,7 @@
 package versola.loadgen.config
 
+import versola.util.postgres.PostgresConfig
+import versola.util.postgres.given
 import zio.Config
 import zio.Duration
 import zio.config.magnolia.DeriveConfig
@@ -72,12 +74,30 @@ case class CoordinatorClientConfig(url: String, pollInterval: Duration)
 
 case class WriteBehindConfig(flushInterval: Duration, batchSize: Int)
 
-/** The emulator's own Postgres -- its bookkeeping, never the SUT's (§6). */
+/** The emulator's own Postgres -- its bookkeeping, never the SUT's (§6).
+  *
+  * `postgres` is `util-postgres`' own [[versola.util.postgres.PostgresConfig]] rather than the
+  * `url` + `maximum-pool-size` pair dev spec §5 sketches, which could not build a pool at all:
+  * no user, no password, no timeouts. Reusing the full block also reuses its pool-tuning
+  * validation and its `Secret`-typed password, and `PostgresHikariDataSource.transactor` reads
+  * it straight out of `store.postgres` via that function's `configPath`.
+  *
+  * The block is nested here rather than being the ambient top-level `postgres { }` precisely
+  * because the seeder role (§10) writes into a *second* database -- the SUT's -- and one
+  * unnamed block cannot name both.
+  */
 case class StoreConfig(
-    url: String,
-    maximumPoolSize: Int,
+    postgres: PostgresConfig,
     writeBehind: WriteBehindConfig,
 )
+
+object StoreConfig:
+  /** Anchored in the companion rather than left to the use site: deriving this needs
+    * `DeriveConfig[Secret]` for the password, which `versola.util.postgres` declares top-level
+    * and which is therefore *not* in scope wherever `deriveConfig[LoadgenConfig]` happens to be
+    * called. Here it is, so every caller gets the derivation without knowing that.
+    */
+  given DeriveConfig[StoreConfig] = DeriveConfig.derived
 
 case class PopulationClassConfig(
     name: String,

--- a/loadgen/src/main/scala/versola/loadgen/model/DeviceSession.scala
+++ b/loadgen/src/main/scala/versola/loadgen/model/DeviceSession.scala
@@ -1,6 +1,6 @@
 package versola.loadgen.model
 
-import versola.loadgen.protocol.{EdgeSession, RefreshToken}
+import versola.loadgen.protocol.{EdgeSession, RefreshToken, SsoSession}
 
 import java.time.Instant
 
@@ -23,6 +23,11 @@ enum SessionKind:
   * -- the session would simply never authenticate again and read as a phantom SUT failure
   * (§8.4).
   *
+  * `ssoSession` is the auth-side `SSO_SESSION` the conversation left behind (§3.2). It is a
+  * credential like the other two, not a convenience: `AuthClient.authorize` takes it to re-run
+  * on the *same* SSO session, which is what a silent reauthorization and an ACR step-up are
+  * (§7.4). A session resumed without it can only start over at credentials.
+  *
   * `acr` is the assurance level the session currently holds, written on the critical path by
   * every occasion that changes it (a refresh exchange or a completed step-up), not on the
   * deferred one. See `DeviceSessionRepository.storeStepUp`.
@@ -34,6 +39,7 @@ case class DeviceSession(
     clientId: String,
     refreshToken: Option[RefreshToken],
     edgeCookie: Option[EdgeSession],
+    ssoSession: Option[SsoSession],
     accessExpiresAt: Option[Instant],
     refreshExpiresAt: Option[Instant],
     acr: Option[String],

--- a/loadgen/src/main/scala/versola/loadgen/model/DeviceSession.scala
+++ b/loadgen/src/main/scala/versola/loadgen/model/DeviceSession.scala
@@ -1,20 +1,43 @@
 package versola.loadgen.model
 
+import versola.loadgen.protocol.{EdgeSession, RefreshToken}
+
+import java.time.Instant
+
 /** Which protocol surface a session was established through -- a mobile bearer token
   * (`AuthClient`) or an edge cookie session (`EdgeClient`). See §8.1-8.4.
   */
 enum SessionKind:
   case MobileToken, WebCookie
 
-/** One row of `vu_sessions` (§6, migration L0002). `generation` is bumped before every refresh
+/** One row of `vu_sessions` (§6, migration V0002). `generation` is bumped before every refresh
   * exchange, not after -- see §7.4's refresh discipline -- so a crash between the bump and the
   * exchange retires the session on restart instead of replaying it into reuse detection.
+  *
+  * Field order matches V0002's column order for the same reason [[VirtualUser]]'s does, and this
+  * is likewise the persisted shape rather than a projection of it: a session without its
+  * credentials cannot be resumed, which is the only reason a driver loads one at startup.
+  *
+  * `refreshToken` and `edgeCookie` are the protocol newtypes rather than `String` because the
+  * two are mutually exclusive per `kind` and interchanging them is a bug no query would reject
+  * -- the session would simply never authenticate again and read as a phantom SUT failure
+  * (§8.4).
+  *
+  * `acr` is the assurance level the session currently holds, written on the critical path by
+  * every occasion that changes it (a refresh exchange or a completed step-up), not on the
+  * deferred one. See `DeviceSessionRepository.storeStepUp`.
   */
 case class DeviceSession(
     id: Long,
     userId: Long,
     kind: SessionKind,
     clientId: String,
+    refreshToken: Option[RefreshToken],
+    edgeCookie: Option[EdgeSession],
+    accessExpiresAt: Option[Instant],
+    refreshExpiresAt: Option[Instant],
+    acr: Option[String],
+    authTime: Option[Instant],
     generation: Int,
     shard: Int,
 )

--- a/loadgen/src/main/scala/versola/loadgen/model/VirtualUser.scala
+++ b/loadgen/src/main/scala/versola/loadgen/model/VirtualUser.scala
@@ -1,5 +1,8 @@
 package versola.loadgen.model
 
+import versola.util.Secret
+
+import java.time.Instant
 import java.util.UUID
 
 /** Cohort a virtual user belongs to (versola-loadgen-dev-spec.md §5's `population.classes`,
@@ -24,17 +27,47 @@ enum CredentialKind:
 enum UserRole:
   case RetailUser, RetailBasic
 
-/** One row of `vu_users` (§6, migration L0001). `id` is the dense shard key -- `shard = id %
+/** Where a virtual user is in its lifecycle against the SUT. `Planned` means the population plan
+  * exists but nothing has been written to the SUT yet, `Registered` means `sutUserId` is set and
+  * the credentials work, and `Broken` is terminal for a user whose login fails in a way no retry
+  * will fix -- the scheduler stops picking it, so the population counts stay honest.
+  */
+enum VirtualUserState:
+  case Planned, Registered, Broken
+
+/** One row of `vu_users` (§6, migration V0001). `id` is the dense shard key -- `shard = id %
   * shardCount` (§7.1) -- deliberately not `sutUserId`, which stays `None` until the user is
   * seeded or registers for real.
+  *
+  * Field order matches the column order of V0001 and of every SELECT in
+  * `PostgresVirtualUserRepository`: magnum reads a derived codec positionally.
+  *
+  * This is the persisted shape, not a projection of it. An earlier version of W1 carried only
+  * the fields a scenario reads to decide what a user does, and the store defined a `VirtualUserRow`
+  * superset alongside it -- but the omitted fields were exactly the credentials that make a user
+  * usable after a driver restart, which the scenario engine needs too, so the two would have
+  * converged anyway while drifting in the meantime.
+  *
+  * @param password
+  *   plaintext, test-only (the SUT stores an Argon2id hash of it). Not a [[Secret]] because the
+  *   seeder must read it back to log the user in, and because there is nothing here worth
+  *   protecting -- every value is generated.
+  * @param passkeyKey
+  *   PKCS#8 P-256 private key of the software authenticator. [[Secret]] rather than a bare
+  *   `Array[Byte]`, so it cannot reach a log line through a `toString` of this type.
   */
 case class VirtualUser(
     id: Long,
     sutUserId: Option[UUID],
     phone: String,
+    password: Option[String],
     activityClass: ActivityClass,
     platform: Platform,
     credential: CredentialKind,
     role: UserRole,
+    passkeyKey: Option[Secret],
+    passkeyCredId: Option[String],
+    state: VirtualUserState,
     shard: Int,
+    lastSeenAt: Option[Instant],
 )

--- a/loadgen/src/main/scala/versola/loadgen/store/DeferredUpdate.scala
+++ b/loadgen/src/main/scala/versola/loadgen/store/DeferredUpdate.scala
@@ -1,0 +1,63 @@
+package versola.loadgen.store
+
+import zio.Chunk
+
+import java.time.Instant
+
+import scala.collection.mutable
+
+/** The deferred half of dev spec §7.5: bookkeeping that describes what already happened, as
+  * opposed to the critical writes (refresh token, generation bump, passkey) whose absence would
+  * lose a credential. Everything here may be batched, reordered against a critical write, or --
+  * under back-pressure -- dropped outright, because none of it is read back to make a decision
+  * during the run.
+  */
+enum DeferredUpdate:
+  case UserSeen(userId: Long, at: Instant)
+  case SessionTouched(touch: SessionTouch)
+  case EventSampled(event: EventRow)
+
+/** A flushable batch: one write per table, per flush.
+  *
+  * @param userTouches
+  *   at most one per user id, latest `lastSeenAt` wins.
+  * @param sessionTouches
+  *   at most one per session id, latest `accessExpiresAt` wins.
+  * @param events
+  *   every event, in arrival order -- the forensic sample is a log, not a state.
+  */
+case class DeferredBatch(
+    userTouches: Chunk[UserTouch],
+    sessionTouches: Chunk[SessionTouch],
+    events: Chunk[EventRow],
+):
+  def isEmpty: Boolean = userTouches.isEmpty && sessionTouches.isEmpty && events.isEmpty
+
+object DeferredBatch:
+  val empty: DeferredBatch = DeferredBatch(Chunk.empty, Chunk.empty, Chunk.empty)
+
+  /** Collapses a flush window's updates into one statement's worth per table.
+    *
+    * The state columns are last-write-wins by construction -- `last_seen_at` and
+    * `access_expires_at` each hold a current value, not a history -- so applying every
+    * intermediate value would be the same result at the cost of the round trips. At the
+    * configured 500-row window a heavy user acting several times inside 200 ms is the ordinary
+    * case, not the exception.
+    *
+    * Insertion order is preserved so a flush writes rows in roughly id order across a batch,
+    * which is also the order the primary-key lookups land in.
+    */
+  def coalesce(updates: Chunk[DeferredUpdate]): DeferredBatch =
+    val users = mutable.LinkedHashMap.empty[Long, UserTouch]
+    val sessions = mutable.LinkedHashMap.empty[Long, SessionTouch]
+    val events = Chunk.newBuilder[EventRow]
+
+    updates.foreach:
+      case DeferredUpdate.UserSeen(userId, at) =>
+        users.update(userId, UserTouch(userId, at))
+      case DeferredUpdate.SessionTouched(touch) =>
+        sessions.update(touch.sessionId, touch)
+      case DeferredUpdate.EventSampled(event) =>
+        events += event
+
+    DeferredBatch(Chunk.fromIterable(users.values), Chunk.fromIterable(sessions.values), events.result())

--- a/loadgen/src/main/scala/versola/loadgen/store/DeviceSessionRepository.scala
+++ b/loadgen/src/main/scala/versola/loadgen/store/DeviceSessionRepository.scala
@@ -1,7 +1,7 @@
 package versola.loadgen.store
 
 import versola.loadgen.model.DeviceSession
-import versola.loadgen.protocol.{EdgeSession, RefreshToken}
+import versola.loadgen.protocol.{EdgeSession, RefreshToken, SsoSession}
 import zio.{Chunk, Task}
 
 import java.time.Instant
@@ -18,9 +18,15 @@ trait DeviceSessionRepository:
 
   def listByUser(userId: Long): Task[Vector[DeviceSession]]
 
-  /** This driver's sessions whose refresh token is still valid at `liveAt`, oldest expiry
-    * first, served by `vu_sessions_shard_idx`. What a driver loads at startup to decide which
-    * users can resume rather than log in again.
+  /** This driver's sessions still resumable at `liveAt`, oldest expiry first, served by
+    * `vu_sessions_shard_idx`. What a driver loads at startup to decide which users can resume
+    * rather than log in again.
+    *
+    * Resumable means whichever credential the session's kind depends on has not expired: the
+    * refresh token for a mobile session, and for a web-cookie session -- which has no refresh
+    * token -- the `EDGE_SESSION` itself, whose expiry is `accessExpiresAt`. Filtering on
+    * `refreshExpiresAt` alone would drop every live web session at startup and shift its
+    * traffic to fresh logins, changing the scenario mix the driver reports it ran.
     */
   def listLive(shard: Int, liveAt: Instant, limit: Int): Task[Vector[DeviceSession]]
 
@@ -58,7 +64,11 @@ trait DeviceSessionRepository:
   def storeEdgeCookie(id: Long, cookie: EdgeSession, accessExpiresAt: Instant): Task[Unit]
 
   /** What a completed step-up leaves behind (§7.4): the session's assurance level, the fresh
-    * `auth_time` behind it, and the token pair the new code exchange produced.
+    * `auth_time` behind it, the token pair the new code exchange produced, and the
+    * `SSO_SESSION` if auth re-set it on the way through.
+    *
+    * `ssoSession` is `None` when the response carried no new cookie, which leaves the stored
+    * one alone rather than clearing it -- the same `COALESCE` rule as the token pair.
     *
     * The step-up path's counterpart to [[storeRotatedRefresh]], and deliberately not guarded by
     * a generation: a step-up is an authorization-code exchange on the same SSO session, not a
@@ -78,6 +88,7 @@ trait DeviceSessionRepository:
       accessExpiresAt: Instant,
       refreshToken: Option[RefreshToken],
       refreshExpiresAt: Option[Instant],
+      ssoSession: Option[SsoSession],
   ): Task[Unit]
 
   /** Deferred write path -- `access_expires_at` only (§7.5, less `acr`; see [[SessionTouch]]). */

--- a/loadgen/src/main/scala/versola/loadgen/store/DeviceSessionRepository.scala
+++ b/loadgen/src/main/scala/versola/loadgen/store/DeviceSessionRepository.scala
@@ -1,0 +1,87 @@
+package versola.loadgen.store
+
+import versola.loadgen.model.DeviceSession
+import versola.loadgen.protocol.{EdgeSession, RefreshToken}
+import zio.{Chunk, Task}
+
+import java.time.Instant
+
+/** `vu_sessions` (migration V0002). The refresh discipline of dev spec §7.4 lives in the
+  * signatures here, not in the caller's discretion: [[bumpGeneration]] returns the generation
+  * the caller now owns, and [[storeRotatedRefresh]] refuses to write against any other one.
+  */
+trait DeviceSessionRepository:
+
+  def insert(session: DeviceSession): Task[Unit]
+
+  def find(id: Long): Task[Option[DeviceSession]]
+
+  def listByUser(userId: Long): Task[Vector[DeviceSession]]
+
+  /** This driver's sessions whose refresh token is still valid at `liveAt`, oldest expiry
+    * first, served by `vu_sessions_shard_idx`. What a driver loads at startup to decide which
+    * users can resume rather than log in again.
+    */
+  def listLive(shard: Int, liveAt: Instant, limit: Int): Task[Vector[DeviceSession]]
+
+  /** Step 2 of §7.4, executed and awaited *before* the token request goes out. Returns the new
+    * generation, or `None` if the session is gone.
+    *
+    * Persisting the intent first is what makes a driver crash recoverable: a session whose
+    * generation was bumped but whose `refresh_token` still holds the predecessor is in an
+    * unknown state on restart and must be retired rather than replayed -- replaying it trips
+    * the SUT's reuse detection and produces a fake `refresh_rejected`, the one metric the
+    * campaign is not allowed to have.
+    */
+  def bumpGeneration(id: Long): Task[Option[Int]]
+
+  /** Step 4 of §7.4, awaited before the new access token is used.
+    *
+    * `expectedGeneration` is the value [[bumpGeneration]] returned. The UPDATE is conditional
+    * on it, so a response that arrives after the session was retired and re-bumped by the
+    * recovery path cannot resurrect a token nobody owns any more. Returns whether the row was
+    * still at that generation, i.e. whether the write took.
+    */
+  def storeRotatedRefresh(
+      id: Long,
+      expectedGeneration: Int,
+      refreshToken: RefreshToken,
+      refreshExpiresAt: Instant,
+      accessExpiresAt: Instant,
+      acr: Option[String],
+      authTime: Instant,
+  ): Task[Boolean]
+
+  /** The cookie half of the same rule (§8.4): edge rotates `EDGE_SESSION` on refresh, and a
+    * driver that loses the rotated value loses the session. Critical, not deferred.
+    */
+  def storeEdgeCookie(id: Long, cookie: EdgeSession, accessExpiresAt: Instant): Task[Unit]
+
+  /** What a completed step-up leaves behind (§7.4): the session's assurance level, the fresh
+    * `auth_time` behind it, and the token pair the new code exchange produced.
+    *
+    * The step-up path's counterpart to [[storeRotatedRefresh]], and deliberately not guarded by
+    * a generation: a step-up is an authorization-code exchange on the same SSO session, not a
+    * refresh exchange, so nothing was bumped and there is no predecessor token the SUT could
+    * detect as reused.
+    *
+    * Critical rather than deferred, which is where dev spec §7.5 puts `acr`. The write costs
+    * nothing extra here (the token beside it has to be persisted anyway), and a dropped `acr`
+    * would leave a resumed session claiming an assurance level it does not hold -- so the
+    * driver would either step up again for no reason, distorting the scenario mix it reports,
+    * or skip a step-up the SUT then demands.
+    */
+  def storeStepUp(
+      id: Long,
+      acr: String,
+      authTime: Instant,
+      accessExpiresAt: Instant,
+      refreshToken: Option[RefreshToken],
+      refreshExpiresAt: Option[Instant],
+  ): Task[Unit]
+
+  /** Deferred write path -- `access_expires_at` only (§7.5, less `acr`; see [[SessionTouch]]). */
+  def touchAll(touches: Chunk[SessionTouch]): Task[Unit]
+
+  /** Removes a session that was logged out, expired, or retired by the recovery path above. */
+  def delete(id: Long): Task[Unit]

--- a/loadgen/src/main/scala/versola/loadgen/store/EventRepository.scala
+++ b/loadgen/src/main/scala/versola/loadgen/store/EventRepository.scala
@@ -1,0 +1,10 @@
+package versola.loadgen.store
+
+import zio.{Chunk, Task}
+
+/** `vu_events` (migration V0003): the 1% forensic sample. Batch-only by construction -- there
+  * is no single-row insert, because a per-step write on the hot path would make the emulator's
+  * own bookkeeping a measurable part of the load it is supposed to be measuring.
+  */
+trait EventRepository:
+  def appendAll(events: Chunk[EventRow]): Task[Unit]

--- a/loadgen/src/main/scala/versola/loadgen/store/LoadgenMigrations.scala
+++ b/loadgen/src/main/scala/versola/loadgen/store/LoadgenMigrations.scala
@@ -1,0 +1,25 @@
+package versola.loadgen.store
+
+/** Where the emulator's own schema lives, for whoever wires the store's `TransactorZIO`.
+  *
+  * Two things about this schema differ from every other one in the repository:
+  *
+  *   1. The directory is `loadgen/migrations`, not `<service>/implementations/postgres/
+  *      migrations`, so `PostgresHikariDataSource`'s auto-detection (which matches paths ending
+  *      in `postgres/migrations`) does not find it. [[locations]] must be passed explicitly as
+  *      that function's `migrationLocations` -- which is also what keeps this schema out of any
+  *      service's Flyway run, and every service's schema out of this one's.
+  *   2. It lives in its own database, so its versions do not share a schema-history table with
+  *      auth's or central's and cannot collide with them.
+  *
+  * Dev spec §6 named these files `L0001__*.sql`. They are `V0001__*.sql` instead, because an
+  * `L` prefix fails silently: Flyway's default `sqlMigrationPrefix` is `V`, and
+  * `PostgresHikariDataSource` sets `validateMigrationNaming(false)`, so an `L`-prefixed file is
+  * **skipped rather than rejected** -- the process boots, reports itself ready, and the first
+  * query fails against a table that was never created. The prefix bought nothing that (1) and
+  * (2) above do not already provide, so it was not worth a new `sqlMigrationPrefix` parameter
+  * on a function every service depends on. `MigrationNamingSpec` guards the naming, since
+  * `validateMigrationNaming(false)` means Flyway itself never will.
+  */
+object LoadgenMigrations:
+  val locations: Seq[String] = Seq("filesystem:./loadgen/migrations")

--- a/loadgen/src/main/scala/versola/loadgen/store/LoadgenStore.scala
+++ b/loadgen/src/main/scala/versola/loadgen/store/LoadgenStore.scala
@@ -1,0 +1,56 @@
+package versola.loadgen.store
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import com.zaxxer.hikari.HikariDataSource
+import versola.loadgen.config.StoreConfig
+import versola.util.postgres.{PostgresConfig, PostgresHikariDataSource}
+import zio.*
+
+/** The emulator's own store, wired end to end: pool and schema, the four repositories, the
+  * deferred sink, and the write-behind buffer in front of it.
+  *
+  * `configPath` is `store.postgres`, not the top-level `postgres { }` every service uses, and
+  * `migrationLocations` is [[LoadgenMigrations.locations]] rather than the auto-detected
+  * `<service>/implementations/postgres/migrations` -- see both of those for why. Getting either
+  * wrong fails silently rather than loudly: the wrong config path is a boot error, but the wrong
+  * locations mean Flyway finds nothing to apply, reports success, and the first query fails
+  * against a table that was never created.
+  */
+object LoadgenStore:
+
+  val configPath: Seq[String] = Seq("store", "postgres")
+
+  /** @param migrate
+    *   whether this process applies the schema. The coordinator does; a driver does not (eight
+    *   of them racing Flyway on startup is a lock convoy at best). `false` still validates the
+    *   schema against these migrations rather than skipping Flyway -- see
+    *   `PostgresHikariDataSource.layer`.
+    */
+  def transactor(
+      migrate: Boolean
+  ): ZLayer[Scope & ConfigProvider, Throwable, TransactorZIO & HikariDataSource & PostgresConfig] =
+    PostgresHikariDataSource.transactor(
+      serviceName = Some("loadgen-store"),
+      migrate = migrate,
+      migrationLocations = Some(LoadgenMigrations.locations),
+      configPath = configPath,
+    )
+
+  val repositories: ZLayer[
+    TransactorZIO,
+    Throwable,
+    VirtualUserRepository & DeviceSessionRepository & EventRepository & MetricSnapshotRepository,
+  ] =
+    PostgresVirtualUserRepository.live ++
+      PostgresDeviceSessionRepository.live ++
+      PostgresEventRepository.live ++
+      PostgresMetricSnapshotRepository.live
+
+  /** Everything a driver needs from this package, given the config and a scope. */
+  def live(migrate: Boolean): ZLayer[
+    Scope & ConfigProvider & StoreConfig,
+    Throwable,
+    VirtualUserRepository & DeviceSessionRepository & EventRepository & MetricSnapshotRepository &
+      WriteBehindBuffer,
+  ] =
+    transactor(migrate) >>> repositories >+> (PostgresDeferredWriteSink.live >>> WriteBehindBuffer.layer)

--- a/loadgen/src/main/scala/versola/loadgen/store/MetricSnapshotRepository.scala
+++ b/loadgen/src/main/scala/versola/loadgen/store/MetricSnapshotRepository.scala
@@ -1,0 +1,26 @@
+package versola.loadgen.store
+
+import zio.{Chunk, Task}
+
+import java.time.Instant
+
+/** `vu_metric_snapshots` (migration V0004): the latency snapshots a driver publishes every 60 s
+  * (dev spec §11) and the coordinator merges into the campaign report (§12).
+  *
+  * Not on the write-behind path, unlike everything else a driver records. A dropped snapshot is
+  * not lost bookkeeping, it is a hole in the measurement the whole campaign exists to produce,
+  * so this is written on its own schedule and awaited.
+  */
+trait MetricSnapshotRepository:
+
+  /** One snapshot interval's histograms, as one batch. Re-writing a snapshot that already
+    * landed is a no-op rather than a duplicate: a retry after a failed write must not
+    * double-count its buckets into the merge (`vu_metric_snapshots_identity_idx`).
+    */
+  def appendAll(snapshots: Chunk[MetricSnapshotRow]): Task[Unit]
+
+  /** Everything recorded for one campaign at or after `since`, oldest interval first --
+    * `GET /report/{campaign}`'s input. `since` is what makes an incremental merge possible
+    * instead of re-reading a multi-hour campaign on every request.
+    */
+  def loadCampaign(campaign: String, since: Instant): Task[Vector[MetricSnapshotRow]]

--- a/loadgen/src/main/scala/versola/loadgen/store/PostgresDeferredWriteSink.scala
+++ b/loadgen/src/main/scala/versola/loadgen/store/PostgresDeferredWriteSink.scala
@@ -1,0 +1,24 @@
+package versola.loadgen.store
+
+import zio.{Task, ZLayer}
+
+/** Applies a coalesced flush window as three batched statements, one per table.
+  *
+  * Not one transaction: the three carry unrelated bookkeeping, and wrapping them together would
+  * make a failure on the events table -- the least important of the three -- discard the
+  * session state as well.
+  */
+class PostgresDeferredWriteSink(
+    users: VirtualUserRepository,
+    sessions: DeviceSessionRepository,
+    events: EventRepository,
+) extends DeferredWriteSink:
+
+  override def write(batch: DeferredBatch): Task[Unit] =
+    users.touchAll(batch.userTouches) *>
+      sessions.touchAll(batch.sessionTouches) *>
+      events.appendAll(batch.events)
+
+object PostgresDeferredWriteSink:
+  def live: ZLayer[VirtualUserRepository & DeviceSessionRepository & EventRepository, Nothing, DeferredWriteSink] =
+    ZLayer.fromFunction(PostgresDeferredWriteSink(_, _, _))

--- a/loadgen/src/main/scala/versola/loadgen/store/PostgresDeviceSessionRepository.scala
+++ b/loadgen/src/main/scala/versola/loadgen/store/PostgresDeviceSessionRepository.scala
@@ -3,7 +3,7 @@ package versola.loadgen.store
 import com.augustnagro.magnum.*
 import com.augustnagro.magnum.magzio.TransactorZIO
 import versola.loadgen.model.DeviceSession
-import versola.loadgen.protocol.{EdgeSession, RefreshToken}
+import versola.loadgen.protocol.{EdgeSession, RefreshToken, SsoSession}
 import zio.{Chunk, Task, ZIO, ZLayer}
 
 import java.time.Instant
@@ -16,13 +16,13 @@ class PostgresDeviceSessionRepository(xa: TransactorZIO) extends DeviceSessionRe
     xa.connectMeasured("insert-device-session"):
       sql"""
         INSERT INTO vu_sessions (
-          id, user_id, kind, client_id, refresh_token, edge_cookie, access_expires_at,
-          refresh_expires_at, acr, auth_time, generation, shard
+          id, user_id, kind, client_id, refresh_token, edge_cookie, sso_session,
+          access_expires_at, refresh_expires_at, acr, auth_time, generation, shard
         ) VALUES (
           ${session.id}, ${session.userId}, ${session.kind}, ${session.clientId},
-          ${session.refreshToken}, ${session.edgeCookie}, ${session.accessExpiresAt},
-          ${session.refreshExpiresAt}, ${session.acr}, ${session.authTime},
-          ${session.generation}, ${session.shard}
+          ${session.refreshToken}, ${session.edgeCookie}, ${session.ssoSession},
+          ${session.accessExpiresAt}, ${session.refreshExpiresAt}, ${session.acr},
+          ${session.authTime}, ${session.generation}, ${session.shard}
         )
       """.update.run()
     .unit
@@ -30,27 +30,31 @@ class PostgresDeviceSessionRepository(xa: TransactorZIO) extends DeviceSessionRe
   override def find(id: Long): Task[Option[DeviceSession]] =
     xa.connectMeasured("find-device-session"):
       sql"""
-        SELECT id, user_id, kind, client_id, refresh_token, edge_cookie, access_expires_at,
-               refresh_expires_at, acr, auth_time, generation, shard
+        SELECT id, user_id, kind, client_id, refresh_token, edge_cookie, sso_session,
+               access_expires_at, refresh_expires_at, acr, auth_time, generation, shard
         FROM vu_sessions WHERE id = $id
       """.query[DeviceSession].run().headOption
 
   override def listByUser(userId: Long): Task[Vector[DeviceSession]] =
     xa.connectMeasured("list-device-sessions-by-user"):
       sql"""
-        SELECT id, user_id, kind, client_id, refresh_token, edge_cookie, access_expires_at,
-               refresh_expires_at, acr, auth_time, generation, shard
+        SELECT id, user_id, kind, client_id, refresh_token, edge_cookie, sso_session,
+               access_expires_at, refresh_expires_at, acr, auth_time, generation, shard
         FROM vu_sessions WHERE user_id = $userId ORDER BY id
       """.query[DeviceSession].run()
 
+  /** The `COALESCE` is written identically in the predicate, the sort and
+    * `vu_sessions_shard_idx`. Written any other way -- `OR`, a `CASE` on `kind` -- it stops
+    * matching the index expression and the startup load becomes a shard-wide sort.
+    */
   override def listLive(shard: Int, liveAt: Instant, limit: Int): Task[Vector[DeviceSession]] =
     xa.connectMeasured("list-live-device-sessions"):
       sql"""
-        SELECT id, user_id, kind, client_id, refresh_token, edge_cookie, access_expires_at,
-               refresh_expires_at, acr, auth_time, generation, shard
+        SELECT id, user_id, kind, client_id, refresh_token, edge_cookie, sso_session,
+               access_expires_at, refresh_expires_at, acr, auth_time, generation, shard
         FROM vu_sessions
-        WHERE shard = $shard AND refresh_expires_at > $liveAt
-        ORDER BY refresh_expires_at
+        WHERE shard = $shard AND COALESCE(refresh_expires_at, access_expires_at) > $liveAt
+        ORDER BY COALESCE(refresh_expires_at, access_expires_at)
         LIMIT $limit
       """.query[DeviceSession].run()
 
@@ -87,8 +91,9 @@ class PostgresDeviceSessionRepository(xa: TransactorZIO) extends DeviceSessionRe
       """.update.run()
     .unit
 
-  /** `COALESCE` on the incoming value, so a session whose refresh expiry is unknown keeps what
-    * the row already holds rather than being nulled by a touch that had no opinion about it.
+  /** `COALESCE` on each incoming value, so a step-up that rotated neither the refresh token,
+    * its expiry, nor the `SSO_SESSION` keeps what the row already holds rather than nulling a
+    * credential it had no opinion about.
     *
     * Batched into one round trip for the same reason as
     * [[PostgresVirtualUserRepository.touchAll]].
@@ -100,6 +105,7 @@ class PostgresDeviceSessionRepository(xa: TransactorZIO) extends DeviceSessionRe
       accessExpiresAt: Instant,
       refreshToken: Option[RefreshToken],
       refreshExpiresAt: Option[Instant],
+      ssoSession: Option[SsoSession],
   ): Task[Unit] =
     xa.connectMeasured("store-device-session-step-up"):
       sql"""
@@ -108,7 +114,8 @@ class PostgresDeviceSessionRepository(xa: TransactorZIO) extends DeviceSessionRe
             auth_time = $authTime,
             access_expires_at = $accessExpiresAt,
             refresh_token = COALESCE(${refreshToken}::text, refresh_token),
-            refresh_expires_at = COALESCE(${refreshExpiresAt}::timestamptz, refresh_expires_at)
+            refresh_expires_at = COALESCE(${refreshExpiresAt}::timestamptz, refresh_expires_at),
+            sso_session = COALESCE(${ssoSession}::text, sso_session)
         WHERE id = $id
       """.update.run()
     .unit

--- a/loadgen/src/main/scala/versola/loadgen/store/PostgresDeviceSessionRepository.scala
+++ b/loadgen/src/main/scala/versola/loadgen/store/PostgresDeviceSessionRepository.scala
@@ -1,0 +1,137 @@
+package versola.loadgen.store
+
+import com.augustnagro.magnum.*
+import com.augustnagro.magnum.magzio.TransactorZIO
+import versola.loadgen.model.DeviceSession
+import versola.loadgen.protocol.{EdgeSession, RefreshToken}
+import zio.{Chunk, Task, ZIO, ZLayer}
+
+import java.time.Instant
+
+class PostgresDeviceSessionRepository(xa: TransactorZIO) extends DeviceSessionRepository, StoreCodecs:
+
+  private given DbCodec[DeviceSession] = DbCodec.derived
+
+  override def insert(session: DeviceSession): Task[Unit] =
+    xa.connectMeasured("insert-device-session"):
+      sql"""
+        INSERT INTO vu_sessions (
+          id, user_id, kind, client_id, refresh_token, edge_cookie, access_expires_at,
+          refresh_expires_at, acr, auth_time, generation, shard
+        ) VALUES (
+          ${session.id}, ${session.userId}, ${session.kind}, ${session.clientId},
+          ${session.refreshToken}, ${session.edgeCookie}, ${session.accessExpiresAt},
+          ${session.refreshExpiresAt}, ${session.acr}, ${session.authTime},
+          ${session.generation}, ${session.shard}
+        )
+      """.update.run()
+    .unit
+
+  override def find(id: Long): Task[Option[DeviceSession]] =
+    xa.connectMeasured("find-device-session"):
+      sql"""
+        SELECT id, user_id, kind, client_id, refresh_token, edge_cookie, access_expires_at,
+               refresh_expires_at, acr, auth_time, generation, shard
+        FROM vu_sessions WHERE id = $id
+      """.query[DeviceSession].run().headOption
+
+  override def listByUser(userId: Long): Task[Vector[DeviceSession]] =
+    xa.connectMeasured("list-device-sessions-by-user"):
+      sql"""
+        SELECT id, user_id, kind, client_id, refresh_token, edge_cookie, access_expires_at,
+               refresh_expires_at, acr, auth_time, generation, shard
+        FROM vu_sessions WHERE user_id = $userId ORDER BY id
+      """.query[DeviceSession].run()
+
+  override def listLive(shard: Int, liveAt: Instant, limit: Int): Task[Vector[DeviceSession]] =
+    xa.connectMeasured("list-live-device-sessions"):
+      sql"""
+        SELECT id, user_id, kind, client_id, refresh_token, edge_cookie, access_expires_at,
+               refresh_expires_at, acr, auth_time, generation, shard
+        FROM vu_sessions
+        WHERE shard = $shard AND refresh_expires_at > $liveAt
+        ORDER BY refresh_expires_at
+        LIMIT $limit
+      """.query[DeviceSession].run()
+
+  override def bumpGeneration(id: Long): Task[Option[Int]] =
+    xa.connectMeasured("bump-device-session-generation"):
+      sql"UPDATE vu_sessions SET generation = generation + 1 WHERE id = $id RETURNING generation"
+        .query[Int].run().headOption
+
+  override def storeRotatedRefresh(
+      id: Long,
+      expectedGeneration: Int,
+      refreshToken: RefreshToken,
+      refreshExpiresAt: Instant,
+      accessExpiresAt: Instant,
+      acr: Option[String],
+      authTime: Instant,
+  ): Task[Boolean] =
+    xa.connectMeasured("store-rotated-refresh-token"):
+      sql"""
+        UPDATE vu_sessions
+        SET refresh_token = $refreshToken,
+            refresh_expires_at = $refreshExpiresAt,
+            access_expires_at = $accessExpiresAt,
+            acr = $acr,
+            auth_time = $authTime
+        WHERE id = $id AND generation = $expectedGeneration
+      """.update.run() > 0
+
+  override def storeEdgeCookie(id: Long, cookie: EdgeSession, accessExpiresAt: Instant): Task[Unit] =
+    xa.connectMeasured("store-edge-session-cookie"):
+      sql"""
+        UPDATE vu_sessions SET edge_cookie = $cookie, access_expires_at = $accessExpiresAt
+        WHERE id = $id
+      """.update.run()
+    .unit
+
+  /** `COALESCE` on the incoming value, so a session whose refresh expiry is unknown keeps what
+    * the row already holds rather than being nulled by a touch that had no opinion about it.
+    *
+    * Batched into one round trip for the same reason as
+    * [[PostgresVirtualUserRepository.touchAll]].
+    */
+  override def storeStepUp(
+      id: Long,
+      acr: String,
+      authTime: Instant,
+      accessExpiresAt: Instant,
+      refreshToken: Option[RefreshToken],
+      refreshExpiresAt: Option[Instant],
+  ): Task[Unit] =
+    xa.connectMeasured("store-device-session-step-up"):
+      sql"""
+        UPDATE vu_sessions
+        SET acr = $acr,
+            auth_time = $authTime,
+            access_expires_at = $accessExpiresAt,
+            refresh_token = COALESCE(${refreshToken}::text, refresh_token),
+            refresh_expires_at = COALESCE(${refreshExpiresAt}::timestamptz, refresh_expires_at)
+        WHERE id = $id
+      """.update.run()
+    .unit
+
+  /** Batched into one round trip for the same reason as
+    * [[PostgresVirtualUserRepository.touchAll]].
+    */
+  override def touchAll(touches: Chunk[SessionTouch]): Task[Unit] =
+    if touches.isEmpty then ZIO.unit
+    else
+      xa.transactMeasured("touch-device-sessions"):
+        batchUpdate(touches): touch =>
+          sql"""
+            UPDATE vu_sessions SET access_expires_at = ${touch.accessExpiresAt}
+            WHERE id = ${touch.sessionId}
+          """.update
+      .unit
+
+  override def delete(id: Long): Task[Unit] =
+    xa.connectMeasured("delete-device-session"):
+      sql"DELETE FROM vu_sessions WHERE id = $id".update.run()
+    .unit
+
+object PostgresDeviceSessionRepository:
+  def live: ZLayer[TransactorZIO, Throwable, DeviceSessionRepository] =
+    ZLayer.fromFunction(PostgresDeviceSessionRepository(_))

--- a/loadgen/src/main/scala/versola/loadgen/store/PostgresEventRepository.scala
+++ b/loadgen/src/main/scala/versola/loadgen/store/PostgresEventRepository.scala
@@ -1,0 +1,23 @@
+package versola.loadgen.store
+
+import com.augustnagro.magnum.*
+import com.augustnagro.magnum.magzio.TransactorZIO
+import zio.{Chunk, Task, ZIO, ZLayer}
+
+class PostgresEventRepository(xa: TransactorZIO) extends EventRepository, StoreCodecs:
+
+  override def appendAll(events: Chunk[EventRow]): Task[Unit] =
+    if events.isEmpty then ZIO.unit
+    else
+      xa.transactMeasured("append-vu-events"):
+        batchUpdate(events): event =>
+          sql"""
+            INSERT INTO vu_events (at, user_id, scenario, step, outcome, latency_ms)
+            VALUES (${event.at}, ${event.userId}, ${event.scenario}, ${event.step},
+                    ${event.outcome}, ${event.latencyMs})
+          """.update
+      .unit
+
+object PostgresEventRepository:
+  def live: ZLayer[TransactorZIO, Throwable, EventRepository] =
+    ZLayer.fromFunction(PostgresEventRepository(_))

--- a/loadgen/src/main/scala/versola/loadgen/store/PostgresMetricSnapshotRepository.scala
+++ b/loadgen/src/main/scala/versola/loadgen/store/PostgresMetricSnapshotRepository.scala
@@ -1,0 +1,44 @@
+package versola.loadgen.store
+
+import com.augustnagro.magnum.*
+import com.augustnagro.magnum.magzio.TransactorZIO
+import zio.{Chunk, Task, ZIO, ZLayer}
+
+import java.time.Instant
+
+class PostgresMetricSnapshotRepository(xa: TransactorZIO) extends MetricSnapshotRepository, StoreCodecs:
+
+  private given DbCodec[MetricSnapshotRow] = DbCodec.derived
+
+  override def appendAll(snapshots: Chunk[MetricSnapshotRow]): Task[Unit] =
+    if snapshots.isEmpty then ZIO.unit
+    else
+      xa.transactMeasured("append-metric-snapshots"):
+        batchUpdate(snapshots): snapshot =>
+          sql"""
+            INSERT INTO vu_metric_snapshots (
+              campaign, driver_id, captured_at, wire_version, kind, scenario, name, unit,
+              sample_count, histogram
+            ) VALUES (
+              ${snapshot.campaign}, ${snapshot.driverId}, ${snapshot.capturedAt},
+              ${snapshot.wireVersion}, ${snapshot.kind}, ${snapshot.scenario}, ${snapshot.name},
+              ${snapshot.unit}, ${snapshot.sampleCount}, ${snapshot.histogram}
+            )
+            ON CONFLICT (campaign, driver_id, captured_at, kind, COALESCE(scenario, ''), name)
+            DO NOTHING
+          """.update
+      .unit
+
+  override def loadCampaign(campaign: String, since: Instant): Task[Vector[MetricSnapshotRow]] =
+    xa.connectMeasured("load-campaign-metric-snapshots"):
+      sql"""
+        SELECT campaign, driver_id, captured_at, wire_version, kind, scenario, name, unit,
+               sample_count, histogram
+        FROM vu_metric_snapshots
+        WHERE campaign = $campaign AND captured_at >= $since
+        ORDER BY captured_at, driver_id
+      """.query[MetricSnapshotRow].run()
+
+object PostgresMetricSnapshotRepository:
+  def live: ZLayer[TransactorZIO, Throwable, MetricSnapshotRepository] =
+    ZLayer.fromFunction(PostgresMetricSnapshotRepository(_))

--- a/loadgen/src/main/scala/versola/loadgen/store/PostgresVirtualUserRepository.scala
+++ b/loadgen/src/main/scala/versola/loadgen/store/PostgresVirtualUserRepository.scala
@@ -1,0 +1,101 @@
+package versola.loadgen.store
+
+import com.augustnagro.magnum.*
+import com.augustnagro.magnum.magzio.TransactorZIO
+import versola.loadgen.model.{VirtualUser, VirtualUserState}
+import versola.util.Secret
+import zio.{Chunk, Task, ZIO, ZLayer}
+
+import java.time.Instant
+import java.util.UUID
+
+class PostgresVirtualUserRepository(xa: TransactorZIO) extends VirtualUserRepository, StoreCodecs:
+
+  private given DbCodec[VirtualUser] = DbCodec.derived
+
+  override def insertAll(users: Chunk[VirtualUser]): Task[Unit] =
+    if users.isEmpty then ZIO.unit
+    else
+      xa.transactMeasured("insert-virtual-users"):
+        batchUpdate(users): user =>
+          sql"""
+            INSERT INTO vu_users (
+              id, sut_user_id, phone, password, activity_class, platform, credential, role,
+              passkey_key, passkey_cred_id, state, shard, last_seen_at
+            ) VALUES (
+              ${user.id}, ${user.sutUserId}, ${user.phone}, ${user.password},
+              ${user.activityClass}, ${user.platform}, ${user.credential}, ${user.role},
+              ${user.passkeyKey}, ${user.passkeyCredId}, ${user.state}, ${user.shard},
+              ${user.lastSeenAt}
+            )
+          """.update
+      .unit
+
+  override def find(id: Long): Task[Option[VirtualUser]] =
+    xa.connectMeasured("find-virtual-user"):
+      sql"""
+        SELECT id, sut_user_id, phone, password, activity_class, platform, credential, role,
+               passkey_key, passkey_cred_id, state, shard, last_seen_at
+        FROM vu_users WHERE id = $id
+      """.query[VirtualUser].run().headOption
+
+  /** `afterId` becomes a sentinel below every possible id rather than a nullable predicate:
+    * `(? IS NULL OR id > ?)` is not sargable, and this query exists to be a range scan of
+    * `vu_users_shard_idx`. Ids are dense and non-negative by construction (dev spec §6), so -1
+    * is below every real one.
+    */
+  override def loadShardSlice(shard: Int, afterId: Option[Long], limit: Int): Task[Vector[VirtualUser]] =
+    val after = afterId.getOrElse(-1L)
+    xa.connectMeasured("load-virtual-user-shard-slice"):
+      sql"""
+        SELECT id, sut_user_id, phone, password, activity_class, platform, credential, role,
+               passkey_key, passkey_cred_id, state, shard, last_seen_at
+        FROM vu_users
+        WHERE shard = $shard AND id > $after
+        ORDER BY id
+        LIMIT $limit
+      """.query[VirtualUser].run()
+
+  override def markRegistered(id: Long, sutUserId: UUID): Task[Unit] =
+    val registered = VirtualUserState.Registered
+    xa.connectMeasured("mark-virtual-user-registered"):
+      sql"""
+        UPDATE vu_users SET sut_user_id = $sutUserId, state = $registered WHERE id = $id
+      """.update.run()
+    .unit
+
+  override def markBroken(id: Long): Task[Unit] =
+    val broken = VirtualUserState.Broken
+    xa.connectMeasured("mark-virtual-user-broken"):
+      sql"UPDATE vu_users SET state = $broken WHERE id = $id".update.run()
+    .unit
+
+  override def recordPasskey(id: Long, key: Secret, credentialId: String): Task[Unit] =
+    xa.connectMeasured("record-virtual-user-passkey"):
+      sql"""
+        UPDATE vu_users SET passkey_key = $key, passkey_cred_id = $credentialId WHERE id = $id
+      """.update.run()
+    .unit
+
+  /** One JDBC batch, one round trip, rather than the `COPY` into a temp table plus
+    * `UPDATE ... FROM` that dev spec §7.5 describes. At the configured batch size (500 rows,
+    * every 200 ms) a batched `UPDATE ... WHERE id = ?` is a primary-key lookup per row against
+    * an UNLOGGED table and is not the cost worth a temp table per flush; `COPY` earns its
+    * setup at the seeder's scale (§10), not at this one.
+    */
+  override def touchAll(touches: Chunk[UserTouch]): Task[Unit] =
+    if touches.isEmpty then ZIO.unit
+    else
+      xa.transactMeasured("touch-virtual-users"):
+        batchUpdate(touches): touch =>
+          sql"UPDATE vu_users SET last_seen_at = ${touch.lastSeenAt} WHERE id = ${touch.userId}".update
+      .unit
+
+  override def countByState: Task[Map[VirtualUserState, Long]] =
+    xa.connectMeasured("count-virtual-users-by-state"):
+      sql"SELECT state, count(*) FROM vu_users GROUP BY state"
+        .query[(VirtualUserState, Long)].run().toMap
+
+object PostgresVirtualUserRepository:
+  def live: ZLayer[TransactorZIO, Throwable, VirtualUserRepository] =
+    ZLayer.fromFunction(PostgresVirtualUserRepository(_))

--- a/loadgen/src/main/scala/versola/loadgen/store/StoreCodecs.scala
+++ b/loadgen/src/main/scala/versola/loadgen/store/StoreCodecs.scala
@@ -1,0 +1,30 @@
+package versola.loadgen.store
+
+import com.augustnagro.magnum.DbCodec
+import versola.loadgen.model.*
+import versola.loadgen.protocol.{EdgeSession, RefreshToken}
+import versola.util.postgres.BasicCodecs
+
+import java.time.Instant
+
+/** magnum codecs shared by the Postgres repositories: the `SMALLINT` enum columns of
+  * V0001/V0002/V0004 via [[StoreCodes]], and the protocol newtypes the session credentials are
+  * typed as. Mixed in rather than imported so `DbCodec.derived` for the row types finds them.
+  */
+private[store] trait StoreCodecs extends BasicCodecs:
+  given DbCodec[Instant] = DbCodec.InstantCodec
+
+  given DbCodec[ActivityClass] = StoreCodecs.smallInt(StoreCodes.activityClass)
+  given DbCodec[Platform] = StoreCodecs.smallInt(StoreCodes.platform)
+  given DbCodec[CredentialKind] = StoreCodecs.smallInt(StoreCodes.credential)
+  given DbCodec[UserRole] = StoreCodecs.smallInt(StoreCodes.role)
+  given DbCodec[VirtualUserState] = StoreCodecs.smallInt(StoreCodes.userState)
+  given DbCodec[SessionKind] = StoreCodecs.smallInt(StoreCodes.sessionKind)
+  given DbCodec[MeasurementKind] = StoreCodecs.smallInt(StoreCodes.measurementKind)
+
+  given DbCodec[RefreshToken] = DbCodec.StringCodec.biMap(RefreshToken(_), _.value)
+  given DbCodec[EdgeSession] = DbCodec.StringCodec.biMap(EdgeSession(_), _.value)
+
+private[store] object StoreCodecs:
+  private def smallInt[A](codes: StoreCodes.Codes[A]): DbCodec[A] =
+    DbCodec.ShortCodec.biMap(codes.decode, codes.encode)

--- a/loadgen/src/main/scala/versola/loadgen/store/StoreCodecs.scala
+++ b/loadgen/src/main/scala/versola/loadgen/store/StoreCodecs.scala
@@ -2,7 +2,7 @@ package versola.loadgen.store
 
 import com.augustnagro.magnum.DbCodec
 import versola.loadgen.model.*
-import versola.loadgen.protocol.{EdgeSession, RefreshToken}
+import versola.loadgen.protocol.{EdgeSession, RefreshToken, SsoSession}
 import versola.util.postgres.BasicCodecs
 
 import java.time.Instant
@@ -24,6 +24,7 @@ private[store] trait StoreCodecs extends BasicCodecs:
 
   given DbCodec[RefreshToken] = DbCodec.StringCodec.biMap(RefreshToken(_), _.value)
   given DbCodec[EdgeSession] = DbCodec.StringCodec.biMap(EdgeSession(_), _.value)
+  given DbCodec[SsoSession] = DbCodec.StringCodec.biMap(SsoSession(_), _.value)
 
 private[store] object StoreCodecs:
   private def smallInt[A](codes: StoreCodes.Codes[A]): DbCodec[A] =

--- a/loadgen/src/main/scala/versola/loadgen/store/StoreCodes.scala
+++ b/loadgen/src/main/scala/versola/loadgen/store/StoreCodes.scala
@@ -1,0 +1,95 @@
+package versola.loadgen.store
+
+import versola.loadgen.model.*
+
+/** The `SMALLINT` codes the enum-valued columns of V0001/V0002 are stored as.
+  *
+  * Written out pair by pair rather than taken from `ordinal`: a `vu_users` row outlives the
+  * process that wrote it (a campaign runs for days across driver restarts and redeploys), so an
+  * enum case inserted in the middle of its declaration would otherwise renumber every code
+  * after it and silently reinterpret rows already on disk -- every `regular` user becoming
+  * `light` is a change to the load being generated, not an error anything would report.
+  *
+  * The [[Codes]] constructor checks that the mapping covers every case of the enum exactly
+  * once, so a case added to the model without a code here fails at class initialisation rather
+  * than on whichever row happens to carry it.
+  */
+object StoreCodes:
+
+  final class Codes[A] private[StoreCodes] (
+      label: String,
+      toCode: Map[A, Short],
+      fromCode: Map[Short, A],
+  ):
+    def encode(value: A): Short = toCode(value)
+
+    def decodeOption(code: Short): Option[A] = fromCode.get(code)
+
+    /** For the read path, where an unknown code means the row was written by a build this one
+      * cannot interpret -- a defect, not a value to fall back on.
+      */
+    def decode(code: Short): A =
+      fromCode.getOrElse(code, throw IllegalStateException(s"Unknown $label code $code"))
+
+  private def codes[A](label: String, all: Array[A], pairs: (A, Short)*): Codes[A] =
+    val toCode = pairs.toMap
+    require(
+      toCode.size == pairs.size && all.forall(toCode.contains) && toCode.size == all.length,
+      s"$label: every case must be mapped to exactly one distinct code",
+    )
+    val fromCode = pairs.map((value, code) => code -> value).toMap
+    require(fromCode.size == pairs.size, s"$label: codes must be distinct")
+    Codes(label, toCode, fromCode)
+
+  val activityClass: Codes[ActivityClass] = codes(
+    "activity_class",
+    ActivityClass.values,
+    ActivityClass.Heavy -> 0,
+    ActivityClass.Regular -> 1,
+    ActivityClass.Light -> 2,
+    ActivityClass.Dormant -> 3,
+  )
+
+  val platform: Codes[Platform] = codes(
+    "platform",
+    Platform.values,
+    Platform.Mobile -> 0,
+    Platform.Web -> 1,
+  )
+
+  val credential: Codes[CredentialKind] = codes(
+    "credential",
+    CredentialKind.values,
+    CredentialKind.Otp -> 0,
+    CredentialKind.OtpPassword -> 1,
+    CredentialKind.Passkey -> 2,
+  )
+
+  val role: Codes[UserRole] = codes(
+    "role",
+    UserRole.values,
+    UserRole.RetailUser -> 0,
+    UserRole.RetailBasic -> 1,
+  )
+
+  val userState: Codes[VirtualUserState] = codes(
+    "state",
+    VirtualUserState.values,
+    VirtualUserState.Planned -> 0,
+    VirtualUserState.Registered -> 1,
+    VirtualUserState.Broken -> 2,
+  )
+
+  val sessionKind: Codes[SessionKind] = codes(
+    "kind",
+    SessionKind.values,
+    SessionKind.MobileToken -> 0,
+    SessionKind.WebCookie -> 1,
+  )
+
+  val measurementKind: Codes[MeasurementKind] = codes(
+    "measurement kind",
+    MeasurementKind.values,
+    MeasurementKind.Step -> 0,
+    MeasurementKind.Flow -> 1,
+  )

--- a/loadgen/src/main/scala/versola/loadgen/store/StoreRows.scala
+++ b/loadgen/src/main/scala/versola/loadgen/store/StoreRows.scala
@@ -1,0 +1,64 @@
+package versola.loadgen.store
+
+import java.time.Instant
+
+/** One `vu_events` row (migration V0003): a sampled step, written on the deferred path.
+  *
+  * `vu_users` and `vu_sessions` have no row type here -- the repositories read and write
+  * `versola.loadgen.model.VirtualUser` / `DeviceSession` directly, whose field order is V0001's
+  * and V0002's column order.
+  */
+case class EventRow(
+    at: Instant,
+    userId: Long,
+    scenario: String,
+    step: String,
+    outcome: String,
+    latencyMs: Int,
+)
+
+/** Deferred `vu_users.last_seen_at` write. Its own type rather than a tuple so the write-behind
+  * batch is self-describing at the point it is applied.
+  */
+case class UserTouch(userId: Long, lastSeenAt: Instant)
+
+/** Deferred `vu_sessions.access_expires_at` write.
+  *
+  * Dev spec §7.5 lists `acr` in the deferred class alongside this column. It is on the critical
+  * path instead: both occasions that change a session's `acr` -- a refresh exchange and a
+  * completed step-up -- already write a credential at the same moment, so the column costs
+  * nothing extra there, while a dropped `acr` would leave a resumed session claiming an
+  * assurance level it does not hold. §7.4 then reads it to decide whether the next L2 action
+  * needs another step-up.
+  */
+case class SessionTouch(sessionId: Long, accessExpiresAt: Instant)
+
+/** One `vu_metric_snapshots` row (migration V0004): a driver's HdrHistogram for one measurement
+  * over one 60-second interval (§11), as handed to the coordinator's merge.
+  *
+  * Deliberately primitives rather than track F's `EncodedHistogram`/`MeasurementId`: the store
+  * persists the wire form, and F owns what produces it. `histogram` is HdrHistogram's own
+  * compressed payload, base64url-encoded -- `wireVersion` is F's envelope version, carried so a
+  * coordinator reading a snapshot written by an older driver can refuse it instead of decoding
+  * it wrongly.
+  */
+case class MetricSnapshotRow(
+    campaign: String,
+    driverId: String,
+    capturedAt: Instant,
+    wireVersion: Int,
+    kind: MeasurementKind,
+    /** The scenario a step belongs to; `None` for a flow, which is named on its own (§11). */
+    scenario: Option[String],
+    /** The step name, or the flow name when [[kind]] is [[MeasurementKind.Flow]]. */
+    name: String,
+    unit: String,
+    sampleCount: Long,
+    histogram: String,
+)
+
+/** Which of §11's two granularities a [[MetricSnapshotRow]] measures. Mirrors track F's
+  * `MeasurementId` without depending on it -- the store's business is the column, not the label.
+  */
+enum MeasurementKind:
+  case Step, Flow

--- a/loadgen/src/main/scala/versola/loadgen/store/VirtualUserRepository.scala
+++ b/loadgen/src/main/scala/versola/loadgen/store/VirtualUserRepository.scala
@@ -1,0 +1,59 @@
+package versola.loadgen.store
+
+import versola.loadgen.model.{VirtualUser, VirtualUserState}
+import versola.util.Secret
+import zio.{Chunk, Task}
+
+import java.time.Instant
+import java.util.UUID
+
+/** `vu_users` (migration V0001). Split by write class per dev spec §7.5: everything here except
+  * [[touchAll]] is on the critical path and is awaited by its caller; `last_seen_at` is the
+  * deferred column and reaches this trait only in batches, from the write-behind buffer.
+  */
+trait VirtualUserRepository:
+
+  /** Bulk insert of a planned population. The seeder (§10) populates 10-20M rows with `COPY`
+    * against this same table and does not go through here; this is the path for the smaller
+    * incremental cohorts -- the registration campaign's arrivals, and test fixtures.
+    */
+  def insertAll(users: Chunk[VirtualUser]): Task[Unit]
+
+  def find(id: Long): Task[Option[VirtualUser]]
+
+  /** One page of this driver's slice, in `id` order, served by `vu_users_shard_idx`.
+    *
+    * Keyset pagination rather than `OFFSET`: a driver walks its whole slice once at startup and
+    * then again per active window, and `OFFSET n` re-reads and discards n index entries per
+    * page, which turns a linear walk into a quadratic one at 10M rows.
+    *
+    * @param afterId
+    *   exclusive lower bound, `None` for the first page.
+    */
+  def loadShardSlice(shard: Int, afterId: Option[Long], limit: Int): Task[Vector[VirtualUser]]
+
+  /** Records the SUT identity a registration or seed produced and moves the row to
+    * [[VirtualUserState.Registered]]. Both in one statement: a user with a `sut_user_id` but
+    * still `planned` would be re-registered by the controller and collide on `phone`.
+    */
+  def markRegistered(id: Long, sutUserId: UUID): Task[Unit]
+
+  /** Terminal state for a user whose credentials no longer work. Deliberately not reversible
+    * here -- a driver retrying its way out of `broken` is how a real SUT failure gets hidden
+    * behind a slowly shrinking active population.
+    */
+  def markBroken(id: Long): Task[Unit]
+
+  /** Critical write (§7.5): persisted before the credential is used, so a driver crash between
+    * enrolment and the first assertion cannot orphan a passkey that only the SUT knows about.
+    */
+  def recordPasskey(id: Long, key: Secret, credentialId: String): Task[Unit]
+
+  /** Deferred write path -- the write-behind buffer's only entry point into this table. */
+  def touchAll(touches: Chunk[UserTouch]): Task[Unit]
+
+  /** Population counts by state, for the coordinator's registration controller and `/status`
+    * (§12). Returns every state the table holds; a state with no rows is absent from the map
+    * rather than present as zero, since the caller renders what exists.
+    */
+  def countByState: Task[Map[VirtualUserState, Long]]

--- a/loadgen/src/main/scala/versola/loadgen/store/WriteBehindBuffer.scala
+++ b/loadgen/src/main/scala/versola/loadgen/store/WriteBehindBuffer.scala
@@ -1,0 +1,141 @@
+package versola.loadgen.store
+
+import versola.loadgen.config.{StoreConfig, WriteBehindConfig}
+import zio.*
+
+/** Applies one coalesced flush window to the store. Separate from [[WriteBehindBuffer]] so the
+  * buffer's batching, timing and drop behaviour are testable without a database.
+  */
+trait DeferredWriteSink:
+  def write(batch: DeferredBatch): Task[Unit]
+
+/** The deferred write path of dev spec §7.5: scenario fibers hand their bookkeeping over and
+  * continue, and a single background fiber applies it every `flush-interval` or every
+  * `batch-size` rows, whichever comes first.
+  *
+  * The queue is bounded and it **drops** on overflow instead of applying back-pressure. That is
+  * the whole point of the component: the emulator is the measuring instrument, and a store that
+  * made scenario fibers wait would distort the very load the campaign is measuring. What is
+  * lost is `last_seen_at`, `access_expires_at` and forensic event samples -- never a credential
+  * and never an `acr`, both of which go through the repositories' critical methods directly (see
+  * [[SessionTouch]] on why `acr` left §7.5's deferred class).
+  */
+trait WriteBehindBuffer:
+  def enqueue(update: DeferredUpdate): UIO[Unit]
+
+  /** Drains everything currently queued, awaited. Used at shutdown and by tests; the ordinary
+    * path is the background loop.
+    */
+  def flush: UIO[Unit]
+
+  /** Updates refused at [[enqueue]] because the bounded queue was full: the store is not
+    * keeping up with the drivers, so the emulator is undersized and the run is invalid.
+    */
+  def droppedOnEnqueue: UIO[Long]
+
+  /** Updates lost because a flush the store rejected was not retried: Postgres returned an
+    * error, which is a defect rather than a capacity problem.
+    *
+    * Separate from [[droppedOnEnqueue]] because the two call for different actions even though
+    * both invalidate a campaign the same way -- one is answered by more store capacity or a
+    * larger queue, the other by reading the log and fixing something.
+    */
+  def droppedOnFlush: UIO[Long]
+
+  /** Source of `loadgen_store_flush_dropped_total` (§11), which must stay at 0. The sum of the
+    * two counters above, so a reader who only wants "did we lose bookkeeping" has one number.
+    */
+  def droppedTotal: UIO[Long]
+
+  /** Current queue depth: the leading indicator for the counter above. */
+  def pending: UIO[Int]
+
+object WriteBehindBuffer:
+
+  /** @param capacity
+    *   bounded queue depth, in updates. Explicit rather than derived inside, because the value
+    *   that makes a test deterministic and the value that makes a driver survive a Postgres
+    *   stall are not the same number.
+    */
+  def make(config: WriteBehindConfig, capacity: Int, sink: DeferredWriteSink): URIO[Scope, WriteBehindBuffer] =
+    for
+      queue <- Queue.dropping[DeferredUpdate](capacity)
+      doorbell <- Queue.dropping[Unit](1)
+      droppedEnqueue <- Ref.make(0L)
+      droppedFlush <- Ref.make(0L)
+      buffer = LiveWriteBehindBuffer(queue, doorbell, droppedEnqueue, droppedFlush, config.batchSize, sink)
+      // Registered before the fork so it runs after it: scope finalizers run in reverse order,
+      // so the loop fiber is interrupted first and this final drain then has the queue to
+      // itself. The other way round, the drain would race a loop that is still adding to it.
+      _ <- ZIO.addFinalizer(buffer.flush)
+      _ <- buffer.flushLoop(config.flushInterval).forkScoped
+    yield buffer
+
+  def layer: ZLayer[StoreConfig & DeferredWriteSink, Nothing, WriteBehindBuffer] =
+    ZLayer.scoped:
+      for
+        store <- ZIO.service[StoreConfig]
+        sink <- ZIO.service[DeferredWriteSink]
+        buffer <- make(store.writeBehind, capacityFor(store.writeBehind), sink)
+      yield buffer
+
+  /** Sixty-four flush windows of backlog -- ~13 s at the configured 200 ms. Long enough to ride
+    * out a checkpoint or a brief stall on the store, short enough that a store which is
+    * genuinely not keeping up starts reporting it within a quarter of a minute rather than
+    * accumulating an unbounded queue in a driver's heap.
+    */
+  def capacityFor(config: WriteBehindConfig): Int = config.batchSize * 64
+
+private final class LiveWriteBehindBuffer(
+    queue: Queue[DeferredUpdate],
+    doorbell: Queue[Unit],
+    droppedEnqueue: Ref[Long],
+    droppedFlush: Ref[Long],
+    batchSize: Int,
+    sink: DeferredWriteSink,
+) extends WriteBehindBuffer:
+
+  override def enqueue(update: DeferredUpdate): UIO[Unit] =
+    queue.offer(update).flatMap:
+      case true => ringDoorbellIfFull
+      case false => droppedEnqueue.update(_ + 1)
+
+  override def flush: UIO[Unit] =
+    queue.takeUpTo(batchSize).flatMap: taken =>
+      if taken.isEmpty then ZIO.unit
+      // A full take means the queue may hold more than one window's worth; keep going rather
+      // than leaving the remainder for the next tick, which under sustained load would let the
+      // queue grow to its bound and start dropping while the flusher idles between ticks.
+      else writeBatch(taken) *> ZIO.when(taken.size >= batchSize)(flush).unit
+
+  override def droppedOnEnqueue: UIO[Long] = droppedEnqueue.get
+
+  override def droppedOnFlush: UIO[Long] = droppedFlush.get
+
+  override def droppedTotal: UIO[Long] =
+    droppedEnqueue.get.zipWith(droppedFlush.get)(_ + _)
+
+  override def pending: UIO[Int] = queue.size
+
+  /** One signal, coalesced (a dropping queue of one): the doorbell only has to wake the loop,
+    * and a second ring while the first is unread would say nothing new.
+    */
+  private def ringDoorbellIfFull: UIO[Unit] =
+    queue.size.flatMap(size => ZIO.when(size >= batchSize)(doorbell.offer(()))).unit
+
+  private def writeBatch(taken: Chunk[DeferredUpdate]): UIO[Unit] =
+    sink.write(DeferredBatch.coalesce(taken)).catchAllCause: cause =>
+      // Deliberately not retried: the batch is superseded by whatever the same users and
+      // sessions do next, so re-sending stale values behind a store that is already struggling
+      // buys nothing. It is counted, because a campaign whose store dropped writes cannot be
+      // reconciled afterwards and the report has to say so.
+      droppedFlush.update(_ + taken.size) *>
+        ZIO.logWarningCause(s"Write-behind flush of ${taken.size} updates failed; dropped", cause)
+
+  private[store] def flushLoop(interval: Duration): UIO[Nothing] =
+    // Whichever comes first: the batch-size doorbell or the interval. The loser is interrupted,
+    // which is safe for both -- the doorbell carries no data, and an interrupted sleep leaves
+    // nothing behind. Taking the batch itself under a race would not be: a partially collected
+    // `takeBetween` loses what it has already taken, which is exactly the silent loss the
+    // dropped counter exists to make visible.
+    (doorbell.take.race(ZIO.sleep(interval)) *> flush).forever

--- a/loadgen/src/test/scala/versola/loadgen/config/LoadgenConfigSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/config/LoadgenConfigSpec.scala
@@ -32,8 +32,16 @@ object LoadgenConfigSpec extends ZIOSpecDefault:
       |coordinator { url = "http://loadgen-coordinator:8100", poll-interval = 10s }
       |
       |store {
-      |  url = "jdbc:postgresql://loadgen-db:5432/loadgen"
-      |  maximum-pool-size = 16
+      |  postgres {
+      |    url = "jdbc:postgresql://loadgen-db:5432/loadgen"
+      |    user = "loadgen"
+      |    password = "loadgen"
+      |    maximum-pool-size = 16
+      |    minimum-idle = 16
+      |    connection-timeout = 30s
+      |    max-lifetime = 30m
+      |    leak-detection-threshold = 0s
+      |  }
       |  write-behind { flush-interval = 200ms, batch-size = 500 }
       |}
       |
@@ -88,6 +96,8 @@ object LoadgenConfigSpec extends ZIOSpecDefault:
           config.role == LoadgenRole.Driver,
           config.shard == Some(ShardConfig(index = 0, count = 8)),
           config.targets.mockUrl == "http://mockapi:8100",
+          config.store.postgres.url == "jdbc:postgresql://loadgen-db:5432/loadgen",
+          config.store.postgres.maximumPoolSize == 16,
           config.store.writeBehind.batchSize == 500,
           config.population.target == 10000000L,
           config.population.classes.map(_.name) == List("heavy", "regular", "light", "dormant"),

--- a/loadgen/src/test/scala/versola/loadgen/store/DeferredBatchSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/store/DeferredBatchSpec.scala
@@ -1,0 +1,51 @@
+package versola.loadgen.store
+
+import zio.Chunk
+import zio.test.*
+
+import java.time.Instant
+
+object DeferredBatchSpec extends ZIOSpecDefault:
+
+  private val t0 = Instant.parse("2026-09-10T20:00:00Z")
+
+  def spec = suite("DeferredBatch.coalesce")(
+    test("keeps only the latest last_seen_at per user") {
+      val batch = DeferredBatch.coalesce(
+        Chunk(
+          DeferredUpdate.UserSeen(1L, t0),
+          DeferredUpdate.UserSeen(2L, t0.plusSeconds(1)),
+          DeferredUpdate.UserSeen(1L, t0.plusSeconds(5)),
+        )
+      )
+      assertTrue(
+        batch.userTouches == Chunk(UserTouch(1L, t0.plusSeconds(5)), UserTouch(2L, t0.plusSeconds(1)))
+      )
+    },
+    test("keeps only the latest access_expires_at per session") {
+      val batch = DeferredBatch.coalesce(
+        Chunk(
+          DeferredUpdate.SessionTouched(SessionTouch(7L, t0.plusSeconds(900))),
+          DeferredUpdate.SessionTouched(SessionTouch(8L, t0.plusSeconds(30))),
+          DeferredUpdate.SessionTouched(SessionTouch(7L, t0.plusSeconds(1800))),
+        )
+      )
+      assertTrue(
+        batch.sessionTouches == Chunk(
+          SessionTouch(7L, t0.plusSeconds(1800)),
+          SessionTouch(8L, t0.plusSeconds(30)),
+        )
+      )
+    },
+    test("keeps every event in arrival order -- the sample is a log, not a state") {
+      val first = EventRow(t0, 1L, "mobile-refresh", "token", "ok", 12)
+      val second = EventRow(t0.plusSeconds(1), 1L, "mobile-refresh", "token", "ok", 15)
+      val batch = DeferredBatch.coalesce(
+        Chunk(DeferredUpdate.EventSampled(first), DeferredUpdate.EventSampled(second))
+      )
+      assertTrue(batch.events == Chunk(first, second))
+    },
+    test("an empty window coalesces to an empty batch") {
+      assertTrue(DeferredBatch.coalesce(Chunk.empty).isEmpty)
+    },
+  )

--- a/loadgen/src/test/scala/versola/loadgen/store/LoadgenPostgresSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/store/LoadgenPostgresSpec.scala
@@ -1,0 +1,82 @@
+package versola.loadgen.store
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import versola.util.postgres.{PostgresConfig, PostgresHikariDataSource, PostgresSpec}
+import zio.*
+import zio.test.ZIOSpec
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.sql.DriverManager
+
+/** What `util-postgres`' [[PostgresSpec]] is for a service, for the emulator's own store: a real
+  * Postgres, the real migrations, the real magnum codecs.
+  *
+  * There is no in-memory implementation of these repositories to test against instead, and a
+  * fake would not have caught either of the two defects this suite was written after -- a
+  * `listLive` predicate that silently matched no web-cookie session, and a persisted shape
+  * missing a credential -- because both were properties of the SQL and the schema, not of the
+  * Scala around them.
+  */
+abstract class LoadgenPostgresSpec extends ZIOSpec[TransactorZIO]:
+
+  override val bootstrap = LoadgenPostgresSpec.transactor
+
+object LoadgenPostgresSpec:
+
+  /** Its own database, not the `auth` one [[PostgresSpec]] uses, because that is the arrangement
+    * production has: this schema numbers its migrations from `V0001` exactly as auth's does, so
+    * sharing a database would put two unrelated `V0001`s in one `flyway_schema_history`. See
+    * [[LoadgenMigrations]].
+    */
+  private val databaseName = "loadgen_test"
+
+  /** sbt runs this project's tests unforked, so every spec shares one JVM and every one of them
+    * would otherwise race to create the database on first use.
+    */
+  private val creation = new Object
+
+  /** Production's own constant, not a path of this spec's, when sbt runs from the repository
+    * root -- which it does; the fallback covers the module directory being the root, as
+    * [[MigrationNamingSpec]]'s does. A spec that named the directory itself would keep passing
+    * if [[LoadgenMigrations.locations]] were wrong, which is the failure that motivated
+    * `MigrationNamingSpec` in the first place.
+    */
+  private val migrationLocations: Seq[String] =
+    if Files.isDirectory(Path.of("loadgen", "migrations")) then LoadgenMigrations.locations
+    else Seq("filesystem:./migrations")
+
+  /** [[PostgresSpec.config]] names the host and credentials CI's service container and the dev
+    * compose both provide; only the database differs, so it is reused rather than restated.
+    */
+  private val config: ZLayer[Any, Throwable, PostgresConfig] =
+    PostgresSpec.config >>> ZLayer.fromZIO:
+      ZIO.serviceWithZIO[PostgresConfig]: auth =>
+        createDatabase(auth).as:
+          auth.copy(url = auth.url.substring(0, auth.url.lastIndexOf('/') + 1) + databaseName)
+
+  /** Flyway applies a schema to a database; it does not create one, and neither CI's service
+    * container nor the dev compose knows about this database. Connects through `auth` -- the one
+    * database both of them do create -- rather than `postgres`, so this needs no privilege
+    * [[PostgresSpec]] does not already rely on.
+    */
+  private def createDatabase(auth: PostgresConfig): Task[Unit] =
+    ZIO.attemptBlocking:
+      creation.synchronized:
+        val password = new String(auth.password, StandardCharsets.UTF_8)
+        val connection = DriverManager.getConnection(auth.url, auth.user, password)
+        try
+          val statement = connection.createStatement()
+          try
+            val existing = statement.executeQuery(s"SELECT 1 FROM pg_database WHERE datname = '$databaseName'")
+            if !existing.next() then statement.execute(s"CREATE DATABASE $databaseName")
+          finally statement.close()
+        finally connection.close()
+
+  val transactor: ZLayer[Any, Throwable, TransactorZIO] =
+    config >>> (Scope.default >>> PostgresHikariDataSource.layer(
+      serviceName = Some("loadgen-store-test"),
+      migrate = true,
+      validateOnMigrate = false,
+      migrationLocations = Some(migrationLocations),
+    )) >>> TransactorZIO.layer

--- a/loadgen/src/test/scala/versola/loadgen/store/MigrationNamingSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/store/MigrationNamingSpec.scala
@@ -1,0 +1,48 @@
+package versola.loadgen.store
+
+import zio.test.*
+
+import java.nio.file.{Files, Path}
+
+import scala.jdk.CollectionConverters.*
+
+/** Guards the one property of this schema that fails silently rather than loudly.
+  *
+  * `PostgresHikariDataSource` configures Flyway with `validateMigrationNaming(false)`, so a
+  * migration whose filename Flyway does not recognise is skipped without complaint: the process
+  * boots, passes its readiness check, and the first query fails against a table that was never
+  * created. Flyway will therefore never catch a file named `L0001__*.sql` or `0001_*.sql` here
+  * -- this test is the only thing that does. See [[LoadgenMigrations]].
+  */
+object MigrationNamingSpec extends ZIOSpecDefault:
+
+  /** sbt runs these tests with the repository root as the working directory; the second
+    * candidate covers being run with the module's own directory as the root instead.
+    */
+  private val migrations: Path =
+    List(Path.of("loadgen", "migrations"), Path.of("migrations"))
+      .find(Files.isDirectory(_))
+      .getOrElse(Path.of("loadgen", "migrations"))
+
+  private val flywayVersioned = raw"V\d{4}__[a-z0-9_]+\.sql".r
+
+  private def sqlFiles: List[String] =
+    Files.list(migrations).iterator().asScala
+      .map(_.getFileName.toString)
+      .filter(_.endsWith(".sql"))
+      .toList
+      .sorted
+
+  def spec = suite("loadgen/migrations")(
+    test("every migration carries Flyway's default V prefix and a four-digit version") {
+      val offenders = sqlFiles.filterNot(flywayVersioned.matches)
+      assertTrue(offenders.isEmpty)
+    },
+    test("versions are unique and contiguous from 0001") {
+      val versions = sqlFiles.map(_.substring(1, 5).toInt)
+      assertTrue(versions == (1 to versions.size).toList)
+    },
+    test("the directory is not empty, so the two assertions above are not vacuous") {
+      assertTrue(sqlFiles.nonEmpty)
+    },
+  )

--- a/loadgen/src/test/scala/versola/loadgen/store/PostgresDeviceSessionRepositorySpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/store/PostgresDeviceSessionRepositorySpec.scala
@@ -1,0 +1,272 @@
+package versola.loadgen.store
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import com.augustnagro.magnum.sql
+import versola.loadgen.model.{DeviceSession, SessionKind}
+import versola.loadgen.protocol.{EdgeSession, RefreshToken, SsoSession}
+import versola.util.DatabaseSpecBase
+import zio.*
+import zio.test.*
+
+import java.time.Instant
+
+final case class DeviceSessionEnv(repository: DeviceSessionRepository)
+
+/** `vu_sessions` against a real Postgres. Most of what this table is for -- surviving a driver
+  * restart with enough of a session left to resume it -- is expressible only as SQL, so this is
+  * where the refresh discipline of dev spec §7.4 and the resumability rule of §8.4 are actually
+  * checked.
+  */
+object PostgresDeviceSessionRepositorySpec extends LoadgenPostgresSpec, DatabaseSpecBase[DeviceSessionEnv]:
+
+  private val now = Instant.parse("2026-01-01T12:00:00Z")
+
+  /** A mobile session holds all three credentials it can hold: the refresh token it resumes
+    * with, and the SSO session it needs to re-run `/authorize` on (§7.4).
+    */
+  private def mobile(id: Long, shard: Int, refreshExpiresAt: Instant): DeviceSession =
+    DeviceSession(
+      id = id,
+      userId = id * 10,
+      kind = SessionKind.MobileToken,
+      clientId = "mobile-otp",
+      refreshToken = Some(RefreshToken(s"refresh-$id")),
+      edgeCookie = None,
+      ssoSession = Some(SsoSession(s"sso-$id")),
+      accessExpiresAt = Some(now.plusSeconds(300)),
+      refreshExpiresAt = Some(refreshExpiresAt),
+      acr = Some("L1"),
+      authTime = Some(now.minusSeconds(600)),
+      generation = 0,
+      shard = shard,
+    )
+
+  /** A web session has no refresh token at all: the `EDGE_SESSION` is the whole credential, and
+    * `accessExpiresAt` is its expiry.
+    */
+  private def web(id: Long, shard: Int, accessExpiresAt: Instant): DeviceSession =
+    DeviceSession(
+      id = id,
+      userId = id * 10,
+      kind = SessionKind.WebCookie,
+      clientId = "web",
+      refreshToken = None,
+      edgeCookie = Some(EdgeSession(s"edge-$id")),
+      ssoSession = None,
+      accessExpiresAt = Some(accessExpiresAt),
+      refreshExpiresAt = None,
+      acr = Some("L1"),
+      authTime = Some(now.minusSeconds(600)),
+      generation = 0,
+      shard = shard,
+    )
+
+  override lazy val environment =
+    ZLayer:
+      ZIO.serviceWith[TransactorZIO](xa => DeviceSessionEnv(PostgresDeviceSessionRepository(xa)))
+
+  override def beforeEach(env: DeviceSessionEnv) =
+    ZIO.serviceWithZIO[TransactorZIO]:
+      _.connect(sql"TRUNCATE TABLE vu_sessions".update.run()).unit
+
+  override def testCases(env: DeviceSessionEnv) = List(
+    test("insert then find round-trips every persisted column, in the order V0002 declares them") {
+      val session = mobile(1, shard = 3, refreshExpiresAt = now.plusSeconds(2592000))
+      for
+        _     <- env.repository.insert(session)
+        found <- env.repository.find(1)
+      yield assertTrue(found.contains(session))
+    },
+    test("a web session round-trips with the cookie and no refresh token, which is not the same as an empty one") {
+      val session = web(1, shard = 3, accessExpiresAt = now.plusSeconds(1200))
+      for
+        _     <- env.repository.insert(session)
+        found <- env.repository.find(1)
+      yield assertTrue(
+        found.contains(session),
+        found.flatMap(_.refreshToken).isEmpty,
+        found.flatMap(_.edgeCookie).contains(EdgeSession("edge-1")),
+      )
+    },
+    test("find answers None for a session that was never written") {
+      env.repository.find(404).map(found => assertTrue(found.isEmpty))
+    },
+    test("listLive returns a live web session, which has no refresh expiry to be live by") {
+      for
+        _      <- env.repository.insert(web(1, shard = 3, accessExpiresAt = now.plusSeconds(1200)))
+        live   <- env.repository.listLive(shard = 3, liveAt = now, limit = 10)
+      yield assertTrue(live.map(_.id) == Vector(1L))
+    },
+    test("listLive orders both kinds by the expiry each is resumable until") {
+      for
+        _    <- env.repository.insert(mobile(1, shard = 3, refreshExpiresAt = now.plusSeconds(2592000)))
+        _    <- env.repository.insert(web(2, shard = 3, accessExpiresAt = now.plusSeconds(1200)))
+        live <- env.repository.listLive(shard = 3, liveAt = now, limit = 10)
+      yield assertTrue(live.map(_.id) == Vector(2L, 1L))
+    },
+    test("listLive excludes an expired session of either kind") {
+      for
+        _    <- env.repository.insert(mobile(1, shard = 3, refreshExpiresAt = now.minusSeconds(60)))
+        _    <- env.repository.insert(web(2, shard = 3, accessExpiresAt = now.minusSeconds(60)))
+        _    <- env.repository.insert(web(3, shard = 3, accessExpiresAt = now.plusSeconds(60)))
+        live <- env.repository.listLive(shard = 3, liveAt = now, limit = 10)
+      yield assertTrue(live.map(_.id) == Vector(3L))
+    },
+    test("listLive is confined to the driver's own shard") {
+      for
+        _    <- env.repository.insert(web(1, shard = 3, accessExpiresAt = now.plusSeconds(1200)))
+        _    <- env.repository.insert(web(2, shard = 4, accessExpiresAt = now.plusSeconds(1200)))
+        live <- env.repository.listLive(shard = 3, liveAt = now, limit = 10)
+      yield assertTrue(live.map(_.id) == Vector(1L))
+    },
+    test("listLive honours its limit, taking the sessions that expire soonest") {
+      for
+        _    <- env.repository.insert(web(1, shard = 3, accessExpiresAt = now.plusSeconds(3600)))
+        _    <- env.repository.insert(web(2, shard = 3, accessExpiresAt = now.plusSeconds(1200)))
+        live <- env.repository.listLive(shard = 3, liveAt = now, limit = 1)
+      yield assertTrue(live.map(_.id) == Vector(2L))
+    },
+    test("listByUser returns one user's sessions in id order and nobody else's") {
+      for
+        _     <- env.repository.insert(mobile(1, shard = 3, refreshExpiresAt = now.plusSeconds(600)).copy(userId = 7))
+        _     <- env.repository.insert(mobile(2, shard = 3, refreshExpiresAt = now.plusSeconds(600)).copy(userId = 7))
+        _     <- env.repository.insert(mobile(3, shard = 3, refreshExpiresAt = now.plusSeconds(600)).copy(userId = 8))
+        found <- env.repository.listByUser(7)
+      yield assertTrue(found.map(_.id) == Vector(1L, 2L))
+    },
+    test("bumpGeneration returns the generation the caller now owns") {
+      for
+        _      <- env.repository.insert(mobile(1, shard = 3, refreshExpiresAt = now.plusSeconds(600)))
+        first  <- env.repository.bumpGeneration(1)
+        second <- env.repository.bumpGeneration(1)
+      yield assertTrue(first.contains(1), second.contains(2))
+    },
+    test("bumpGeneration answers None for a session that is gone, rather than inventing one") {
+      env.repository.bumpGeneration(404).map(bumped => assertTrue(bumped.isEmpty))
+    },
+    test("storeRotatedRefresh writes at the generation it was given") {
+      val rotatedUntil = now.plusSeconds(2592000)
+      for
+        _          <- env.repository.insert(mobile(1, shard = 3, refreshExpiresAt = now.plusSeconds(600)))
+        generation <- env.repository.bumpGeneration(1)
+        wrote <- env.repository.storeRotatedRefresh(
+          id = 1,
+          expectedGeneration = generation.get,
+          refreshToken = RefreshToken("rotated"),
+          refreshExpiresAt = rotatedUntil,
+          accessExpiresAt = now.plusSeconds(900),
+          acr = Some("L2"),
+          authTime = now,
+        )
+        found <- env.repository.find(1)
+      yield assertTrue(
+        wrote,
+        found.flatMap(_.refreshToken).contains(RefreshToken("rotated")),
+        found.flatMap(_.refreshExpiresAt).contains(rotatedUntil),
+        found.flatMap(_.acr).contains("L2"),
+        found.map(_.generation).contains(1),
+      )
+    },
+    test("storeRotatedRefresh refuses a stale generation instead of resurrecting a retired token") {
+      for
+        _ <- env.repository.insert(mobile(1, shard = 3, refreshExpiresAt = now.plusSeconds(600)))
+        _ <- env.repository.bumpGeneration(1)
+        _ <- env.repository.bumpGeneration(1)
+        wrote <- env.repository.storeRotatedRefresh(
+          id = 1,
+          expectedGeneration = 1,
+          refreshToken = RefreshToken("stale"),
+          refreshExpiresAt = now.plusSeconds(2592000),
+          accessExpiresAt = now.plusSeconds(900),
+          acr = None,
+          authTime = now,
+        )
+        found <- env.repository.find(1)
+      yield assertTrue(!wrote, found.flatMap(_.refreshToken).contains(RefreshToken("refresh-1")))
+    },
+    test("storeEdgeCookie adopts the cookie edge rotated, with its new expiry") {
+      val rotatedUntil = now.plusSeconds(1800)
+      for
+        _     <- env.repository.insert(web(1, shard = 3, accessExpiresAt = now.plusSeconds(600)))
+        _     <- env.repository.storeEdgeCookie(1, EdgeSession("edge-rotated"), rotatedUntil)
+        found <- env.repository.find(1)
+      yield assertTrue(
+        found.flatMap(_.edgeCookie).contains(EdgeSession("edge-rotated")),
+        found.flatMap(_.accessExpiresAt).contains(rotatedUntil),
+      )
+    },
+    test("storeStepUp records the assurance level and the credentials the step-up produced") {
+      val steppedUpAt = now.plusSeconds(30)
+      val refreshUntil = now.plusSeconds(2592000)
+      for
+        _ <- env.repository.insert(mobile(1, shard = 3, refreshExpiresAt = now.plusSeconds(600)))
+        _ <- env.repository.storeStepUp(
+          id = 1,
+          acr = "L2",
+          authTime = steppedUpAt,
+          accessExpiresAt = now.plusSeconds(900),
+          refreshToken = Some(RefreshToken("stepped-up")),
+          refreshExpiresAt = Some(refreshUntil),
+          ssoSession = Some(SsoSession("sso-rotated")),
+        )
+        found <- env.repository.find(1)
+      yield assertTrue(
+        found.flatMap(_.acr).contains("L2"),
+        found.flatMap(_.authTime).contains(steppedUpAt),
+        found.flatMap(_.refreshToken).contains(RefreshToken("stepped-up")),
+        found.flatMap(_.refreshExpiresAt).contains(refreshUntil),
+        found.flatMap(_.ssoSession).contains(SsoSession("sso-rotated")),
+      )
+    },
+    test("storeStepUp keeps the credentials the step-up did not rotate, rather than nulling them") {
+      val refreshUntil = now.plusSeconds(600)
+      for
+        _ <- env.repository.insert(mobile(1, shard = 3, refreshExpiresAt = refreshUntil))
+        _ <- env.repository.storeStepUp(
+          id = 1,
+          acr = "L2",
+          authTime = now,
+          accessExpiresAt = now.plusSeconds(900),
+          refreshToken = None,
+          refreshExpiresAt = None,
+          ssoSession = None,
+        )
+        found <- env.repository.find(1)
+      yield assertTrue(
+        found.flatMap(_.acr).contains("L2"),
+        found.flatMap(_.refreshToken).contains(RefreshToken("refresh-1")),
+        found.flatMap(_.refreshExpiresAt).contains(refreshUntil),
+        found.flatMap(_.ssoSession).contains(SsoSession("sso-1")),
+      )
+    },
+    test("a session restored after a restart still carries the SSO session it was established on") {
+      for
+        _    <- env.repository.insert(mobile(1, shard = 3, refreshExpiresAt = now.plusSeconds(2592000)))
+        live <- env.repository.listLive(shard = 3, liveAt = now, limit = 10)
+      yield assertTrue(live.flatMap(_.ssoSession) == Vector(SsoSession("sso-1")))
+    },
+    test("touchAll moves the access expiry of the batch, and of nothing else") {
+      val touchedTo = now.plusSeconds(1800)
+      for
+        _ <- env.repository.insert(mobile(1, shard = 3, refreshExpiresAt = now.plusSeconds(600)))
+        _ <- env.repository.insert(mobile(2, shard = 3, refreshExpiresAt = now.plusSeconds(600)))
+        _ <- env.repository.touchAll(Chunk(SessionTouch(1, touchedTo)))
+        touched   <- env.repository.find(1)
+        untouched <- env.repository.find(2)
+      yield assertTrue(
+        touched.flatMap(_.accessExpiresAt).contains(touchedTo),
+        untouched.flatMap(_.accessExpiresAt).contains(now.plusSeconds(300)),
+        touched.flatMap(_.refreshToken).contains(RefreshToken("refresh-1")),
+      )
+    },
+    test("touchAll on an empty batch is a no-op, not an empty round trip") {
+      env.repository.touchAll(Chunk.empty).as(assertCompletes)
+    },
+    test("delete removes the session the recovery path retired") {
+      for
+        _     <- env.repository.insert(mobile(1, shard = 3, refreshExpiresAt = now.plusSeconds(600)))
+        _     <- env.repository.delete(1)
+        found <- env.repository.find(1)
+      yield assertTrue(found.isEmpty)
+    },
+  )

--- a/loadgen/src/test/scala/versola/loadgen/store/PostgresEventRepositorySpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/store/PostgresEventRepositorySpec.scala
@@ -1,0 +1,78 @@
+package versola.loadgen.store
+
+import com.augustnagro.magnum.{DbCodec, sql}
+import com.augustnagro.magnum.magzio.TransactorZIO
+import versola.util.DatabaseSpecBase
+import zio.*
+import zio.test.*
+
+import java.time.Instant
+
+/** Carries the transactor as well as the repository: `vu_events` has no read method to check a
+  * write with, by design, so the spec reads the table itself.
+  */
+final case class EventEnv(repository: EventRepository, xa: TransactorZIO)
+
+/** `vu_events` against a real Postgres. The table has no primary key, no index and no read
+  * method (dev spec §6), so the only thing to establish is that the forensic sample lands in
+  * full and with every column in the right place -- the sample is read by hand, once, long
+  * after the campaign, and a column silently written into the wrong one is not recoverable then.
+  */
+object PostgresEventRepositorySpec extends LoadgenPostgresSpec, DatabaseSpecBase[EventEnv], StoreCodecs:
+
+  private given DbCodec[EventRow] = DbCodec.derived
+
+  private val now = Instant.parse("2026-01-01T12:00:00Z")
+
+  private def event(secondsIn: Int, step: String): EventRow =
+    EventRow(
+      at = now.plusSeconds(secondsIn),
+      userId = 7,
+      scenario = "mobile-login",
+      step = step,
+      outcome = "ok",
+      latencyMs = 12 + secondsIn,
+    )
+
+  private def stored(env: EventEnv): Task[Vector[EventRow]] =
+    env.xa.connect:
+      sql"""
+        SELECT at, user_id, scenario, step, outcome, latency_ms FROM vu_events ORDER BY at
+      """.query[EventRow].run()
+
+  override lazy val environment =
+    ZLayer:
+      ZIO.serviceWith[TransactorZIO](xa => EventEnv(PostgresEventRepository(xa), xa))
+
+  override def beforeEach(env: EventEnv) =
+    ZIO.serviceWithZIO[TransactorZIO]:
+      _.connect(sql"TRUNCATE TABLE vu_events".update.run()).unit
+
+  override def testCases(env: EventEnv) = List(
+    test("appendAll writes every sampled step, with every column where it belongs") {
+      val sample = Chunk(event(0, "authorize"), event(1, "submit-otp"), event(2, "exchange-code"))
+      for
+        _     <- env.repository.appendAll(sample)
+        found <- stored(env)
+      yield assertTrue(found == sample.toVector)
+    },
+    test("appendAll appends rather than replaces, so two flushes both survive") {
+      for
+        _     <- env.repository.appendAll(Chunk(event(0, "authorize")))
+        _     <- env.repository.appendAll(Chunk(event(1, "submit-otp")))
+        found <- stored(env)
+      yield assertTrue(found.map(_.step) == Vector("authorize", "submit-otp"))
+    },
+    test("appendAll keeps a duplicate, because the sample is a log and not a state") {
+      for
+        _     <- env.repository.appendAll(Chunk(event(0, "authorize"), event(0, "authorize")))
+        found <- stored(env)
+      yield assertTrue(found.size == 2)
+    },
+    test("appendAll on an empty chunk is a no-op, not an empty round trip") {
+      for
+        _     <- env.repository.appendAll(Chunk.empty)
+        found <- stored(env)
+      yield assertTrue(found.isEmpty)
+    },
+  )

--- a/loadgen/src/test/scala/versola/loadgen/store/PostgresMetricSnapshotRepositorySpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/store/PostgresMetricSnapshotRepositorySpec.scala
@@ -1,0 +1,125 @@
+package versola.loadgen.store
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import com.augustnagro.magnum.sql
+import versola.util.DatabaseSpecBase
+import zio.*
+import zio.test.*
+
+import java.time.Instant
+
+final case class MetricSnapshotEnv(repository: MetricSnapshotRepository)
+
+/** `vu_metric_snapshots` against a real Postgres.
+  *
+  * The idempotency this table claims is not in the Scala: it is one `ON CONFLICT` target that
+  * has to name exactly the columns `vu_metric_snapshots_identity_idx` indexes, including the
+  * `COALESCE(scenario, '')` that makes a flow snapshot -- whose `scenario` is NULL -- comparable
+  * at all. Get that wrong and a retried write double-counts its buckets into the campaign's
+  * merged latency, which is the number the whole campaign exists to produce.
+  */
+object PostgresMetricSnapshotRepositorySpec extends LoadgenPostgresSpec, DatabaseSpecBase[MetricSnapshotEnv]:
+
+  private val now = Instant.parse("2026-01-01T12:00:00Z")
+
+  private def step(driverId: String, capturedAt: Instant, name: String = "authorize"): MetricSnapshotRow =
+    MetricSnapshotRow(
+      campaign = "nightly",
+      driverId = driverId,
+      capturedAt = capturedAt,
+      wireVersion = 1,
+      kind = MeasurementKind.Step,
+      scenario = Some("mobile-login"),
+      name = name,
+      unit = "ms",
+      sampleCount = 1024,
+      histogram = "HISTFAAAAB4",
+    )
+
+  /** §11 labels a flow on its own rather than inside a scenario, so this is the NULL-`scenario`
+    * row the identity index has to cope with.
+    */
+  private def flow(driverId: String, capturedAt: Instant): MetricSnapshotRow =
+    step(driverId, capturedAt).copy(kind = MeasurementKind.Flow, scenario = None, name = "login")
+
+  override lazy val environment =
+    ZLayer:
+      ZIO.serviceWith[TransactorZIO](xa => MetricSnapshotEnv(PostgresMetricSnapshotRepository(xa)))
+
+  override def beforeEach(env: MetricSnapshotEnv) =
+    ZIO.serviceWithZIO[TransactorZIO]:
+      _.connect(sql"TRUNCATE TABLE vu_metric_snapshots".update.run()).unit
+
+  override def testCases(env: MetricSnapshotEnv) = List(
+    test("appendAll then loadCampaign round-trips a snapshot, histogram payload included") {
+      val snapshot = step("driver-0", now)
+      for
+        _     <- env.repository.appendAll(Chunk(snapshot))
+        found <- env.repository.loadCampaign("nightly", now.minusSeconds(60))
+      yield assertTrue(found == Vector(snapshot))
+    },
+    test("a flow snapshot round-trips with no scenario, which means not applicable and not unknown") {
+      val snapshot = flow("driver-0", now)
+      for
+        _     <- env.repository.appendAll(Chunk(snapshot))
+        found <- env.repository.loadCampaign("nightly", now.minusSeconds(60))
+      yield assertTrue(found == Vector(snapshot), found.head.scenario.isEmpty)
+    },
+    test("re-writing a snapshot that already landed adds nothing, so a retry cannot double-count") {
+      val snapshot = step("driver-0", now)
+      for
+        _     <- env.repository.appendAll(Chunk(snapshot))
+        _     <- env.repository.appendAll(Chunk(snapshot.copy(sampleCount = 2048, histogram = "HISTFAAAAB5")))
+        found <- env.repository.loadCampaign("nightly", now.minusSeconds(60))
+      yield assertTrue(found.size == 1, found.head.sampleCount == 1024L)
+    },
+    test("a retried flow snapshot is deduplicated too, though its scenario is NULL") {
+      val snapshot = flow("driver-0", now)
+      for
+        _     <- env.repository.appendAll(Chunk(snapshot))
+        _     <- env.repository.appendAll(Chunk(snapshot))
+        found <- env.repository.loadCampaign("nightly", now.minusSeconds(60))
+      yield assertTrue(found.size == 1)
+    },
+    test("a step and a flow of the same interval are different snapshots, not a conflict") {
+      for
+        _     <- env.repository.appendAll(Chunk(step("driver-0", now), flow("driver-0", now)))
+        found <- env.repository.loadCampaign("nightly", now.minusSeconds(60))
+      yield assertTrue(found.size == 2)
+    },
+    test("two drivers' snapshots of the same interval both land") {
+      for
+        _     <- env.repository.appendAll(Chunk(step("driver-0", now), step("driver-1", now)))
+        found <- env.repository.loadCampaign("nightly", now.minusSeconds(60))
+      yield assertTrue(found.map(_.driverId) == Vector("driver-0", "driver-1"))
+    },
+    test("loadCampaign returns the campaign in interval order, driver by driver within one") {
+      val later = now.plusSeconds(60)
+      for
+        _ <- env.repository.appendAll(Chunk(step("driver-1", later), step("driver-1", now), step("driver-0", now)))
+        found <- env.repository.loadCampaign("nightly", now.minusSeconds(60))
+      yield assertTrue(
+        found.map(row => (row.driverId, row.capturedAt)) ==
+          Vector(("driver-0", now), ("driver-1", now), ("driver-1", later))
+      )
+    },
+    test("loadCampaign reads one campaign, not the run before it") {
+      for
+        _     <- env.repository.appendAll(Chunk(step("driver-0", now), step("driver-0", now).copy(campaign = "smoke")))
+        found <- env.repository.loadCampaign("nightly", now.minusSeconds(60))
+      yield assertTrue(found.map(_.campaign) == Vector("nightly"))
+    },
+    test("loadCampaign starts at `since`, so a merge can be incremental") {
+      val later = now.plusSeconds(60)
+      for
+        _     <- env.repository.appendAll(Chunk(step("driver-0", now), step("driver-0", later)))
+        found <- env.repository.loadCampaign("nightly", later)
+      yield assertTrue(found.map(_.capturedAt) == Vector(later))
+    },
+    test("appendAll on an empty chunk is a no-op, not an empty round trip") {
+      for
+        _     <- env.repository.appendAll(Chunk.empty)
+        found <- env.repository.loadCampaign("nightly", now.minusSeconds(60))
+      yield assertTrue(found.isEmpty)
+    },
+  )

--- a/loadgen/src/test/scala/versola/loadgen/store/PostgresVirtualUserRepositorySpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/store/PostgresVirtualUserRepositorySpec.scala
@@ -1,0 +1,163 @@
+package versola.loadgen.store
+
+import com.augustnagro.magnum.magzio.TransactorZIO
+import com.augustnagro.magnum.sql
+import versola.loadgen.model.*
+import versola.util.{DatabaseSpecBase, Secret}
+import zio.*
+import zio.test.*
+
+import java.util.UUID
+
+final case class VirtualUserEnv(repository: VirtualUserRepository)
+
+/** `vu_users` against a real Postgres: the keyset pagination every driver walks its slice with,
+  * the state transitions the coordinator's registration controller drives, and the `phone`
+  * constraint the seeder detects collisions by.
+  */
+object PostgresVirtualUserRepositorySpec extends LoadgenPostgresSpec, DatabaseSpecBase[VirtualUserEnv]:
+
+  private def user(id: Long, shard: Int, state: VirtualUserState = VirtualUserState.Planned): VirtualUser =
+    VirtualUser(
+      id = id,
+      sutUserId = None,
+      phone = f"+7700000$id%04d",
+      password = Some(s"secret-$id"),
+      activityClass = ActivityClass.Regular,
+      platform = Platform.Mobile,
+      credential = CredentialKind.OtpPassword,
+      role = UserRole.RetailUser,
+      passkeyKey = None,
+      passkeyCredId = None,
+      state = state,
+      shard = shard,
+      lastSeenAt = None,
+    )
+
+  /** `Secret` is an `Array[Byte]` newtype, so a case-class comparison of two of them is a
+    * reference comparison. Compared as bytes here, and excluded from the whole-row comparison.
+    */
+  private def bytes(secret: Option[Secret]): Option[Seq[Byte]] = secret.map(_.toSeq)
+
+  override lazy val environment =
+    ZLayer:
+      ZIO.serviceWith[TransactorZIO](xa => VirtualUserEnv(PostgresVirtualUserRepository(xa)))
+
+  override def beforeEach(env: VirtualUserEnv) =
+    ZIO.serviceWithZIO[TransactorZIO]:
+      _.connect(sql"TRUNCATE TABLE vu_users".update.run()).unit
+
+  override def testCases(env: VirtualUserEnv) = List(
+    test("insertAll then find round-trips every persisted column, in the order V0001 declares them") {
+      val planned = user(1, shard = 0)
+      for
+        _     <- env.repository.insertAll(Chunk(planned))
+        found <- env.repository.find(1)
+      yield assertTrue(found.contains(planned))
+    },
+    test("a registered user round-trips its SUT identity and its passkey material") {
+      val enrolled = user(1, shard = 0, state = VirtualUserState.Registered).copy(
+        sutUserId = Some(UUID.fromString("00000000-0000-0000-0000-0000000000ff")),
+        credential = CredentialKind.Passkey,
+        platform = Platform.Web,
+        activityClass = ActivityClass.Heavy,
+        role = UserRole.RetailBasic,
+        passkeyKey = Some(Secret.fromString("pkcs8-private-key")),
+        passkeyCredId = Some("credential-1"),
+      )
+      for
+        _     <- env.repository.insertAll(Chunk(enrolled))
+        found <- env.repository.find(1)
+      yield assertTrue(
+        found.map(_.copy(passkeyKey = None)).contains(enrolled.copy(passkeyKey = None)),
+        found.map(u => bytes(u.passkeyKey)).contains(bytes(enrolled.passkeyKey)),
+      )
+    },
+    test("insertAll on an empty chunk is a no-op, not an empty round trip") {
+      env.repository.insertAll(Chunk.empty).as(assertCompletes)
+    },
+    test("the phone constraint rejects a second user claiming the same number") {
+      val taken = user(1, shard = 0)
+      for
+        _    <- env.repository.insertAll(Chunk(taken))
+        exit <- env.repository.insertAll(Chunk(user(2, shard = 0).copy(phone = taken.phone))).exit
+      yield assertTrue(exit.isFailure)
+    },
+    test("loadShardSlice pages through one driver's slice by keyset, without repeating a row") {
+      val population = Chunk(user(1, 0), user(2, 1), user(3, 0), user(4, 1), user(5, 0))
+      for
+        _      <- env.repository.insertAll(population)
+        first  <- env.repository.loadShardSlice(shard = 0, afterId = None, limit = 2)
+        second <- env.repository.loadShardSlice(shard = 0, afterId = first.lastOption.map(_.id), limit = 2)
+        third  <- env.repository.loadShardSlice(shard = 0, afterId = second.lastOption.map(_.id), limit = 2)
+      yield assertTrue(
+        first.map(_.id) == Vector(1L, 3L),
+        second.map(_.id) == Vector(5L),
+        third.isEmpty,
+      )
+    },
+    test("loadShardSlice starting from no id begins at the first user, not the second") {
+      for
+        _     <- env.repository.insertAll(Chunk(user(1, 0), user(2, 0)))
+        slice <- env.repository.loadShardSlice(shard = 0, afterId = None, limit = 10)
+      yield assertTrue(slice.map(_.id) == Vector(1L, 2L))
+    },
+    test("markRegistered records the SUT identity and leaves the state registered in one statement") {
+      val sutUserId = UUID.fromString("00000000-0000-0000-0000-00000000000a")
+      for
+        _     <- env.repository.insertAll(Chunk(user(1, shard = 0)))
+        _     <- env.repository.markRegistered(1, sutUserId)
+        found <- env.repository.find(1)
+      yield assertTrue(
+        found.flatMap(_.sutUserId).contains(sutUserId),
+        found.map(_.state).contains(VirtualUserState.Registered),
+      )
+    },
+    test("markBroken moves a user out of the population the scheduler picks from") {
+      for
+        _     <- env.repository.insertAll(Chunk(user(1, shard = 0, state = VirtualUserState.Registered)))
+        _     <- env.repository.markBroken(1)
+        found <- env.repository.find(1)
+      yield assertTrue(found.map(_.state).contains(VirtualUserState.Broken))
+    },
+    test("recordPasskey persists the key and the credential id the SUT now knows about") {
+      val key = Secret.fromString("pkcs8-private-key")
+      for
+        _     <- env.repository.insertAll(Chunk(user(1, shard = 0)))
+        _     <- env.repository.recordPasskey(1, key, "credential-1")
+        found <- env.repository.find(1)
+      yield assertTrue(
+        found.map(u => bytes(u.passkeyKey)).contains(Some(key.toSeq)),
+        found.flatMap(_.passkeyCredId).contains("credential-1"),
+      )
+    },
+    test("touchAll moves last_seen_at for the batch, and of nothing else") {
+      val seenAt = java.time.Instant.parse("2026-01-01T12:00:00Z")
+      for
+        _         <- env.repository.insertAll(Chunk(user(1, 0), user(2, 0)))
+        _         <- env.repository.touchAll(Chunk(UserTouch(1, seenAt)))
+        touched   <- env.repository.find(1)
+        untouched <- env.repository.find(2)
+      yield assertTrue(
+        touched.flatMap(_.lastSeenAt).contains(seenAt),
+        untouched.flatMap(_.lastSeenAt).isEmpty,
+      )
+    },
+    test("touchAll on an empty batch is a no-op, not an empty round trip") {
+      env.repository.touchAll(Chunk.empty).as(assertCompletes)
+    },
+    test("countByState counts every state that has rows, and omits the ones that do not") {
+      val population = Chunk(
+        user(1, 0),
+        user(2, 0),
+        user(3, 0, state = VirtualUserState.Registered),
+      )
+      for
+        _      <- env.repository.insertAll(population)
+        counts <- env.repository.countByState
+      yield assertTrue(
+        counts == Map(VirtualUserState.Planned -> 2L, VirtualUserState.Registered -> 1L),
+        !counts.contains(VirtualUserState.Broken),
+      )
+    },
+  )

--- a/loadgen/src/test/scala/versola/loadgen/store/StoreCodesSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/store/StoreCodesSpec.scala
@@ -1,0 +1,51 @@
+package versola.loadgen.store
+
+import versola.loadgen.model.*
+import zio.test.*
+
+/** The codes are a storage format: a campaign's rows outlive the driver that wrote them, so
+  * these numbers are pinned here as well as in [[StoreCodes]]. A change that renumbers a case
+  * has to fail a test rather than quietly reinterpret every row already in `vu_users`.
+  */
+object StoreCodesSpec extends ZIOSpecDefault:
+
+  private def roundTrips[A](codes: StoreCodes.Codes[A], all: Array[A]): Boolean =
+    all.forall(value => codes.decode(codes.encode(value)) == value)
+
+  def spec = suite("StoreCodes")(
+    test("every enum case round-trips through its SMALLINT code") {
+      assertTrue(
+        roundTrips(StoreCodes.activityClass, ActivityClass.values),
+        roundTrips(StoreCodes.platform, Platform.values),
+        roundTrips(StoreCodes.credential, CredentialKind.values),
+        roundTrips(StoreCodes.role, UserRole.values),
+        roundTrips(StoreCodes.userState, VirtualUserState.values),
+        roundTrips(StoreCodes.sessionKind, SessionKind.values),
+        roundTrips(StoreCodes.measurementKind, MeasurementKind.values),
+      )
+    },
+    test("codes are the pinned values, not the declaration order of the enum") {
+      assertTrue(
+        StoreCodes.activityClass.encode(ActivityClass.Heavy) == 0.toShort,
+        StoreCodes.activityClass.encode(ActivityClass.Regular) == 1.toShort,
+        StoreCodes.activityClass.encode(ActivityClass.Light) == 2.toShort,
+        StoreCodes.activityClass.encode(ActivityClass.Dormant) == 3.toShort,
+        StoreCodes.credential.encode(CredentialKind.Otp) == 0.toShort,
+        StoreCodes.credential.encode(CredentialKind.OtpPassword) == 1.toShort,
+        StoreCodes.credential.encode(CredentialKind.Passkey) == 2.toShort,
+        StoreCodes.userState.encode(VirtualUserState.Planned) == 0.toShort,
+        StoreCodes.userState.encode(VirtualUserState.Registered) == 1.toShort,
+        StoreCodes.userState.encode(VirtualUserState.Broken) == 2.toShort,
+        StoreCodes.sessionKind.encode(SessionKind.MobileToken) == 0.toShort,
+        StoreCodes.sessionKind.encode(SessionKind.WebCookie) == 1.toShort,
+        StoreCodes.measurementKind.encode(MeasurementKind.Step) == 0.toShort,
+        StoreCodes.measurementKind.encode(MeasurementKind.Flow) == 1.toShort,
+      )
+    },
+    test("an unrecognised code is a defect on the read path, not a fallback value") {
+      assertTrue(
+        StoreCodes.userState.decodeOption(9) == None,
+        scala.util.Try(StoreCodes.userState.decode(9)).isFailure,
+      )
+    },
+  )

--- a/loadgen/src/test/scala/versola/loadgen/store/WriteBehindBufferSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/store/WriteBehindBufferSpec.scala
@@ -1,0 +1,152 @@
+package versola.loadgen.store
+
+import versola.loadgen.config.WriteBehindConfig
+import zio.*
+import zio.test.*
+
+import java.time.Instant
+
+/** Covers the batching, timing and drop behaviour of the deferred write path (dev spec §7.5)
+  * against a recording sink. The Postgres side of the store cannot be exercised here -- there
+  * is no database in this build -- so everything below is about what the buffer decides to
+  * hand the sink and when, not about what the sink then writes.
+  */
+object WriteBehindBufferSpec extends ZIOSpecDefault:
+
+  private val t0 = Instant.parse("2026-09-10T20:00:00Z")
+
+  private final class RecordingSink(batches: Queue[DeferredBatch], failing: Ref[Boolean]) extends DeferredWriteSink:
+    override def write(batch: DeferredBatch): Task[Unit] =
+      failing.get.flatMap:
+        case true => ZIO.fail(RuntimeException("store unavailable"))
+        case false => batches.offer(batch).unit
+
+  private def recordingSink(failing: Ref[Boolean]): UIO[(Queue[DeferredBatch], DeferredWriteSink)] =
+    Queue.unbounded[DeferredBatch].map(queue => (queue, RecordingSink(queue, failing)))
+
+  /** Takes batches until `count` user touches have arrived. Blocking rather than polling: the
+    * background loop and an explicit flush may split the same updates differently, and this
+    * asserts on what reached the sink, not on how it was cut up.
+    */
+  private def takeUserTouches(batches: Queue[DeferredBatch], count: Int): UIO[Chunk[UserTouch]] =
+    def loop(acc: Chunk[UserTouch]): UIO[Chunk[UserTouch]] =
+      if acc.size >= count then ZIO.succeed(acc)
+      else batches.take.flatMap(batch => loop(acc ++ batch.userTouches))
+    loop(Chunk.empty)
+
+  def spec = suite("WriteBehindBuffer")(
+    test("holds a partial batch until the flush interval elapses, then writes it") {
+      for
+        failing <- Ref.make(false)
+        (batches, sink) <- recordingSink(failing)
+        result <- ZIO.scoped:
+          for
+            buffer <- WriteBehindBuffer.make(WriteBehindConfig(1.second, 500), 1000, sink)
+            _ <- ZIO.foreachDiscard(1L to 3L)(id => buffer.enqueue(DeferredUpdate.UserSeen(id, t0)))
+            _ <- ZIO.yieldNow
+            beforeTick <- batches.takeAll
+            _ <- TestClock.adjust(1.second)
+            touches <- takeUserTouches(batches, 3)
+          yield assertTrue(
+            beforeTick.isEmpty,
+            touches.map(_.userId).toSet == Set(1L, 2L, 3L),
+          )
+      yield result
+    },
+    test("flushes as soon as batch-size updates are queued, without waiting for the interval") {
+      for
+        failing <- Ref.make(false)
+        (batches, sink) <- recordingSink(failing)
+        result <- ZIO.scoped:
+          for
+            // An interval long enough that a flush within this test can only be the doorbell.
+            buffer <- WriteBehindBuffer.make(WriteBehindConfig(1.hour, 4), 1000, sink)
+            _ <- ZIO.foreachDiscard(1L to 4L)(id => buffer.enqueue(DeferredUpdate.UserSeen(id, t0)))
+            touches <- takeUserTouches(batches, 4)
+            pending <- buffer.pending
+          yield assertTrue(touches.size == 4, pending == 0)
+      yield result
+    },
+    test("coalesces a window down to one write per user before handing it to the sink") {
+      for
+        failing <- Ref.make(false)
+        (batches, sink) <- recordingSink(failing)
+        result <- ZIO.scoped:
+          for
+            buffer <- WriteBehindBuffer.make(WriteBehindConfig(1.second, 500), 1000, sink)
+            _ <- buffer.enqueue(DeferredUpdate.UserSeen(1L, t0))
+            _ <- buffer.enqueue(DeferredUpdate.UserSeen(1L, t0.plusSeconds(3)))
+            _ <- TestClock.adjust(1.second)
+            batch <- batches.take
+          yield assertTrue(batch.userTouches == Chunk(UserTouch(1L, t0.plusSeconds(3))))
+      yield result
+    },
+    test("drops on overflow and counts it, instead of making the caller wait") {
+      for
+        failing <- Ref.make(false)
+        (_, sink) <- recordingSink(failing)
+        result <- ZIO.scoped:
+          for
+            buffer <- WriteBehindBuffer.make(WriteBehindConfig(1.hour, 100), 4, sink)
+            // Ten enqueues into a queue of four, with no flush possible: the interval is an
+            // hour away on a clock nothing advances, and the doorbell needs 100.
+            _ <- ZIO.foreachDiscard(1L to 10L)(id => buffer.enqueue(DeferredUpdate.UserSeen(id, t0)))
+            onEnqueue <- buffer.droppedOnEnqueue
+            onFlush <- buffer.droppedOnFlush
+            dropped <- buffer.droppedTotal
+            pending <- buffer.pending
+          yield assertTrue(onEnqueue == 6L, onFlush == 0L, dropped == 6L, pending == 4)
+      yield result
+    },
+    test("counts a batch the store rejected as dropped rather than retrying it") {
+      for
+        failing <- Ref.make(true)
+        (_, sink) <- recordingSink(failing)
+        result <- ZIO.scoped:
+          for
+            buffer <- WriteBehindBuffer.make(WriteBehindConfig(1.hour, 100), 1000, sink)
+            _ <- buffer.enqueue(DeferredUpdate.UserSeen(1L, t0))
+            _ <- buffer.enqueue(DeferredUpdate.UserSeen(2L, t0))
+            _ <- buffer.flush
+            onFlush <- buffer.droppedOnFlush
+            onEnqueue <- buffer.droppedOnEnqueue
+            dropped <- buffer.droppedTotal
+            pending <- buffer.pending
+          yield assertTrue(onFlush == 2L, onEnqueue == 0L, dropped == 2L, pending == 0)
+      yield result
+    },
+    test("an explicit flush drains more than one batch-size window") {
+      for
+        failing <- Ref.make(false)
+        (batches, sink) <- recordingSink(failing)
+        result <- ZIO.scoped:
+          for
+            buffer <- WriteBehindBuffer.make(WriteBehindConfig(1.hour, 2), 1000, sink)
+            _ <- ZIO.foreachDiscard(1L to 5L)(id => buffer.enqueue(DeferredUpdate.UserSeen(id, t0)))
+            _ <- buffer.flush
+            touches <- takeUserTouches(batches, 5)
+            pending <- buffer.pending
+            dropped <- buffer.droppedTotal
+          yield assertTrue(
+            touches.map(_.userId).toSet == Set(1L, 2L, 3L, 4L, 5L),
+            pending == 0,
+            dropped == 0L,
+          )
+      yield result
+    },
+    test("drains what is still queued when its scope closes") {
+      for
+        failing <- Ref.make(false)
+        (batches, sink) <- recordingSink(failing)
+        _ <- ZIO.scoped:
+          for
+            buffer <- WriteBehindBuffer.make(WriteBehindConfig(1.hour, 100), 1000, sink)
+            _ <- buffer.enqueue(DeferredUpdate.EventSampled(EventRow(t0, 1L, "mobile-otp", "token", "ok", 9)))
+          yield ()
+        flushed <- batches.take
+      yield assertTrue(flushed.events.map(_.userId) == Chunk(1L))
+    },
+    test("capacity is sixty-four flush windows of the configured batch size") {
+      assertTrue(WriteBehindBuffer.capacityFor(WriteBehindConfig(200.millis, 500)) == 32_000)
+    },
+  )


### PR DESCRIPTION
Closes #272. Part of #267.

> Base branch is #295 (`feat/postgres-config-path`), which this needs — see "Blockers, both now closed" below. W0 (#264), W1 (#265/#291) and track A (#287) are already in `main`. Merge order: #295 → this.

Track C: the emulator's own Postgres — where virtual users and device sessions live. Not the SUT's database.

## What this adds

- **Migrations** `V0001__virtual_users.sql`, `V0002__device_sessions.sql`, `V0003__events.sql`, `V0004__metric_snapshots.sql`. The first three are `UNLOGGED`, none has a `DEFAULT` on any column (per #267), and there is no FK from `vu_sessions` to `vu_users`. `synchronous_commit = off` is applied in V0001 via `ALTER DATABASE current_database()` inside a `DO` block that downgrades `insufficient_privilege` to a `WARNING`, so a non-owner role doesn't turn it into a boot failure.
- **Repository traits + Postgres implementations** for virtual users, device sessions, events and metric snapshots, following the house magnum pattern. The traits live here rather than in W1 deliberately: they should be defined by what the migrations actually persist, not guessed ahead of them.
- **`LoadgenStore`** — the whole store as one layer: pool + schema, the four repositories, the deferred sink, the write-behind buffer.
- **Write-behind buffer** (§7.5) driven by the existing `WriteBehindConfig`, with `DeferredBatch.coalesce` collapsing repeated touches of the same row.

### Index layout

| Table | Index | Query it serves |
|---|---|---|
| `vu_users` | PK `(id)` | `find(id)` |
| | `(shard, id)` | `loadShardSlice`: keyset pagination, range scan, no sort |
| | `phone UNIQUE` | seeder collision detection |
| | `(state)` — added | coordinator's `GROUP BY state` every 60 s; otherwise a full scan of 10–20M rows on a fixed timer |
| `vu_sessions` | PK `(id)`, `(user_id)` | `find`, `listByUser` |
| | `(shard, COALESCE(refresh_expires_at, access_expires_at))` | `listLive`: driver startup load of its own still-resumable sessions, mobile and web alike |
| `vu_events` | none, deliberately | append-only at ~5M rows/day, never read during a run |
| `vu_metric_snapshots` | `(campaign, driver_id, captured_at, kind, COALESCE(scenario,''), name) UNIQUE` | snapshot identity, so a retried write can't double-count buckets |
| | `(campaign, captured_at)` | `GET /report/{campaign}`'s scan |

### What track F reads

`WriteBehindBuffer.droppedOnEnqueue` and `droppedOnFlush`, summed by `droppedTotal` → `loadgen_store_flush_dropped_total`, plus `pending` (queue depth, the leading indicator). The two causes are counted separately because they call for different actions — a full queue means the emulator is undersized and the run is invalid, a rejected flush means Postgres returned an error and something is broken — even though both invalidate a campaign the same way. Failed batches are counted and logged, never retried. Capacity is `batchSize × 64`, ~13 s of backlog at the configured 200 ms flush interval.

F also has a table to write its 60-second snapshots into now; see decision 7.

## Verified

`sbt "loadgen/compile" "loadgen/Test/compile" "loadgen/test"` — **70 tests pass**: the original 24 pure ones (write-behind batching/flush/split-drop accounting under `TestClock`, batch coalescing, enum codecs, migration naming) plus 46 repository tests against a real Postgres, below. `sbt compile "tools/compile" "mockapi/compile"` clean, and `scalafmtCheck` clean on every file this PR touches.

V0001–V0004 also applied to a real Postgres 15 for the first time, which is how the `listLive` defect below was confirmed rather than argued: with one mobile, one live web and one expired web session in the same shard, the old predicate returned the mobile session alone, the new one returns both live sessions in expiry order, and `EXPLAIN` shows `Index Scan using vu_sessions_shard_idx` with no `Sort` node — so the expression index is accepted and still serves the ordering.

### Repository tests

Every test this track had was pure, both defects review found were in SQL, and neither was reachable from any of them — so the store now has a database-backed suite.

`LoadgenPostgresSpec` is `util-postgres`' `PostgresSpec` for the emulator's own store: same host and credentials, its own database, because this schema numbers its migrations from `V0001` exactly as auth's does and one `flyway_schema_history` cannot hold both. Flyway applies a schema but does not create a database, and neither CI's service container nor the dev compose knows about this one, so the layer creates it — connecting through `auth`, the database both of them do create, so it needs no privilege `PostgresSpec` does not already use. Migration locations come from `LoadgenMigrations.locations` rather than a path of the spec's own: a spec that named the directory itself would keep passing if the production constant were wrong, which is the failure `MigrationNamingSpec` exists for.

| Suite | Covers |
|---|---|
| `PostgresDeviceSessionRepositorySpec` | column-order round trip for both kinds, the §7.4 generation guard (a stale generation cannot resurrect a retired token), `storeStepUp`'s `COALESCE` keeping what a step-up did not rotate, `listLive`'s resumability rule per kind, shard confinement, ordering and limit |
| `PostgresVirtualUserRepositorySpec` | round trip including the passkey `Secret`, keyset pagination that neither repeats nor skips a row, `markRegistered`/`markBroken`/`recordPasskey`, batched touches, `countByState` omitting states with no rows, and the `phone` constraint the seeder detects collisions by |
| `PostgresMetricSnapshotRepositorySpec` | the identity index, including the flow snapshot whose NULL `scenario` is the entire reason it is an expression index — a retried write adds nothing, a step and a flow of the same interval do not collide |
| `PostgresEventRepositorySpec` | the forensic sample lands in full, in order, duplicates kept (it is a log, not a state), with every column where it belongs — the table has no read path, so a misplaced column is unrecoverable at forensics time |

Checked against the defects, not only against the fix: reverting the `listLive` predicate fails five of these, and dropping the `sso_session` write or the `COALESCE` from the snapshot `ON CONFLICT` target fails ten.

Two consequences worth flagging: **`sbt loadgen/test` now needs a Postgres**, as root's `sbt test` already does, and `Test / parallelExecution := false` is set for the same reason the three `*-postgres-impl` projects set it. CI still runs none of it — that is #268's workflow change, unchanged by this PR.

## Blockers, both now closed

1. **Flyway would not have picked up `L`-prefixed migrations.** Flyway's default `sqlMigrationPrefix` is `V` and `PostgresHikariDataSource` sets `validateMigrationNaming(false)`, so `L0001__*.sql` was **skipped, not rejected**: the process boots, reports itself ready, and the first query fails against a table that was never created.

   Resolved by renaming to `V0001__*`, against dev spec §6's naming. The `L` prefix was there to tell this schema apart from a service's, and it bought nothing that isn't already true: the directory is `loadgen/migrations`, which `PostgresHikariDataSource`'s auto-detection (paths ending `postgres/migrations`) never matches, so `migrationLocations` has to be passed explicitly either way — and the schema lives in its own database, so its versions share no history table with auth's and cannot collide. That left a silent-skip failure mode and a new `sqlMigrationPrefix` parameter on a function every service depends on as the entire cost of the prefix.

   The requirement behind the prefix — this schema is never applied together with another project's — is enforced structurally instead: `LoadgenStore.transactor` is the only way to build the store's pool, and it always passes `LoadgenMigrations.locations`. Since Flyway is configured never to validate naming, `MigrationNamingSpec` does: every file must match `V\d{4}__[a-z0-9_]+\.sql`, versions unique and contiguous, directory non-empty so neither assertion is vacuous.

2. **`StoreConfig` could not build a datasource.** It carried `url` + `maximum-pool-size` — no user, password, `minimumIdle` or timeouts — so there was no way to construct a `TransactorZIO` for the emulator's database, and the repositories were left as `ZLayer[TransactorZIO, …]` with nothing to provide it.

   Resolved by `store { postgres { … } }` carrying `util-postgres`' own `PostgresConfig`, read through the `configPath` parameter #295 adds to `PostgresHikariDataSource.transactor`. That reuses the pool-tuning validation, the `Secret`-typed password and the `migrate`-vs-`validate` semantics instead of hand-rolling a second copy of all of it.

   The block stays nested rather than becoming the ambient top-level `postgres { }`, which was the other option on the table, because `loadgen` genuinely talks to **two** databases: this one, and — in its `seed` role (§10) — the SUT's, which it `COPY`s 10–20M users into. One unnamed block cannot name both, so `store.url` is not redundant, it is one of two.

## Decisions taken

3. **`shard = id % shardCount` stays; the prose was what was wrong.** Dev spec §6/§7.1 justified the dense `BIGINT` with "range scan" and "re-sharding is a predictable range move", which modulo does not deliver — but the range scan never depended on a driver's ids being contiguous. It comes from `vu_users_shard_idx` on `(shard, id)`, where one driver's slice *is* one contiguous stretch, and that is what this builds for. Modulo also stays balanced when the population has holes (broken users) and needs no shard map for the seeder, the drivers and the coordinator to agree.

   What it costs is re-sharding: 8→16 moves half the rows, where range assignment would move only boundaries. That is affordable because re-sharding is legal only at a phase boundary behind the coordinator's drain protocol (§12), so it is a bulk `UPDATE … SET shard = id % 16` on an `UNLOGGED` table while nothing is running. The dev spec's §6/§7.1 wording and design doc §6.2's "assigns user-id ranges to drivers" are corrected to match. Track D (#289) hit the same contradiction from the other side and lands on the same rule.

4. **The W1 model types *are* the persisted shapes now.** `VirtualUserRow`/`DeviceSessionRow` are gone; `model.VirtualUser` and `model.DeviceSession` carry what V0001/V0002 persist, in column order, and `VirtualUserState` moved next to `ActivityClass`/`Platform`.

   Two types differing only by omission drift, and the omission wasn't a domain distinction — it was W1 guessing ahead of the migrations. What the rows added were exactly the credentials that make a user or session resumable, which the scenario engine (track I) needs to run a session at all, so the two would have converged anyway. The enum↔`SMALLINT` mapping stays in `StoreCodecs`, which is a codec concern rather than a reason for a second data shape. `passkeyKey` is `Option[Secret]` so widening the model can't put a private key into a log line.

5. **`acr` moves from §7.5's deferred class to the critical one.** Both occasions that change it already write a credential at the same moment: a refresh exchange (`storeRotatedRefresh`, which persisted `acr` already) and a completed step-up (`storeStepUp`, new here). So the column costs nothing extra, while a dropped `acr` would leave a resumed session claiming an assurance level it does not hold — the driver would then either step up again for no reason, distorting the scenario mix it reports, or skip one the SUT demands. `SessionTouch` is down to `access_expires_at`, and `DeferredBatch`'s column-wise merge went with it.

   `storeStepUp` is deliberately not generation-guarded, unlike `storeRotatedRefresh`: a step-up is an authorization-code exchange on the same SSO session, so nothing was bumped and there is no predecessor token the SUT could detect as reused.

6. **Write-behind keeps magnum `batchUpdate` over §7.5's `COPY` into a temp table + `UPDATE … FROM`.** At 500 rows against an `UNLOGGED` table the temp-table setup costs more than the round trip it saves. `COPY` keeps the seeder's millions-of-rows path (§10) — this is not a retreat from it. Cheap to revisit once a DB-backed benchmark can disagree.

7. **`V0004__metric_snapshots.sql` defines the table §11 asks for and doesn't name.** It didn't need track F's JSON format to settle: HdrHistogram's compressed encoding is its own stable format, so the column is that payload base64url'd plus its coordinates (campaign, driver, interval, measurement, unit, count) and F's envelope version, so a coordinator can refuse a payload it can't read rather than decode it into a plausible-looking histogram of the wrong shape. `MetricSnapshotRow` is deliberately primitives rather than F's `EncodedHistogram`/`MeasurementId` — the store persists the wire form, F owns what produces it.

   **It is the only `LOGGED` table in this schema**, against §6's blanket rule. Everything else here is reconstructible by a re-seed, which is what justifies `UNLOGGED` — and `UNLOGGED` means *truncated* on crash recovery, not merely stale. These rows are the campaign's measured latency, accumulated over a run that takes hours, and the merged p99 is the whole deliverable; losing them to an unrelated Postgres restart means re-running the campaign.

8. **The `Sharding` overlap with track D is resolved here, not left to merge order.** `store/Sharding.scala` and its spec are deleted; track D's `scheduler/ShardAssignment` (#289) is the single implementation of §7.1's `shard = id % count`, and it is the richer one — config-aware, with `firstOwnedIdAtOrAfter` and `validate`.

   Nothing in this track needed a second copy: every repository takes `shard: Int` from its caller, so C had no production call site at all, only a test exercising a function C never invoked. The two facts that made the store's copy look load-bearing stay where they belong — V0001's comment on `vu_users_shard_idx` for why `shard` is a denormalised column rather than an `id % ?` predicate (not sargable), and `loadShardSlice`'s own doc for the `-1` sentinel. The first caller that actually needs `shardOf` is the seeder (§10, track H), which lands after both.

## Review fixes

9. **A restored session carried no `SSO_SESSION`, so it could not be the session it resumed.** `AuthClient.authorize` takes the cookie precisely so a silent reauthorization or an ACR step-up runs on the driver's existing SSO session (§7.4). Without it persisted, a restarted driver starts a new one: the silent reauth degrades into a credential login and the step-up has nothing to step up, so the campaign reports a scenario mix it did not run.

   `sso_session TEXT` joins the other two credentials in V0002 and `ssoSession: Option[SsoSession]` joins them in `DeviceSession`, on the critical write path for the same reason `acr` is (decision 5): written by `insert`, and by `storeStepUp` under the same `COALESCE(…::text, sso_session)` rule as the token pair, since a step-up is the one flow where auth can re-set the cookie and `None` means "carried no new cookie", not "clear it". `storeRotatedRefresh` leaves it alone — a refresh-token grant is a back-channel call with no browser cookie in play. Nullable, because a web-cookie session never sees one: edge holds the SSO session server-side and the driver only ever gets `EDGE_SESSION`.

10. **`listLive` could not see a live web session at all.** It filtered on `refresh_expires_at`, which a web-cookie session does not have — `NULL > now()` is NULL, so every one of them was dropped from the startup load and its traffic went to a fresh login instead of a resume. Silent by construction: it inflates the login rate and deflates the resume rate rather than failing.

    Which credential bounds resumability depends on the kind — the refresh token for a mobile session, the `EDGE_SESSION` for a web one, whose expiry is `access_expires_at` — so the predicate, the sort and `vu_sessions_shard_idx` are all `COALESCE(refresh_expires_at, access_expires_at)`, written identically because an `OR` or a `CASE` on `kind` stops matching the index expression and turns the startup load into a shard-wide sort. `COALESCE` over `GREATEST` deliberately: the two agree on every row this schema can produce, but `COALESCE` states the rule instead of relying on refresh expiry always being the later of the two.
