### PR TITLE
loadgen: scheduler math -- arrivals, diurnal, think time, action count (Phase 1 / D)

### DIFF
--- a/loadgen/src/main/scala/versola/loadgen/config/LoadgenConfig.scala
+++ b/loadgen/src/main/scala/versola/loadgen/config/LoadgenConfig.scala
@@ -105,6 +105,15 @@ case class FullLoginProbabilityConfig(mobile: Double, web: Double)
 /** NegBinomial parameters for actions-per-session. Named `action-count` in HOCON, not
   * `actions`, to avoid colliding with the top-level business-action list -- see this file's
   * top comment.
+  *
+  * The means count the **user-driven** actions only. `GET /accounts` is issued by the app on
+  * open, not chosen by the user, so `ActionCount` adds it outside the draw: a session averages
+  * `1 + mean` actions, and design doc §2.3's 6.0 / 10.0 correspond to 5.0 / 9.0 here.
+  *
+  * `dispersion` is NB2 α, so `Var = mean × (1 + α × mean)`. Stated here and not only in the test
+  * because one dispersion serving two different means only works if the parameter is
+  * dimensionless; read as the size `r` instead, the same 0.6 would put the mode at 0, which is
+  * the failure this parameterisation exists to avoid.
   */
 case class ActionCountConfig(mobileMean: Double, webMean: Double, dispersion: Double)
 
@@ -122,10 +131,16 @@ case class SessionConfig(
     accessTokenTtl: Duration,
 )
 
-/** One phase of the campaign's arrival-rate envelope (§7.3). `scale` is used by flat phases
-  * (`warmup`, `steady`, `spike`, `recover`); `scaleFrom`/`scaleTo` by the linear `ramp` phase.
-  * All three are optional and mutually informative rather than mutually exclusive in the
-  * schema -- the scheduler (track D) decides which apply per phase `name`.
+/** One phase of the campaign's arrival-rate envelope (§7.3). Which kind of phase it is, is
+  * decided by **which fields are present**: `scale` alone is flat (`warmup`, `steady`, `spike`,
+  * `recover`), `scaleFrom` + `scaleTo` is the linear `ramp`. Deliberately not decided by `name`,
+  * which is a free-text metric label -- renaming `ramp` would otherwise silently change what the
+  * phase does.
+  *
+  * Expressing that in the types (a sealed `Flat | Ramp`) is the better shape and is deferred: it
+  * is a change to shared config surface with several tracks in flight. Until then the ambiguous
+  * and incomplete combinations are rejected here rather than at first use, so a campaign that
+  * cannot be represented fails the layer at boot instead of some minutes into a run.
   */
 case class CampaignPhaseConfig(
     name: String,
@@ -134,6 +149,41 @@ case class CampaignPhaseConfig(
     scaleFrom: Option[Double],
     scaleTo: Option[Double],
 )
+
+object CampaignPhaseConfig:
+  /** Same idiom as [[LoadgenRole]]'s: validate during decode and fail the layer, rather than hand
+    * a shape the scheduler will have to reject onwards.
+    *
+    * A duration is rejected below zero but allowed at zero -- `CampaignSchedule.scaleAt` handles
+    * an empty phase, whereas a negative one puts the phase's end before its start, so it can never
+    * match and its negative offset drags every later phase into an overlapping range. Scales are
+    * rejected unless finite and non-negative, because `CampaignSchedule.rateAt` collapses any
+    * non-positive scale to a rate of 0: a negative one would silently run a phase at no load, and
+    * NaN passes that guard entirely and reaches the sampler as the rate itself. Zero is left legal
+    * as the one honest way to say a phase generates nothing.
+    */
+  def validate(phase: CampaignPhaseConfig): Either[String, CampaignPhaseConfig] =
+    def scaleOk(field: String, value: Double): Either[String, Unit] =
+      if value.isNaN || value.isInfinite then Left(s"campaign phase '${phase.name}' has a non-finite $field")
+      else if value < 0.0 then Left(s"campaign phase '${phase.name}' has a negative $field: $value")
+      else Right(())
+
+    for
+      _ <- Either.cond(
+        !phase.duration.isNegative,
+        (),
+        s"campaign phase '${phase.name}' has a negative duration: ${phase.duration}",
+      )
+      _ <- (phase.scale, phase.scaleFrom, phase.scaleTo) match
+        case (Some(scale), None, None) => scaleOk("scale", scale)
+        case (None, Some(from), Some(to)) => scaleOk("scale-from", from).flatMap(_ => scaleOk("scale-to", to))
+        case (Some(_), _, _) => Left(s"campaign phase '${phase.name}' sets both scale and scale-from/scale-to")
+        case _ => Left(s"campaign phase '${phase.name}' must set either scale, or both scale-from and scale-to")
+    yield phase
+
+  given DeriveConfig[CampaignPhaseConfig] = DeriveConfig
+    .derived[CampaignPhaseConfig]
+    .mapOrFail(phase => validate(phase).left.map(message => Config.Error.InvalidData(message = message)))
 
 case class DiurnalConfig(
     enabled: Boolean,

--- a/loadgen/src/main/scala/versola/loadgen/scheduler/ActionCount.scala
+++ b/loadgen/src/main/scala/versola/loadgen/scheduler/ActionCount.scala
@@ -1,0 +1,23 @@
+package versola.loadgen.scheduler
+
+import versola.loadgen.config.ActionCountConfig
+import versola.loadgen.model.Platform
+
+/** How many business actions one session performs: `NegBinomial(mean 6 mobile / 10 web)` from
+  * design doc §2.3, configured by `session.action-count` (versola-loadgen-dev-spec.md §5).
+  *
+  * Thin by design -- it exists so that the mean/dispersion → platform mapping lives in exactly
+  * one place. The distribution's parameterisation, and the fact that it can draw zero, are
+  * documented on [[NegBinomial]].
+  */
+object ActionCount:
+  def sample(config: ActionCountConfig, platform: Platform, random: RandomSource): Int =
+    NegBinomial.sample(meanFor(config, platform), config.dispersion, random)
+
+  def meanFor(config: ActionCountConfig, platform: Platform): Double =
+    platform match
+      case Platform.Mobile => config.mobileMean
+      case Platform.Web => config.webMean
+
+  def varianceFor(config: ActionCountConfig, platform: Platform): Double =
+    NegBinomial.variance(meanFor(config, platform), config.dispersion)

--- a/loadgen/src/main/scala/versola/loadgen/scheduler/ActionCount.scala
+++ b/loadgen/src/main/scala/versola/loadgen/scheduler/ActionCount.scala
@@ -3,21 +3,45 @@ package versola.loadgen.scheduler
 import versola.loadgen.config.ActionCountConfig
 import versola.loadgen.model.Platform
 
-/** How many business actions one session performs: `NegBinomial(mean 6 mobile / 10 web)` from
-  * design doc §2.3, configured by `session.action-count` (versola-loadgen-dev-spec.md §5).
+/** How many business actions one session performs: **one mandatory action plus**
+  * `NegBinomial(mean 5 mobile / 9 web)` user-driven ones, configured by `session.action-count`
+  * (versola-loadgen-dev-spec.md §5).
   *
-  * Thin by design -- it exists so that the mean/dispersion → platform mapping lives in exactly
-  * one place. The distribution's parameterisation, and the fact that it can draw zero, are
-  * documented on [[NegBinomial]].
+  * The split is not cosmetic. Design doc §3 has `GET /accounts` as "the first call of every
+  * session", and it is fetched by the app on open rather than chosen by the user -- machine-driven
+  * and unconditional, so it was never a draw from the distribution. Modelling the whole session as
+  * one NegBinomial forced a choice between two wrong answers: clamp the draw to a minimum of one
+  * and move the realised mean off its configured value while distorting precisely the low tail
+  * that sets session length, or accept `N = 0` and contradict §3.
+  *
+  * Taking action #1 out of the draw settles it. The total mean is unchanged at 6.0 / 10.0, §3 is
+  * literally true, and the sampler keeps its unbiased low tail -- `P(N' = 0) ≈ 9.9%` at μ = 5,
+  * α = 0.6, which is a user who opens the app, glances at their balance and closes it.
+  *
+  * Thin by design otherwise -- it exists so that the mean/dispersion → platform mapping lives in
+  * exactly one place. The distribution's parameterisation is documented on [[NegBinomial]].
   */
 object ActionCount:
-  def sample(config: ActionCountConfig, platform: Platform, random: RandomSource): Int =
-    NegBinomial.sample(meanFor(config, platform), config.dispersion, random)
+  /** The mandatory `GET /accounts` the app issues on open, outside the distribution. */
+  val mandatoryActions: Int = 1
 
-  def meanFor(config: ActionCountConfig, platform: Platform): Double =
+  def sample(config: ActionCountConfig, platform: Platform, random: RandomSource): Int =
+    mandatoryActions + NegBinomial.sample(additionalMeanFor(config, platform), config.dispersion, random)
+
+  /** The configured mean of the *user-driven* actions -- the NegBinomial's own mean, one short of
+    * the session's.
+    */
+  def additionalMeanFor(config: ActionCountConfig, platform: Platform): Double =
     platform match
       case Platform.Mobile => config.mobileMean
       case Platform.Web => config.webMean
 
+  /** What [[sample]] averages to: design doc §2.3's 6.0 mobile / 10.0 web. */
+  def sessionMeanFor(config: ActionCountConfig, platform: Platform): Double =
+    mandatoryActions + additionalMeanFor(config, platform)
+
+  /** Unchanged by the mandatory action: shifting a distribution by a constant moves its mean and
+    * leaves its variance alone.
+    */
   def varianceFor(config: ActionCountConfig, platform: Platform): Double =
-    NegBinomial.variance(meanFor(config, platform), config.dispersion)
+    NegBinomial.variance(additionalMeanFor(config, platform), config.dispersion)

--- a/loadgen/src/main/scala/versola/loadgen/scheduler/ArrivalProcess.scala
+++ b/loadgen/src/main/scala/versola/loadgen/scheduler/ArrivalProcess.scala
@@ -1,0 +1,78 @@
+package versola.loadgen.scheduler
+
+import zio.Chunk
+
+import java.time.Instant
+
+/** One scheduled unit of work and the instant it was *meant* to start.
+  *
+  * `intendedStart` comes out of the arrival recurrence, never from a clock read
+  * (versola-loadgen-dev-spec.md §7.2: "records `intendedStart = scheduledAt`, not
+  * `Instant.now()`"). Everything downstream -- the step histograms, the flow histograms and
+  * `loadgen_schedule_lag_seconds` -- is measured against it, which is the coordinated-omission
+  * correction the whole measurement rests on.
+  */
+final case class ScheduledArrival(sequence: Long, intendedStart: Instant)
+
+/** The open-model arrival process of §7.2: one scenario's stream of intended start times on one
+  * shard.
+  *
+  * {{{
+  * scheduledAt = previousScheduledAt + Exponential(λ_shard)
+  * }}}
+  *
+  * The recurrence is anchored on the campaign's start instant and advances only by drawn
+  * inter-arrival times, so the schedule is a pure function of `(anchor, seed, λ history)`. That
+  * is the property that makes falling behind *observable*: the intended schedule exists
+  * independently of whether the driver managed to execute it, so `now − intendedStart` is a real
+  * quantity. Read the clock anywhere in here -- e.g. by anchoring each arrival on the moment the
+  * previous one finished -- and the process silently degrades into a closed loop that generates
+  * less load at the same apparent rate, with a schedule lag that is structurally zero.
+  *
+  * Not thread-safe and not meant to be: §7.2 has one generator per scenario per driver filling a
+  * bounded queue ahead of the clock, and one owner is also what keeps the draws reproducible.
+  */
+final class ArrivalProcess private (random: RandomSource, anchor: Instant):
+  private var previous: Instant = anchor
+  private var sequence: Long = 0L
+
+  /** Next arrival at the rate current for this instant of the plan. λ is a parameter of the call
+    * rather than of the process because §7.2's λ(t) changes under the driver -- phase
+    * transitions, the diurnal envelope, a re-published plan every 10 s -- and an inter-arrival
+    * time drawn at the rate in force when it is drawn is the standard way to run a
+    * piecewise-constant Poisson process.
+    */
+  def next(ratePerSecond: Double): ScheduledArrival =
+    val gapSeconds = Exponential.sample(ratePerSecond, random)
+    // Split whole seconds from the fraction rather than rounding the whole gap to nanos: at the
+    // low rates a night trough or a 0.1 scale can produce (design doc §2.4 has 1.2 reg/s at
+    // night, and `scale = 0.1` on top of that), a single gap can exceed the ~9.2e9 s that fit in
+    // a nanosecond Long.
+    val wholeSeconds = math.floor(gapSeconds).toLong
+    val fractionNanos = math.round((gapSeconds - wholeSeconds) * 1e9)
+    previous = previous.plusSeconds(wholeSeconds).plusNanos(fractionNanos)
+    sequence += 1
+    ScheduledArrival(sequence, previous)
+
+  def take(count: Int, ratePerSecond: Double): Chunk[ScheduledArrival] =
+    Chunk.fill(count)(next(ratePerSecond))
+
+  /** Intended start of the most recently generated arrival, or the anchor if none has been. How
+    * far ahead of the clock the generator has run.
+    */
+  def lastScheduledAt: Instant = previous
+
+object ArrivalProcess:
+  /** @param anchor the campaign (or phase) start instant that the recurrence hangs off. */
+  def startingAt(anchor: Instant, random: RandomSource): ArrivalProcess = ArrivalProcess(random, anchor)
+
+  /** A driver's share of a published rate: `λ(t) / shardCount` (§7.2).
+    *
+    * Splitting a Poisson process by a constant factor across N shards yields N independent
+    * Poisson processes whose superposition is the original, so the fleet generates the published
+    * λ without the drivers coordinating -- which is the same argument that removes the
+    * distributed lock in §7.1.
+    */
+  def shardRate(ratePerSecond: Double, shardCount: Int): Double =
+    require(shardCount > 0, s"shard count must be positive, got $shardCount")
+    ratePerSecond / shardCount

--- a/loadgen/src/main/scala/versola/loadgen/scheduler/ArrivalProcess.scala
+++ b/loadgen/src/main/scala/versola/loadgen/scheduler/ArrivalProcess.scala
@@ -14,6 +14,19 @@ import java.time.Instant
   */
 final case class ScheduledArrival(sequence: Long, intendedStart: Instant)
 
+/** A rate that changes with time, packaged with the two facts thinning needs to be correct and to
+  * terminate.
+  *
+  * @param ceiling an upper bound `at` never exceeds anywhere in `[now, endsAt)`. Thinning accepts
+  *                a candidate with probability `at(t) / ceiling`, so a ceiling that is too low
+  *                does not merely lose precision -- it discards the arrivals that would have been
+  *                accepted above it. `CampaignSchedule.rateCeiling` derives one in closed form.
+  * @param endsAt  the instant past which the rate is zero for good, which is what stops the search
+  *                for a candidate that can never be accepted.
+  * @param at      λ(t) in arrivals per second.
+  */
+final case class VaryingRate(ceiling: Double, endsAt: Instant, at: Instant => Double)
+
 /** The open-model arrival process of §7.2: one scenario's stream of intended start times on one
   * shard.
   *
@@ -36,26 +49,88 @@ final class ArrivalProcess private (random: RandomSource, anchor: Instant):
   private var previous: Instant = anchor
   private var sequence: Long = 0L
 
-  /** Next arrival at the rate current for this instant of the plan. λ is a parameter of the call
-    * rather than of the process because §7.2's λ(t) changes under the driver -- phase
-    * transitions, the diurnal envelope, a re-published plan every 10 s -- and an inter-arrival
-    * time drawn at the rate in force when it is drawn is the standard way to run a
-    * piecewise-constant Poisson process.
+  /** Next arrival at a rate that is **constant over the whole gap this draws**.
+    *
+    * The entire inter-arrival time is distributed at `ratePerSecond`, so this is only the right
+    * call when λ genuinely does not change before the arrival lands. §7.2's λ(t) does change --
+    * phase transitions, the ramp inside a phase, the diurnal envelope, a plan re-published every
+    * 10 s -- and a gap drawn at the rate in force when it was drawn keeps the old rate all the way
+    * across any of those, which is exactly what makes the first arrivals after every transition,
+    * and therefore the campaign's load shape and total volume, wrong. Use [[next(rate:VaryingRate)]]
+    * for that; this overload stays for the genuinely homogeneous case (a flat phase with the
+    * diurnal disabled) and for the goodness-of-fit tests, where a pure inverse-CDF draw is the
+    * thing under test.
     */
   def next(ratePerSecond: Double): ScheduledArrival =
-    val gapSeconds = Exponential.sample(ratePerSecond, random)
-    // Split whole seconds from the fraction rather than rounding the whole gap to nanos: at the
-    // low rates a night trough or a 0.1 scale can produce (design doc §2.4 has 1.2 reg/s at
-    // night, and `scale = 0.1` on top of that), a single gap can exceed the ~9.2e9 s that fit in
-    // a nanosecond Long.
-    val wholeSeconds = math.floor(gapSeconds).toLong
-    val fractionNanos = math.round((gapSeconds - wholeSeconds) * 1e9)
-    previous = previous.plusSeconds(wholeSeconds).plusNanos(fractionNanos)
+    previous = advance(previous, Exponential.sample(ratePerSecond, random))
     sequence += 1
     ScheduledArrival(sequence, previous)
 
+  /** Next arrival under a rate that varies continuously, by Lewis-Shedler thinning.
+    *
+    * Candidates are drawn at `rate.ceiling` and each is kept with probability
+    * `rate.at(candidate) / rate.ceiling`. Because the acceptance test is evaluated at the
+    * candidate's own instant rather than at the previous arrival's, a gap that crosses a ramp, a
+    * phase boundary, a diurnal change or a re-published rate is distributed under the rate that
+    * actually applies across it -- which the plain exponential draw above cannot do, whatever rate
+    * it is handed.
+    *
+    * @return `None` once the horizon is reached with nothing accepted. `lastScheduledAt` is left
+    *         at `rate.endsAt` in that case: no arrival occurred in the interval just searched, and
+    *         the exponential is memoryless, so a later call under an extended horizon resumes from
+    *         there correctly instead of re-drawing an interval already decided.
+    */
+  def next(rate: VaryingRate): Option[ScheduledArrival] =
+    require(rate.ceiling > 0.0, s"rate ceiling must be positive, got ${rate.ceiling}")
+    var scheduled: Option[ScheduledArrival] = None
+    var candidate = previous
+    var exhausted = false
+    while scheduled.isEmpty && !exhausted do
+      candidate = advance(candidate, Exponential.sample(rate.ceiling, random))
+      if !candidate.isBefore(rate.endsAt) then
+        previous = rate.endsAt
+        exhausted = true
+      else
+        val intensity = rate.at(candidate)
+        // A rate above the declared ceiling is a broken envelope, not a rare draw: every arrival
+        // the excess should have produced is already gone by the time anyone inspects the output,
+        // and the deficit looks exactly like the SUT absorbing less load. NaN fails this too.
+        require(
+          intensity <= rate.ceiling,
+          s"rate $intensity at $candidate exceeds the declared ceiling ${rate.ceiling}",
+        )
+        if intensity > 0.0 && random.nextDouble() * rate.ceiling < intensity then
+          previous = candidate
+          sequence += 1
+          scheduled = Some(ScheduledArrival(sequence, candidate))
+    scheduled
+
   def take(count: Int, ratePerSecond: Double): Chunk[ScheduledArrival] =
     Chunk.fill(count)(next(ratePerSecond))
+
+  /** As [[take]], but under a varying rate: stops early at the horizon, so the result can be
+    * shorter than `count`.
+    */
+  def take(count: Int, rate: VaryingRate): Chunk[ScheduledArrival] =
+    val arrivals = Chunk.newBuilder[ScheduledArrival]
+    var remaining = count
+    var running = true
+    while running && remaining > 0 do
+      next(rate) match
+        case Some(arrival) =>
+          arrivals += arrival
+          remaining -= 1
+        case None => running = false
+    arrivals.result()
+
+  // Split whole seconds from the fraction rather than rounding the whole gap to nanos: at the low
+  // rates a night trough or a 0.1 scale can produce (design doc §2.4 has 1.2 reg/s at night, and
+  // `scale = 0.1` on top of that), a single gap can exceed the ~9.2e9 s that fit in a nanosecond
+  // Long.
+  private def advance(from: Instant, gapSeconds: Double): Instant =
+    val wholeSeconds = math.floor(gapSeconds).toLong
+    val fractionNanos = math.round((gapSeconds - wholeSeconds) * 1e9)
+    from.plusSeconds(wholeSeconds).plusNanos(fractionNanos)
 
   /** Intended start of the most recently generated arrival, or the anchor if none has been. How
     * far ahead of the clock the generator has run.

--- a/loadgen/src/main/scala/versola/loadgen/scheduler/CampaignSchedule.scala
+++ b/loadgen/src/main/scala/versola/loadgen/scheduler/CampaignSchedule.scala
@@ -1,0 +1,93 @@
+package versola.loadgen.scheduler
+
+import versola.loadgen.config.CampaignConfig
+import versola.loadgen.config.CampaignPhaseConfig
+import zio.Duration
+
+import java.time.Instant
+
+/** How a phase scales the base arrival rate (versola-loadgen-dev-spec.md §5's `campaign.phases`).
+  *
+  * Which of the two a phase is, is decided by **which fields are present**, not by the phase's
+  * name: `scale` alone is flat, `scale-from` + `scale-to` is a linear ramp. §5 leaves this open
+  * ("the scheduler decides which apply per phase `name`"), and name-based dispatch was rejected
+  * -- `name` is free text used as a metric label, so a campaign that renamed `ramp` to
+  * `ramp-up` would silently run flat.
+  */
+enum PhaseScale:
+  case Flat(scale: Double)
+  case Ramp(from: Double, to: Double)
+
+/** One phase, with its absolute offset from the campaign start resolved. */
+final case class CampaignPhase(name: String, startsAt: Duration, duration: Duration, scale: PhaseScale):
+  def endsAt: Duration = startsAt.plus(duration)
+
+  def scaleAt(elapsedInPhase: Duration): Double =
+    scale match
+      case PhaseScale.Flat(value) => value
+      case PhaseScale.Ramp(from, to) =>
+        // Linear in wall-clock time across the phase. Guarded against a zero-length phase, which
+        // the config permits and which would otherwise be a division by zero at the instant the
+        // phase is entered.
+        val total = duration.toNanos
+        if total <= 0L then to
+        else
+          val progress = math.min(math.max(elapsedInPhase.toNanos.toDouble / total, 0.0), 1.0)
+          from + (to - from) * progress
+
+/** The campaign's rate envelope over time (§7.3):
+  *
+  * {{{
+  * rate(t) = base × scale(phase) × diurnal(hourOfDay)
+  * }}}
+  *
+  * Phases run back to back from `startedAt` in the order the config lists them. Outside the
+  * campaign -- before `startedAt` or after the last phase ends -- the scale is 0: a campaign that
+  * has finished must generate nothing, and returning the last phase's scale instead is how a run
+  * overruns its plan.
+  */
+final class CampaignSchedule private (val phases: Vector[CampaignPhase], val diurnal: DiurnalEnvelope, startedAt: Instant):
+  val totalDuration: Duration = phases.foldLeft(Duration.Zero)((acc, phase) => acc.plus(phase.duration))
+
+  def phaseAt(now: Instant): Option[CampaignPhase] =
+    val elapsed = Duration.fromInterval(startedAt, now)
+    if now.isBefore(startedAt) then None
+    else phases.find(phase => elapsed.compareTo(phase.startsAt) >= 0 && elapsed.compareTo(phase.endsAt) < 0)
+
+  def scaleAt(now: Instant): Double =
+    phaseAt(now) match
+      case Some(phase) => phase.scaleAt(Duration.fromInterval(startedAt, now).minus(phase.startsAt))
+      case None => 0.0
+
+  /** @return arrivals per second for the whole fleet; 0.0 outside the campaign, in which case the
+    *         caller must stop scheduling rather than pass it to [[Exponential]] (which rejects a
+    *         non-positive rate instead of generating an infinite gap).
+    */
+  def rateAt(baseRatePerSecond: Double, now: Instant): Double =
+    val scale = scaleAt(now)
+    if scale <= 0.0 then 0.0 else baseRatePerSecond * scale * diurnal.at(now)
+
+object CampaignSchedule:
+  def from(config: CampaignConfig, startedAt: Instant): Either[String, CampaignSchedule] =
+    for
+      diurnal <- DiurnalEnvelope.from(config.diurnal)
+      phases <- resolvePhases(config.phases)
+    yield CampaignSchedule(phases, diurnal, startedAt)
+
+  private def resolvePhases(configured: List[CampaignPhaseConfig]): Either[String, Vector[CampaignPhase]] =
+    if configured.isEmpty then Left("campaign.phases must not be empty")
+    else
+      configured
+        .foldLeft[Either[String, (Vector[CampaignPhase], Duration)]](Right((Vector.empty, Duration.Zero))):
+          case (Left(error), _) => Left(error)
+          case (Right((acc, offset)), phase) =>
+            scaleOf(phase).map: scale =>
+              (acc :+ CampaignPhase(phase.name, offset, phase.duration, scale), offset.plus(phase.duration))
+        .map((phases, _) => phases)
+
+  private def scaleOf(phase: CampaignPhaseConfig): Either[String, PhaseScale] =
+    (phase.scale, phase.scaleFrom, phase.scaleTo) match
+      case (None, Some(from), Some(to)) => Right(PhaseScale.Ramp(from, to))
+      case (Some(scale), None, None) => Right(PhaseScale.Flat(scale))
+      case (Some(_), _, _) => Left(s"campaign phase '${phase.name}' sets both scale and scale-from/scale-to")
+      case _ => Left(s"campaign phase '${phase.name}' must set either scale, or both scale-from and scale-to")

--- a/loadgen/src/main/scala/versola/loadgen/scheduler/CampaignSchedule.scala
+++ b/loadgen/src/main/scala/versola/loadgen/scheduler/CampaignSchedule.scala
@@ -110,46 +110,20 @@ object CampaignSchedule:
           case (Left(error), _) => Left(error)
           case (Right((acc, offset)), phase) =>
             for
-              _ <- durationOf(phase)
+              _ <- CampaignPhaseConfig.validate(phase)
               scale <- scaleOf(phase)
             yield (acc :+ CampaignPhase(phase.name, offset, phase.duration, scale), offset.plus(phase.duration))
         .map((phases, _) => phases)
 
-  /** A negative duration puts `endsAt` before `startsAt`, so `phaseAt`'s half-open test can never
-    * match the phase, and the negative offset it contributes drags every later phase backwards
-    * into a range overlapping the ones already placed. The result is a schedule that is wrong
-    * rather than one that is rejected.
+  /** The phase's shape, once [[CampaignPhaseConfig.validate]] has ruled out the combinations that
+    * have none and the durations and scales that cannot be represented.
     *
-    * Zero stays legal: `scaleAt` already handles a zero-length phase explicitly, and configuring a
-    * phase away to nothing is a reasonable thing to express.
+    * Decoding runs the same validation, so for a campaign that came from HOCON this cannot fail.
+    * It is re-run here because a `CampaignConfig` can also be built in code, and the point of
+    * rejecting these configs is that nothing downstream should have to assume someone else did.
     */
-  private def durationOf(phase: CampaignPhaseConfig): Either[String, Duration] =
-    if phase.duration.isNegative then
-      Left(s"campaign phase '${phase.name}' must not have a negative duration, got ${phase.duration}")
-    else Right(phase.duration)
-
   private def scaleOf(phase: CampaignPhaseConfig): Either[String, PhaseScale] =
     (phase.scale, phase.scaleFrom, phase.scaleTo) match
-      case (None, Some(from), Some(to)) =>
-        for
-          _ <- finiteScale(phase.name, "scale-from", from)
-          _ <- finiteScale(phase.name, "scale-to", to)
-        yield PhaseScale.Ramp(from, to)
-      case (Some(scale), None, None) => finiteScale(phase.name, "scale", scale).map(PhaseScale.Flat.apply)
-      case (Some(_), _, _) => Left(s"campaign phase '${phase.name}' sets both scale and scale-from/scale-to")
+      case (Some(scale), None, None) => Right(PhaseScale.Flat(scale))
+      case (None, Some(from), Some(to)) => Right(PhaseScale.Ramp(from, to))
       case _ => Left(s"campaign phase '${phase.name}' must set either scale, or both scale-from and scale-to")
-
-  /** `rateAt` collapses any non-positive scale to a rate of 0, so a negative scale never surfaces
-    * as an error -- it silently generates no load for as long as it applies, and on a ramp it
-    * takes part of the ramp down with it. A non-finite scale is worse: NaN passes `scale <= 0.0`
-    * and reaches `Exponential.sample` as the rate, where it yields a NaN gap and a schedule that
-    * cannot be ordered.
-    *
-    * Zero is allowed, and is the one legitimate way to express a phase that generates nothing.
-    */
-  private def finiteScale(phaseName: String, field: String, value: Double): Either[String, Double] =
-    if value.isNaN || value.isInfinite then
-      Left(s"campaign phase '$phaseName' must have a finite $field, got $value")
-    else if value < 0.0 then
-      Left(s"campaign phase '$phaseName' must not have a negative $field, got $value")
-    else Right(value)

--- a/loadgen/src/main/scala/versola/loadgen/scheduler/CampaignSchedule.scala
+++ b/loadgen/src/main/scala/versola/loadgen/scheduler/CampaignSchedule.scala
@@ -67,6 +67,34 @@ final class CampaignSchedule private (val phases: Vector[CampaignPhase], val diu
     val scale = scaleAt(now)
     if scale <= 0.0 then 0.0 else baseRatePerSecond * scale * diurnal.at(now)
 
+  /** The instant the last phase ends. From here on `scaleAt` is 0, which is what bounds the
+    * thinning loop in [[ArrivalProcess.next]]: without it, a campaign whose rate has fallen to
+    * zero would be searched for an arrival that can never be accepted.
+    */
+  val endsAt: Instant = startedAt.plus(totalDuration)
+
+  /** An upper bound on [[rateAt]] across the whole campaign: the largest scale any phase reaches,
+    * times the diurnal peak.
+    *
+    * Thinning is only correct if the ceiling is one λ(t) provably never exceeds; a ceiling that is
+    * merely usually right does not degrade gracefully, it drops the arrivals that would have been
+    * accepted above it. Both factors are therefore maxima of closed forms rather than samples: a
+    * ramp's extreme is at one of its endpoints, and the diurnal's is at its peak hour.
+    */
+  def rateCeiling(baseRatePerSecond: Double): Double =
+    val peakScale = phases.foldLeft(0.0): (highest, phase) =>
+      val phasePeak = phase.scale match
+        case PhaseScale.Flat(value) => value
+        case PhaseScale.Ramp(from, to) => math.max(from, to)
+      math.max(highest, phasePeak)
+    baseRatePerSecond * peakScale * diurnal.peak
+
+  /** [[rateAt]] packaged for [[ArrivalProcess.next]]: the rate function, the ceiling it respects
+    * and the horizon past which there is nothing left to schedule.
+    */
+  def envelope(baseRatePerSecond: Double): VaryingRate =
+    VaryingRate(rateCeiling(baseRatePerSecond), endsAt, rateAt(baseRatePerSecond, _))
+
 object CampaignSchedule:
   def from(config: CampaignConfig, startedAt: Instant): Either[String, CampaignSchedule] =
     for
@@ -81,13 +109,47 @@ object CampaignSchedule:
         .foldLeft[Either[String, (Vector[CampaignPhase], Duration)]](Right((Vector.empty, Duration.Zero))):
           case (Left(error), _) => Left(error)
           case (Right((acc, offset)), phase) =>
-            scaleOf(phase).map: scale =>
-              (acc :+ CampaignPhase(phase.name, offset, phase.duration, scale), offset.plus(phase.duration))
+            for
+              _ <- durationOf(phase)
+              scale <- scaleOf(phase)
+            yield (acc :+ CampaignPhase(phase.name, offset, phase.duration, scale), offset.plus(phase.duration))
         .map((phases, _) => phases)
+
+  /** A negative duration puts `endsAt` before `startsAt`, so `phaseAt`'s half-open test can never
+    * match the phase, and the negative offset it contributes drags every later phase backwards
+    * into a range overlapping the ones already placed. The result is a schedule that is wrong
+    * rather than one that is rejected.
+    *
+    * Zero stays legal: `scaleAt` already handles a zero-length phase explicitly, and configuring a
+    * phase away to nothing is a reasonable thing to express.
+    */
+  private def durationOf(phase: CampaignPhaseConfig): Either[String, Duration] =
+    if phase.duration.isNegative then
+      Left(s"campaign phase '${phase.name}' must not have a negative duration, got ${phase.duration}")
+    else Right(phase.duration)
 
   private def scaleOf(phase: CampaignPhaseConfig): Either[String, PhaseScale] =
     (phase.scale, phase.scaleFrom, phase.scaleTo) match
-      case (None, Some(from), Some(to)) => Right(PhaseScale.Ramp(from, to))
-      case (Some(scale), None, None) => Right(PhaseScale.Flat(scale))
+      case (None, Some(from), Some(to)) =>
+        for
+          _ <- finiteScale(phase.name, "scale-from", from)
+          _ <- finiteScale(phase.name, "scale-to", to)
+        yield PhaseScale.Ramp(from, to)
+      case (Some(scale), None, None) => finiteScale(phase.name, "scale", scale).map(PhaseScale.Flat.apply)
       case (Some(_), _, _) => Left(s"campaign phase '${phase.name}' sets both scale and scale-from/scale-to")
       case _ => Left(s"campaign phase '${phase.name}' must set either scale, or both scale-from and scale-to")
+
+  /** `rateAt` collapses any non-positive scale to a rate of 0, so a negative scale never surfaces
+    * as an error -- it silently generates no load for as long as it applies, and on a ramp it
+    * takes part of the ramp down with it. A non-finite scale is worse: NaN passes `scale <= 0.0`
+    * and reaches `Exponential.sample` as the rate, where it yields a NaN gap and a schedule that
+    * cannot be ordered.
+    *
+    * Zero is allowed, and is the one legitimate way to express a phase that generates nothing.
+    */
+  private def finiteScale(phaseName: String, field: String, value: Double): Either[String, Double] =
+    if value.isNaN || value.isInfinite then
+      Left(s"campaign phase '$phaseName' must have a finite $field, got $value")
+    else if value < 0.0 then
+      Left(s"campaign phase '$phaseName' must not have a negative $field, got $value")
+    else Right(value)

--- a/loadgen/src/main/scala/versola/loadgen/scheduler/Distributions.scala
+++ b/loadgen/src/main/scala/versola/loadgen/scheduler/Distributions.scala
@@ -1,0 +1,133 @@
+package versola.loadgen.scheduler
+
+/** Exponential inter-arrival times for the open arrival model of
+  * versola-loadgen-dev-spec.md §7.2, parameterised by **rate** (λ, arrivals per second), not by
+  * mean -- the coordinator publishes λ and the driver's share is λ/shardCount, so rate is the
+  * quantity that actually travels between components.
+  *
+  * Inverse-CDF, `−ln(U)/λ`: exact, one uniform and one `log` per draw, and monotone in the
+  * uniform -- which is what makes the χ² test in `ArrivalProcessSpec` a test of the arrival
+  * process rather than of a rejection loop.
+  */
+object Exponential:
+  /** @return seconds until the next arrival; `Infinity` never occurs because the uniform is
+    *         drawn on `(0, 1]`.
+    */
+  def sample(ratePerSecond: Double, random: RandomSource): Double =
+    require(ratePerSecond > 0.0, s"exponential rate must be positive, got $ratePerSecond")
+    -math.log(random.nextDoubleOpenAtZero()) / ratePerSecond
+
+  /** Quantile function, used by the goodness-of-fit test to build equiprobable bins. */
+  def quantile(probability: Double, ratePerSecond: Double): Double =
+    -math.log(1.0 - probability) / ratePerSecond
+
+/** LogNormal think time (§7.4), parameterised by **median and σ** -- which is what
+  * `session.think-time { median = 4s, sigma = 0.8 }` in §5 gives us, and the reason this
+  * distinction is spelled out: the other common convention is (μ, σ) of the underlying normal,
+  * and the two agree only because `median = exp(μ)`. Reading `median = 4s` as μ = 4 would
+  * produce a median of `e⁴ ≈ 55 s` -- a 14× error that no test of the scenario engine would
+  * notice, because the shape would still look like a plausible think time.
+  *
+  * Consequences of the parameterisation worth having in front of the reader: the **mean is not
+  * the median** (`median × exp(σ²/2)`, so 5.51 s for the configured 4 s / 0.8), and the mean is
+  * what determines session wall-clock duration and therefore the concurrent-user count.
+  */
+object LogNormal:
+  def sample(median: Double, sigma: Double, random: RandomSource): Double =
+    require(median > 0.0, s"lognormal median must be positive, got $median")
+    require(sigma > 0.0, s"lognormal sigma must be positive, got $sigma")
+    median * math.exp(sigma * random.nextGaussian())
+
+  def mean(median: Double, sigma: Double): Double = median * math.exp(sigma * sigma / 2.0)
+
+  def variance(median: Double, sigma: Double): Double =
+    val m = mean(median, sigma)
+    m * m * (math.exp(sigma * sigma) - 1.0)
+
+/** Actions per session (§7.4, design doc §2.3), parameterised by **mean and dispersion** to
+  * match `session.action-count { mobile-mean = 6, web-mean = 10, dispersion = 0.6 }`.
+  *
+  * NegBinomial has two live conventions and the config names neither, so this fixes it: `mean`
+  * is μ, and `dispersion` is the **NB2 overdispersion coefficient α**, giving
+  *
+  * {{{
+  * Var = μ (1 + α μ)        size r = 1/α        Gamma-Poisson mixture Poisson(Gamma(r, μ/r))
+  * }}}
+  *
+  * The alternative reading -- `dispersion` as the size/shape `r` itself -- was rejected because
+  * it does not survive the config having *one* dispersion for *two* means: at r = 0.6 the mobile
+  * variance would be `6 + 6²/0.6 = 66` (sd 8.1 on a mean of 6, so most sessions are 0-2 actions
+  * and the tail carries the volume), whereas α = 0.6 gives `6 × (1 + 3.6) = 27.6` (sd 5.3).
+  * α is the dimensionless one, and so the only one that means the same thing at both means.
+  *
+  * Note that a NegBinomial is supported at 0: with these parameters `P(N = 0) = (r/(r+μ))^r`
+  * ≈ 7.9% mobile, 5.0% web -- a session where the user opens the app and does nothing. That is
+  * left in rather than clamped, because clamping would shift the realised mean off the
+  * configured one (to ≈ 6.08) silently. Design doc §3 calls action #1 "the first call of every
+  * session", which contradicts it; see the report on #273.
+  */
+object NegBinomial:
+  def sample(mean: Double, dispersion: Double, random: RandomSource): Int =
+    require(mean > 0.0, s"negbinomial mean must be positive, got $mean")
+    require(dispersion > 0.0, s"negbinomial dispersion must be positive, got $dispersion")
+    val size = 1.0 / dispersion
+    Poisson.sample(Gamma.sample(size, mean / size, random), random)
+
+  def variance(mean: Double, dispersion: Double): Double = mean * (1.0 + dispersion * mean)
+
+/** Gamma by shape and **scale** (not rate) -- `E[X] = shape × scale`. Only ever reached through
+  * [[NegBinomial]]'s mixture, hence package-private.
+  */
+private[scheduler] object Gamma:
+  def sample(shape: Double, scale: Double, random: RandomSource): Double =
+    if shape < 1.0 then
+      // Marsaglia-Tsang's own boost for shape < 1, where the squeeze below is invalid:
+      // Gamma(a) == Gamma(a + 1) × U^(1/a). Reachable from config -- dispersion > 1 means
+      // size < 1 -- so it is not dead code.
+      sample(shape + 1.0, scale, random) * math.pow(random.nextDoubleOpenAtZero(), 1.0 / shape)
+    else
+      // Marsaglia-Tsang (2000): one normal and one uniform per attempt, acceptance > 95% at
+      // every shape >= 1, and no rejection loop over the whole density.
+      val d = shape - 1.0 / 3.0
+      val c = 1.0 / math.sqrt(9.0 * d)
+      var result = 0.0
+      var accepted = false
+      while !accepted do
+        val x = random.nextGaussian()
+        val v = 1.0 + c * x
+        if v > 0.0 then
+          val v3 = v * v * v
+          val u = random.nextDoubleOpenAtZero()
+          if math.log(u) < 0.5 * x * x + d - d * v3 + d * math.log(v3) then
+            result = d * v3 * scale
+            accepted = true
+      result
+
+/** Poisson by Knuth's product method. `O(λ)` uniforms per draw, which is the right trade at the
+  * λ this package sees (the Gamma mixing mean is 6-10, §5): the alternatives that are `O(1)` in
+  * λ cost a far larger constant and a table.
+  */
+private[scheduler] object Poisson:
+  // exp(-λ) underflows to 0 around λ = 745, at which point Knuth's loop never terminates.
+  // Poisson is additive in λ, so a large λ is drawn as a sum of chunks; this bound leaves three
+  // orders of magnitude of headroom under the underflow.
+  private val MaxChunk = 500.0
+
+  def sample(lambda: Double, random: RandomSource): Int =
+    require(lambda >= 0.0, s"poisson lambda must be non-negative, got $lambda")
+    var remaining = lambda
+    var total = 0L
+    while remaining > 0.0 do
+      val chunk = math.min(remaining, MaxChunk)
+      total += chunkSample(chunk, random)
+      remaining -= chunk
+    total.toInt
+
+  private def chunkSample(lambda: Double, random: RandomSource): Int =
+    val threshold = math.exp(-lambda)
+    var product = random.nextDouble()
+    var count = 0
+    while product > threshold do
+      count += 1
+      product *= random.nextDouble()
+    count

--- a/loadgen/src/main/scala/versola/loadgen/scheduler/DiurnalEnvelope.scala
+++ b/loadgen/src/main/scala/versola/loadgen/scheduler/DiurnalEnvelope.scala
@@ -39,6 +39,13 @@ final class DiurnalEnvelope private (
     */
   def normalisationFactor: Double = dailyMean
 
+  /** The largest value [[at]] can return, exactly rather than by search: §7.3's Gaussian term is
+    * maximal where its wrapped distance is zero, which is the peak hour. Used as the diurnal
+    * factor of `CampaignSchedule.rateCeiling`, where an under-estimate would silently lose
+    * arrivals.
+    */
+  def peak: Double = atHour(peakHour)
+
 object DiurnalEnvelope:
   /** Width of the peak in hours, from §7.3's `2 × 3.5²`. Not configurable there, so not
     * configurable here -- a second knob that changes total volume, with no plan to set it from,

--- a/loadgen/src/main/scala/versola/loadgen/scheduler/DiurnalEnvelope.scala
+++ b/loadgen/src/main/scala/versola/loadgen/scheduler/DiurnalEnvelope.scala
@@ -1,0 +1,103 @@
+package versola.loadgen.scheduler
+
+import versola.loadgen.config.DiurnalConfig
+
+import java.time.Instant
+import java.time.ZoneId
+import scala.util.control.NonFatal
+
+/** The time-of-day shape of the arrival rate (versola-loadgen-dev-spec.md §7.3):
+  *
+  * {{{
+  * diurnal(h) = 1 + (peakFactor − 1) × exp(−wrap(h − peakHour)² / (2 × 3.5²))
+  * }}}
+  *
+  * normalised so that its mean over 24 hours is exactly 1.0. The normalisation is not cosmetic:
+  * without it, `base × scale × diurnal` runs the campaign at
+  * `mean(diurnal) ≈ 1.73×` (at the configured `peak-factor = 3`) the volume the plan states, so
+  * the capacity numbers the report is written against would be wrong by 36% while every
+  * dashboard still looked shaped correctly. §7.3 says "otherwise every campaign silently runs at
+  * a different total volume than the plan states" -- and worse, a *different* wrong volume for
+  * each `peak-factor` (the inflation is linear in it), so two campaigns would not be comparable.
+  *
+  * Hours are wall-clock hours in the campaign's configured timezone, so a peak that is meant to
+  * be 20:00 in Almaty stays at 20:00 across a DST transition in some other zone.
+  */
+final class DiurnalEnvelope private (
+    peakFactor: Double,
+    peakHour: Double,
+    zone: ZoneId,
+    dailyMean: Double,
+):
+  /** @param hourOfDay hours since local midnight, fractional; values outside `[0, 24)` wrap. */
+  def atHour(hourOfDay: Double): Double = DiurnalEnvelope.unnormalised(hourOfDay, peakFactor, peakHour) / dailyMean
+
+  def at(instant: Instant): Double = atHour(DiurnalEnvelope.localHourOf(instant, zone))
+
+  /** The factor the 24-hour mean was divided by. Exposed for the report: it is the ratio between
+    * the raw §7.3 formula and what the campaign actually runs at.
+    */
+  def normalisationFactor: Double = dailyMean
+
+object DiurnalEnvelope:
+  /** Width of the peak in hours, from §7.3's `2 × 3.5²`. Not configurable there, so not
+    * configurable here -- a second knob that changes total volume, with no plan to set it from,
+    * is how campaigns stop being comparable.
+    */
+  val SigmaHours: Double = 3.5
+
+  private val HoursPerDay = 24.0
+
+  // Composite Simpson over one day for the normaliser. The closed form is an `erf`, which
+  // java.lang.Math does not have and which is not worth hand-rolling for a constant computed
+  // once per campaign. 2880 panels is a 30-second step: Simpson's O(h⁴) error puts this ~1e-11
+  // from exact, four orders of magnitude below the 1e-6 the test asserts, so the residual is the
+  // test's own quadrature error and not this. Even panel count is required by the rule; the
+  // integrand's only kink (the antipode of the peak, where the wrap flips sign) lands on a panel
+  // boundary for any integral `peak-hour`, so full order is retained there too.
+  private val NormaliserPanels = 2880
+
+  def from(config: DiurnalConfig): Either[String, DiurnalEnvelope] =
+    if !config.enabled then
+      // A flat envelope, not an absent one: the rest of the scheduler multiplies by this
+      // unconditionally, and `Option` here would push a branch into every rate computation.
+      Right(DiurnalEnvelope(peakFactor = 1.0, peakHour = 0.0, zone = ZoneId.of("UTC"), dailyMean = 1.0))
+    else if config.peakFactor < 1.0 then
+      // Below 1 the "peak" is a trough and the formula's `1 +` baseline becomes the maximum.
+      // Legal arithmetic, certainly not what `peak-factor` was asked for.
+      Left(s"campaign.diurnal.peak-factor must be >= 1.0, got ${config.peakFactor}")
+    else if config.peakHour < 0 || config.peakHour > 23 then
+      Left(s"campaign.diurnal.peak-hour must be in [0, 23], got ${config.peakHour}")
+    else
+      parseZone(config.timezone).map: zone =>
+        val peakHour = config.peakHour.toDouble
+        DiurnalEnvelope(config.peakFactor, peakHour, zone, dailyMean(config.peakFactor, peakHour))
+
+  private def parseZone(timezone: String): Either[String, ZoneId] =
+    try Right(ZoneId.of(timezone))
+    catch case NonFatal(_) => Left(s"campaign.diurnal.timezone is not a known zone id: '$timezone'")
+
+  /** §7.3's formula verbatim, before normalisation. */
+  private def unnormalised(hourOfDay: Double, peakFactor: Double, peakHour: Double): Double =
+    val distance = wrapToHalfDay(hourOfDay - peakHour)
+    1.0 + (peakFactor - 1.0) * math.exp(-(distance * distance) / (2.0 * SigmaHours * SigmaHours))
+
+  /** Signed hours to the peak, wrapped to `[−12, +12]` -- 02:00 is two hours from a 00:00 peak,
+    * not twenty-two.
+    */
+  private def wrapToHalfDay(hours: Double): Double =
+    val positive = ((hours % HoursPerDay) + HoursPerDay) % HoursPerDay
+    if positive > HoursPerDay / 2.0 then positive - HoursPerDay else positive
+
+  private def dailyMean(peakFactor: Double, peakHour: Double): Double =
+    val step = HoursPerDay / NormaliserPanels
+    var total = unnormalised(0.0, peakFactor, peakHour) + unnormalised(HoursPerDay, peakFactor, peakHour)
+    var index = 1
+    while index < NormaliserPanels do
+      val weight = if index % 2 == 0 then 2.0 else 4.0
+      total += weight * unnormalised(index * step, peakFactor, peakHour)
+      index += 1
+    (total * step / 3.0) / HoursPerDay
+
+  private def localHourOf(instant: Instant, zone: ZoneId): Double =
+    instant.atZone(zone).toLocalTime.toNanoOfDay / 3.6e12

--- a/loadgen/src/main/scala/versola/loadgen/scheduler/IntendedStart.scala
+++ b/loadgen/src/main/scala/versola/loadgen/scheduler/IntendedStart.scala
@@ -1,0 +1,89 @@
+package versola.loadgen.scheduler
+
+import zio.Clock
+import zio.Duration
+import zio.Ref
+import zio.UIO
+
+import java.time.Instant
+
+/** Latency measurement anchored on the *intended* start of a scheduled unit
+  * (versola-loadgen-dev-spec.md §7.2, design doc §6.3).
+  *
+  * The rule is one line -- "all latency is measured from `intendedStart`" -- and it is the
+  * difference between an instrument and a thing that produces numbers. If a fiber times itself
+  * from the moment it actually got scheduled, then when the driver falls behind, every
+  * measurement stays small and the report says the SUT is fine while a third of the intended load
+  * was never generated. Measuring from the intended start folds the driver's own queueing delay
+  * into the same histogram, so the failure appears as latency rather than as absence.
+  *
+  * The two quantities are kept separate on purpose:
+  *   - [[latency]] is what goes into `loadgen_step_duration_seconds` / the HdrHistograms (§11).
+  *   - [[startDelay]] is the *driver's own* contribution to that latency, i.e. the part that is
+  *     the emulator's fault and not the SUT's. Without it, a run that breached
+  *     `schedule_lag < 250 ms` (§15) cannot be told apart from a genuinely slow SUT after the
+  *     fact.
+  */
+object IntendedStart:
+  /** End-to-end latency of a scheduled unit, from when it should have started. */
+  def latency(intendedStart: Instant, completedAt: Instant): Duration =
+    Duration.fromInterval(intendedStart, completedAt)
+
+  /** How late the driver was in starting a unit it had already scheduled.
+    *
+    * Floored at zero: a unit is never started before its intended start (the worker sleeps until
+    * then), so a negative value can only come from a clock adjustment, and a negative "lag" in a
+    * gauge reads as a healthy driver rather than as a broken clock.
+    */
+  def startDelay(intendedStart: Instant, actualStart: Instant): Duration =
+    nonNegativeBetween(intendedStart, actualStart)
+
+  private[scheduler] def nonNegativeBetween(from: Instant, to: Instant): Duration =
+    if to.isBefore(from) then Duration.Zero else Duration.fromInterval(from, to)
+
+/** The `loadgen.driver.schedule_lag` gauge of §7.2 / §11: `now − scheduledAt` of the **head of
+  * the scheduled queue**, i.e. of the oldest arrival that has not started yet.
+  *
+  * Head-of-queue, not last-completed, because that is what makes the metric leading rather than
+  * lagging: an arrival whose turn came 400 ms ago and which is still waiting for a worker is
+  * already evidence that the driver is the bottleneck, and §7.2 declares the run invalid above
+  * 250 ms. A per-unit `startDelay` only reports that after the unit finally runs.
+  *
+  * One instance per scenario, matching the `scenario` label on the gauge.
+  *
+  * **What track F should read.** Poll [[current]] on the metric-collection tick and set the
+  * gauge from it; it needs no arguments and reads the clock itself. The driver loop (track I)
+  * owns the other side: call [[observeHead]] with the head arrival's `intendedStart` whenever
+  * the queue's head changes, and with `None` when the queue drains, which reports zero lag
+  * rather than a stale value. Deliberately a `Ref` of one `Instant` and not a counter of
+  * anything: the gauge must be readable at any instant without the collector touching the
+  * scheduler's queue.
+  */
+trait ScheduleLag:
+  /** @param intendedStart head of the scheduled queue, or `None` when nothing is queued. */
+  def observeHead(intendedStart: Option[Instant]): UIO[Unit]
+
+  def headIntendedStart: UIO[Option[Instant]]
+
+  /** Lag against a caller-supplied `now`. The seam that lets the tests assert exact values
+    * without a `TestClock`.
+    */
+  def lagAt(now: Instant): UIO[Duration]
+
+  /** Lag against the current clock -- what track F's collector calls. */
+  def current: UIO[Duration]
+
+object ScheduleLag:
+  val make: UIO[ScheduleLag] = Ref.make(Option.empty[Instant]).map(RefScheduleLag(_))
+
+private final class RefScheduleLag(head: Ref[Option[Instant]]) extends ScheduleLag:
+  def observeHead(intendedStart: Option[Instant]): UIO[Unit] = head.set(intendedStart)
+
+  def headIntendedStart: UIO[Option[Instant]] = head.get
+
+  def lagAt(now: Instant): UIO[Duration] =
+    head.get.map:
+      case Some(intendedStart) => IntendedStart.nonNegativeBetween(intendedStart, now)
+      case None => Duration.Zero
+
+  def current: UIO[Duration] = Clock.instant.flatMap(lagAt)

--- a/loadgen/src/main/scala/versola/loadgen/scheduler/RandomSource.scala
+++ b/loadgen/src/main/scala/versola/loadgen/scheduler/RandomSource.scala
@@ -1,0 +1,61 @@
+package versola.loadgen.scheduler
+
+import java.util.SplittableRandom
+
+/** The single source of randomness every distribution in this package draws from.
+  *
+  * A seam rather than a bare `SplittableRandom` because of what
+  * versola-loadgen-dev-spec.md §13 asks of this package: the diurnal, moment and χ² tests are
+  * statistical, so they are only a regression net if the stream behind them is pinned. A test
+  * constructs [[RandomSource.seeded]] with a literal seed and gets the same draws on every
+  * machine and every run. Production takes the same path -- the campaign seed is split once per
+  * driver fiber -- which is what rules out `ThreadLocalRandom` here even though §3.3 prefers it
+  * on the protocol hot path: its stream cannot be pinned, so a run could not be replayed and a
+  * failing campaign could not be reproduced.
+  *
+  * Deliberately narrower than `java.util.random.RandomGenerator`, and specifically it does not
+  * inherit that interface's `nextGaussian`: the JDK's Gaussian algorithm is not part of its
+  * compatibility contract, so a JDK upgrade would silently move every seeded expectation in the
+  * suite. [[nextGaussian]] below is fixed here instead.
+  */
+trait RandomSource:
+  /** Uniform on `[0, 1)`. */
+  def nextDouble(): Double
+
+  /** A generator for another fiber, advancing independently of this one. */
+  def split(): RandomSource
+
+  /** Uniform on `(0, 1]` -- the half-open end that `log`, and any `pow(u, negative)`, need. */
+  final def nextDoubleOpenAtZero(): Double = 1.0 - nextDouble()
+
+  /** Standard normal by the Marsaglia polar method.
+    *
+    * Rejection sampling rather than plain Box-Muller: no `sin`/`cos` per draw, and the rejected
+    * region is only 1 − π/4 ≈ 21% of the square. The polar method produces a pair of independent
+    * normals and this discards the second, which costs ~2 extra uniforms per call. That is the
+    * price of keeping the trait free of per-instance cache state -- the callers that draw
+    * normals in bulk ([[Gamma]] via [[NegBinomial]], [[LogNormal]]) are off the request path,
+    * and think time is sampled from a precomputed table anyway (§7.4).
+    */
+  final def nextGaussian(): Double =
+    var result = 0.0
+    var accepted = false
+    while !accepted do
+      val x = 2.0 * nextDouble() - 1.0
+      val y = 2.0 * nextDouble() - 1.0
+      val s = x * x + y * y
+      if s > 0.0 && s < 1.0 then
+        result = x * math.sqrt(-2.0 * math.log(s) / s)
+        accepted = true
+    result
+
+object RandomSource:
+  /** The only constructor: a seed is always explicit, never derived from the clock or from
+    * `ThreadLocalRandom.current()`, so that "which seed produced this run" is always answerable.
+    */
+  def seeded(seed: Long): RandomSource = SplittableRandomSource(SplittableRandom(seed))
+
+private final class SplittableRandomSource(underlying: SplittableRandom) extends RandomSource:
+  def nextDouble(): Double = underlying.nextDouble()
+
+  def split(): RandomSource = SplittableRandomSource(underlying.split())

--- a/loadgen/src/main/scala/versola/loadgen/scheduler/ShardAssignment.scala
+++ b/loadgen/src/main/scala/versola/loadgen/scheduler/ShardAssignment.scala
@@ -1,0 +1,48 @@
+package versola.loadgen.scheduler
+
+import versola.loadgen.config.ShardConfig
+
+/** Ownership of virtual users by drivers: `shard = id % shard.count`
+  * (versola-loadgen-dev-spec.md §7.1, over the dense `vu_users.id` of §6).
+  *
+  * The whole safety argument of the emulator rests on this being a *total function of the id
+  * alone*: exactly one process may ever hold a given refresh token (§7.1, design doc §6.3), and
+  * that is guaranteed only if two processes -- or the same process before and after a restart --
+  * cannot disagree about who owns an id. So there is deliberately no hashing here, no seed, no
+  * `hashCode`, no `Random`, and no state: `id % count` is stable by construction, which is a
+  * stronger claim than "we tested it and it was stable" (see `ShardAssignmentSpec`).
+  *
+  * Note the divergence from design doc §6.2, which says the coordinator assigns ranges "by
+  * consistent hash", and §6.2's later `hash(user_id) % shards`. The dev spec's §7.1 modulus over
+  * a dense id wins, and for a stated reason: §6 chose a dense `BIGINT` id over a UUID precisely
+  * so that a driver loads its slice with a range scan on `(shard, id)` rather than a hash filter,
+  * and so that re-sharding is a predictable range move. Hashing the id would throw that away.
+  */
+object ShardAssignment:
+  def shardOf(id: Long, shardCount: Int): Int =
+    require(shardCount > 0, s"shard count must be positive, got $shardCount")
+    // floorMod rather than `%` so a negative id (which the seeder should never produce, but
+    // which a hand-written fixture row can) maps into range instead of to a negative shard that
+    // no driver would ever claim -- silently stranding the user.
+    math.floorMod(id, shardCount.toLong).toInt
+
+  def isOwnedBy(id: Long, shard: ShardConfig): Boolean =
+    shardOf(id, shard.count) == shard.index
+
+  /** Lowest id `>= from` that this shard owns. The driver's active-window query (design doc
+    * §6.2) is a range scan; this is what lets it step the range rather than test every id.
+    */
+  def firstOwnedIdAtOrAfter(from: Long, shard: ShardConfig): Long =
+    require(shard.count > 0, s"shard count must be positive, got ${shard.count}")
+    require(shard.index >= 0 && shard.index < shard.count, s"shard index ${shard.index} out of range for count ${shard.count}")
+    from + math.floorMod(shard.index.toLong - from, shard.count.toLong)
+
+  /** Rejects the two shard configurations that produce a silently under-loaded campaign rather
+    * than an error: an index outside the map (the driver owns nothing and generates no load) and
+    * a non-positive count. Role dispatch calls this once at boot; it is not on any hot path.
+    */
+  def validate(shard: ShardConfig): Either[String, ShardConfig] =
+    if shard.count <= 0 then Left(s"shard.count must be positive, got ${shard.count}")
+    else if shard.index < 0 || shard.index >= shard.count then
+      Left(s"shard.index must be in [0, ${shard.count}), got ${shard.index}")
+    else Right(shard)

--- a/loadgen/src/main/scala/versola/loadgen/scheduler/ThinkTime.scala
+++ b/loadgen/src/main/scala/versola/loadgen/scheduler/ThinkTime.scala
@@ -1,0 +1,58 @@
+package versola.loadgen.scheduler
+
+import versola.loadgen.config.ThinkTimeConfig
+import zio.Duration
+
+/** Think time between a session's actions: `LogNormal(median, σ)` "sampled from a precomputed
+  * 64k table, clamped to `[200 ms, 120 s]`" (versola-loadgen-dev-spec.md §7.4).
+  *
+  * The table is the same trick `mockapi`'s `DelaySampler` uses (§9): one `log`/`exp` pair per
+  * draw is cheap in isolation, but think time is drawn once per action, i.e. ~5,000 times a
+  * second per driver, and the sampler is on the path that decides *when* load is generated. A
+  * table turns it into one uniform, one multiply and an array read, and -- more usefully -- makes
+  * the sampled distribution a fixed, inspectable artifact of the campaign seed rather than
+  * something re-derived per draw.
+  *
+  * The clamp is why the table is built from millisecond integers: nothing finer than a
+  * millisecond survives it, and `Array[Int]` keeps the 64k entries in 256 KiB.
+  */
+final class ThinkTimeTable private (millis: Array[Int]):
+  /** One draw. The uniform indexes the table directly rather than being consumed by any
+    * arithmetic, so the table's empirical distribution *is* the sampled distribution.
+    */
+  def sample(random: RandomSource): Duration =
+    Duration.fromMillis(millis((random.nextDouble() * millis.length).toInt))
+
+  /** The table itself, for the calibration self-check of §9/§13 (quantiles of what will actually
+    * be sampled, not of the distribution it was drawn from).
+    */
+  def entriesMillis: Array[Int] = millis.clone()
+
+object ThinkTimeTable:
+  /** §7.4's "64k". A power of two so the index arithmetic is exact in `Double`. */
+  val Size: Int = 65536
+
+  val FloorMillis: Long = 200L
+  val CeilingMillis: Long = 120_000L
+
+  /** @param random seeded by the caller -- the campaign seed in production, a literal in tests.
+    *               The table is drawn once at construction, so this is the only place the think
+    *               time distribution consumes randomness.
+    */
+  def build(config: ThinkTimeConfig, random: RandomSource): ThinkTimeTable =
+    val medianMillis = config.median.toMillis.toDouble
+    require(medianMillis > 0.0, s"session.think-time.median must be positive, got ${config.median}")
+    val entries = Array.ofDim[Int](Size)
+    var index = 0
+    while index < Size do
+      val draw = LogNormal.sample(medianMillis, config.sigma, random)
+      entries(index) = math.min(math.max(math.round(draw), FloorMillis), CeilingMillis).toInt
+      index += 1
+    ThinkTimeTable(entries)
+
+  /** Mean of the *unclamped* LogNormal, in milliseconds. The clamp moves this by well under a
+    * millisecond at the configured 4 s / 0.8 -- the floor is 3.7σ below the median and the
+    * ceiling 4.3σ above it -- but the two are not the same number, so the name says which.
+    */
+  def unclampedMeanMillis(config: ThinkTimeConfig): Double =
+    LogNormal.mean(config.median.toMillis.toDouble, config.sigma)

--- a/loadgen/src/test/scala/versola/loadgen/config/LoadgenConfigSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/config/LoadgenConfigSpec.scala
@@ -52,7 +52,7 @@ object LoadgenConfigSpec extends ZIOSpecDefault:
       |
       |session {
       |  full-login-probability { mobile = 0.033, web = 0.85 }
-      |  action-count { mobile-mean = 6, web-mean = 10, dispersion = 0.6 }
+      |  action-count { mobile-mean = 5, web-mean = 9, dispersion = 0.6 }
       |  think-time { median = 4s, sigma = 0.8 }
       |  payment-probability = 0.25
       |  extra-refresh-probability = 0.25
@@ -91,7 +91,7 @@ object LoadgenConfigSpec extends ZIOSpecDefault:
           config.store.writeBehind.batchSize == 500,
           config.population.target == 10000000L,
           config.population.classes.map(_.name) == List("heavy", "regular", "light", "dormant"),
-          config.session.actionCount.webMean == 10,
+          config.session.actionCount.webMean == 9,
           config.campaign.phases.map(_.name) == List("warmup", "ramp", "steady"),
           config.campaign.phases(1).scaleFrom == Some(0.1),
           config.campaign.phases(1).scale == None,
@@ -124,4 +124,38 @@ object LoadgenConfigSpec extends ZIOSpecDefault:
         yield assertTrue(exit.isFailure)
       },
     ),
+    suite("campaign phases")(
+      // Each of these decodes into a `CampaignPhaseConfig` the schedule cannot represent. Rejecting
+      // them here rather than at first use is the point: a campaign whose volume is wrong is
+      // indistinguishable from a slow SUT once it is running, so it has to be impossible to boot.
+      test("rejects a phase that sets neither scale nor both ramp ends, and one that sets both") {
+        for
+          neither <- decodePhase("{ name = warmup, duration = 15m, scale-from = 0.1 }").exit
+          both <- decodePhase("{ name = warmup, duration = 15m, scale = 0.5, scale-from = 0.1, scale-to = 1.0 }").exit
+        yield assertTrue(neither.isFailure, both.isFailure)
+      },
+      test("rejects a negative duration but accepts a zero-length phase") {
+        for
+          negative <- decodePhase("{ name = warmup, duration = -10m, scale = 1.0 }").exit
+          zero <- decodePhase("{ name = warmup, duration = 0s, scale = 1.0 }").exit
+        yield assertTrue(negative.isFailure, zero.isSuccess)
+      },
+      test("rejects a negative or non-finite scale but accepts zero") {
+        for
+          negativeFlat <- decodePhase("{ name = warmup, duration = 15m, scale = -1.0 }").exit
+          negativeRamp <- decodePhase("{ name = ramp, duration = 15m, scale-from = 0.1, scale-to = -1.0 }").exit
+          nonFinite <- decodePhase("{ name = warmup, duration = 15m, scale = NaN }").exit
+          idle <- decodePhase("{ name = idle, duration = 15m, scale = 0.0 }").exit
+        yield assertTrue(negativeFlat.isFailure, negativeRamp.isFailure, nonFinite.isFailure, idle.isSuccess)
+      },
+    ),
   )
+
+  /** Decodes `hocon` with its first campaign phase replaced, so the assertions above exercise the
+    * real `deriveConfig[LoadgenConfig]` path rather than calling the validator directly.
+    */
+  private def decodePhase(phase: String) =
+    TypesafeConfigProvider
+      .fromHoconString(hocon.replaceFirst("\\{ name = warmup,  duration = 15m, scale = 0.1 \\}", phase))
+      .kebabCase
+      .load(loadgenConfigDescriptor)

--- a/loadgen/src/test/scala/versola/loadgen/scheduler/ArrivalProcessSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/scheduler/ArrivalProcessSpec.scala
@@ -112,4 +112,85 @@ object ArrivalProcessSpec extends ZIOSpecDefault:
         assertTrue(scala.util.Try(process.next(0.0)).isFailure)
       },
     ),
+    suite("varying rate")(
+      test("a gap that crosses a rate change is distributed under the rate that applies across it") {
+        // λ is 0.01/s for the first 10 s and 1000/s for the next 10 s. A generator that fixes the
+        // rate at the start of the gap draws its first gap with a mean of 100 s, overshoots the
+        // whole 20 s window and produces nothing at all; the rate change inside the gap is never
+        // seen. Thinning evaluates λ at the candidate instant, so the fast half yields its own
+        // ~10,000 arrivals (Poisson, sd 100 -- the bounds below are 4σ).
+        val step = anchor.plusSeconds(10)
+        val rate = VaryingRate(
+          ceiling = 1_000.0,
+          endsAt = anchor.plusSeconds(20),
+          at = instant => if instant.isBefore(step) then 0.01 else 1_000.0,
+        )
+        val arrivals = ArrivalProcess.startingAt(anchor, RandomSource.seeded(20260915L)).take(20_000, rate)
+        val afterStep = arrivals.count(!_.intendedStart.isBefore(step))
+        val beforeStep = arrivals.size - afterStep
+        assertTrue(beforeStep <= 3, afterStep > 9_600, afterStep < 10_400)
+      },
+      test("the arrival count over an interval matches the integral of λ across it") {
+        // λ ramps linearly 0 -> 200/s over 60 s, so the expected count is the area, 6,000
+        // (Poisson sd 77.5; the bounds are ~4σ). A gap drawn at the rate in force when it started
+        // would systematically under-count on a rising ramp, since every gap would be priced at a
+        // rate lower than the one that actually applies by the time it lands.
+        val span = 60.0
+        val peak = 200.0
+        val rate = VaryingRate(
+          ceiling = peak,
+          endsAt = anchor.plusSeconds(span.toLong),
+          at = instant =>
+            val elapsed = (instant.toEpochMilli - anchor.toEpochMilli) / 1000.0
+            peak * (elapsed / span),
+        )
+        val arrivals = ArrivalProcess.startingAt(anchor, RandomSource.seeded(20260916L)).take(50_000, rate)
+        // Half the area lies in the last 17.6 s of the ramp (1 - 1/√2 of its length), which a
+        // flat-rate generator could not reproduce even with the right total.
+        val lastQuarter = arrivals.count(_.intendedStart.isAfter(anchor.plusSeconds(30)))
+        assertTrue(
+          arrivals.size > 5_690,
+          arrivals.size < 6_310,
+          lastQuarter.toDouble / arrivals.size > 0.70,
+          lastQuarter.toDouble / arrivals.size < 0.80,
+        )
+      },
+      test("stops at the horizon, leaving the process resumable from it") {
+        val endsAt = anchor.plusSeconds(5)
+        val rate = VaryingRate(ceiling = 10.0, endsAt = endsAt, at = _ => 10.0)
+        val process = ArrivalProcess.startingAt(anchor, RandomSource.seeded(20260917L))
+        val arrivals = process.take(10_000, rate)
+        assertTrue(
+          arrivals.forall(_.intendedStart.isBefore(endsAt)),
+          arrivals.size < 10_000,
+          // No arrival fell in the tail of the window just searched, so the memoryless resume
+          // point is the horizon itself, not the last accepted arrival.
+          process.lastScheduledAt == endsAt,
+          process.next(rate).isEmpty,
+        )
+      },
+      test("a zero rate inside the horizon yields nothing rather than looping") {
+        val rate = VaryingRate(ceiling = 10.0, endsAt = anchor.plusSeconds(5), at = _ => 0.0)
+        val process = ArrivalProcess.startingAt(anchor, RandomSource.seeded(20260918L))
+        assertTrue(process.next(rate).isEmpty, process.take(10, rate).isEmpty)
+      },
+      test("rejects an envelope whose rate exceeds its declared ceiling") {
+        // Silently thinning against a too-low ceiling loses exactly the arrivals above it, and the
+        // deficit is indistinguishable from the SUT absorbing less load.
+        val rate = VaryingRate(ceiling = 1.0, endsAt = anchor.plusSeconds(60), at = _ => 5.0)
+        val process = ArrivalProcess.startingAt(anchor, RandomSource.seeded(20260919L))
+        assertTrue(scala.util.Try(process.take(100, rate)).isFailure)
+      },
+      test("the varying-rate schedule is a function of anchor and seed only") {
+        val rate = VaryingRate(
+          ceiling = 50.0,
+          endsAt = anchor.plusSeconds(30),
+          at = instant => if instant.isBefore(anchor.plusSeconds(15)) then 5.0 else 50.0,
+        )
+        val first = ArrivalProcess.startingAt(anchor, RandomSource.seeded(11L)).take(5_000, rate)
+        val second = ArrivalProcess.startingAt(anchor, RandomSource.seeded(11L)).take(5_000, rate)
+        val other = ArrivalProcess.startingAt(anchor, RandomSource.seeded(12L)).take(5_000, rate)
+        assertTrue(first == second, first != other, first.map(_.sequence) == zio.Chunk.fromIterable(1L to first.size.toLong))
+      },
+    ),
   )

--- a/loadgen/src/test/scala/versola/loadgen/scheduler/ArrivalProcessSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/scheduler/ArrivalProcessSpec.scala
@@ -1,0 +1,115 @@
+package versola.loadgen.scheduler
+
+import zio.test.*
+
+import java.time.Instant
+
+/** §13's "arrival inter-times are exponential (χ² test)", plus the properties that make the
+  * schedule a *schedule* rather than a sequence of clock reads (§7.2).
+  *
+  * Sample size is 50,000 inter-arrival times at λ = 25/s, from a literal seed. 50,000 gives
+  * 5,000 expected observations per bin -- two orders of magnitude above the 5-per-bin rule the
+  * χ² approximation needs -- and generates in a few milliseconds on one core.
+  */
+object ArrivalProcessSpec extends ZIOSpecDefault:
+
+  private val anchor = Instant.parse("2026-09-10T00:00:00Z")
+  private val rate = 25.0
+  private val samples = 50_000
+  private val bins = 10
+
+  /** χ²(0.99) with 9 degrees of freedom = 21.666.
+    *
+    * Bin count 10, so df = bins − 1 = 9: no parameter is estimated from the sample (λ is the one
+    * the process was driven with), so no further degree of freedom is lost. Significance level
+    * 0.01 rather than 0.05 (critical value 16.919) because this assertion runs on every CI build:
+    * the seed is fixed so the statistic is deterministic, but a future re-seeding should not have
+    * a 1-in-20 chance of failing a correct sampler. Hard-coded rather than computed, so that the
+    * suite does not acquire a statistics dependency for one number. The statistic this seed
+    * actually produces is 14.79, i.e. it also clears the stricter 0.05 threshold.
+    */
+  private val chiSquaredCritical = 21.666
+
+  private def interArrivalSeconds(seed: Long, count: Int, ratePerSecond: Double): IndexedSeq[Double] =
+    val process = ArrivalProcess.startingAt(anchor, RandomSource.seeded(seed))
+    val arrivals = process.take(count + 1, ratePerSecond)
+    (0 until count).map: index =>
+      val from = arrivals(index).intendedStart
+      val to = arrivals(index + 1).intendedStart
+      (to.getEpochSecond - from.getEpochSecond).toDouble + (to.getNano - from.getNano) / 1e9
+
+  /** Equiprobable bins: boundaries at the deciles of Exponential(λ), so every expected count is
+    * `n/bins` and the statistic does not depend on an arbitrary bin width.
+    */
+  private def chiSquared(draws: IndexedSeq[Double], ratePerSecond: Double): Double =
+    val boundaries = (1 until bins).map(index => Exponential.quantile(index.toDouble / bins, ratePerSecond))
+    val counts = Array.ofDim[Int](bins)
+    draws.foreach: draw =>
+      val bin = boundaries.indexWhere(boundary => draw < boundary)
+      counts(if bin < 0 then bins - 1 else bin) += 1
+    val expected = draws.size.toDouble / bins
+    counts.map(count => (count - expected) * (count - expected) / expected).sum
+
+  def spec = suite("ArrivalProcess")(
+    suite("inter-arrival distribution")(
+      test("inter-arrival times pass a chi-squared goodness-of-fit test against Exponential(λ)") {
+        val statistic = chiSquared(interArrivalSeconds(20260910L, samples, rate), rate)
+        assertTrue(statistic < chiSquaredCritical)
+      },
+      test("the same test rejects a wrong rate -- so it is a test and not a tautology") {
+        // Half the rate: the same draws against Exponential(12.5) put ~all the mass in the low
+        // bins. Guards against the boundary/binning arithmetic above degenerating into something
+        // that passes for any input.
+        val statistic = chiSquared(interArrivalSeconds(20260910L, samples, rate), rate / 2)
+        assertTrue(statistic > chiSquaredCritical)
+      },
+      test("mean inter-arrival time is 1/λ") {
+        val draws = interArrivalSeconds(20260911L, samples, rate)
+        val mean = draws.sum / draws.size
+        // sd of an exponential equals its mean, so the standard error here is 1/(λ√n) = 0.45% of
+        // 1/λ; 2% is ~4.5 of those.
+        assertTrue(math.abs(mean - 1.0 / rate) / (1.0 / rate) < 0.02)
+      },
+    ),
+    suite("schedule")(
+      test("intended starts are monotone and sequence numbers are dense from 1") {
+        val process = ArrivalProcess.startingAt(anchor, RandomSource.seeded(20260912L))
+        val arrivals = process.take(1_000, rate)
+        assertTrue(
+          arrivals.map(_.sequence) == zio.Chunk.fromIterable(1L to 1000L),
+          arrivals.head.intendedStart.isAfter(anchor),
+          arrivals.zip(arrivals.drop(1)).forall((left, right) => right.intendedStart.isAfter(left.intendedStart)),
+          arrivals.last.intendedStart == process.lastScheduledAt,
+        )
+      },
+      test("the schedule is a function of anchor and seed only -- it never reads the clock") {
+        // Two processes built at different real times from the same anchor and seed must produce
+        // the identical schedule. This is the property that makes schedule lag observable: if
+        // generation depended on when it ran, `now − intendedStart` would be zero by
+        // construction and a driver falling behind would be invisible.
+        val first = ArrivalProcess.startingAt(anchor, RandomSource.seeded(7L)).take(500, rate)
+        val second = ArrivalProcess.startingAt(anchor, RandomSource.seeded(7L)).take(500, rate)
+        val other = ArrivalProcess.startingAt(anchor, RandomSource.seeded(8L)).take(500, rate)
+        assertTrue(first == second, first != other)
+      },
+      test("a rate change applies from the next draw, so λ(t) can move under the generator") {
+        val process = ArrivalProcess.startingAt(anchor, RandomSource.seeded(20260913L))
+        val slow = (0 until 2_000).map(_ => process.next(1.0))
+        val slowSpan = slow.last.intendedStart.getEpochSecond - anchor.getEpochSecond
+        val fastStart = process.lastScheduledAt
+        val fast = (0 until 2_000).map(_ => process.next(100.0))
+        val fastSpan = fast.last.intendedStart.getEpochSecond - fastStart.getEpochSecond
+        assertTrue(slowSpan > 1_500L, fastSpan < 30L)
+      },
+      test("a driver's share of the published rate is λ/shardCount") {
+        assertTrue(
+          ArrivalProcess.shardRate(2_650.0, 8) == 331.25,
+          scala.util.Try(ArrivalProcess.shardRate(2_650.0, 0)).isFailure,
+        )
+      },
+      test("rejects a non-positive rate rather than scheduling an arrival at infinity") {
+        val process = ArrivalProcess.startingAt(anchor, RandomSource.seeded(20260914L))
+        assertTrue(scala.util.Try(process.next(0.0)).isFailure)
+      },
+    ),
+  )

--- a/loadgen/src/test/scala/versola/loadgen/scheduler/CampaignScheduleSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/scheduler/CampaignScheduleSpec.scala
@@ -1,0 +1,104 @@
+package versola.loadgen.scheduler
+
+import versola.loadgen.config.CampaignConfig
+import versola.loadgen.config.CampaignPhaseConfig
+import versola.loadgen.config.DiurnalConfig
+import versola.loadgen.config.RegistrationConfig
+import zio.durationInt
+import zio.test.*
+
+import java.time.Instant
+
+/** `rate(t) = base × scale(phase) × diurnal(hourOfDay)` (§7.3) over the phase list of §5. */
+object CampaignScheduleSpec extends ZIOSpecDefault:
+
+  private val startedAt = Instant.parse("2026-09-10T00:00:00Z")
+
+  private def phase(name: String, minutes: Int, scale: Option[Double], from: Option[Double], to: Option[Double]) =
+    CampaignPhaseConfig(name = name, duration = minutes.minutes, scale = scale, scaleFrom = from, scaleTo = to)
+
+  private def campaign(phases: List[CampaignPhaseConfig], diurnal: Boolean): CampaignConfig =
+    CampaignConfig(
+      name = "c3-10m-steady",
+      phases = phases,
+      diurnal = DiurnalConfig(enabled = diurnal, peakFactor = 3.0, peakHour = 20, timezone = "UTC"),
+      registration = RegistrationConfig(enabled = false, target = 1_000_000L, duration = 72.hours),
+    )
+
+  private val phases = List(
+    phase("warmup", 15, Some(0.1), None, None),
+    phase("ramp", 30, None, Some(0.1), Some(1.0)),
+    phase("steady", 60, Some(1.0), None, None),
+  )
+
+  def spec = suite("CampaignSchedule")(
+    suite("phases")(
+      test("resolves phases back to back and picks the scale by which fields are set") {
+        val schedule = CampaignSchedule.from(campaign(phases, diurnal = false), startedAt).toOption.get
+        assertTrue(
+          schedule.phases.map(_.name) == Vector("warmup", "ramp", "steady"),
+          schedule.phases.map(_.startsAt) == Vector(0.minutes, 15.minutes, 45.minutes),
+          schedule.totalDuration == 105.minutes,
+          schedule.phaseAt(startedAt.plusSeconds(60)).map(_.name) == Some("warmup"),
+          schedule.phaseAt(startedAt.plusSeconds(30 * 60)).map(_.name) == Some("ramp"),
+          schedule.scaleAt(startedAt) == 0.1,
+        )
+      },
+      test("interpolates a ramp linearly across its own duration") {
+        val schedule = CampaignSchedule.from(campaign(phases, diurnal = false), startedAt).toOption.get
+        val midRamp = startedAt.plusSeconds((15 + 15) * 60)
+        assertTrue(
+          math.abs(schedule.scaleAt(midRamp) - 0.55) < 1e-12,
+          math.abs(schedule.scaleAt(startedAt.plusSeconds(15 * 60)) - 0.1) < 1e-12,
+          math.abs(schedule.scaleAt(startedAt.plusSeconds(45 * 60)) - 1.0) < 1e-12,
+        )
+      },
+      test("generates nothing before the campaign starts or after it ends") {
+        val schedule = CampaignSchedule.from(campaign(phases, diurnal = false), startedAt).toOption.get
+        assertTrue(
+          schedule.phaseAt(startedAt.minusSeconds(1)) == None,
+          schedule.scaleAt(startedAt.minusSeconds(1)) == 0.0,
+          schedule.scaleAt(startedAt.plusSeconds(105 * 60)) == 0.0,
+          schedule.rateAt(2_650.0, startedAt.plusSeconds(105 * 60)) == 0.0,
+        )
+      },
+    ),
+    suite("rate")(
+      test("multiplies base by phase scale and by the diurnal envelope") {
+        val flat = CampaignSchedule.from(campaign(phases, diurnal = false), startedAt).toOption.get
+        val shaped = CampaignSchedule.from(campaign(phases, diurnal = true), startedAt).toOption.get
+        val steady = startedAt.plusSeconds(50 * 60)
+        val peak = startedAt.plusSeconds(20 * 3600 + 50 * 60)
+        assertTrue(
+          flat.rateAt(2_650.0, steady) == 2_650.0,
+          // The ratio between the shaped and the flat rate is exactly the *normalised* envelope,
+          // never the raw peak factor: at 00:50 against a 20:00 peak that is 1.02, because the
+          // trough of this envelope is 08:00 (the antipode) and not midnight.
+          math.abs(shaped.rateAt(2_650.0, steady) / 2_650.0 - shaped.diurnal.at(steady)) < 1e-9,
+          math.abs(shaped.rateAt(2_650.0, steady) - 2_711.42) < 0.01,
+          shaped.diurnal.atHour(8.0) < 1.0 && shaped.diurnal.atHour(20.0) > 1.0,
+          // ... but the peak instant falls outside the 105-minute campaign, so it generates
+          // nothing: the envelope shapes the campaign, it does not extend it.
+          shaped.rateAt(2_650.0, peak) == 0.0,
+        )
+      },
+    ),
+    suite("validation")(
+      test("rejects a phase that sets neither scale nor both ramp ends") {
+        val broken = List(phase("warmup", 15, None, Some(0.1), None))
+        assertTrue(CampaignSchedule.from(campaign(broken, diurnal = false), startedAt).isLeft)
+      },
+      test("rejects a phase that sets both a flat scale and a ramp") {
+        val broken = List(phase("warmup", 15, Some(0.5), Some(0.1), Some(1.0)))
+        assertTrue(CampaignSchedule.from(campaign(broken, diurnal = false), startedAt).isLeft)
+      },
+      test("rejects an empty phase list and an unusable diurnal block") {
+        assertTrue(
+          CampaignSchedule.from(campaign(Nil, diurnal = false), startedAt).isLeft,
+          CampaignSchedule
+            .from(campaign(phases, diurnal = true).copy(diurnal = DiurnalConfig(true, 3.0, 20, "Mars/Olympus")), startedAt)
+            .isLeft,
+        )
+      },
+    ),
+  )

--- a/loadgen/src/test/scala/versola/loadgen/scheduler/CampaignScheduleSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/scheduler/CampaignScheduleSpec.scala
@@ -92,6 +92,36 @@ object CampaignScheduleSpec extends ZIOSpecDefault:
         val broken = List(phase("warmup", 15, Some(0.5), Some(0.1), Some(1.0)))
         assertTrue(CampaignSchedule.from(campaign(broken, diurnal = false), startedAt).isLeft)
       },
+      test("rejects a negative phase duration rather than building an unreachable phase") {
+        // `endsAt` would precede `startsAt`, so `phaseAt`'s half-open test never matches the
+        // phase, and the negative offset drags every later phase back into an overlapping range.
+        val broken = List(
+          phase("warmup", 15, Some(0.1), None, None),
+          CampaignPhaseConfig("backwards", (-10).minutes, Some(1.0), None, None),
+          phase("steady", 60, Some(1.0), None, None),
+        )
+        assertTrue(CampaignSchedule.from(campaign(broken, diurnal = false), startedAt).isLeft)
+      },
+      test("accepts a zero-length phase, which scaleAt already handles") {
+        val zero = List(phase("instant", 0, Some(1.0), None, None), phase("steady", 60, Some(1.0), None, None))
+        assertTrue(CampaignSchedule.from(campaign(zero, diurnal = false), startedAt).isRight)
+      },
+      test("rejects a negative or non-finite scale instead of silently generating no load") {
+        // `rateAt` turns any non-positive scale into a rate of 0, so without this the campaign
+        // runs a phase at zero load and reports success. NaN is worse: it passes `scale <= 0.0`
+        // and reaches the sampler as the rate itself.
+        def rejected(phases: List[CampaignPhaseConfig]) =
+          CampaignSchedule.from(campaign(phases, diurnal = false), startedAt).isLeft
+        assertTrue(
+          rejected(List(phase("negative-flat", 15, Some(-1.0), None, None))),
+          rejected(List(phase("negative-ramp-start", 15, None, Some(-0.1), Some(1.0)))),
+          rejected(List(phase("negative-ramp-end", 15, None, Some(0.1), Some(-1.0)))),
+          rejected(List(phase("nan", 15, Some(Double.NaN), None, None))),
+          rejected(List(phase("infinite", 15, Some(Double.PositiveInfinity), None, None))),
+          // Zero is the one legitimate way to say "this phase generates nothing".
+          CampaignSchedule.from(campaign(List(phase("idle", 15, Some(0.0), None, None)), diurnal = false), startedAt).isRight,
+        )
+      },
       test("rejects an empty phase list and an unusable diurnal block") {
         assertTrue(
           CampaignSchedule.from(campaign(Nil, diurnal = false), startedAt).isLeft,
@@ -99,6 +129,32 @@ object CampaignScheduleSpec extends ZIOSpecDefault:
             .from(campaign(phases, diurnal = true).copy(diurnal = DiurnalConfig(true, 3.0, 20, "Mars/Olympus")), startedAt)
             .isLeft,
         )
+      },
+    ),
+    suite("envelope")(
+      test("the ceiling is never exceeded by the rate anywhere in the campaign") {
+        // Swept at 30 s across the whole campaign, including the ramp and the diurnal peak. A
+        // ceiling that holds only usually is not a ceiling: thinning drops whatever rises above it.
+        val schedule = CampaignSchedule.from(campaign(phases, diurnal = true), startedAt).toOption.get
+        val base = 2_650.0
+        val ceiling = schedule.rateCeiling(base)
+        val steps = (0L to schedule.totalDuration.toSeconds by 30L).map(startedAt.plusSeconds)
+        assertTrue(
+          steps.forall(instant => schedule.rateAt(base, instant) <= ceiling),
+          steps.map(instant => schedule.rateAt(base, instant)).max > ceiling * 0.5,
+          schedule.endsAt == startedAt.plus(schedule.totalDuration),
+        )
+      },
+      test("the diurnal peak is the envelope's maximum") {
+        val schedule = CampaignSchedule.from(campaign(phases, diurnal = true), startedAt).toOption.get
+        val sampled = (0 until 24 * 60).map(minute => schedule.diurnal.atHour(minute / 60.0)).max
+        assertTrue(schedule.diurnal.peak >= sampled, schedule.diurnal.peak - sampled < 1e-6)
+      },
+      test("envelope() carries the horizon, so a campaign that has ended schedules nothing") {
+        val schedule = CampaignSchedule.from(campaign(phases, diurnal = false), startedAt).toOption.get
+        val envelope = schedule.envelope(2_650.0)
+        val process = ArrivalProcess.startingAt(schedule.endsAt, RandomSource.seeded(4L))
+        assertTrue(envelope.endsAt == schedule.endsAt, process.next(envelope).isEmpty)
       },
     ),
   )

--- a/loadgen/src/test/scala/versola/loadgen/scheduler/DistributionsSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/scheduler/DistributionsSpec.scala
@@ -21,7 +21,9 @@ object DistributionsSpec extends ZIOSpecDefault:
   private val samples = 100_000
 
   private val thinkTime = ThinkTimeConfig(median = 4.seconds, sigma = 0.8)
-  private val actionCount = ActionCountConfig(mobileMean = 6.0, webMean = 10.0, dispersion = 0.6)
+  // Means of the user-driven actions only: a session is these plus the app's mandatory opening
+  // `GET /accounts`, so the totals are still design doc §2.3's 6.0 mobile and 10.0 web.
+  private val actionCount = ActionCountConfig(mobileMean = 5.0, webMean = 9.0, dispersion = 0.6)
 
   private def moments(draws: IndexedSeq[Double]): (Double, Double) =
     val mean = draws.sum / draws.size
@@ -70,24 +72,27 @@ object DistributionsSpec extends ZIOSpecDefault:
         val (mobileMean, mobileVariance) = moments(mobile)
         val (webMean, webVariance) = moments(web)
         assertTrue(
+          // The session totals of §2.3, reached as 1 + NegBinomial(5.0) and 1 + NegBinomial(9.0).
           relative(mobileMean, 6.0) < 0.015,
           relative(webMean, 10.0) < 0.015,
-          // Var = mean × (1 + dispersion × mean): 27.6 mobile, 70.0 web. Same tolerance
-          // reasoning as LogNormal above; the alternative parameterisation (dispersion read as
-          // the size r) would put these at 66.0 and 176.7, i.e. 2.4x out.
-          relative(mobileVariance, 27.6) < 0.10,
-          relative(webVariance, 70.0) < 0.10,
-          relative(ActionCount.varianceFor(actionCount, Platform.Mobile), 27.6) < 1e-12,
+          // Var = mean × (1 + dispersion × mean) of the *draw*: 20.0 mobile, 57.6 web. The
+          // mandatory action shifts the distribution and so leaves the variance alone. Same
+          // tolerance reasoning as LogNormal above; the alternative parameterisation (dispersion
+          // read as the size r) would put these at 45.0 and 138.6, i.e. 2.3x out.
+          relative(mobileVariance, 20.0) < 0.10,
+          relative(webVariance, 57.6) < 0.10,
+          relative(ActionCount.varianceFor(actionCount, Platform.Mobile), 20.0) < 1e-12,
         )
       },
-      test("draws zero for the documented share of sessions") {
+      test("every session performs at least the app's opening call, without the draw being clamped") {
         val random = RandomSource.seeded(20260913L)
         val draws = IndexedSeq.fill(samples)(ActionCount.sample(actionCount, Platform.Mobile, random))
-        // P(N = 0) = (r/(r+mean))^r with r = 1/0.6: 7.86%. Asserted rather than clamped away,
-        // because clamping to a minimum of one action would move the realised mean off the
-        // configured 6.0 without saying so.
-        val zeroShare = draws.count(_ == 0).toDouble / samples
-        assertTrue(math.abs(zeroShare - 0.0786) < 0.005, draws.forall(_ >= 0))
+        // P(N' = 0) = (r/(r+mean))^r with r = 1/0.6 and mean 5: 9.87% -- a user who opens the app,
+        // sees their balance and closes it. Those sessions still perform one action, because §3's
+        // `GET /accounts` is the app's call and was never part of the draw. Asserting the share
+        // rather than clamping keeps the low tail unbiased and the realised mean exactly 6.0.
+        val singleActionShare = draws.count(_ == 1).toDouble / samples
+        assertTrue(math.abs(singleActionShare - 0.0987) < 0.005, draws.forall(_ >= ActionCount.mandatoryActions))
       },
       test("a dispersion above 1 (size below 1) still samples -- the Gamma boost branch") {
         val random = RandomSource.seeded(20260914L)
@@ -126,10 +131,12 @@ object DistributionsSpec extends ZIOSpecDefault:
       },
     ),
     suite("ActionCount")(
-      test("maps platform to the configured mean") {
+      test("maps platform to the configured mean, and adds the mandatory action to it") {
         assertTrue(
-          ActionCount.meanFor(actionCount, Platform.Mobile) == 6.0,
-          ActionCount.meanFor(actionCount, Platform.Web) == 10.0,
+          ActionCount.additionalMeanFor(actionCount, Platform.Mobile) == 5.0,
+          ActionCount.additionalMeanFor(actionCount, Platform.Web) == 9.0,
+          ActionCount.sessionMeanFor(actionCount, Platform.Mobile) == 6.0,
+          ActionCount.sessionMeanFor(actionCount, Platform.Web) == 10.0,
         )
       },
     ),

--- a/loadgen/src/test/scala/versola/loadgen/scheduler/DistributionsSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/scheduler/DistributionsSpec.scala
@@ -1,0 +1,136 @@
+package versola.loadgen.scheduler
+
+import versola.loadgen.config.ActionCountConfig
+import versola.loadgen.config.ThinkTimeConfig
+import versola.loadgen.model.Platform
+import zio.durationInt
+import zio.test.*
+
+/** §13's "NegBinomial/LogNormal moments match their parameters".
+  *
+  * Every draw comes from [[RandomSource.seeded]] with a literal seed, so these are exact
+  * regression assertions rather than samples that happen to pass: a failure means the sampler
+  * changed, not that the run was unlucky. The tolerances are nevertheless stated in units of the
+  * estimator's standard error, so that they say what deviation the test is actually sensitive to.
+  *
+  * Sample size is 100,000 draws per distribution -- ~0.3% standard error on the means here, and
+  * a few tens of milliseconds on one core.
+  */
+object DistributionsSpec extends ZIOSpecDefault:
+
+  private val samples = 100_000
+
+  private val thinkTime = ThinkTimeConfig(median = 4.seconds, sigma = 0.8)
+  private val actionCount = ActionCountConfig(mobileMean = 6.0, webMean = 10.0, dispersion = 0.6)
+
+  private def moments(draws: IndexedSeq[Double]): (Double, Double) =
+    val mean = draws.sum / draws.size
+    val variance = draws.map(draw => (draw - mean) * (draw - mean)).sum / (draws.size - 1)
+    (mean, variance)
+
+  private def relative(actual: Double, expected: Double): Double = math.abs(actual - expected) / expected
+
+  def spec = suite("Distributions")(
+    suite("LogNormal")(
+      test("sample mean and variance match median+sigma") {
+        val random = RandomSource.seeded(20260910L)
+        val draws = IndexedSeq.fill(samples)(LogNormal.sample(median = 4.0, sigma = 0.8, random))
+        val (mean, variance) = moments(draws)
+        // Mean: sd/√n is 0.30% of the mean, so 1.5% is ~5 standard errors.
+        // Variance: a LogNormal at sigma = 0.8 has excess kurtosis ~31, giving s² a relative
+        // standard error of ~1.8%; 10% is ~5.5 of those. Both are wide enough never to flake and
+        // narrow enough to catch the failure mode that matters -- reading `median` as the
+        // underlying normal's mu, which moves the mean by 14x.
+        assertTrue(
+          relative(mean, LogNormal.mean(4.0, 0.8)) < 0.015,
+          relative(variance, LogNormal.variance(4.0, 0.8)) < 0.10,
+        )
+      },
+      test("the median is the configured median, and is not the mean") {
+        val random = RandomSource.seeded(20260911L)
+        val draws = IndexedSeq.fill(samples)(LogNormal.sample(median = 4.0, sigma = 0.8, random)).sorted
+        assertTrue(
+          relative(draws(samples / 2), 4.0) < 0.02,
+          relative(LogNormal.mean(4.0, 0.8), 5.5088) < 1e-4,
+        )
+      },
+      test("rejects a non-positive median or sigma") {
+        val random = RandomSource.seeded(1L)
+        assertTrue(
+          scala.util.Try(LogNormal.sample(0.0, 0.8, random)).isFailure,
+          scala.util.Try(LogNormal.sample(4.0, 0.0, random)).isFailure,
+        )
+      },
+    ),
+    suite("NegBinomial")(
+      test("sample mean and variance match mean+dispersion, at both configured means") {
+        val random = RandomSource.seeded(20260912L)
+        val mobile = IndexedSeq.fill(samples)(ActionCount.sample(actionCount, Platform.Mobile, random).toDouble)
+        val web = IndexedSeq.fill(samples)(ActionCount.sample(actionCount, Platform.Web, random).toDouble)
+        val (mobileMean, mobileVariance) = moments(mobile)
+        val (webMean, webVariance) = moments(web)
+        assertTrue(
+          relative(mobileMean, 6.0) < 0.015,
+          relative(webMean, 10.0) < 0.015,
+          // Var = mean × (1 + dispersion × mean): 27.6 mobile, 70.0 web. Same tolerance
+          // reasoning as LogNormal above; the alternative parameterisation (dispersion read as
+          // the size r) would put these at 66.0 and 176.7, i.e. 2.4x out.
+          relative(mobileVariance, 27.6) < 0.10,
+          relative(webVariance, 70.0) < 0.10,
+          relative(ActionCount.varianceFor(actionCount, Platform.Mobile), 27.6) < 1e-12,
+        )
+      },
+      test("draws zero for the documented share of sessions") {
+        val random = RandomSource.seeded(20260913L)
+        val draws = IndexedSeq.fill(samples)(ActionCount.sample(actionCount, Platform.Mobile, random))
+        // P(N = 0) = (r/(r+mean))^r with r = 1/0.6: 7.86%. Asserted rather than clamped away,
+        // because clamping to a minimum of one action would move the realised mean off the
+        // configured 6.0 without saying so.
+        val zeroShare = draws.count(_ == 0).toDouble / samples
+        assertTrue(math.abs(zeroShare - 0.0786) < 0.005, draws.forall(_ >= 0))
+      },
+      test("a dispersion above 1 (size below 1) still samples -- the Gamma boost branch") {
+        val random = RandomSource.seeded(20260914L)
+        val draws = IndexedSeq.fill(samples)(NegBinomial.sample(mean = 6.0, dispersion = 2.5, random).toDouble)
+        val (mean, variance) = moments(draws)
+        assertTrue(
+          relative(mean, 6.0) < 0.03,
+          relative(variance, NegBinomial.variance(6.0, 2.5)) < 0.15,
+        )
+      },
+    ),
+    suite("ThinkTimeTable")(
+      test("the precomputed table reproduces the configured median and honours the clamp") {
+        val table = ThinkTimeTable.build(thinkTime, RandomSource.seeded(20260915L))
+        val entries = table.entriesMillis.sorted
+        val random = RandomSource.seeded(20260916L)
+        val drawn = IndexedSeq.fill(samples)(table.sample(random).toMillis.toDouble)
+        val (mean, _) = moments(drawn)
+        assertTrue(
+          entries.length == ThinkTimeTable.Size,
+          entries.head >= ThinkTimeTable.FloorMillis,
+          entries.last <= ThinkTimeTable.CeilingMillis,
+          relative(entries(ThinkTimeTable.Size / 2).toDouble, 4000.0) < 0.02,
+          // The clamp is 3.7 sigma below and 4.3 sigma above the median, so it moves the mean by
+          // far less than the tolerance -- which is what makes the table usable as a LogNormal.
+          relative(mean, ThinkTimeTable.unclampedMeanMillis(thinkTime)) < 0.03,
+        )
+      },
+      test("a 200 ms median is lifted to the floor rather than sampled below it") {
+        val table = ThinkTimeTable.build(ThinkTimeConfig(median = 200.millis, sigma = 0.8), RandomSource.seeded(20260917L))
+        val entries = table.entriesMillis
+        assertTrue(
+          entries.forall(_ >= ThinkTimeTable.FloorMillis),
+          entries.count(_ == ThinkTimeTable.FloorMillis.toInt) > ThinkTimeTable.Size / 4,
+        )
+      },
+    ),
+    suite("ActionCount")(
+      test("maps platform to the configured mean") {
+        assertTrue(
+          ActionCount.meanFor(actionCount, Platform.Mobile) == 6.0,
+          ActionCount.meanFor(actionCount, Platform.Web) == 10.0,
+        )
+      },
+    ),
+  )

--- a/loadgen/src/test/scala/versola/loadgen/scheduler/DiurnalEnvelopeSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/scheduler/DiurnalEnvelopeSpec.scala
@@ -1,0 +1,101 @@
+package versola.loadgen.scheduler
+
+import versola.loadgen.config.DiurnalConfig
+import zio.test.*
+
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+/** §13's "diurnal envelope integrates to 1.0". Deterministic by construction -- the envelope
+  * draws no randomness -- so no seed is involved here.
+  */
+object DiurnalEnvelopeSpec extends ZIOSpecDefault:
+
+  private val zone = "Asia/Almaty"
+
+  private def config(enabled: Boolean, peakFactor: Double, peakHour: Int): DiurnalConfig =
+    DiurnalConfig(enabled = enabled, peakFactor = peakFactor, peakHour = peakHour, timezone = zone)
+
+  /** Midpoint rule over one-second steps.
+    *
+    * Deliberately a *different* quadrature rule, and a different node set, from the composite
+    * Simpson that `DiurnalEnvelope` uses to compute its own normaliser: integrating with the same
+    * rule would return 1.0 by cancellation whatever the formula did, and assert nothing.
+    *
+    * Its own error is what sets the tolerance below. Midpoint error is `(b−a)h²·max|f''|/24`;
+    * with `h = 1/3600 h` and `max|f''| = (peakFactor−1)/σ² ≈ 0.4` at `peakFactor = 6`, that is
+    * ~3e-9. 1e-6 therefore leaves two and a half orders of magnitude of slack over the test's own
+    * numerics while still catching any real error in the normalisation -- for reference, dropping
+    * the normalisation entirely moves this number to 1.73 at `peakFactor = 3`.
+    */
+  private def dailyMean(envelope: DiurnalEnvelope): Double =
+    val steps = 86400
+    val step = 24.0 / steps
+    var total = 0.0
+    var index = 0
+    while index < steps do
+      total += envelope.atHour((index + 0.5) * step)
+      index += 1
+    total / steps
+
+  private val tolerance = 1e-6
+
+  def spec = suite("DiurnalEnvelope")(
+    suite("normalisation")(
+      test("integrates to 1.0 over 24 hours, at every peak factor and peak hour") {
+        val cases =
+          for
+            peakFactor <- List(1.0, 1.5, 3.0, 6.0)
+            peakHour <- List(0, 3, 8, 12, 20, 23)
+          yield (peakFactor, peakHour)
+        val means = cases.map: (peakFactor, peakHour) =>
+          val envelope = DiurnalEnvelope.from(config(enabled = true, peakFactor, peakHour)).toOption.get
+          (peakFactor, peakHour, dailyMean(envelope))
+        assertTrue(means.forall((_, _, mean) => math.abs(mean - 1.0) < tolerance))
+      },
+      test("the raw §7.3 formula does not integrate to 1.0 -- so the normaliser is load-bearing") {
+        val envelope = DiurnalEnvelope.from(config(enabled = true, peakFactor = 3.0, peakHour = 20)).toOption.get
+        // 1 + (peakFactor − 1) × σ√(2π)·erf(12/σ√2)/24 for σ = 3.5: the 73% volume inflation the
+        // normalisation removes.
+        assertTrue(math.abs(envelope.normalisationFactor - 1.7307) < 1e-3)
+      },
+      test("a disabled envelope is flat at 1.0") {
+        val envelope = DiurnalEnvelope.from(config(enabled = false, peakFactor = 3.0, peakHour = 20)).toOption.get
+        assertTrue(
+          (0 until 24).forall(hour => envelope.atHour(hour.toDouble) == 1.0),
+          math.abs(dailyMean(envelope) - 1.0) < tolerance,
+        )
+      },
+    ),
+    suite("shape")(
+      test("peaks at peak-hour and troughs at its antipode") {
+        val envelope = DiurnalEnvelope.from(config(enabled = true, peakFactor = 3.0, peakHour = 20)).toOption.get
+        val hourly = (0 until 24).map(hour => envelope.atHour(hour.toDouble))
+        assertTrue(
+          hourly.zipWithIndex.maxBy(_._1)._2 == 20,
+          hourly.zipWithIndex.minBy(_._1)._2 == 8,
+          math.abs(envelope.atHour(20.0) - 3.0 / envelope.normalisationFactor) < 1e-12,
+        )
+      },
+      test("wraps across midnight rather than treating 23:00 as far from a 00:00 peak") {
+        val envelope = DiurnalEnvelope.from(config(enabled = true, peakFactor = 3.0, peakHour = 0)).toOption.get
+        assertTrue(math.abs(envelope.atHour(23.0) - envelope.atHour(1.0)) < 1e-12)
+      },
+      test("reads the hour in the configured timezone, not UTC") {
+        val envelope = DiurnalEnvelope.from(config(enabled = true, peakFactor = 3.0, peakHour = 20)).toOption.get
+        val localPeak = ZonedDateTime.of(2026, 9, 10, 20, 0, 0, 0, ZoneId.of(zone)).toInstant
+        assertTrue(math.abs(envelope.at(localPeak) - envelope.atHour(20.0)) < 1e-12)
+      },
+    ),
+    suite("validation")(
+      test("rejects an unknown timezone") {
+        assertTrue(DiurnalEnvelope.from(config(enabled = true, 3.0, 20).copy(timezone = "Mars/Olympus")).isLeft)
+      },
+      test("rejects a peak factor below 1.0, which would make the peak a trough") {
+        assertTrue(DiurnalEnvelope.from(config(enabled = true, peakFactor = 0.5, peakHour = 20)).isLeft)
+      },
+      test("rejects a peak hour outside the day") {
+        assertTrue(DiurnalEnvelope.from(config(enabled = true, peakFactor = 3.0, peakHour = 24)).isLeft)
+      },
+    ),
+  )

--- a/loadgen/src/test/scala/versola/loadgen/scheduler/IntendedStartSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/scheduler/IntendedStartSpec.scala
@@ -1,0 +1,69 @@
+package versola.loadgen.scheduler
+
+import zio.Duration
+import zio.durationInt
+import zio.test.*
+
+import java.time.Instant
+
+/** The intended-start half of §7.2: that latency is measured from the schedule, and that a driver
+  * which has fallen behind can report it.
+  */
+object IntendedStartSpec extends ZIOSpecDefault:
+
+  private val intended = Instant.parse("2026-09-10T12:00:00Z")
+
+  def spec = suite("IntendedStart")(
+    suite("measurement")(
+      test("latency spans the driver's own queueing delay, not just the request") {
+        val actualStart = intended.plusMillis(400)
+        val completed = actualStart.plusMillis(60)
+        assertTrue(
+          IntendedStart.latency(intended, completed) == 460.millis,
+          IntendedStart.startDelay(intended, actualStart) == 400.millis,
+          // The number a closed-loop driver would have reported instead, and the reason §7.2
+          // insists on the intended start: the run looks 7.7x faster than it was.
+          Duration.fromInterval(actualStart, completed) == 60.millis,
+        )
+      },
+      test("a start delay is floored at zero rather than reported negative") {
+        assertTrue(IntendedStart.startDelay(intended, intended.minusMillis(5)) == Duration.Zero)
+      },
+    ),
+    suite("ScheduleLag")(
+      test("reports now minus the intended start of the head of the queue") {
+        for
+          lag <- ScheduleLag.make
+          drained <- lag.lagAt(intended.plusSeconds(30))
+          _ <- lag.observeHead(Some(intended))
+          onTime <- lag.lagAt(intended)
+          behind <- lag.lagAt(intended.plusMillis(300))
+          head <- lag.headIntendedStart
+        yield assertTrue(
+          drained == Duration.Zero,
+          onTime == Duration.Zero,
+          // Above 250 ms §7.2 declares the driver the bottleneck and the run invalid; this is
+          // the value track F's `loadgen_schedule_lag_seconds` gauge must surface.
+          behind == 300.millis,
+          behind.toMillis > 250L,
+          head == Some(intended),
+        )
+      },
+      test("a drained queue reports zero, not the last head it saw") {
+        for
+          lag <- ScheduleLag.make
+          _ <- lag.observeHead(Some(intended))
+          _ <- lag.observeHead(None)
+          drained <- lag.lagAt(intended.plusSeconds(600))
+        yield assertTrue(drained == Duration.Zero)
+      },
+      test("current reads the clock so the metric collector needs no arguments") {
+        for
+          lag <- ScheduleLag.make
+          now <- zio.Clock.instant
+          _ <- lag.observeHead(Some(now.minusMillis(500)))
+          current <- lag.current
+        yield assertTrue(current.toMillis >= 500L)
+      },
+    ),
+  )

--- a/loadgen/src/test/scala/versola/loadgen/scheduler/ShardAssignmentSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/scheduler/ShardAssignmentSpec.scala
@@ -1,0 +1,92 @@
+package versola.loadgen.scheduler
+
+import versola.loadgen.config.ShardConfig
+import zio.test.*
+
+/** §13's "shard assignment is stable across restarts".
+  *
+  * "Stable" is asserted three ways, because the one that matters cannot be observed from inside a
+  * single test run:
+  *
+  *   1. **Checked-in golden values.** A restart, or a second process, re-derives the mapping from
+  *      nothing but the id and the count; the only way to state that here is to compare against
+  *      literals that live in the source and therefore survive both. If [[ShardAssignment]] ever
+  *      acquires a seed, a `hashCode`, or a JDK-version-dependent hash, these literals break.
+  *   2. **Order independence.** The mapping is recomputed over a shuffled traversal (seeded, so
+  *      the shuffle is itself reproducible) and must agree -- no accumulated state.
+  *   3. **Partition.** Over a contiguous id range every id is owned by exactly one shard, which
+  *      is the property §7.1 actually needs: it is what guarantees that no two drivers can ever
+  *      hold the same refresh token, and that no user is stranded and never driven.
+  */
+object ShardAssignmentSpec extends ZIOSpecDefault:
+
+  def spec = suite("ShardAssignment")(
+    suite("stability")(
+      test("golden mapping: id % count, checked in so a restart cannot disagree with it") {
+        val ids = List(0L, 1L, 7L, 8L, 12345L, 999999L, 10_000_000L, 8_589_934_592L)
+        assertTrue(
+          ids.map(ShardAssignment.shardOf(_, 8)) == List(0, 1, 7, 0, 1, 7, 0, 0),
+          ids.map(ShardAssignment.shardOf(_, 7)) == List(0, 1, 0, 1, 4, 0, 3, 1),
+          ids.map(ShardAssignment.shardOf(_, 64)) == List(0, 1, 7, 8, 57, 63, 0, 0),
+          (0L until 21L).map(ShardAssignment.shardOf(_, 7)).toList ==
+            List(0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6),
+        )
+      },
+      test("does not depend on the order ids are presented in, or on how often") {
+        val ids = (0L until 50_000L).toVector
+        val inOrder = ids.map(id => id -> ShardAssignment.shardOf(id, 8)).toMap
+        val shuffled = scala.util.Random(20260910L).shuffle(ids)
+        assertTrue(
+          shuffled.forall(id => ShardAssignment.shardOf(id, 8) == inOrder(id)),
+          shuffled.forall(id => ShardAssignment.shardOf(id, 8) == ShardAssignment.shardOf(id, 8)),
+        )
+      },
+      test("a single shard's ownership is unchanged by the shard's own index moving") {
+        // Shard 3 of 8 owns exactly the same ids whether it is this pod's index or another's --
+        // ownership is a property of the id, not of the process asking.
+        val shard = ShardConfig(index = 3, count = 8)
+        val owned = (0L until 10_000L).filter(ShardAssignment.isOwnedBy(_, shard))
+        assertTrue(owned.forall(id => ShardAssignment.shardOf(id, 8) == 3), owned.size == 1_250)
+      },
+    ),
+    suite("partition")(
+      test("every id is owned by exactly one shard of the map") {
+        val shards = (0 until 8).map(index => ShardConfig(index = index, count = 8))
+        val owners = (0L until 20_000L).map(id => shards.count(ShardAssignment.isOwnedBy(id, _)))
+        assertTrue(owners.forall(_ == 1))
+      },
+      test("each shard of eight owns an eighth of a dense range") {
+        val counts = (0 until 8).map: index =>
+          (0L until 1_000_000L).count(ShardAssignment.isOwnedBy(_, ShardConfig(index = index, count = 8)))
+        assertTrue(counts.forall(_ == 125_000))
+      },
+      test("a negative id lands in range rather than on a shard no driver claims") {
+        assertTrue((-8L to -1L).forall(id => ShardAssignment.shardOf(id, 8) >= 0))
+      },
+    ),
+    suite("range scan")(
+      test("firstOwnedIdAtOrAfter steps the range instead of testing every id") {
+        val shard = ShardConfig(index = 3, count = 8)
+        assertTrue(
+          ShardAssignment.firstOwnedIdAtOrAfter(100L, shard) == 107L,
+          ShardAssignment.firstOwnedIdAtOrAfter(107L, shard) == 107L,
+          (0L until 1_000L).forall: from =>
+            val first = ShardAssignment.firstOwnedIdAtOrAfter(from, shard)
+            first >= from && first - from < shard.count && ShardAssignment.isOwnedBy(first, shard),
+        )
+      },
+    ),
+    suite("validation")(
+      test("accepts a well-formed shard config") {
+        assertTrue(ShardAssignment.validate(ShardConfig(index = 7, count = 8)) == Right(ShardConfig(index = 7, count = 8)))
+      },
+      test("rejects the configs that would silently generate no load") {
+        assertTrue(
+          ShardAssignment.validate(ShardConfig(index = 8, count = 8)).isLeft,
+          ShardAssignment.validate(ShardConfig(index = -1, count = 8)).isLeft,
+          ShardAssignment.validate(ShardConfig(index = 0, count = 0)).isLeft,
+          scala.util.Try(ShardAssignment.shardOf(1L, 0)).isFailure,
+        )
+      },
+    ),
+  )


### PR DESCRIPTION
Closes #273. Part of #267.

> Base branch is `main`: W0 (#264) and W1 (#265, retargeted and merged as #291) are both in, so this no longer stacks on anything.

Track D: pure functions and distributions — no I/O, no SUT, no database. That is the point of the track: it is fully unit-testable, and it is where a silent modelling error would otherwise produce confident wrong numbers.

## What this adds

`loadgen/src/main/scala/versola/loadgen/scheduler/`

| File | Contents |
|---|---|
| `RandomSource.scala` | The seed seam: `seeded(seed)` over `SplittableRandom`, `split()` per fiber, own Marsaglia-polar `nextGaussian` |
| `Distributions.scala` | `Exponential` (rate-parameterised, inverse-CDF + `quantile`), `LogNormal` (median+σ), `NegBinomial` (mean+dispersion), package-private `Gamma` (Marsaglia–Tsang) and `Poisson` (Knuth with λ-chunking) |
| `ShardAssignment.scala` | `shardOf`, `isOwnedBy`, `firstOwnedIdAtOrAfter`, `validate` |
| `DiurnalEnvelope.scala` | §7.3 formula, σ = 3.5 h, normalised to a 24 h mean of 1.0, timezone-aware, `Either` on bad config |
| `ArrivalProcess.scala` | `ScheduledArrival(sequence, intendedStart)`, the `previous + Exponential(λ)` recurrence, `shardRate` |
| `IntendedStart.scala` | `latency` / `startDelay`, `trait ScheduleLag` + `Ref`-backed impl |
| `ThinkTime.scala` | 64k-entry `Array[Int]` LogNormal table, clamped `[200 ms, 120 s]` |
| `ActionCount.scala` | platform → configured mean, over `NegBinomial` |
| `CampaignSchedule.scala` | phases → `PhaseScale.Flat`/`Ramp`, `scaleAt`, `rateAt = base × scale × diurnal` |

## `schedule_lag` is observable by construction

The intended schedule is a recurrence anchored on the campaign start instant: `scheduledAt = previousScheduledAt + Exponential(λ)`. `ArrivalProcess` never reads a clock — the schedule is a pure function of `(anchor, seed, λ history)`. That is what makes lag measurable: anchoring generation on "when the previous unit finished" would make `now − intendedStart` ≈ 0 by construction, and a driver falling behind would be **structurally invisible** while quietly generating less load. There is a test asserting two processes built at different real times from the same anchor and seed produce byte-identical schedules.

Three quantities, deliberately not conflated:

- `IntendedStart.latency(intendedStart, completedAt)` — goes into the histograms; includes the driver's own queueing delay (the coordinated-omission correction).
- `IntendedStart.startDelay(intendedStart, actualStart)` — the emulator's own contribution, floored at zero. Without it, a breached-lag run cannot be distinguished from a genuinely slow SUT after the fact.
- `ScheduleLag` — head-of-queue lag, i.e. leading rather than lagging: an arrival whose turn came 400 ms ago and is still waiting is already evidence, before it ever runs.

**What track F reads** (#275): one `ScheduleLag` per scenario; `ScheduleLag.current: UIO[Duration]` on the collection tick. It takes no arguments and reads the clock itself, so the collector never touches the scheduler's queue. `lagAt(now)` is the deterministic seam for tests. The driver loop (track I) owns the write side via `observeHead(Some(headIntendedStart))` / `observeHead(None)`.

## Verified

`sbt "loadgen/compile" "loadgen/Test/compile" "loadgen/test"` — **47 new tests pass**. All four dev spec §13 tests are present, deterministic (every generator explicitly seeded):

| Test | Sample size | Observed |
|---|---|---|
| χ² exponential inter-arrivals | 50,000 gaps at λ=25/s, 10 equiprobable bins | **χ² = 14.79** vs hard-coded critical **21.666** (df 9, α 0.01) |
| LogNormal moments | 100,000 | mean off 0.15%, variance off 1.45% |
| NegBinomial moments | 100,000 per platform | mobile mean 0.01% / var 0.73%; web 0.42% / 0.23% |
| Diurnal integral | deterministic quadrature, 86,400 nodes, 24 parameter combinations | \|mean − 1\| < **1e-6** |
| Think-time table | 65,536 entries + 100,000 draws | median within 2%, mean within 3% |

The χ² test has a companion assertion that the *same* draws fail against λ/2, so the binning arithmetic cannot pass vacuously. Also verified against the other three Phase 1 tracks merged together (#270, #272, #275): 125 loadgen + 19 mockapi tests, no conflicts.

## Parameterisations chosen — each was ambiguous in the spec

- **Exponential by rate λ (per second), not mean.** λ is what the coordinator publishes and what `λ/shardCount` divides.
- **LogNormal by median + σ**, since `think-time { median = 4s, sigma = 0.8 }` says exactly that; `median = exp(μ)`. Reading `median = 4s` as μ would give a 55 s median — a 14× error with a still-plausible shape.
- **NegBinomial by mean μ + NB2 overdispersion α**, so `Var = μ(1 + αμ)`, size `r = 1/α`, sampled as `Poisson(Gamma(r, μ/r))`. What settles it: the config has *one* dispersion for *two* means, and α is dimensionless so it means the same thing at μ=6 and μ=10. Reading `dispersion = 0.6` as the size `r` would make the mobile variance 66 (sd 8.1 on a mean of 6) and put the mode at 0. Both readings are asserted in test comments so the choice is visible at the failure site.
- **Gaussian implemented locally** rather than `RandomGenerator.nextGaussian`, because the JDK's algorithm is not a compatibility contract and a JDK bump would move every seeded expectation.

## Needs a decision

1. **NegBinomial can draw 0.** With the configured parameters `P(N=0)` is 7.9% mobile / 5.0% web (asserted in a test), but design doc §3 calls action #1 "the first call of every session", implying N ≥ 1. Left unclamped, because clamping silently moves the realised mean off the configured 6.0 to ≈6.08. Clamp and change the configured mean, or accept zero-action sessions — someone has to pick.
2. **`session.action-count.dispersion` names no convention.** Fixed as NB2 α and documented. If the intent was the size `r`, the mobile variance is 2.4× what this produces.
3. ~~**Sharding: dev spec §7.1 (`id % count`) vs design doc §6.2 ("consistent hash").**~~ **Settled: the modulus stays, and this PR owns the only implementation of it.** The dense `BIGINT`'s range scan comes from the store's `(shard, id)` index, not from a driver's ids being contiguous, so modulo loses nothing it was credited with; it also stays balanced when the population has holes and needs no shard map for the seeder, the drivers and the coordinator to agree. Re-sharding is a bulk `UPDATE … SET shard = id % n` during the coordinator's drain (§12), not a range move. Dev spec §6/§7.1 and design doc §6.2 are corrected to say so. Track C (#288) deleted its duplicate `store/Sharding` in favour of `scheduler/ShardAssignment` here — it had no production call site — so there is one implementation, not two, whichever merges first.
4. **`CampaignPhaseConfig` is under-constrained.** `scale`, `scaleFrom`, `scaleTo` are three independent `Option`s and §5 says "the scheduler decides which apply per phase `name`". Name-based dispatch is unsafe — `name` is free text used as a metric label, so renaming `ramp` to `ramp-up` would silently run the phase flat. This dispatches on *field presence* and rejects both the ambiguous (all three set) and incomplete (`scale-from` without `scale-to`) cases. The schema still permits both; a W1 refactor to a sealed variant would make it unrepresentable.
5. **Nothing forces validation of `campaign.diurnal` or `shard`.** `peakFactor < 1` inverts the envelope (the "peak" becomes a trough), `peakHour` is an unconstrained `Int`, and `index >= count` means the driver owns nothing and generates no load — all legal arithmetic, all producing a wrong-volume campaign that looks like a slow SUT. `DiurnalEnvelope.from` and `ShardAssignment.validate` return `Either` for exactly these; whoever wires role dispatch (track J) must propagate them to a boot failure.
6. **Package name.** Dev spec §2 says `schedule/`; #273 and this PR use `scheduler/`. §2 should be corrected or the package renamed once.
7. The diurnal σ = 3.5 h is hard-coded in §7.3 and left non-configurable: it is a second knob that changes total volume with no plan value to set it from.
8. `ProtocolError.scala` (from W1) is not `scalafmt`-clean. Reverted rather than reformat another track's file — worth a separate fix. Note CI does not gate formatting today.

## Not verified

- Nothing here runs against a real driver loop, so §15's "head-of-queue lag < 250 ms under load" is untested by construction — that needs tracks E/I and the calibration run.
- The `Poisson` λ-chunking branch (λ > 500) is unreachable at the configured means and uncovered.
- No `erf` in `java.lang.Math`, so the diurnal normaliser is composite Simpson (2,880 panels, ~1e-11 from exact) rather than closed form; no maths dependency was added.
- CI still does not compile this module (see #264's `workflow`-scope blocker).