### PR TITLE
loadgen: metrics -- Prometheus, HdrHistogram merge, error taxonomy (Phase 1 / F)

### DIFF
--- a/loadgen/src/main/scala/versola/loadgen/metrics/CampaignReport.scala
+++ b/loadgen/src/main/scala/versola/loadgen/metrics/CampaignReport.scala
@@ -28,6 +28,7 @@ case class AcceptanceThresholds(
     maxFlushDropped: Long,
     maxDriverCpu: Double,
     maxErrorBudgetRatio: Double,
+    maxLatencyClamped: Long,
 )
 
 object AcceptanceThresholds:
@@ -49,6 +50,12 @@ object AcceptanceThresholds:
       maxFlushDropped = 0L,
       maxDriverCpu = 0.4,
       maxErrorBudgetRatio = 0.0,
+      // A clamped sample is an instrument failure, not a slow SUT: the reported tail becomes a
+      // floor rather than a measurement, and §6.7 rests the whole report's credibility on the
+      // recorder being in range. One is enough to fail the campaign. With the driver's request
+      // timeout at 30 s against a 60 s recorder ceiling, a clamp is structurally unreachable
+      // without a bug in the driver, which is the correct reading of the signal.
+      maxLatencyClamped = 0L,
     )
 
 /** Fleet-wide driver-health figures at the end of a campaign, as the coordinator has them.
@@ -62,6 +69,7 @@ case class CampaignHealth(
     flushDroppedTotal: Long,
     maxDriverCpu: Option[Double],
     scheduleLagP99: Option[Duration],
+    latencyClampedTotal: Long,
 ) derives JsonCodec
 
 /** One line of the verdict. `detail` carries the measured value so a failed check is actionable
@@ -185,6 +193,11 @@ object CampaignReport:
         name = "dropped write-behind rows",
         passed = health.flushDroppedTotal <= thresholds.maxFlushDropped,
         detail = s"${health.flushDroppedTotal} against a limit of ${thresholds.maxFlushDropped}",
+      ),
+      ReportCheck(
+        name = "clamped latencies",
+        passed = health.latencyClampedTotal <= thresholds.maxLatencyClamped,
+        detail = s"${health.latencyClampedTotal} against a limit of ${thresholds.maxLatencyClamped}",
       ),
       ReportCheck(
         name = "error budget",

--- a/loadgen/src/main/scala/versola/loadgen/metrics/CampaignReport.scala
+++ b/loadgen/src/main/scala/versola/loadgen/metrics/CampaignReport.scala
@@ -1,0 +1,199 @@
+package versola.loadgen.metrics
+
+import zio.json.JsonCodec
+import zio.{Chunk, Duration}
+
+/** An absolute latency ceiling: `p99` of `id` must not exceed this. Backs the design doc's
+  * "auth `/token` p99 ≤ 120 ms".
+  */
+case class LatencyThreshold(id: MeasurementId, p99: Duration)
+
+/** A latency ceiling stated relative to another measurement, plus a margin: backs "edge proxy
+  * p99 ≤ backend p99 + 15 ms", which is the one criterion that cannot be evaluated from a single
+  * histogram and is therefore the clearest illustration of why the merge has to be lossless -- it
+  * compares two campaign-wide p99s, not two averages of pod p99s.
+  */
+case class RelativeLatencyThreshold(id: MeasurementId, relativeTo: MeasurementId, margin: Duration)
+
+/** What `GET /report/{campaign}` judges the campaign against (design doc §6.7, dev spec §15).
+  *
+  * No defaults anywhere (versolauth/versola#267): every campaign states its own thresholds, and
+  * [[AcceptanceThresholds.designDefaults]] exists for the ones the design doc fixes.
+  */
+case class AcceptanceThresholds(
+    latency: List[LatencyThreshold],
+    relativeLatency: List[RelativeLatencyThreshold],
+    scheduleLagP99: Duration,
+    maxRefreshRejected: Long,
+    maxFlushDropped: Long,
+    maxDriverCpu: Double,
+    maxErrorBudgetRatio: Double,
+)
+
+object AcceptanceThresholds:
+
+  /** The figures the design doc fixes. The measurement ids are parameters rather than constants
+    * because the scenario/step naming belongs to the scenario engine, and hard-coding a guess at
+    * it here would produce a verdict that silently evaluates nothing when the names differ.
+    */
+  def designDefaults(
+      tokenRefresh: MeasurementId,
+      edgeProxy: MeasurementId,
+      mockBackend: MeasurementId,
+  ): AcceptanceThresholds =
+    AcceptanceThresholds(
+      latency = List(LatencyThreshold(tokenRefresh, Duration.fromMillis(120))),
+      relativeLatency = List(RelativeLatencyThreshold(edgeProxy, mockBackend, Duration.fromMillis(15))),
+      scheduleLagP99 = Duration.fromMillis(250),
+      maxRefreshRejected = 0L,
+      maxFlushDropped = 0L,
+      maxDriverCpu = 0.4,
+      maxErrorBudgetRatio = 0.0,
+    )
+
+/** Fleet-wide driver-health figures at the end of a campaign, as the coordinator has them.
+  *
+  * `maxDriverCpu` and `scheduleLagP99` are the worst reading over the fleet, not the mean: one
+  * saturated driver distorts the latencies of its own shard, and averaging that away is how a
+  * campaign passes while a sixth of its measurements are client-side queueing.
+  */
+case class CampaignHealth(
+    refreshRejectedTotal: Long,
+    flushDroppedTotal: Long,
+    maxDriverCpu: Option[Double],
+    scheduleLagP99: Option[Duration],
+) derives JsonCodec
+
+/** One line of the verdict. `detail` carries the measured value so a failed check is actionable
+  * without going back to the raw histograms.
+  */
+case class ReportCheck(name: String, passed: Boolean, detail: String) derives JsonCodec
+
+/** The body of `GET /report/{campaign}` (§12): merged quantiles, the error taxonomy, and the
+  * verdict.
+  *
+  * `notEvaluated` is separate from a failed check on purpose. A threshold whose measurement never
+  * recorded a sample has not passed -- it was not tested - and folding that into `passed` in
+  * either direction is a lie: `true` claims a criterion was met that nobody measured, `false`
+  * fails a campaign for a step the plan never scheduled.
+  */
+case class CampaignReport(
+    campaign: String,
+    drivers: List[String],
+    latency: List[LatencySummary],
+    taxonomy: ErrorTaxonomy,
+    health: CampaignHealth,
+    checks: List[ReportCheck],
+    notEvaluated: List[String],
+    passed: Boolean,
+) derives JsonCodec
+
+object CampaignReport:
+
+  def assemble(
+      campaign: String,
+      reports: List[DriverHistogramReport],
+      taxonomy: ErrorTaxonomy,
+      health: CampaignHealth,
+      thresholds: AcceptanceThresholds,
+  ): Either[String, CampaignReport] =
+    for
+      _ <- reports.find(_.campaign != campaign) match
+        case Some(foreign) =>
+          Left(s"report for campaign '${foreign.campaign}' handed to the '$campaign' merge (driver ${foreign.driverId})")
+        case None => Right(())
+      samples <- reports.foldLeft[Either[String, Chunk[HistogramSample]]](Right(Chunk.empty)):
+        case (Left(error), _)          => Left(error)
+        case (Right(accumulated), one) => HistogramWire.decodeReport(one).map(accumulated ++ _)
+    yield
+      val merged = HistogramWire.merge(samples)
+      val (checks, notEvaluated) = evaluate(merged, taxonomy, health, thresholds)
+      CampaignReport(
+        campaign = campaign,
+        drivers = reports.map(_.driverId).distinct.sorted,
+        latency = HistogramWire.summarise(merged).sortBy(_.id.toString),
+        taxonomy = taxonomy,
+        health = health,
+        checks = checks,
+        notEvaluated = notEvaluated,
+        passed = checks.forall(_.passed) && notEvaluated.isEmpty,
+      )
+
+  private def evaluate(
+      merged: Map[MeasurementId, org.HdrHistogram.Histogram],
+      taxonomy: ErrorTaxonomy,
+      health: CampaignHealth,
+      thresholds: AcceptanceThresholds,
+  ): (List[ReportCheck], List[String]) =
+    val absolute = thresholds.latency.map: threshold =>
+      merged.get(threshold.id) match
+        case None => Right(s"p99 of ${threshold.id}")
+        case Some(histogram) =>
+          val measured = histogram.getValueAtPercentile(99.0)
+          val limit = HistogramWire.micros(threshold.p99)
+          Left(
+            ReportCheck(
+              name = s"p99 of ${threshold.id}",
+              passed = measured <= limit,
+              detail = s"${measured}µs against a ${limit}µs ceiling",
+            ),
+          )
+
+    val relative = thresholds.relativeLatency.map: threshold =>
+      (merged.get(threshold.id), merged.get(threshold.relativeTo)) match
+        case (Some(subject), Some(baseline)) =>
+          val measured = subject.getValueAtPercentile(99.0)
+          val limit = baseline.getValueAtPercentile(99.0) + HistogramWire.micros(threshold.margin)
+          Left(
+            ReportCheck(
+              name = s"p99 of ${threshold.id} within ${threshold.margin.toMillis}ms of ${threshold.relativeTo}",
+              passed = measured <= limit,
+              detail = s"${measured}µs against a ${limit}µs ceiling",
+            ),
+          )
+        case _ => Right(s"p99 of ${threshold.id} relative to ${threshold.relativeTo}")
+
+    val health1 = health.scheduleLagP99 match
+      case None => Right("schedule lag p99")
+      case Some(lag) =>
+        Left(
+          ReportCheck(
+            name = "schedule lag p99",
+            passed = lag.toNanos <= thresholds.scheduleLagP99.toNanos,
+            detail = s"${lag.toMillis}ms against a ${thresholds.scheduleLagP99.toMillis}ms ceiling",
+          ),
+        )
+
+    val health2 = health.maxDriverCpu match
+      case None => Right("driver CPU")
+      case Some(cpu) =>
+        Left(
+          ReportCheck(
+            name = "driver CPU",
+            passed = cpu <= thresholds.maxDriverCpu,
+            detail = f"${cpu * 100}%.1f%% against a ${thresholds.maxDriverCpu * 100}%.1f%% ceiling",
+          ),
+        )
+
+    val counters = List(
+      ReportCheck(
+        name = "refresh rejections",
+        passed = health.refreshRejectedTotal <= thresholds.maxRefreshRejected,
+        detail = s"${health.refreshRejectedTotal} against a limit of ${thresholds.maxRefreshRejected}",
+      ),
+      ReportCheck(
+        name = "dropped write-behind rows",
+        passed = health.flushDroppedTotal <= thresholds.maxFlushDropped,
+        detail = s"${health.flushDroppedTotal} against a limit of ${thresholds.maxFlushDropped}",
+      ),
+      ReportCheck(
+        name = "error budget",
+        passed = taxonomy.budgetRatio <= thresholds.maxErrorBudgetRatio,
+        detail =
+          f"${taxonomy.budgetConsumed} of ${taxonomy.total} steps (${taxonomy.budgetRatio * 100}%.4f%%) " +
+            f"against a ${thresholds.maxErrorBudgetRatio * 100}%.4f%% ceiling",
+      ),
+    )
+
+    val outcomes = absolute ++ relative ++ List(health1, health2)
+    (outcomes.collect { case Left(check) => check } ++ counters, outcomes.collect { case Right(missing) => missing })

--- a/loadgen/src/main/scala/versola/loadgen/metrics/CampaignReport.scala
+++ b/loadgen/src/main/scala/versola/loadgen/metrics/CampaignReport.scala
@@ -126,7 +126,7 @@ object CampaignReport:
       thresholds: AcceptanceThresholds,
   ): (List[ReportCheck], List[String]) =
     val absolute = thresholds.latency.map: threshold =>
-      merged.get(threshold.id) match
+      measured(merged, threshold.id) match
         case None => Right(s"p99 of ${threshold.id}")
         case Some(histogram) =>
           val measured = histogram.getValueAtPercentile(99.0)
@@ -140,7 +140,7 @@ object CampaignReport:
           )
 
     val relative = thresholds.relativeLatency.map: threshold =>
-      (merged.get(threshold.id), merged.get(threshold.relativeTo)) match
+      (measured(merged, threshold.id), measured(merged, threshold.relativeTo)) match
         case (Some(subject), Some(baseline)) =>
           val measured = subject.getValueAtPercentile(99.0)
           val limit = baseline.getValueAtPercentile(99.0) + HistogramWire.micros(threshold.margin)
@@ -197,3 +197,19 @@ object CampaignReport:
 
     val outcomes = absolute ++ relative ++ List(health1, health2)
     (outcomes.collect { case Left(check) => check } ++ counters, outcomes.collect { case Right(missing) => missing })
+
+  /** A measurement is only evaluable if something was actually recorded into it.
+    *
+    * HdrHistogram answers every percentile query on an empty histogram with 0, so a threshold
+    * checked against one passes on a measured p99 of 0 rather than landing in `notEvaluated`. The
+    * map having a key for the measurement is not enough: a driver that registered a recorder and
+    * never recorded a sample -- a scenario that was configured but never ran, a step every attempt
+    * failed before reaching -- reports a present, empty histogram. A campaign that measured
+    * nothing at all would then report `passed = true`, which is the one answer the report must
+    * never give by default.
+    */
+  private def measured(
+      merged: Map[MeasurementId, org.HdrHistogram.Histogram],
+      id: MeasurementId,
+  ): Option[org.HdrHistogram.Histogram] =
+    merged.get(id).filter(_.getTotalCount > 0L)

--- a/loadgen/src/main/scala/versola/loadgen/metrics/DriverHealth.scala
+++ b/loadgen/src/main/scala/versola/loadgen/metrics/DriverHealth.scala
@@ -1,0 +1,103 @@
+package versola.loadgen.metrics
+
+import zio.{Duration, Ref, Schedule, UIO, ZIO}
+
+/** One reading of "is this driver still a trustworthy instrument".
+  *
+  * Nothing here describes the SUT. Every field is a way the emulator can quietly stop measuring
+  * what it claims to measure: schedule lag means the arrival process is behind and the load being
+  * applied is not the load that was planned; dropped write-behind rows mean session state was
+  * lost, which resurfaces later as a broken virtual user; CPU past ~40% means the client's own
+  * queueing is inside the latencies it is reporting (design doc §6.5 sizes the fleet at 30% CPU
+  * precisely so this cannot happen).
+  *
+  * `cpuUtilisation` is optional because the JVM genuinely cannot always answer -- `getProcessCpuLoad`
+  * returns a negative value until it has two samples to difference. A `0.0` there would read as a
+  * perfectly idle driver, which is the one answer that must not be guessed.
+  */
+case class DriverHealthSample(
+    scheduleLagByScenario: Map[String, Duration],
+    busyUsers: Int,
+    inflightRequests: Int,
+    storeFlushDroppedTotal: Long,
+    cpuUtilisation: Option[Double],
+)
+
+/** This package's side of the driver-health contract.
+  *
+  * The two readings §11 needs are produced by packages this track does not own -- the scheduler
+  * measures its own lag against intended start times, and the write-behind buffer counts its own
+  * dropped rows -- so they arrive as effects to be pulled, not as a dependency to be imported.
+  * `metrics` owns only the CPU reading and the publishing.
+  */
+trait DriverHealthSource:
+  def sample: UIO[DriverHealthSample]
+
+object DriverHealthSource:
+
+  /** Assembles a source from the sibling packages' readings. This is the one-line wiring point:
+    * each parameter is a read of a value the owning package already keeps, and none of them needs
+    * to know this package exists.
+    */
+  def from(
+      scheduleLagByScenario: UIO[Map[String, Duration]],
+      busyUsers: UIO[Int],
+      inflightRequests: UIO[Int],
+      storeFlushDroppedTotal: UIO[Long],
+  ): DriverHealthSource =
+    new DriverHealthSource:
+      override def sample: UIO[DriverHealthSample] =
+        for
+          lag <- scheduleLagByScenario
+          busy <- busyUsers
+          inflight <- inflightRequests
+          dropped <- storeFlushDroppedTotal
+          cpu <- ProcessCpu.utilisation
+        yield DriverHealthSample(lag, busy, inflight, dropped, cpu)
+
+/** Process CPU load from the JVM's own platform bean.
+  *
+  * Deliberately the *process* load, not the machine's: a driver pod shares its node with other
+  * drivers, and the number the definition of done is stated against ("driver CPU < 40%") is this
+  * driver's share of its own allocation.
+  */
+object ProcessCpu:
+
+  val utilisation: UIO[Option[Double]] =
+    ZIO.succeed:
+      java.lang.management.ManagementFactory.getOperatingSystemMXBean match
+        case bean: com.sun.management.OperatingSystemMXBean =>
+          val load = bean.getProcessCpuLoad
+          if load < 0.0 then None else Some(math.min(load, 1.0))
+        case _ => None
+
+/** Publishes [[DriverHealthSample]]s onto the Prometheus surface on a timer. */
+final class DriverHealthReporter private (source: DriverHealthSource, lastFlushDropped: Ref[Long]):
+
+  def publish: UIO[Unit] =
+    for
+      sample <- source.sample
+      _ <- ZIO.foreachDiscard(sample.scheduleLagByScenario) { case (scenario, lag) =>
+        LoadgenMetrics.scheduleLag(scenario, lag)
+      }
+      _ <- LoadgenMetrics.busyUsers(sample.busyUsers)
+      _ <- LoadgenMetrics.inflightRequests(sample.inflightRequests)
+      _ <- flushDroppedDelta(sample.storeFlushDroppedTotal).flatMap(LoadgenMetrics.storeFlushDropped)
+      _ <- ZIO.foreachDiscard(sample.cpuUtilisation)(LoadgenMetrics.driverCpu)
+    yield ()
+
+  def run(interval: Duration): UIO[Unit] =
+    publish.repeat(Schedule.spaced(interval)).unit
+
+  /** The source's figure is cumulative and the metric is a counter, so only the increase is
+    * added. A decrease means the source's own counter restarted (a reconnect, a re-created
+    * buffer), and the honest response is to add nothing and re-baseline -- a Prometheus counter
+    * cannot go down, and pretending the drop was progress would invent dropped rows.
+    */
+  private def flushDroppedDelta(cumulative: Long): UIO[Long] =
+    lastFlushDropped.modify: previous =>
+      if cumulative >= previous then (cumulative - previous, cumulative) else (0L, cumulative)
+
+object DriverHealthReporter:
+  def make(source: DriverHealthSource): UIO[DriverHealthReporter] =
+    Ref.make(0L).map(DriverHealthReporter(source, _))

--- a/loadgen/src/main/scala/versola/loadgen/metrics/DriverHealth.scala
+++ b/loadgen/src/main/scala/versola/loadgen/metrics/DriverHealth.scala
@@ -11,16 +11,16 @@ import zio.{Duration, Ref, Schedule, UIO, ZIO}
   * queueing is inside the latencies it is reporting (design doc §6.5 sizes the fleet at 30% CPU
   * precisely so this cannot happen).
   *
-  * `cpuUtilisation` is optional because the JVM genuinely cannot always answer -- `getProcessCpuLoad`
-  * returns a negative value until it has two samples to difference. A `0.0` there would read as a
-  * perfectly idle driver, which is the one answer that must not be guessed.
+  * `cpuRatio` is optional because it takes two readings to difference before there is an answer
+  * at all -- see [[ProcessCpu]]. A `0.0` in the meantime would read as a perfectly idle driver,
+  * which is the one answer that must not be guessed.
   */
 case class DriverHealthSample(
     scheduleLagByScenario: Map[String, Duration],
     busyUsers: Int,
     inflightRequests: Int,
     storeFlushDroppedTotal: Long,
-    cpuUtilisation: Option[Double],
+    cpuRatio: Option[Double],
 )
 
 /** This package's side of the driver-health contract.
@@ -44,31 +44,71 @@ object DriverHealthSource:
       busyUsers: UIO[Int],
       inflightRequests: UIO[Int],
       storeFlushDroppedTotal: UIO[Long],
-  ): DriverHealthSource =
-    new DriverHealthSource:
-      override def sample: UIO[DriverHealthSample] =
-        for
-          lag <- scheduleLagByScenario
-          busy <- busyUsers
-          inflight <- inflightRequests
-          dropped <- storeFlushDroppedTotal
-          cpu <- ProcessCpu.utilisation
-        yield DriverHealthSample(lag, busy, inflight, dropped, cpu)
+  ): UIO[DriverHealthSource] =
+    ProcessCpu.make.map: processCpu =>
+      new DriverHealthSource:
+        override def sample: UIO[DriverHealthSample] =
+          for
+            lag <- scheduleLagByScenario
+            busy <- busyUsers
+            inflight <- inflightRequests
+            dropped <- storeFlushDroppedTotal
+            cpu <- processCpu.ratio
+          yield DriverHealthSample(lag, busy, inflight, dropped, cpu)
 
-/** Process CPU load from the JVM's own platform bean.
+/** This driver's CPU use as a fraction of **its own allocation**, which is what the definition of
+  * done's "driver CPU < 40%" is stated against.
   *
-  * Deliberately the *process* load, not the machine's: a driver pod shares its node with other
-  * drivers, and the number the definition of done is stated against ("driver CPU < 40%") is this
-  * driver's share of its own allocation.
+  * Not `getProcessCpuLoad`, despite the name. That returns the process's use as a fraction of all
+  * host CPUs: on a 64-core node with a 2-core cgroup quota, a driver pegged at 100% of its quota
+  * reports about 0.03. The gate would then never fire, and the one check that proves the
+  * instrument was not itself the bottleneck would silently always pass -- which is exactly the
+  * class of failure this track exists to catch.
+  *
+  * Computed from CPU-time deltas against the allocation instead:
+  * {{{ratio = ΔprocessCpuTime / (ΔwallClock × availableProcessors)}}}
+  * `availableProcessors` is cgroup-aware under `UseContainerSupport`, so it already equals the
+  * quota rather than the node's core count.
   */
+final class ProcessCpu private (previous: Ref[Option[ProcessCpu.Reading]]):
+
+  /** `None` until there are two readings to difference -- the same reason the bean's own load is
+    * negative at first. A `0.0` there would read as a perfectly idle driver, which is the one
+    * answer that must not be guessed.
+    *
+    * Also `None` if the clock has not advanced between two calls, since the ratio would divide by
+    * zero. Clamped to 1.0 at the top: rounding between two clocks sampled a few nanoseconds apart
+    * can put a fully busy process marginally over.
+    */
+  def ratio: UIO[Option[Double]] =
+    ProcessCpu.read.flatMap:
+      case None => ZIO.none
+      case Some(current) =>
+        previous.modify: before =>
+          val computed = before.flatMap: earlier =>
+            val cpuNanos = (current.cpuTimeNanos - earlier.cpuTimeNanos).toDouble
+            val wallNanos = (current.wallNanos - earlier.wallNanos).toDouble
+            val capacity = wallNanos * ProcessCpu.availableProcessors
+            if capacity <= 0.0 || cpuNanos < 0.0 then None
+            else Some(math.min(cpuNanos / capacity, 1.0))
+          (computed, Some(current))
+
 object ProcessCpu:
 
-  val utilisation: UIO[Option[Double]] =
+  private[metrics] final case class Reading(cpuTimeNanos: Long, wallNanos: Long)
+
+  val make: UIO[ProcessCpu] =
+    Ref.make(Option.empty[Reading]).map(ProcessCpu(_))
+
+  private def availableProcessors: Int =
+    Runtime.getRuntime.availableProcessors
+
+  private val read: UIO[Option[Reading]] =
     ZIO.succeed:
       java.lang.management.ManagementFactory.getOperatingSystemMXBean match
         case bean: com.sun.management.OperatingSystemMXBean =>
-          val load = bean.getProcessCpuLoad
-          if load < 0.0 then None else Some(math.min(load, 1.0))
+          val cpuTime = bean.getProcessCpuTime
+          if cpuTime < 0L then None else Some(Reading(cpuTime, java.lang.System.nanoTime()))
         case _ => None
 
 /** Publishes [[DriverHealthSample]]s onto the Prometheus surface on a timer. */
@@ -83,7 +123,7 @@ final class DriverHealthReporter private (source: DriverHealthSource, lastFlushD
       _ <- LoadgenMetrics.busyUsers(sample.busyUsers)
       _ <- LoadgenMetrics.inflightRequests(sample.inflightRequests)
       _ <- flushDroppedDelta(sample.storeFlushDroppedTotal).flatMap(LoadgenMetrics.storeFlushDropped)
-      _ <- ZIO.foreachDiscard(sample.cpuUtilisation)(LoadgenMetrics.driverCpu)
+      _ <- ZIO.foreachDiscard(sample.cpuRatio)(LoadgenMetrics.driverCpu)
     yield ()
 
   def run(interval: Duration): UIO[Unit] =

--- a/loadgen/src/main/scala/versola/loadgen/metrics/ErrorTaxonomy.scala
+++ b/loadgen/src/main/scala/versola/loadgen/metrics/ErrorTaxonomy.scala
@@ -73,30 +73,48 @@ enum StepOutcome derives JsonCodec:
     case Planned(outcome) => outcome.label
     case Failed(outcome)  => outcome.label
 
+/** A campaign that cannot produce a defensible number, and so must stop rather than carry on
+  * measuring: `detail` is the misconfiguration that made it so.
+  *
+  * Separate from the taxonomy on purpose. An unregistered `client_id` or an endpoint URL that
+  * does not parse is a fault in the emulator, not a measurement of the SUT, so counting it would
+  * put our own bugs in the error budget's denominator -- which is the thing that makes a budget
+  * meaningless. There is also nothing to preserve by continuing: whatever the run measured, it
+  * measured against something other than what it claims.
+  */
+final case class CampaignAbort(detail: String)
+
 object StepOutcome:
   val ok: StepOutcome = Planned(PlannedOutcome.Ok)
 
-  /** The single place [[ProtocolError]]'s shape is turned into a taxonomy class.
+  /** The single place [[ProtocolError]]'s shape is turned into a taxonomy class, or into a reason
+    * to stop.
     *
     * No `case _` fallthrough on purpose. A wildcard would quietly file a future ADT case into
     * whichever bucket it happened to be written next to -- and the direction that mistake takes
     * matters: a new expected outcome landing in the error budget makes a healthy campaign look
     * failed, and a new failure landing among the planned outcomes hides a real defect. With an
     * exhaustive match, adding a case to `ProtocolError` produces a compiler warning here and a
-    * `MatchError` at the first call, both of which demand an explicit decision.
+    * `MatchError` at the first call, both of which demand an explicit decision. That is what
+    * `Misconfigured` did when track B added it, rather than arriving as a mislabelled bucket.
+    *
+    * The `Left` is the answer to it. Returning it rather than throwing keeps the decision on the
+    * caller's type: an abort cannot be recorded as an outcome, and it cannot be dropped without
+    * the compiler saying so.
     */
-  def of(error: ProtocolError): StepOutcome = error match
-    case _: ProtocolError.Transport         => Failed(FailedOutcome.Transport)
-    case _: ProtocolError.UnexpectedStatus  => Failed(FailedOutcome.UnexpectedStatus)
-    case _: ProtocolError.MalformedResponse => Failed(FailedOutcome.Malformed)
-    case _: ProtocolError.StepUpRequired    => Planned(PlannedOutcome.StepUp)
-    case _: ProtocolError.Forbidden         => Planned(PlannedOutcome.Forbidden)
-    case _: ProtocolError.Unauthorized      => Planned(PlannedOutcome.Unauthorized)
-    case _: ProtocolError.RefreshRejected   => Failed(FailedOutcome.RefreshRejected)
+  def of(error: ProtocolError): Either[CampaignAbort, StepOutcome] = error match
+    case _: ProtocolError.Transport          => Right(Failed(FailedOutcome.Transport))
+    case _: ProtocolError.UnexpectedStatus   => Right(Failed(FailedOutcome.UnexpectedStatus))
+    case _: ProtocolError.MalformedResponse  => Right(Failed(FailedOutcome.Malformed))
+    case _: ProtocolError.StepUpRequired     => Right(Planned(PlannedOutcome.StepUp))
+    case _: ProtocolError.Forbidden          => Right(Planned(PlannedOutcome.Forbidden))
+    case _: ProtocolError.Unauthorized       => Right(Planned(PlannedOutcome.Unauthorized))
+    case _: ProtocolError.RefreshRejected    => Right(Failed(FailedOutcome.RefreshRejected))
+    case ProtocolError.Misconfigured(detail) => Left(CampaignAbort(detail))
 
-  def of[A](result: Either[ProtocolError, A]): StepOutcome = result match
+  def of[A](result: Either[ProtocolError, A]): Either[CampaignAbort, StepOutcome] = result match
     case Left(error) => of(error)
-    case Right(_)    => ok
+    case Right(_)    => Right(ok)
 
 /** The campaign's error taxonomy: two disjoint tallies, and the arithmetic the verdict is drawn
   * from.
@@ -117,7 +135,7 @@ case class ErrorTaxonomy(
   def recordMany(outcome: StepOutcome, count: Long): ErrorTaxonomy =
     outcome match
       case StepOutcome.Planned(o) => copy(planned = planned.updatedWith(o)(c => Some(c.getOrElse(0L) + count)))
-      case StepOutcome.Failed(o)  => copy(failed = failed.updatedWith(o)(c => Some(c.getOrElse(0L) + count)))
+      case StepOutcome.Failed(o) => copy(failed = failed.updatedWith(o)(c => Some(c.getOrElse(0L) + count)))
 
   /** Per-driver tallies add: every step is counted by exactly one driver (a virtual user is owned
     * by exactly one shard, §6.2), so summing across drivers double-counts nothing.
@@ -164,6 +182,6 @@ object ErrorTaxonomy:
 object RefreshRejectionLabel:
   def of(rejection: RefreshRejection): String = rejection match
     case RefreshRejection.AlreadyExchanged => "already_exchanged"
-    case RefreshRejection.SessionRevoked   => "session_revoked"
-    case RefreshRejection.Expired          => "expired"
-    case RefreshRejection.Unknown(_)       => "unknown"
+    case RefreshRejection.SessionRevoked => "session_revoked"
+    case RefreshRejection.Expired => "expired"
+    case RefreshRejection.Unknown(_) => "unknown"

--- a/loadgen/src/main/scala/versola/loadgen/metrics/ErrorTaxonomy.scala
+++ b/loadgen/src/main/scala/versola/loadgen/metrics/ErrorTaxonomy.scala
@@ -1,0 +1,169 @@
+package versola.loadgen.metrics
+
+import versola.loadgen.protocol.{ProtocolError, RefreshRejection}
+import zio.json.{JsonCodec, JsonFieldDecoder, JsonFieldEncoder}
+
+/** An outcome the behaviour model plans for. These are branches of the session state machine,
+  * not defects: `retail-basic` users are *supposed* to be forbidden on ~1% of actions
+  * (design doc §3), a payment action is *supposed* to be answered with
+  * `insufficient_user_authentication` when the token's acr is below L2 (§2.3), and an access
+  * token is *supposed* to expire mid-session. A campaign in which these are zero has failed to
+  * exercise the paths that matter most.
+  *
+  * There is deliberately no conversion between this enum and [[FailedOutcome]], in either
+  * direction: the two are the taxonomy's split, and the error budget is defined over the other
+  * one only.
+  */
+enum PlannedOutcome(val label: String):
+  case Ok extends PlannedOutcome("ok")
+  case StepUp extends PlannedOutcome("stepup")
+  case Forbidden extends PlannedOutcome("forbidden")
+  case Unauthorized extends PlannedOutcome("unauthorized")
+
+object PlannedOutcome:
+  private val byLabel: Map[String, PlannedOutcome] = values.map(o => o.label -> o).toMap
+
+  // The label is the wire representation too, not just the Prometheus one: a dashboard, a stored
+  // report and a merged report all name the same bucket the same way.
+  given JsonCodec[PlannedOutcome] =
+    JsonCodec.string.transformOrFail(
+      label => byLabel.get(label).toRight(s"unknown planned outcome: $label"),
+      _.label,
+    )
+
+  given JsonFieldEncoder[PlannedOutcome] = JsonFieldEncoder.string.contramap(_.label)
+
+  given JsonFieldDecoder[PlannedOutcome] =
+    JsonFieldDecoder.string.mapOrFail(label => byLabel.get(label).toRight(s"unknown planned outcome: $label"))
+
+/** An outcome that consumes the error budget: the SUT, the network or the emulator itself did
+  * something the behaviour model has no branch for.
+  *
+  * `RefreshRejected` sits here rather than among the planned outcomes even though the protocol
+  * layer models it as an ordinary rejection, because §7.4 and §11 require reuse detection to stay
+  * at ~0 for the whole campaign -- a non-zero rate means either two fibers touched one session or
+  * the SUT lost a rotation, and in both cases the numbers after that point are not trustworthy.
+  */
+enum FailedOutcome(val label: String):
+  case Transport extends FailedOutcome("transport")
+  case UnexpectedStatus extends FailedOutcome("unexpected_status")
+  case Malformed extends FailedOutcome("malformed")
+  case RefreshRejected extends FailedOutcome("refresh_rejected")
+
+object FailedOutcome:
+  private val byLabel: Map[String, FailedOutcome] = values.map(o => o.label -> o).toMap
+
+  given JsonCodec[FailedOutcome] =
+    JsonCodec.string.transformOrFail(
+      label => byLabel.get(label).toRight(s"unknown failed outcome: $label"),
+      _.label,
+    )
+
+  given JsonFieldEncoder[FailedOutcome] = JsonFieldEncoder.string.contramap(_.label)
+
+  given JsonFieldDecoder[FailedOutcome] =
+    JsonFieldDecoder.string.mapOrFail(label => byLabel.get(label).toRight(s"unknown failed outcome: $label"))
+
+/** How one step ended, classified into exactly one side of the taxonomy. */
+enum StepOutcome derives JsonCodec:
+  case Planned(outcome: PlannedOutcome)
+  case Failed(outcome: FailedOutcome)
+
+  def label: String = this match
+    case Planned(outcome) => outcome.label
+    case Failed(outcome)  => outcome.label
+
+object StepOutcome:
+  val ok: StepOutcome = Planned(PlannedOutcome.Ok)
+
+  /** The single place [[ProtocolError]]'s shape is turned into a taxonomy class.
+    *
+    * No `case _` fallthrough on purpose. A wildcard would quietly file a future ADT case into
+    * whichever bucket it happened to be written next to -- and the direction that mistake takes
+    * matters: a new expected outcome landing in the error budget makes a healthy campaign look
+    * failed, and a new failure landing among the planned outcomes hides a real defect. With an
+    * exhaustive match, adding a case to `ProtocolError` produces a compiler warning here and a
+    * `MatchError` at the first call, both of which demand an explicit decision.
+    */
+  def of(error: ProtocolError): StepOutcome = error match
+    case _: ProtocolError.Transport         => Failed(FailedOutcome.Transport)
+    case _: ProtocolError.UnexpectedStatus  => Failed(FailedOutcome.UnexpectedStatus)
+    case _: ProtocolError.MalformedResponse => Failed(FailedOutcome.Malformed)
+    case _: ProtocolError.StepUpRequired    => Planned(PlannedOutcome.StepUp)
+    case _: ProtocolError.Forbidden         => Planned(PlannedOutcome.Forbidden)
+    case _: ProtocolError.Unauthorized      => Planned(PlannedOutcome.Unauthorized)
+    case _: ProtocolError.RefreshRejected   => Failed(FailedOutcome.RefreshRejected)
+
+  def of[A](result: Either[ProtocolError, A]): StepOutcome = result match
+    case Left(error) => of(error)
+    case Right(_)    => ok
+
+/** The campaign's error taxonomy: two disjoint tallies, and the arithmetic the verdict is drawn
+  * from.
+  *
+  * [[budgetConsumed]] is a function of [[failed]] alone, and `Map[FailedOutcome, Long]` has no
+  * inhabitant that means "step-up required" -- so the split is enforced by the types rather than
+  * by everyone remembering to subtract three buckets before dividing. Both tallies are reported,
+  * because a step-up rate that collapses is as interesting as an error rate that rises.
+  */
+case class ErrorTaxonomy(
+    planned: Map[PlannedOutcome, Long],
+    failed: Map[FailedOutcome, Long],
+) derives JsonCodec:
+
+  def record(outcome: StepOutcome): ErrorTaxonomy =
+    recordMany(outcome, 1L)
+
+  def recordMany(outcome: StepOutcome, count: Long): ErrorTaxonomy =
+    outcome match
+      case StepOutcome.Planned(o) => copy(planned = planned.updatedWith(o)(c => Some(c.getOrElse(0L) + count)))
+      case StepOutcome.Failed(o)  => copy(failed = failed.updatedWith(o)(c => Some(c.getOrElse(0L) + count)))
+
+  /** Per-driver tallies add: every step is counted by exactly one driver (a virtual user is owned
+    * by exactly one shard, §6.2), so summing across drivers double-counts nothing.
+    */
+  def merge(other: ErrorTaxonomy): ErrorTaxonomy =
+    ErrorTaxonomy(
+      planned = ErrorTaxonomy.sum(planned, other.planned),
+      failed = ErrorTaxonomy.sum(failed, other.failed),
+    )
+
+  def plannedCount(outcome: PlannedOutcome): Long = planned.getOrElse(outcome, 0L)
+
+  def failedCount(outcome: FailedOutcome): Long = failed.getOrElse(outcome, 0L)
+
+  def plannedTotal: Long = planned.values.sum
+
+  def budgetConsumed: Long = failed.values.sum
+
+  def total: Long = plannedTotal + budgetConsumed
+
+  /** Share of all steps that consumed the error budget. Zero for an empty taxonomy rather than
+    * `NaN`, so a report assembled before any traffic ran does not read as a failed verdict.
+    */
+  def budgetRatio: Double =
+    if total == 0L then 0.0 else budgetConsumed.toDouble / total.toDouble
+
+object ErrorTaxonomy:
+  val empty: ErrorTaxonomy = ErrorTaxonomy(Map.empty, Map.empty)
+
+  def mergeAll(taxonomies: Iterable[ErrorTaxonomy]): ErrorTaxonomy =
+    taxonomies.foldLeft(empty)((acc, one) => acc.merge(one))
+
+  private def sum[A](left: Map[A, Long], right: Map[A, Long]): Map[A, Long] =
+    right.foldLeft(left) { case (acc, (key, count)) =>
+      acc.updatedWith(key)(existing => Some(existing.getOrElse(0L) + count))
+    }
+
+/** Fixed label value for `loadgen_refresh_rejected_total{reason}`.
+  *
+  * `RefreshRejection.Unknown` carries a free-text detail straight off the SUT's response; putting
+  * that in a label value would let the SUT dictate this metric's cardinality, so it collapses to
+  * `unknown` here and the detail stays in the logs.
+  */
+object RefreshRejectionLabel:
+  def of(rejection: RefreshRejection): String = rejection match
+    case RefreshRejection.AlreadyExchanged => "already_exchanged"
+    case RefreshRejection.SessionRevoked   => "session_revoked"
+    case RefreshRejection.Expired          => "expired"
+    case RefreshRejection.Unknown(_)       => "unknown"

--- a/loadgen/src/main/scala/versola/loadgen/metrics/HistogramWire.scala
+++ b/loadgen/src/main/scala/versola/loadgen/metrics/HistogramWire.scala
@@ -91,12 +91,44 @@ object HistogramWire:
       for
         bytes <- decodeBase64(encoded.encoding)
         histogram <- decodeHistogram(bytes)
+        _ <- sameGeometry(histogram)
         _ <- Either.cond(
           histogram.getTotalCount == encoded.count,
           (),
           s"histogram count mismatch: envelope says ${encoded.count}, payload holds ${histogram.getTotalCount}",
         )
       yield HistogramSample(encoded.id, histogram)
+
+  /** [[merge]] is only plain addition of bucket counts -- the property the whole "lossless" claim
+    * rests on -- when every input has the geometry [[LatencyRecorder.emptyHistogram]] was built
+    * with. `decodeFromCompressedByteBuffer`'s second argument is a *floor* on the highest
+    * trackable value, not an assertion about it, so a payload declaring a wider range or a
+    * different precision decodes without complaint and then fails in one of two ways: `add`
+    * throws on a value past the fixed target's range, taking the whole campaign report with it,
+    * or the counts are re-bucketed into the target's precision and the quantiles quietly stop
+    * being the ones the driver measured.
+    *
+    * A driver on a different build is the realistic source, which is the same failure the report
+    * `version` guards against and deserves the same treatment: reject the payload rather than
+    * merge it.
+    */
+  private def sameGeometry(histogram: Histogram): Either[String, Unit] =
+    if histogram.getLowestDiscernibleValue != LatencyRecorder.lowestDiscernibleMicros then
+      Left(
+        s"histogram lowest discernible value is ${histogram.getLowestDiscernibleValue}µs, " +
+          s"expected ${LatencyRecorder.lowestDiscernibleMicros}µs",
+      )
+    else if histogram.getHighestTrackableValue != LatencyRecorder.highestTrackableMicros then
+      Left(
+        s"histogram highest trackable value is ${histogram.getHighestTrackableValue}µs, " +
+          s"expected ${LatencyRecorder.highestTrackableMicros}µs",
+      )
+    else if histogram.getNumberOfSignificantValueDigits != LatencyRecorder.significantDigits then
+      Left(
+        s"histogram precision is ${histogram.getNumberOfSignificantValueDigits} significant digits, " +
+          s"expected ${LatencyRecorder.significantDigits}",
+      )
+    else Right(())
 
   def report(
       campaign: String,

--- a/loadgen/src/main/scala/versola/loadgen/metrics/HistogramWire.scala
+++ b/loadgen/src/main/scala/versola/loadgen/metrics/HistogramWire.scala
@@ -1,0 +1,167 @@
+package versola.loadgen.metrics
+
+import org.HdrHistogram.Histogram
+import zio.json.JsonCodec
+import zio.{Chunk, Duration}
+
+import java.nio.ByteBuffer
+import java.time.Instant
+import java.util.Base64
+import java.util.zip.DataFormatException
+
+/** One measurement's histogram as it travels from a driver to the coordinator.
+  *
+  * `encoding` is HdrHistogram's own compressed V2 payload, base64url'd so it survives JSON and a
+  * `text` column unchanged. Re-summarising into quantiles before the handoff was the alternative
+  * and is wrong for the same reason the Prometheus histograms are not the report: quantiles do
+  * not add. The bucket counts do, so the buckets are what gets shipped.
+  *
+  * `unit` and `count` are redundant with the payload on purpose. They are the cheap end of a
+  * decode check -- a truncated or re-encoded payload is otherwise perfectly capable of decoding
+  * into a plausible-looking histogram of the wrong size, and a campaign verdict is not a good
+  * place to discover that.
+  */
+case class EncodedHistogram(
+    id: MeasurementId,
+    unit: String,
+    count: Long,
+    encoding: String,
+) derives JsonCodec
+
+/** What one driver hands over per snapshot interval (§11: every 60 s), and what `GET
+  * /report/{campaign}` consumes N of (§12).
+  *
+  * `driverId` is on the envelope rather than in the histogram labels because it must not become a
+  * dimension of the report: the campaign's p99 is over the whole fleet, and a per-driver
+  * breakdown is a debugging view for when one pod is the outlier. `capturedAtEpochMillis` is what
+  * lets the coordinator tell a stalled driver from a quiet one.
+  */
+case class DriverHistogramReport(
+    version: Int,
+    campaign: String,
+    driverId: String,
+    capturedAtEpochMillis: Long,
+    histograms: List[EncodedHistogram],
+) derives JsonCodec
+
+/** Quantiles of a merged histogram, in microseconds -- the shape `GET /report/{campaign}` and
+  * `GET /status` publish. Microseconds, not `Duration`, because these numbers are read by
+  * dashboards and by whoever is arguing about the capacity plan, and a serialised `Duration`
+  * round-trips as an ISO-8601 string nobody can sort.
+  */
+case class LatencySummary(
+    id: MeasurementId,
+    count: Long,
+    minMicros: Long,
+    maxMicros: Long,
+    meanMicros: Double,
+    p50Micros: Long,
+    p90Micros: Long,
+    p95Micros: Long,
+    p99Micros: Long,
+    p999Micros: Long,
+) derives JsonCodec
+
+object HistogramWire:
+
+  /** Bumped whenever [[DriverHistogramReport]]'s shape changes. Decoding rejects anything else
+    * rather than guessing: a campaign spans days, and a rolling driver upgrade mid-run is exactly
+    * when a silently misread payload would be most expensive.
+    */
+  val version: Int = 1
+
+  val unit: String = "microseconds"
+
+  def encode(sample: HistogramSample): EncodedHistogram =
+    val buffer = ByteBuffer.allocate(sample.histogram.getNeededByteBufferCapacity)
+    val written = sample.histogram.encodeIntoCompressedByteBuffer(buffer)
+    val bytes = new Array[Byte](written)
+    buffer.rewind()
+    buffer.get(bytes)
+    EncodedHistogram(
+      id = sample.id,
+      unit = unit,
+      count = sample.histogram.getTotalCount,
+      encoding = Base64.getUrlEncoder.encodeToString(bytes),
+    )
+
+  def decode(encoded: EncodedHistogram): Either[String, HistogramSample] =
+    if encoded.unit != unit then Left(s"unsupported histogram unit '${encoded.unit}' (expected '$unit')")
+    else
+      for
+        bytes <- decodeBase64(encoded.encoding)
+        histogram <- decodeHistogram(bytes)
+        _ <- Either.cond(
+          histogram.getTotalCount == encoded.count,
+          (),
+          s"histogram count mismatch: envelope says ${encoded.count}, payload holds ${histogram.getTotalCount}",
+        )
+      yield HistogramSample(encoded.id, histogram)
+
+  def report(
+      campaign: String,
+      driverId: String,
+      capturedAt: Instant,
+      samples: Chunk[HistogramSample],
+  ): DriverHistogramReport =
+    DriverHistogramReport(
+      version = version,
+      campaign = campaign,
+      driverId = driverId,
+      capturedAtEpochMillis = capturedAt.toEpochMilli,
+      histograms = samples.map(encode).toList,
+    )
+
+  def decodeReport(report: DriverHistogramReport): Either[String, Chunk[HistogramSample]] =
+    if report.version != version then
+      Left(s"unsupported histogram report version ${report.version} (this build reads $version)")
+    else
+      report.histograms.foldLeft[Either[String, Chunk[HistogramSample]]](Right(Chunk.empty)):
+        case (Left(error), _)          => Left(error)
+        case (Right(accumulated), one) => decode(one).map(accumulated :+ _)
+
+  /** Lossless merge across drivers and across snapshot intervals.
+    *
+    * Every histogram is built with the same bounds and precision, so `add` is plain addition of
+    * bucket counts: the merged histogram is bit-for-bit what a single histogram fed the union of
+    * the samples would hold, and its quantiles are the campaign's quantiles. Merging into a fresh
+    * histogram rather than into the first input keeps the inputs usable afterwards -- the
+    * coordinator holds them for the per-driver debugging view.
+    */
+  def merge(samples: Iterable[HistogramSample]): Map[MeasurementId, Histogram] =
+    samples.foldLeft(Map.empty[MeasurementId, Histogram]): (merged, sample) =>
+      val target = merged.getOrElse(sample.id, LatencyRecorder.emptyHistogram)
+      target.add(sample.histogram)
+      merged.updated(sample.id, target)
+
+  def summarise(id: MeasurementId, histogram: Histogram): LatencySummary =
+    LatencySummary(
+      id = id,
+      count = histogram.getTotalCount,
+      minMicros = histogram.getMinValue,
+      maxMicros = histogram.getMaxValue,
+      meanMicros = histogram.getMean,
+      p50Micros = histogram.getValueAtPercentile(50.0),
+      p90Micros = histogram.getValueAtPercentile(90.0),
+      p95Micros = histogram.getValueAtPercentile(95.0),
+      p99Micros = histogram.getValueAtPercentile(99.0),
+      p999Micros = histogram.getValueAtPercentile(99.9),
+    )
+
+  def summarise(merged: Map[MeasurementId, Histogram]): List[LatencySummary] =
+    merged.toList.map { case (id, histogram) => summarise(id, histogram) }
+
+  def micros(duration: Duration): Long =
+    duration.toNanos / 1000L
+
+  private def decodeBase64(encoding: String): Either[String, Array[Byte]] =
+    try Right(Base64.getUrlDecoder.decode(encoding))
+    catch case ex: IllegalArgumentException => Left(s"histogram payload is not base64url: ${ex.getMessage}")
+
+  private def decodeHistogram(bytes: Array[Byte]): Either[String, Histogram] =
+    try Right(Histogram.decodeFromCompressedByteBuffer(ByteBuffer.wrap(bytes), LatencyRecorder.highestTrackableMicros))
+    catch
+      case ex: DataFormatException =>
+        Left(s"histogram payload is not a valid HdrHistogram encoding: ${ex.getMessage}")
+      case ex: IllegalArgumentException =>
+        Left(s"histogram payload is not a valid HdrHistogram encoding: ${ex.getMessage}")

--- a/loadgen/src/main/scala/versola/loadgen/metrics/LatencyRecorder.scala
+++ b/loadgen/src/main/scala/versola/loadgen/metrics/LatencyRecorder.scala
@@ -1,0 +1,76 @@
+package versola.loadgen.metrics
+
+import org.HdrHistogram.{Histogram, Recorder}
+import zio.{Chunk, Ref, UIO, ULayer, ZIO, ZLayer}
+
+/** One [[MeasurementId]]'s worth of recorded latencies, in microseconds. */
+case class HistogramSample(id: MeasurementId, histogram: Histogram)
+
+/** The driver's HdrHistogram sink: the source of every quantile the campaign's verdict rests on.
+  *
+  * §11's range and precision, 1 µs to 60 s at 3 significant digits, is what makes the merge
+  * lossless -- two drivers' histograms have identical bucket geometry, so
+  * `AbstractHistogram.add` is exact addition of counts and the merged p99 is the p99 of the
+  * union of the samples. That property is the reason the report does not use the Prometheus
+  * histograms, whose per-pod bucket sums cannot be combined into a campaign-wide quantile.
+  */
+trait LatencyRecorder:
+  def record(id: MeasurementId, latency: IntendedLatency): UIO[Unit]
+
+  /** Takes and resets the interval for every measurement recorded so far.
+    *
+    * Resetting matters for the handoff: §11 has each driver writing a snapshot every 60 s, and
+    * the coordinator summing them. Consecutive snapshots therefore have to *partition* the
+    * recorded values -- a cumulative snapshot would be counted once per interval it appears in,
+    * inflating the campaign's sample count by the number of snapshots and dragging the merged
+    * quantiles toward whatever the early intervals looked like.
+    */
+  def snapshot: UIO[Chunk[HistogramSample]]
+
+object LatencyRecorder:
+  val lowestDiscernibleMicros: Long = 1L
+  val highestTrackableMicros: Long = 60L * 1000L * 1000L
+  val significantDigits: Int = 3
+
+  def emptyHistogram: Histogram =
+    Histogram(lowestDiscernibleMicros, highestTrackableMicros, significantDigits)
+
+  val make: UIO[LatencyRecorder] =
+    Ref.Synchronized.make(Map.empty[MeasurementId, Recorder]).map(Live(_))
+
+  val layer: ULayer[LatencyRecorder] =
+    ZLayer.fromZIO(make)
+
+  /** `Recorder` rather than a bare `Histogram` guarded by a lock: it is HdrHistogram's own
+    * multi-writer/single-reader structure, so the thousands of fibers recording per second never
+    * contend with each other, only with the once-a-minute snapshot.
+    */
+  private final class Live(recorders: Ref.Synchronized[Map[MeasurementId, Recorder]]) extends LatencyRecorder:
+
+    override def record(id: MeasurementId, latency: IntendedLatency): UIO[Unit] =
+      val micros = latency.micros
+      val clamped = math.max(lowestDiscernibleMicros, math.min(micros, highestTrackableMicros))
+      for
+        recorder <- recorderFor(id)
+        _ <- ZIO.succeed(recorder.recordValue(clamped))
+        _ <- LoadgenMetrics.latencyClamped.when(micros > highestTrackableMicros)
+      yield ()
+
+    override def snapshot: UIO[Chunk[HistogramSample]] =
+      recorders.get.flatMap: current =>
+        ZIO.succeed:
+          Chunk.fromIterable(current).map { case (id, recorder) =>
+            HistogramSample(id, recorder.getIntervalHistogram)
+          }
+
+    private def recorderFor(id: MeasurementId): UIO[Recorder] =
+      recorders.get.flatMap:
+        case current if current.contains(id) => ZIO.succeed(current(id))
+        case _ =>
+          recorders.modifyZIO: current =>
+            ZIO.succeed:
+              current.get(id) match
+                case Some(existing) => (existing, current)
+                case None =>
+                  val created = Recorder(lowestDiscernibleMicros, highestTrackableMicros, significantDigits)
+                  (created, current.updated(id, created))

--- a/loadgen/src/main/scala/versola/loadgen/metrics/LoadgenMetrics.scala
+++ b/loadgen/src/main/scala/versola/loadgen/metrics/LoadgenMetrics.scala
@@ -48,10 +48,11 @@ object LoadgenMetrics:
   private val populationGauge = Metric.gauge("loadgen_population")
 
   /** Not in §11's table, but named by the definition of done ("driver CPU < 40%"). A fraction in
-    * `[0, 1]` of one whole pod's CPU allocation, matching `getProcessCpuLoad`'s own scale, so the
-    * threshold can be read off the graph without knowing the pod's core count.
+    * `[0, 1]` of the pod's own CPU allocation -- see [[ProcessCpu]] -- so the threshold can be
+    * read off the graph without knowing the node's core count. `_ratio` rather than
+    * `_utilisation` because that is Prometheus's suffix for a unitless `[0, 1]` gauge.
     */
-  private val driverCpuGauge = Metric.gauge("loadgen_driver_cpu_utilisation")
+  private val driverCpuGauge = Metric.gauge("loadgen_driver_cpu_ratio")
 
   /** Recorded latencies above [[LatencyRecorder.highestTrackableMicros]] are clamped before they
     * reach the HdrHistogram. That is invisible in the quantiles, so it is counted here: any

--- a/loadgen/src/main/scala/versola/loadgen/metrics/LoadgenMetrics.scala
+++ b/loadgen/src/main/scala/versola/loadgen/metrics/LoadgenMetrics.scala
@@ -1,0 +1,114 @@
+package versola.loadgen.metrics
+
+import versola.loadgen.protocol.RefreshRejection
+import zio.metrics.MetricKeyType.Histogram.Boundaries
+import zio.metrics.{Metric, MetricLabel}
+import zio.{Chunk, Duration, UIO}
+
+/** Which slice of the population a `loadgen_population` reading describes. `Broken` is the count
+  * of virtual users the driver has retired -- a lost refresh rotation, a dead cookie session --
+  * and it is the number that tells you whether a falling arrival rate is the SUT slowing down or
+  * the emulator eating its own population.
+  */
+enum PopulationState(val label: String):
+  case Planned extends PopulationState("planned")
+  case Registered extends PopulationState("registered")
+  case Broken extends PopulationState("broken")
+
+/** The live Prometheus surface of §11, scraped off `VersolaApp`'s diagnostics port.
+  *
+  * These metrics are for dashboards and alerts, and nothing else. Their quantiles are computed
+  * from fixed bucket boundaries per pod, and neither buckets nor quantiles can be merged across
+  * pods into a correct campaign-wide quantile -- averaging pod p99s is not a p99 of anything. The
+  * defensible number the report is judged on comes from the HdrHistograms of [[LatencyRecorder]],
+  * merged losslessly by the coordinator. Both are recorded from the same measurement so they
+  * cannot disagree about what happened, only about how precisely it is summarised.
+  *
+  * Every label value here is drawn from configuration or from a closed enum. §11's cardinality
+  * budget is not a guideline: at ~5,300 rps across a fleet, one user id in a label value is a
+  * dead Prometheus.
+  */
+object LoadgenMetrics:
+
+  /** Exponential boundaries rather than the linear-ish set `Observability` uses for the SUT's own
+    * HTTP metrics: the campaign spans 1 ms cache hits and multi-second Argon2 queueing, and a
+    * fixed-width set cannot resolve both ends. 1 ms doubling to ~65 s, 17 buckets.
+    */
+  val latencyBoundaries: Boundaries = Boundaries.exponential(0.001, 2.0, 17)
+
+  private val stepDuration = Metric.histogram("loadgen_step_duration_seconds", latencyBoundaries)
+  private val flowDuration = Metric.histogram("loadgen_flow_duration_seconds", latencyBoundaries)
+  private val arrivalsTotal = Metric.counter("loadgen_arrivals_total")
+  private val outcomesTotal = Metric.counter("loadgen_outcomes_total")
+  private val scheduleLagSeconds = Metric.gauge("loadgen_schedule_lag_seconds")
+  private val busyUsersGauge = Metric.gauge("loadgen_busy_users")
+  private val inflightRequestsGauge = Metric.gauge("loadgen_inflight_requests")
+  private val refreshRejectedTotal = Metric.counter("loadgen_refresh_rejected_total")
+  private val storeFlushDroppedTotal = Metric.counter("loadgen_store_flush_dropped_total")
+  private val populationGauge = Metric.gauge("loadgen_population")
+
+  /** Not in §11's table, but named by the definition of done ("driver CPU < 40%"). A fraction in
+    * `[0, 1]` of one whole pod's CPU allocation, matching `getProcessCpuLoad`'s own scale, so the
+    * threshold can be read off the graph without knowing the pod's core count.
+    */
+  private val driverCpuGauge = Metric.gauge("loadgen_driver_cpu_utilisation")
+
+  /** Recorded latencies above [[LatencyRecorder.highestTrackableMicros]] are clamped before they
+    * reach the HdrHistogram. That is invisible in the quantiles, so it is counted here: any
+    * non-zero value means the report's tail is a floor, not a measurement.
+    */
+  private val latencyClampedTotal = Metric.counter("loadgen_latency_clamped_total")
+
+  def arrival(scenario: String): UIO[Unit] =
+    arrivalsTotal.tagged(labels("scenario" -> scenario)).increment
+
+  /** Records one completed step: its duration and its taxonomy bucket.
+    *
+    * Both in one call deliberately. The two are the same event, and a step that is timed but not
+    * counted (or the reverse) leaves the report's rate and its error budget describing different
+    * populations -- a discrepancy that is very hard to spot after the fact and impossible to
+    * repair.
+    */
+  def stepCompleted(scenario: String, step: String, outcome: StepOutcome, latency: IntendedLatency): UIO[Unit] =
+    stepDuration
+      .tagged(labels("scenario" -> scenario, "step" -> step, "outcome" -> outcome.label))
+      .update(latency.seconds) *>
+      outcomesTotal.tagged(labels("scenario" -> scenario, "outcome" -> outcome.label)).increment
+
+  /** Records one completed flow (login, refresh, step-up, ...). Deliberately does not touch
+    * `loadgen_outcomes_total`: the taxonomy counts steps, and counting flows there too would
+    * inflate the denominator of the error budget with the steps they are made of.
+    */
+  def flowCompleted(flow: String, outcome: StepOutcome, latency: IntendedLatency): UIO[Unit] =
+    flowDuration.tagged(labels("flow" -> flow, "outcome" -> outcome.label)).update(latency.seconds)
+
+  def scheduleLag(scenario: String, lag: Duration): UIO[Unit] =
+    scheduleLagSeconds.tagged(labels("scenario" -> scenario)).set(lag.toNanos.toDouble / 1e9)
+
+  def busyUsers(count: Int): UIO[Unit] =
+    busyUsersGauge.set(count.toDouble)
+
+  def inflightRequests(count: Int): UIO[Unit] =
+    inflightRequestsGauge.set(count.toDouble)
+
+  def refreshRejected(rejection: RefreshRejection): UIO[Unit] =
+    refreshRejectedTotal.tagged(labels("reason" -> RefreshRejectionLabel.of(rejection))).increment
+
+  /** Adds newly dropped write-behind rows. The store (track C) holds a cumulative figure; this
+    * takes the increment, because a Prometheus counter that is `set` rather than added to loses
+    * every increase that happened between two scrapes.
+    */
+  def storeFlushDropped(added: Long): UIO[Unit] =
+    if added <= 0L then zio.ZIO.unit else storeFlushDroppedTotal.incrementBy(added)
+
+  def population(state: PopulationState, count: Long): UIO[Unit] =
+    populationGauge.tagged(labels("state" -> state.label)).set(count.toDouble)
+
+  def driverCpu(utilisation: Double): UIO[Unit] =
+    driverCpuGauge.set(utilisation)
+
+  def latencyClamped: UIO[Unit] =
+    latencyClampedTotal.increment
+
+  private def labels(pairs: (String, String)*): Set[MetricLabel] =
+    Chunk.fromIterable(pairs).map { case (name, value) => MetricLabel(name, value) }.toSet

--- a/loadgen/src/main/scala/versola/loadgen/metrics/Measurement.scala
+++ b/loadgen/src/main/scala/versola/loadgen/metrics/Measurement.scala
@@ -1,0 +1,44 @@
+package versola.loadgen.metrics
+
+import zio.Duration
+import zio.json.JsonCodec
+
+import java.time.Instant
+
+/** What a recorded latency belongs to. Two shapes, because §11 asks for two granularities and
+  * they carry different labels: a step lives inside a scenario
+  * (`loadgen_step_duration_seconds{scenario,step,outcome}`) while a flow is named on its own
+  * (`loadgen_flow_duration_seconds{flow,outcome}`).
+  *
+  * Everything in here is a label value on the Prometheus side and a map key on the report side,
+  * so it is bound by §11's cardinality budget: scenario/step/flow names come from configuration
+  * and code, never from a user id, a session id or a parameterised path.
+  */
+enum MeasurementId derives JsonCodec:
+  case Step(scenario: String, step: String)
+  case Flow(flow: String)
+
+/** Elapsed time from the *intended* start of an operation to its completion, which is the only
+  * latency this package will record.
+  *
+  * The distinction is the whole point of the open-model design (design doc §6.3): with a
+  * scheduled start time, a driver that falls behind reports the wait it imposed on itself as part
+  * of the latency, instead of silently throttling and reporting a flattering number for the SUT.
+  * A plain `Duration` would let a caller pass `completedAt - actuallyStartedAt` and lose that
+  * correction with no visible symptom, so the type the recorder accepts can only be built by
+  * naming the intended start (or by an explicit [[IntendedLatency.unsafe]] for the cases -- a
+  * synthetic value in a test, a flow whose start is not scheduled -- where there is none).
+  */
+opaque type IntendedLatency = Duration
+
+object IntendedLatency:
+  def between(intendedStart: Instant, completedAt: Instant): IntendedLatency =
+    val elapsed = Duration.fromInterval(intendedStart, completedAt)
+    if elapsed.isNegative then Duration.Zero else elapsed
+
+  def unsafe(elapsed: Duration): IntendedLatency = elapsed
+
+  extension (latency: IntendedLatency)
+    def toDuration: Duration = latency
+    def micros: Long = latency.toNanos / 1000L
+    def seconds: Double = latency.toNanos.toDouble / 1e9

--- a/loadgen/src/test/scala/versola/loadgen/metrics/CampaignReportSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/metrics/CampaignReportSpec.scala
@@ -128,6 +128,47 @@ object CampaignReportSpec extends ZIOSpecDefault:
         report.map(_.checks.forall(_.passed)) == Right(true),
       )
     },
+    test("a present but empty histogram is not evaluated, so a zero-sample campaign cannot pass") {
+      // A recorder registered and never written to: HdrHistogram answers p99 with 0, which clears
+      // every ceiling. Absence and emptiness have to reach the same branch or the report's worst
+      // failure mode is available -- a campaign that measured nothing reporting success.
+      val empty = HistogramSample(tokenRefresh, LatencyRecorder.emptyHistogram)
+      val reports = List(
+        driverReport(
+          "c3",
+          "driver-0",
+          empty,
+          HistogramSample(edgeProxy, LatencyRecorder.emptyHistogram),
+          HistogramSample(mockBackend, LatencyRecorder.emptyHistogram),
+        ),
+      )
+      val report = CampaignReport.assemble("c3", reports, ErrorTaxonomy.empty, healthyRun, thresholds)
+      assertTrue(
+        report.map(_.passed) == Right(false),
+        report.map(_.notEvaluated.sorted) == Right(
+          List(s"p99 of $edgeProxy relative to $mockBackend", s"p99 of $tokenRefresh").sorted,
+        ),
+      )
+    },
+    test("an empty baseline does not silently become a zero-microsecond relative ceiling") {
+      // The subject has real samples; only the baseline is empty. Evaluating it would compare a
+      // measured p99 against `0 + margin` and fail the campaign for the wrong reason.
+      val reports = List(
+        driverReport(
+          "c3",
+          "driver-0",
+          sample(tokenRefresh, 90_000L, 10L),
+          sample(edgeProxy, 40_000L, 10L),
+          HistogramSample(mockBackend, LatencyRecorder.emptyHistogram),
+        ),
+      )
+      val report = CampaignReport.assemble("c3", reports, ErrorTaxonomy.empty, healthyRun, thresholds)
+      assertTrue(
+        report.map(_.notEvaluated) == Right(List(s"p99 of $edgeProxy relative to $mockBackend")),
+        report.map(_.checks.forall(_.passed)) == Right(true),
+        report.map(_.passed) == Right(false),
+      )
+    },
     test("merges every driver's histograms into one set of quantiles") {
       val reports = List(
         driverReport("c3", "driver-1", sample(tokenRefresh, 1000L, 100L)),

--- a/loadgen/src/test/scala/versola/loadgen/metrics/CampaignReportSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/metrics/CampaignReportSpec.scala
@@ -1,0 +1,164 @@
+package versola.loadgen.metrics
+
+import zio.json.*
+import zio.test.*
+import zio.{Chunk, Duration}
+
+import java.time.Instant
+
+object CampaignReportSpec extends ZIOSpecDefault:
+
+  private val tokenRefresh = MeasurementId.Step("mobile-otp", "token-refresh")
+  private val edgeProxy = MeasurementId.Step("mobile-otp", "proxy-accounts")
+  private val mockBackend = MeasurementId.Step("mockapi", "accounts")
+
+  private val thresholds = AcceptanceThresholds.designDefaults(tokenRefresh, edgeProxy, mockBackend)
+
+  private def sample(id: MeasurementId, micros: Long, count: Long): HistogramSample =
+    val histogram = LatencyRecorder.emptyHistogram
+    histogram.recordValueWithCount(micros, count)
+    HistogramSample(id, histogram)
+
+  private def driverReport(campaign: String, driverId: String, samples: HistogramSample*): DriverHistogramReport =
+    HistogramWire.report(campaign, driverId, Instant.parse("2026-09-10T18:00:00Z"), Chunk.fromIterable(samples))
+
+  private val healthyRun = CampaignHealth(
+    refreshRejectedTotal = 0L,
+    flushDroppedTotal = 0L,
+    maxDriverCpu = Some(0.29),
+    scheduleLagP99 = Some(Duration.fromMillis(180)),
+  )
+
+  private val allMeasured = List(
+    driverReport(
+      "c3-10m-steady",
+      "driver-0",
+      sample(tokenRefresh, 90_000L, 100L),
+      sample(edgeProxy, 40_000L, 100L),
+      sample(mockBackend, 30_000L, 100L),
+    ),
+  )
+
+  def spec = suite("CampaignReport")(
+    test("the design doc's thresholds are the ones being applied") {
+      assertTrue(
+        thresholds.latency == List(LatencyThreshold(tokenRefresh, Duration.fromMillis(120))),
+        thresholds.relativeLatency == List(RelativeLatencyThreshold(edgeProxy, mockBackend, Duration.fromMillis(15))),
+        thresholds.scheduleLagP99 == Duration.fromMillis(250),
+        thresholds.maxRefreshRejected == 0L,
+        thresholds.maxFlushDropped == 0L,
+        thresholds.maxDriverCpu == 0.4,
+      )
+    },
+    test("passes a campaign that meets every criterion") {
+      val report = CampaignReport.assemble("c3-10m-steady", allMeasured, ErrorTaxonomy.empty, healthyRun, thresholds)
+      assertTrue(
+        report.map(_.passed) == Right(true),
+        report.map(_.notEvaluated) == Right(Nil),
+        report.map(_.checks.size) == Right(7),
+        report.map(_.drivers) == Right(List("driver-0")),
+        report.map(_.latency.map(_.count)) == Right(List(100L, 100L, 100L)),
+      )
+    },
+    test("fails on the token endpoint's absolute p99") {
+      val reports = List(
+        driverReport(
+          "c3",
+          "driver-0",
+          sample(tokenRefresh, 140_000L, 10L),
+          sample(edgeProxy, 40_000L, 10L),
+          sample(mockBackend, 30_000L, 10L),
+        ),
+      )
+      val report = CampaignReport.assemble("c3", reports, ErrorTaxonomy.empty, healthyRun, thresholds)
+      assertTrue(
+        report.map(_.passed) == Right(false),
+        report.map(_.checks.filterNot(_.passed).map(_.name)) == Right(List(s"p99 of $tokenRefresh")),
+      )
+    },
+    test("fails when edge's p99 exceeds the backend's by more than the margin") {
+      val reports = List(
+        driverReport(
+          "c3",
+          "driver-0",
+          sample(tokenRefresh, 90_000L, 10L),
+          sample(edgeProxy, 60_000L, 10L),
+          sample(mockBackend, 30_000L, 10L),
+        ),
+      )
+      val report = CampaignReport.assemble("c3", reports, ErrorTaxonomy.empty, healthyRun, thresholds)
+      assertTrue(
+        report.map(_.passed) == Right(false),
+        report.map(_.checks.count(_.passed == false)) == Right(1),
+      )
+    },
+    test("a step-up-heavy campaign with no failures still passes the error budget") {
+      val taxonomy = ErrorTaxonomy.empty
+        .recordMany(StepOutcome.ok, 100_000L)
+        .recordMany(StepOutcome.Planned(PlannedOutcome.StepUp), 30_000L)
+        .recordMany(StepOutcome.Planned(PlannedOutcome.Forbidden), 1_000L)
+        .recordMany(StepOutcome.Planned(PlannedOutcome.Unauthorized), 4_000L)
+      val report = CampaignReport.assemble("c3-10m-steady", allMeasured, taxonomy, healthyRun, thresholds)
+      assertTrue(
+        report.map(_.passed) == Right(true),
+        report.map(_.taxonomy.budgetConsumed) == Right(0L),
+      )
+    },
+    test("fails on driver health rather than blaming the SUT") {
+      val unhealthy = CampaignHealth(
+        refreshRejectedTotal = 3L,
+        flushDroppedTotal = 41L,
+        maxDriverCpu = Some(0.62),
+        scheduleLagP99 = Some(Duration.fromMillis(900)),
+      )
+      val report = CampaignReport.assemble("c3-10m-steady", allMeasured, ErrorTaxonomy.empty, unhealthy, thresholds)
+      assertTrue(
+        report.map(_.passed) == Right(false),
+        report.map(_.checks.filterNot(_.passed).map(_.name).sorted) == Right(
+          List("driver CPU", "dropped write-behind rows", "refresh rejections", "schedule lag p99"),
+        ),
+      )
+    },
+    test("an unmeasured threshold is reported as not evaluated, not as a pass") {
+      val reports = List(driverReport("c3", "driver-0", sample(tokenRefresh, 90_000L, 10L)))
+      val report = CampaignReport.assemble("c3", reports, ErrorTaxonomy.empty, healthyRun, thresholds)
+      assertTrue(
+        report.map(_.passed) == Right(false),
+        report.map(_.notEvaluated) == Right(List(s"p99 of $edgeProxy relative to $mockBackend")),
+        report.map(_.checks.forall(_.passed)) == Right(true),
+      )
+    },
+    test("merges every driver's histograms into one set of quantiles") {
+      val reports = List(
+        driverReport("c3", "driver-1", sample(tokenRefresh, 1000L, 100L)),
+        driverReport("c3", "driver-0", sample(tokenRefresh, 2000L, 100L)),
+      )
+      val report = CampaignReport.assemble("c3", reports, ErrorTaxonomy.empty, healthyRun, thresholds)
+      assertTrue(
+        report.map(_.drivers) == Right(List("driver-0", "driver-1")),
+        report.map(_.latency.map(_.count)) == Right(List(200L)),
+        report.map(_.latency.map(_.p50Micros)) == Right(List(1000L)),
+        report.map(_.latency.map(_.p99Micros)) == Right(List(2000L)),
+        report.map(_.latency.map(_.meanMicros)) == Right(List(1500.0)),
+      )
+    },
+    test("refuses a driver's report from a different campaign") {
+      val reports = List(
+        driverReport("c3", "driver-0", sample(tokenRefresh, 1000L, 1L)),
+        driverReport("c7-20m", "driver-1", sample(tokenRefresh, 1000L, 1L)),
+      )
+      assertTrue(
+        CampaignReport.assemble("c3", reports, ErrorTaxonomy.empty, healthyRun, thresholds).isLeft,
+      )
+    },
+    test("serialises to JSON for GET /report/{campaign}") {
+      val report =
+        CampaignReport.assemble("c3-10m-steady", allMeasured, ErrorTaxonomy.empty, healthyRun, thresholds).toOption.get
+      val json = report.toJson
+      assertTrue(
+        json.fromJson[CampaignReport].map(_.passed) == Right(true),
+        json.fromJson[CampaignReport].map(_.latency.size) == Right(3),
+        json.fromJson[CampaignReport].map(_.health) == Right(healthyRun),
+      )
+    },
+  )

--- a/loadgen/src/test/scala/versola/loadgen/metrics/CampaignReportSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/metrics/CampaignReportSpec.scala
@@ -27,6 +27,7 @@ object CampaignReportSpec extends ZIOSpecDefault:
     flushDroppedTotal = 0L,
     maxDriverCpu = Some(0.29),
     scheduleLagP99 = Some(Duration.fromMillis(180)),
+    latencyClampedTotal = 0L,
   )
 
   private val allMeasured = List(
@@ -48,6 +49,7 @@ object CampaignReportSpec extends ZIOSpecDefault:
         thresholds.maxRefreshRejected == 0L,
         thresholds.maxFlushDropped == 0L,
         thresholds.maxDriverCpu == 0.4,
+        thresholds.maxLatencyClamped == 0L,
       )
     },
     test("passes a campaign that meets every criterion") {
@@ -55,7 +57,7 @@ object CampaignReportSpec extends ZIOSpecDefault:
       assertTrue(
         report.map(_.passed) == Right(true),
         report.map(_.notEvaluated) == Right(Nil),
-        report.map(_.checks.size) == Right(7),
+        report.map(_.checks.size) == Right(8),
         report.map(_.drivers) == Right(List("driver-0")),
         report.map(_.latency.map(_.count)) == Right(List(100L, 100L, 100L)),
       )
@@ -110,6 +112,7 @@ object CampaignReportSpec extends ZIOSpecDefault:
         flushDroppedTotal = 41L,
         maxDriverCpu = Some(0.62),
         scheduleLagP99 = Some(Duration.fromMillis(900)),
+        latencyClampedTotal = 0L,
       )
       val report = CampaignReport.assemble("c3-10m-steady", allMeasured, ErrorTaxonomy.empty, unhealthy, thresholds)
       assertTrue(
@@ -126,6 +129,19 @@ object CampaignReportSpec extends ZIOSpecDefault:
         report.map(_.passed) == Right(false),
         report.map(_.notEvaluated) == Right(List(s"p99 of $edgeProxy relative to $mockBackend")),
         report.map(_.checks.forall(_.passed)) == Right(true),
+      )
+    },
+    test("a single clamped latency fails the campaign") {
+      // A clamped sample means the reported tail is a floor rather than a measurement, so the
+      // report's headline number is no longer the thing it claims to be. With the driver timing
+      // out at 30 s against a 60 s recorder ceiling it also cannot happen without a bug in the
+      // driver -- so one is the limit, and everything else about the run being healthy is exactly
+      // when this needs to still fail.
+      val clamped = healthyRun.copy(latencyClampedTotal = 1L)
+      val report = CampaignReport.assemble("c3-10m-steady", allMeasured, ErrorTaxonomy.empty, clamped, thresholds)
+      assertTrue(
+        report.map(_.passed) == Right(false),
+        report.map(_.checks.filterNot(_.passed).map(_.name)) == Right(List("clamped latencies")),
       )
     },
     test("a present but empty histogram is not evaluated, so a zero-sample campaign cannot pass") {

--- a/loadgen/src/test/scala/versola/loadgen/metrics/ErrorTaxonomySpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/metrics/ErrorTaxonomySpec.scala
@@ -20,34 +20,52 @@ object ErrorTaxonomySpec extends ZIOSpecDefault:
   private val forbidden = ProtocolError.Forbidden("/resources/pay/templates")
   private val unauthorized = ProtocolError.Unauthorized("/resources/core/cards")
   private val refreshRejected = ProtocolError.RefreshRejected(RefreshRejection.AlreadyExchanged)
+  private val misconfigured = ProtocolError.Misconfigured("client_id 'loadgen' is not registered")
 
   private val everyError = List(transport, unexpectedStatus, malformed, stepUp, forbidden, unauthorized, refreshRejected)
+
+  /** The classification, for the cases that have one. Every call below is on an error the match
+    * maps to a `Right`; `Misconfigured` is asserted separately, as the one that does not.
+    */
+  private def classify(error: ProtocolError): StepOutcome =
+    StepOutcome.of(error).toOption.get
 
   def spec = suite("ErrorTaxonomy")(
     test("classifies step-up, forbidden and unauthorized as planned outcomes") {
       assertTrue(
-        StepOutcome.of(stepUp) == StepOutcome.Planned(PlannedOutcome.StepUp),
-        StepOutcome.of(forbidden) == StepOutcome.Planned(PlannedOutcome.Forbidden),
-        StepOutcome.of(unauthorized) == StepOutcome.Planned(PlannedOutcome.Unauthorized),
+        classify(stepUp) == StepOutcome.Planned(PlannedOutcome.StepUp),
+        classify(forbidden) == StepOutcome.Planned(PlannedOutcome.Forbidden),
+        classify(unauthorized) == StepOutcome.Planned(PlannedOutcome.Unauthorized),
       )
     },
     test("classifies transport, status, malformed and refresh rejection as failures") {
       assertTrue(
-        StepOutcome.of(transport) == StepOutcome.Failed(FailedOutcome.Transport),
-        StepOutcome.of(unexpectedStatus) == StepOutcome.Failed(FailedOutcome.UnexpectedStatus),
-        StepOutcome.of(malformed) == StepOutcome.Failed(FailedOutcome.Malformed),
-        StepOutcome.of(refreshRejected) == StepOutcome.Failed(FailedOutcome.RefreshRejected),
+        classify(transport) == StepOutcome.Failed(FailedOutcome.Transport),
+        classify(unexpectedStatus) == StepOutcome.Failed(FailedOutcome.UnexpectedStatus),
+        classify(malformed) == StepOutcome.Failed(FailedOutcome.Malformed),
+        classify(refreshRejected) == StepOutcome.Failed(FailedOutcome.RefreshRejected),
+      )
+    },
+    test("a misconfiguration aborts the campaign instead of becoming an outcome") {
+      // An unregistered client_id or an unparseable endpoint is our fault, not a reading of the
+      // SUT. Tallying it would put emulator bugs in the error budget's denominator, and there is
+      // nothing to salvage by continuing: the run measured something other than what it claims.
+      // The `Left` keeps that on the caller's type, so the abort cannot be recorded or dropped.
+      assertTrue(
+        StepOutcome.of(misconfigured) == Left(CampaignAbort("client_id 'loadgen' is not registered")),
+        StepOutcome.of(Left(misconfigured)).isLeft,
+        everyError.forall(StepOutcome.of(_).isRight),
       )
     },
     test("classifies a successful result as ok") {
-      assertTrue(StepOutcome.of(Right(())) == StepOutcome.ok, StepOutcome.ok.label == "ok")
+      assertTrue(StepOutcome.of(Right(())) == Right(StepOutcome.ok), StepOutcome.ok.label == "ok")
     },
     test("no protocol error is left unclassified") {
-      val classified = everyError.map(StepOutcome.of)
+      val classified = everyError.map(classify)
       assertTrue(classified.size == everyError.size, classified.forall(_.label.nonEmpty))
     },
     test("planned outcomes never consume the error budget") {
-      val taxonomy = everyError.foldLeft(ErrorTaxonomy.empty)((acc, error) => acc.record(StepOutcome.of(error)))
+      val taxonomy = everyError.foldLeft(ErrorTaxonomy.empty)((acc, error) => acc.record(classify(error)))
       // Seven errors in, three of them planned: the budget must see exactly the other four.
       assertTrue(
         taxonomy.total == 7L,
@@ -59,7 +77,7 @@ object ErrorTaxonomySpec extends ZIOSpecDefault:
     },
     test("a campaign of nothing but step-ups and 403s consumes no budget at all") {
       val taxonomy = List.fill(500)(stepUp).appendedAll(List.fill(120)(forbidden))
-        .foldLeft(ErrorTaxonomy.empty)((acc, error) => acc.record(StepOutcome.of(error)))
+        .foldLeft(ErrorTaxonomy.empty)((acc, error) => acc.record(classify(error)))
       assertTrue(taxonomy.total == 620L, taxonomy.budgetConsumed == 0L, taxonomy.budgetRatio == 0.0)
     },
     test("the budget ratio is failures over all steps") {

--- a/loadgen/src/test/scala/versola/loadgen/metrics/ErrorTaxonomySpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/metrics/ErrorTaxonomySpec.scala
@@ -1,0 +1,111 @@
+package versola.loadgen.metrics
+
+import versola.loadgen.protocol.{ProtocolError, RefreshRejection}
+import zio.http.Status
+import zio.json.*
+import zio.test.*
+
+/** The taxonomy's whole job is the outcome/failure split, so this spec asserts the split for
+  * every constructor of [[ProtocolError]] by name. Listed exhaustively rather than derived: a case
+  * added to the ADT without a decision about which side it lands on should show up here as a
+  * missing test, not be swept along by a generic property.
+  */
+object ErrorTaxonomySpec extends ZIOSpecDefault:
+
+  private val transport = ProtocolError.Transport(RuntimeException("connection reset"))
+  private val unexpectedStatus =
+    ProtocolError.UnexpectedStatus(Set(Status.Ok), Status.InternalServerError, "/resources/core/accounts")
+  private val malformed = ProtocolError.MalformedResponse("/token", "no access_token in body")
+  private val stepUp = ProtocolError.StepUpRequired(List("otp-level"), "/resources/pay/p2p")
+  private val forbidden = ProtocolError.Forbidden("/resources/pay/templates")
+  private val unauthorized = ProtocolError.Unauthorized("/resources/core/cards")
+  private val refreshRejected = ProtocolError.RefreshRejected(RefreshRejection.AlreadyExchanged)
+
+  private val everyError = List(transport, unexpectedStatus, malformed, stepUp, forbidden, unauthorized, refreshRejected)
+
+  def spec = suite("ErrorTaxonomy")(
+    test("classifies step-up, forbidden and unauthorized as planned outcomes") {
+      assertTrue(
+        StepOutcome.of(stepUp) == StepOutcome.Planned(PlannedOutcome.StepUp),
+        StepOutcome.of(forbidden) == StepOutcome.Planned(PlannedOutcome.Forbidden),
+        StepOutcome.of(unauthorized) == StepOutcome.Planned(PlannedOutcome.Unauthorized),
+      )
+    },
+    test("classifies transport, status, malformed and refresh rejection as failures") {
+      assertTrue(
+        StepOutcome.of(transport) == StepOutcome.Failed(FailedOutcome.Transport),
+        StepOutcome.of(unexpectedStatus) == StepOutcome.Failed(FailedOutcome.UnexpectedStatus),
+        StepOutcome.of(malformed) == StepOutcome.Failed(FailedOutcome.Malformed),
+        StepOutcome.of(refreshRejected) == StepOutcome.Failed(FailedOutcome.RefreshRejected),
+      )
+    },
+    test("classifies a successful result as ok") {
+      assertTrue(StepOutcome.of(Right(())) == StepOutcome.ok, StepOutcome.ok.label == "ok")
+    },
+    test("no protocol error is left unclassified") {
+      val classified = everyError.map(StepOutcome.of)
+      assertTrue(classified.size == everyError.size, classified.forall(_.label.nonEmpty))
+    },
+    test("planned outcomes never consume the error budget") {
+      val taxonomy = everyError.foldLeft(ErrorTaxonomy.empty)((acc, error) => acc.record(StepOutcome.of(error)))
+      // Seven errors in, three of them planned: the budget must see exactly the other four.
+      assertTrue(
+        taxonomy.total == 7L,
+        taxonomy.plannedTotal == 3L,
+        taxonomy.budgetConsumed == 4L,
+        taxonomy.plannedCount(PlannedOutcome.StepUp) == 1L,
+        taxonomy.failedCount(FailedOutcome.RefreshRejected) == 1L,
+      )
+    },
+    test("a campaign of nothing but step-ups and 403s consumes no budget at all") {
+      val taxonomy = List.fill(500)(stepUp).appendedAll(List.fill(120)(forbidden))
+        .foldLeft(ErrorTaxonomy.empty)((acc, error) => acc.record(StepOutcome.of(error)))
+      assertTrue(taxonomy.total == 620L, taxonomy.budgetConsumed == 0L, taxonomy.budgetRatio == 0.0)
+    },
+    test("the budget ratio is failures over all steps") {
+      val taxonomy = ErrorTaxonomy.empty
+        .recordMany(StepOutcome.ok, 990L)
+        .recordMany(StepOutcome.Planned(PlannedOutcome.StepUp), 500L)
+        .recordMany(StepOutcome.Failed(FailedOutcome.Transport), 10L)
+      assertTrue(taxonomy.total == 1500L, taxonomy.budgetRatio == 10.0 / 1500.0)
+    },
+    test("an empty taxonomy has a zero ratio rather than a NaN") {
+      assertTrue(ErrorTaxonomy.empty.budgetRatio == 0.0, ErrorTaxonomy.empty.total == 0L)
+    },
+    test("per-driver tallies add") {
+      val one = ErrorTaxonomy.empty.recordMany(StepOutcome.ok, 3L).recordMany(
+        StepOutcome.Failed(FailedOutcome.Transport),
+        1L,
+      )
+      val two = ErrorTaxonomy.empty.recordMany(StepOutcome.ok, 5L).recordMany(
+        StepOutcome.Planned(PlannedOutcome.Forbidden),
+        2L,
+      )
+      val merged = ErrorTaxonomy.mergeAll(List(one, two))
+      assertTrue(
+        merged.plannedCount(PlannedOutcome.Ok) == 8L,
+        merged.plannedCount(PlannedOutcome.Forbidden) == 2L,
+        merged.budgetConsumed == 1L,
+        merged == two.merge(one),
+      )
+    },
+    test("round-trips through JSON keyed by the Prometheus label values") {
+      val taxonomy = ErrorTaxonomy.empty
+        .recordMany(StepOutcome.Planned(PlannedOutcome.StepUp), 4L)
+        .recordMany(StepOutcome.Failed(FailedOutcome.UnexpectedStatus), 2L)
+      val json = taxonomy.toJson
+      assertTrue(
+        json.contains("\"stepup\":4"),
+        json.contains("\"unexpected_status\":2"),
+        json.fromJson[ErrorTaxonomy] == Right(taxonomy),
+      )
+    },
+    test("collapses the refresh rejection reason to a bounded set of labels") {
+      assertTrue(
+        RefreshRejectionLabel.of(RefreshRejection.AlreadyExchanged) == "already_exchanged",
+        RefreshRejectionLabel.of(RefreshRejection.SessionRevoked) == "session_revoked",
+        RefreshRejectionLabel.of(RefreshRejection.Expired) == "expired",
+        RefreshRejectionLabel.of(RefreshRejection.Unknown("invalid_grant: whatever the SUT said")) == "unknown",
+      )
+    },
+  )

--- a/loadgen/src/test/scala/versola/loadgen/metrics/HistogramWireSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/metrics/HistogramWireSpec.scala
@@ -133,6 +133,36 @@ object HistogramWireSpec extends ZIOSpecDefault:
         HistogramWire.decode(encoded.copy(encoding = "not-a-histogram")).isLeft,
       )
     },
+    test("rejects a payload whose range or precision is not the one merge assumes") {
+      // `decodeFromCompressedByteBuffer` takes a *floor* on the highest trackable value, so a
+      // wider or differently-quantised histogram -- a driver on another build -- decodes happily
+      // and only fails later: `add` throws on a value past the fixed merge target's range, and a
+      // precision mismatch re-buckets the counts, so the merged quantiles stop being the measured
+      // ones while still being reported as lossless.
+      def encodeOf(histogram: org.HdrHistogram.Histogram) =
+        HistogramWire.encode(HistogramSample(proxyStep, histogram))
+
+      val wider = org.HdrHistogram.Histogram(
+        LatencyRecorder.lowestDiscernibleMicros,
+        LatencyRecorder.highestTrackableMicros * 10L,
+        LatencyRecorder.significantDigits,
+      )
+      wider.recordValue(LatencyRecorder.highestTrackableMicros * 5L)
+
+      val coarser = org.HdrHistogram.Histogram(
+        LatencyRecorder.lowestDiscernibleMicros,
+        LatencyRecorder.highestTrackableMicros,
+        LatencyRecorder.significantDigits - 1,
+      )
+      coarser.recordValue(1000L)
+
+      assertTrue(
+        HistogramWire.decode(encodeOf(wider)).isLeft,
+        HistogramWire.decode(encodeOf(coarser)).isLeft,
+        // The geometry this build writes still round-trips.
+        HistogramWire.decode(HistogramWire.encode(driverOne)).isRight,
+      )
+    },
     test("summing consecutive interval snapshots equals one histogram over the whole run") {
       val values = (1L to 200L).toList
       val whole = LatencyRecorder.emptyHistogram

--- a/loadgen/src/test/scala/versola/loadgen/metrics/HistogramWireSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/metrics/HistogramWireSpec.scala
@@ -1,0 +1,158 @@
+package versola.loadgen.metrics
+
+import zio.json.*
+import zio.test.*
+import zio.{Chunk, Duration}
+
+import java.time.Instant
+
+object HistogramWireSpec extends ZIOSpecDefault:
+
+  private val proxyStep = MeasurementId.Step("mobile-otp", "proxy-accounts")
+  private val loginFlow = MeasurementId.Flow("full-login")
+
+  private def histogramOf(values: (Long, Long)*): org.HdrHistogram.Histogram =
+    val histogram = LatencyRecorder.emptyHistogram
+    values.foreach { case (value, count) => histogram.recordValueWithCount(value, count) }
+    histogram
+
+  /** Two drivers, one measurement, and an answer that does not depend on this implementation:
+    * 100 samples of exactly 1,000 µs and 100 of exactly 2,000 µs. Both values are below 2,048, so
+    * with 3 significant digits (2,048 sub-buckets) every bucket in that range is one microsecond
+    * wide and HdrHistogram stores them exactly -- no quantisation to reason about.
+    *
+    * The merged set of 200 samples therefore has count 200, min 1,000, max 2,000, mean 1,500, and
+    * a median of 1,000 (the 100th of 200 ordered samples is the last of the 1,000s). p90 and p99
+    * fall in the upper half, so both are 2,000.
+    */
+  private val driverOne = HistogramSample(proxyStep, histogramOf(1000L -> 100L))
+  private val driverTwo = HistogramSample(proxyStep, histogramOf(2000L -> 100L))
+
+  def spec = suite("HistogramWire")(
+    test("merges two drivers' histograms into the union of their samples") {
+      val merged = HistogramWire.merge(List(driverOne, driverTwo))
+      val histogram = merged(proxyStep)
+      assertTrue(
+        merged.keySet == Set(proxyStep),
+        histogram.getTotalCount == 200L,
+        histogram.getCountAtValue(1000L) == 100L,
+        histogram.getCountAtValue(2000L) == 100L,
+        histogram.getMinValue == 1000L,
+        histogram.getMaxValue == 2000L,
+        histogram.getMean == 1500.0,
+        histogram.getValueAtPercentile(50.0) == 1000L,
+        histogram.getValueAtPercentile(90.0) == 2000L,
+        histogram.getValueAtPercentile(99.0) == 2000L,
+      )
+    },
+    test("merging leaves the inputs intact for the per-driver view") {
+      val _ = HistogramWire.merge(List(driverOne, driverTwo))
+      assertTrue(
+        driverOne.histogram.getTotalCount == 100L,
+        driverOne.histogram.getMaxValue == 1000L,
+        driverTwo.histogram.getTotalCount == 100L,
+        driverTwo.histogram.getMinValue == 2000L,
+      )
+    },
+    test("merges measurements independently") {
+      val merged = HistogramWire.merge(
+        List(driverOne, driverTwo, HistogramSample(loginFlow, histogramOf(7000L -> 3L))),
+      )
+      assertTrue(
+        merged.keySet == Set(proxyStep, loginFlow),
+        merged(proxyStep).getTotalCount == 200L,
+        merged(loginFlow).getTotalCount == 3L,
+      )
+    },
+    test("summarises the merged histogram in microseconds") {
+      val summary = HistogramWire.summarise(proxyStep, HistogramWire.merge(List(driverOne, driverTwo))(proxyStep))
+      assertTrue(
+        summary == LatencySummary(
+          id = proxyStep,
+          count = 200L,
+          minMicros = 1000L,
+          maxMicros = 2000L,
+          meanMicros = 1500.0,
+          p50Micros = 1000L,
+          p90Micros = 2000L,
+          p95Micros = 2000L,
+          p99Micros = 2000L,
+          p999Micros = 2000L,
+        ),
+      )
+    },
+    test("a snapshot round-trips through the wire format unchanged") {
+      val sample = HistogramSample(proxyStep, histogramOf(1000L -> 100L, 2000L -> 100L, 47_000L -> 5L))
+      val encoded = HistogramWire.encode(sample)
+      val decoded = HistogramWire.decode(encoded)
+      assertTrue(
+        encoded.unit == "microseconds",
+        encoded.count == 205L,
+        decoded.map(_.id) == Right(proxyStep),
+        decoded.map(_.histogram.getTotalCount) == Right(205L),
+        decoded.map(_.histogram.getCountAtValue(1000L)) == Right(100L),
+        decoded.map(_.histogram.getValueAtPercentile(99.0)) == Right(sample.histogram.getValueAtPercentile(99.0)),
+        decoded.map(_.histogram.equals(sample.histogram)) == Right(true),
+      )
+    },
+    test("a full driver report round-trips through JSON and merges to the same numbers") {
+      val report = HistogramWire.report(
+        campaign = "c3-10m-steady",
+        driverId = "loadgen-driver-2",
+        capturedAt = Instant.parse("2026-09-10T18:00:00Z"),
+        samples = Chunk(driverOne, HistogramSample(loginFlow, histogramOf(7000L -> 3L))),
+      )
+      val json = report.toJson
+      val parsed = json.fromJson[DriverHistogramReport]
+      val samples = parsed.left.map(_.toString).flatMap(HistogramWire.decodeReport)
+      val merged = samples.map(HistogramWire.merge)
+      assertTrue(
+        report.version == HistogramWire.version,
+        parsed.map(_.campaign) == Right("c3-10m-steady"),
+        parsed.map(_.driverId) == Right("loadgen-driver-2"),
+        parsed.map(_.capturedAtEpochMillis) == Right(Instant.parse("2026-09-10T18:00:00Z").toEpochMilli),
+        merged.map(_(proxyStep).getTotalCount) == Right(100L),
+        merged.map(_(proxyStep).getValueAtPercentile(50.0)) == Right(1000L),
+        merged.map(_(loginFlow).getTotalCount) == Right(3L),
+      )
+    },
+    test("rejects a report from a future wire version instead of guessing at it") {
+      val report = HistogramWire
+        .report("c3", "driver-0", Instant.EPOCH, Chunk(driverOne))
+        .copy(version = HistogramWire.version + 1)
+      assertTrue(HistogramWire.decodeReport(report).isLeft)
+    },
+    test("rejects a payload whose count disagrees with its envelope") {
+      val tampered = HistogramWire.encode(driverOne).copy(count = 99L)
+      assertTrue(HistogramWire.decode(tampered).isLeft)
+    },
+    test("rejects an unknown unit and an unreadable payload") {
+      val encoded = HistogramWire.encode(driverOne)
+      assertTrue(
+        HistogramWire.decode(encoded.copy(unit = "milliseconds")).isLeft,
+        HistogramWire.decode(encoded.copy(encoding = "not-a-histogram")).isLeft,
+      )
+    },
+    test("summing consecutive interval snapshots equals one histogram over the whole run") {
+      val values = (1L to 200L).toList
+      val whole = LatencyRecorder.emptyHistogram
+      values.foreach(whole.recordValue)
+      val firstInterval = histogramOf(values.take(120).map(_ -> 1L)*)
+      val secondInterval = histogramOf(values.drop(120).map(_ -> 1L)*)
+      val merged = HistogramWire.merge(
+        List(HistogramSample(proxyStep, firstInterval), HistogramSample(proxyStep, secondInterval)),
+      )(proxyStep)
+      assertTrue(
+        merged.getTotalCount == whole.getTotalCount,
+        merged.getValueAtPercentile(50.0) == whole.getValueAtPercentile(50.0),
+        merged.getValueAtPercentile(99.0) == whole.getValueAtPercentile(99.0),
+        merged.equals(whole),
+      )
+    },
+    test("converts durations to the microseconds the report is stated in") {
+      assertTrue(
+        HistogramWire.micros(Duration.fromMillis(120)) == 120_000L,
+        HistogramWire.micros(Duration.fromMillis(15)) == 15_000L,
+      )
+    },
+  )

--- a/loadgen/src/test/scala/versola/loadgen/metrics/LatencyRecorderSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/metrics/LatencyRecorderSpec.scala
@@ -1,0 +1,97 @@
+package versola.loadgen.metrics
+
+import zio.test.*
+import zio.{Duration, ZIO}
+
+import java.time.Instant
+
+object LatencyRecorderSpec extends ZIOSpecDefault:
+
+  private val step = MeasurementId.Step("mobile-otp", "token-refresh")
+  private val flow = MeasurementId.Flow("refresh")
+
+  private def latency(millis: Long): IntendedLatency =
+    IntendedLatency.unsafe(Duration.fromMillis(millis))
+
+  private def sampleFor(samples: zio.Chunk[HistogramSample], id: MeasurementId): org.HdrHistogram.Histogram =
+    samples.collectFirst { case HistogramSample(`id`, histogram) => histogram }.get
+
+  def spec = suite("LatencyRecorder")(
+    test("records per measurement, in microseconds") {
+      for
+        recorder <- LatencyRecorder.make
+        _ <- ZIO.foreachDiscard(List(10L, 10L, 20L))(millis => recorder.record(step, latency(millis)))
+        _ <- recorder.record(flow, latency(300))
+        samples <- recorder.snapshot
+        stepHistogram = sampleFor(samples, step)
+        flowHistogram = sampleFor(samples, flow)
+      yield assertTrue(
+        samples.size == 2,
+        stepHistogram.getTotalCount == 3L,
+        stepHistogram.getCountAtValue(10_000L) == 2L,
+        // Compared through `valuesAreEquivalent` because 3 significant digits quantise anything
+        // above 2,048 µs into a bucket a few microseconds wide; the bucket is the measurement.
+        stepHistogram.valuesAreEquivalent(stepHistogram.getValueAtPercentile(100.0), 20_000L),
+        flowHistogram.getTotalCount == 1L,
+        flowHistogram.valuesAreEquivalent(flowHistogram.getValueAtPercentile(100.0), 300_000L),
+      )
+    },
+    test("consecutive snapshots partition the recorded values rather than repeating them") {
+      for
+        recorder <- LatencyRecorder.make
+        _ <- ZIO.foreachDiscard(1 to 5)(_ => recorder.record(step, latency(10)))
+        first <- recorder.snapshot
+        _ <- ZIO.foreachDiscard(1 to 3)(_ => recorder.record(step, latency(10)))
+        second <- recorder.snapshot
+        third <- recorder.snapshot
+      yield assertTrue(
+        sampleFor(first, step).getTotalCount == 5L,
+        sampleFor(second, step).getTotalCount == 3L,
+        sampleFor(third, step).getTotalCount == 0L,
+      )
+    },
+    test("clamps a latency past the tracked range and counts the clamp") {
+      val clamped = zio.metrics.Metric.counter("loadgen_latency_clamped_total")
+      for
+        recorder <- LatencyRecorder.make
+        before <- clamped.value.map(_.count)
+        _ <- recorder.record(step, IntendedLatency.unsafe(Duration.fromSeconds(120)))
+        after <- clamped.value.map(_.count)
+        samples <- recorder.snapshot
+        histogram = sampleFor(samples, step)
+      yield assertTrue(
+        histogram.getTotalCount == 1L,
+        histogram.valuesAreEquivalent(histogram.getMaxValue, LatencyRecorder.highestTrackableMicros),
+        after - before == 1.0,
+      )
+    },
+    test("records a sub-microsecond latency at the lowest discernible value") {
+      for
+        recorder <- LatencyRecorder.make
+        _ <- recorder.record(step, IntendedLatency.unsafe(Duration.fromNanos(400)))
+        samples <- recorder.snapshot
+      yield assertTrue(sampleFor(samples, step).getMaxValue == LatencyRecorder.lowestDiscernibleMicros)
+    },
+    test("measures from the intended start, not from when the request actually went out") {
+      val intendedStart = Instant.parse("2026-09-10T18:00:00Z")
+      val actualStart = intendedStart.plusMillis(80)
+      val completedAt = actualStart.plusMillis(45)
+      assertTrue(
+        IntendedLatency.between(intendedStart, completedAt).toDuration == Duration.fromMillis(125),
+        IntendedLatency.between(intendedStart, completedAt).micros == 125_000L,
+        IntendedLatency.between(intendedStart, completedAt).seconds == 0.125,
+      )
+    },
+    test("a completion before its intended start reads as zero, not as a negative latency") {
+      val intendedStart = Instant.parse("2026-09-10T18:00:00Z")
+      assertTrue(IntendedLatency.between(intendedStart, intendedStart.minusMillis(5)).toDuration == Duration.Zero)
+    },
+    test("the tracked range and precision are the ones the spec fixes") {
+      assertTrue(
+        LatencyRecorder.lowestDiscernibleMicros == 1L,
+        LatencyRecorder.highestTrackableMicros == 60_000_000L,
+        LatencyRecorder.significantDigits == 3,
+        LatencyRecorder.emptyHistogram.getNumberOfSignificantValueDigits == 3,
+      )
+    },
+  )

--- a/loadgen/src/test/scala/versola/loadgen/metrics/LoadgenMetricsSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/metrics/LoadgenMetricsSpec.scala
@@ -110,7 +110,7 @@ object LoadgenMetricsSpec extends ZIOSpecDefault:
           busyUsers = 4_200,
           inflightRequests = 93,
           storeFlushDroppedTotal = 0L,
-          cpuUtilisation = Some(0.31),
+          cpuRatio = Some(0.31),
         )
         for
           reporter <- DriverHealthReporter.make(healthSource(ZIO.succeed(sample)))
@@ -118,7 +118,7 @@ object LoadgenMetricsSpec extends ZIOSpecDefault:
           lag <- gauge("loadgen_schedule_lag_seconds", "scenario" -> "steady-mobile")
           busy <- gauge("loadgen_busy_users")
           inflight <- gauge("loadgen_inflight_requests")
-          cpu <- gauge("loadgen_driver_cpu_utilisation")
+          cpu <- gauge("loadgen_driver_cpu_ratio")
         yield assertTrue(lag == 0.12, busy == 4200.0, inflight == 93.0, cpu == 0.31)
       },
       test("turns the store's cumulative dropped count into counter increments") {
@@ -153,12 +153,20 @@ object LoadgenMetricsSpec extends ZIOSpecDefault:
           )
           _ <- LoadgenMetrics.driverCpu(0.77)
           _ <- reporter.publish
-          cpu <- gauge("loadgen_driver_cpu_utilisation")
+          cpu <- gauge("loadgen_driver_cpu_ratio")
         yield assertTrue(cpu == 0.77)
       },
-      test("the process CPU reading, when present, is a fraction of one pod") {
-        for reading <- ProcessCpu.utilisation
-        yield assertTrue(reading.forall(load => load >= 0.0 && load <= 1.0))
+      test("the process CPU reading needs two samples, and is a fraction of this pod's allocation") {
+        // A single reading has nothing to difference, so the honest answer is None rather than a
+        // 0.0 that would read as a perfectly idle driver. The magnitude cannot be asserted on a
+        // shared build box; the scale can -- and the scale is the point, since the old
+        // `getProcessCpuLoad` divided by every core on the node and so could never reach the 40%
+        // gate on a large one.
+        for
+          cpu <- ProcessCpu.make
+          first <- cpu.ratio
+          second <- cpu.ratio
+        yield assertTrue(first.isEmpty, second.forall(ratio => ratio >= 0.0 && ratio <= 1.0))
       },
     ) @@ TestAspect.sequential,
   ) @@ TestAspect.sequential

--- a/loadgen/src/test/scala/versola/loadgen/metrics/LoadgenMetricsSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/metrics/LoadgenMetricsSpec.scala
@@ -1,0 +1,164 @@
+package versola.loadgen.metrics
+
+import versola.loadgen.protocol.RefreshRejection
+import zio.metrics.{Metric, MetricLabel}
+import zio.test.*
+import zio.{Duration, Ref, UIO, ZIO}
+
+/** Asserts the Prometheus surface's shape: metric names, label sets and label values, plus the
+  * counter/gauge distinction. Scenario and step names are made unique per test because the metric
+  * registry is process-wide and specs share a JVM -- the same reason `AuthMetricsSpec` does it.
+  */
+object LoadgenMetricsSpec extends ZIOSpecDefault:
+
+  private def labelSet(labels: Seq[(String, String)]): Set[MetricLabel] =
+    labels.map { case (name, value) => MetricLabel(name, value) }.toSet
+
+  private def counter(name: String, labels: (String, String)*): UIO[Double] =
+    Metric.counter(name).tagged(labelSet(labels)).value.map(_.count)
+
+  private def histogramCount(name: String, labels: (String, String)*): UIO[Double] =
+    Metric.histogram(name, LoadgenMetrics.latencyBoundaries)
+      .tagged(labelSet(labels))
+      .value
+      .map(_.count.toDouble)
+
+  private def gauge(name: String, labels: (String, String)*): UIO[Double] =
+    Metric.gauge(name).tagged(labelSet(labels)).value.map(_.value)
+
+  private def unique(prefix: String): UIO[String] =
+    zio.Random.nextUUID.map(id => s"$prefix-$id")
+
+  private def healthSource(reading: UIO[DriverHealthSample]): DriverHealthSource =
+    new DriverHealthSource:
+      override def sample: UIO[DriverHealthSample] = reading
+
+  def spec = suite("LoadgenMetrics")(
+    test("counts arrivals per scenario") {
+      for
+        scenario <- unique("arrivals")
+        _ <- LoadgenMetrics.arrival(scenario)
+        _ <- LoadgenMetrics.arrival(scenario)
+        count <- counter("loadgen_arrivals_total", "scenario" -> scenario)
+      yield assertTrue(count == 2.0)
+    },
+    test("a completed step is timed and counted in the same call") {
+      for
+        scenario <- unique("step")
+        _ <- LoadgenMetrics.stepCompleted(scenario, "proxy-accounts", StepOutcome.ok, IntendedLatency.unsafe(Duration.fromMillis(12)))
+        timed <- histogramCount("loadgen_step_duration_seconds", "scenario" -> scenario, "step" -> "proxy-accounts", "outcome" -> "ok")
+        counted <- counter("loadgen_outcomes_total", "scenario" -> scenario, "outcome" -> "ok")
+      yield assertTrue(timed == 1.0, counted == 1.0)
+    },
+    test("a step-up outcome is labelled stepup and never lands in a failure bucket") {
+      for
+        scenario <- unique("stepup")
+        _ <- LoadgenMetrics.stepCompleted(scenario, "pay-p2p", StepOutcome.Planned(PlannedOutcome.StepUp), IntendedLatency.unsafe(Duration.fromMillis(30)))
+        stepup <- counter("loadgen_outcomes_total", "scenario" -> scenario, "outcome" -> "stepup")
+        transport <- counter("loadgen_outcomes_total", "scenario" -> scenario, "outcome" -> "transport")
+        unexpected <- counter("loadgen_outcomes_total", "scenario" -> scenario, "outcome" -> "unexpected_status")
+      yield assertTrue(stepup == 1.0, transport == 0.0, unexpected == 0.0)
+    },
+    test("a completed flow is timed but stays out of the step taxonomy") {
+      for
+        flow <- unique("flow")
+        _ <- LoadgenMetrics.flowCompleted(flow, StepOutcome.ok, IntendedLatency.unsafe(Duration.fromMillis(7)))
+        timed <- histogramCount("loadgen_flow_duration_seconds", "flow" -> flow, "outcome" -> "ok")
+        counted <- counter("loadgen_outcomes_total", "scenario" -> flow, "outcome" -> "ok")
+      yield assertTrue(timed == 1.0, counted == 0.0)
+    },
+    test("schedule lag is a gauge in seconds, per scenario") {
+      for
+        scenario <- unique("lag")
+        _ <- LoadgenMetrics.scheduleLag(scenario, Duration.fromMillis(180))
+        lag <- gauge("loadgen_schedule_lag_seconds", "scenario" -> scenario)
+      yield assertTrue(lag == 0.18)
+    },
+    test("refresh rejections are labelled by a bounded reason") {
+      for
+        before <- counter("loadgen_refresh_rejected_total", "reason" -> "unknown")
+        _ <- LoadgenMetrics.refreshRejected(RefreshRejection.Unknown("invalid_grant: reuse of a rotated token"))
+        after <- counter("loadgen_refresh_rejected_total", "reason" -> "unknown")
+        exchanged <- counter("loadgen_refresh_rejected_total", "reason" -> "already_exchanged")
+        _ <- LoadgenMetrics.refreshRejected(RefreshRejection.AlreadyExchanged)
+        exchangedAfter <- counter("loadgen_refresh_rejected_total", "reason" -> "already_exchanged")
+      yield assertTrue(after - before == 1.0, exchangedAfter - exchanged == 1.0)
+    },
+    test("population is a gauge per state") {
+      for
+        _ <- LoadgenMetrics.population(PopulationState.Planned, 1_000_000L)
+        _ <- LoadgenMetrics.population(PopulationState.Registered, 998_431L)
+        _ <- LoadgenMetrics.population(PopulationState.Broken, 12L)
+        planned <- gauge("loadgen_population", "state" -> "planned")
+        registered <- gauge("loadgen_population", "state" -> "registered")
+        broken <- gauge("loadgen_population", "state" -> "broken")
+      yield assertTrue(planned == 1_000_000.0, registered == 998_431.0, broken == 12.0)
+    },
+    test("dropped write-behind rows only ever move the counter forward") {
+      for
+        before <- counter("loadgen_store_flush_dropped_total")
+        _ <- LoadgenMetrics.storeFlushDropped(4L)
+        _ <- LoadgenMetrics.storeFlushDropped(0L)
+        _ <- LoadgenMetrics.storeFlushDropped(-3L)
+        after <- counter("loadgen_store_flush_dropped_total")
+      yield assertTrue(after - before == 4.0)
+    },
+    suite("DriverHealthReporter")(
+      test("publishes every driver-health reading of the spec") {
+        val sample = DriverHealthSample(
+          scheduleLagByScenario = Map("steady-mobile" -> Duration.fromMillis(120)),
+          busyUsers = 4_200,
+          inflightRequests = 93,
+          storeFlushDroppedTotal = 0L,
+          cpuUtilisation = Some(0.31),
+        )
+        for
+          reporter <- DriverHealthReporter.make(healthSource(ZIO.succeed(sample)))
+          _ <- reporter.publish
+          lag <- gauge("loadgen_schedule_lag_seconds", "scenario" -> "steady-mobile")
+          busy <- gauge("loadgen_busy_users")
+          inflight <- gauge("loadgen_inflight_requests")
+          cpu <- gauge("loadgen_driver_cpu_utilisation")
+        yield assertTrue(lag == 0.12, busy == 4200.0, inflight == 93.0, cpu == 0.31)
+      },
+      test("turns the store's cumulative dropped count into counter increments") {
+        for
+          cumulative <- Ref.make(0L)
+          reporter <- DriverHealthReporter.make(
+            healthSource(
+              cumulative.get.map(dropped => DriverHealthSample(Map.empty, 0, 0, dropped, None)),
+            ),
+          )
+          before <- counter("loadgen_store_flush_dropped_total")
+          _ <- cumulative.set(7L) *> reporter.publish
+          afterFirst <- counter("loadgen_store_flush_dropped_total")
+          _ <- cumulative.set(11L) *> reporter.publish
+          afterSecond <- counter("loadgen_store_flush_dropped_total")
+          // The store's own counter restarting must not read as progress.
+          _ <- cumulative.set(2L) *> reporter.publish
+          afterReset <- counter("loadgen_store_flush_dropped_total")
+          _ <- cumulative.set(5L) *> reporter.publish
+          afterRebaseline <- counter("loadgen_store_flush_dropped_total")
+        yield assertTrue(
+          afterFirst - before == 7.0,
+          afterSecond - before == 11.0,
+          afterReset - before == 11.0,
+          afterRebaseline - before == 14.0,
+        )
+      },
+      test("leaves the CPU gauge alone when the JVM has no answer yet") {
+        for
+          reporter <- DriverHealthReporter.make(
+            healthSource(ZIO.succeed(DriverHealthSample(Map.empty, 0, 0, 0L, None))),
+          )
+          _ <- LoadgenMetrics.driverCpu(0.77)
+          _ <- reporter.publish
+          cpu <- gauge("loadgen_driver_cpu_utilisation")
+        yield assertTrue(cpu == 0.77)
+      },
+      test("the process CPU reading, when present, is a fraction of one pod") {
+        for reading <- ProcessCpu.utilisation
+        yield assertTrue(reading.forall(load => load >= 0.0 && load <= 1.0))
+      },
+    ) @@ TestAspect.sequential,
+  ) @@ TestAspect.sequential


### PR DESCRIPTION
Closes #275. Part of #267.

> Base branch is `feat/loadgen-contracts` (W1, #265), itself stacked on `feat/loadgen-skeleton` (W0, #264). Merge order: #264 → #265 → this.

Track F: the track that decides whether the reported p99 means anything.

## What this adds

`loadgen/src/main/scala/versola/loadgen/metrics/`

- `Measurement.scala` — `MeasurementId` (Step/Flow) and the `IntendedLatency` opaque type.
- `ErrorTaxonomy.scala` — `PlannedOutcome`, `FailedOutcome`, `StepOutcome`, the tally/merge/budget arithmetic, `RefreshRejectionLabel`.
- `LoadgenMetrics.scala` — the §11 Prometheus surface, `PopulationState`.
- `LatencyRecorder.scala` — HdrHistogram sink (1 µs–60 s, 3 significant digits) + `HistogramSample`.
- `HistogramWire.scala` — `EncodedHistogram`, `DriverHistogramReport`, `LatencySummary`, encode/decode/merge/summarise.
- `DriverHealth.scala` — `DriverHealthSample`, `DriverHealthSource`, `ProcessCpu`, `DriverHealthReporter`.
- `CampaignReport.scala` — `AcceptanceThresholds`, `CampaignHealth`, `ReportCheck`, `CampaignReport.assemble`.

## The outcome/failure split is enforced structurally, not by convention

Counting `StepUpRequired` against the error budget is the most common way a load report becomes unreadable, so this does not rely on anyone remembering:

1. **Two disjoint enums with no supertype and no conversion.** `PlannedOutcome` (`ok`, `stepup`, `forbidden`, `unauthorized`) and `FailedOutcome` (`transport`, `unexpected_status`, `malformed`, `refresh_rejected`). `StepOutcome` is the only thing holding either, and it tags which side it came from.
2. **The error budget is a function of `Map[FailedOutcome, Long]` alone**, and `FailedOutcome` has no inhabitant meaning "step-up required" — so passing one in is not expressible at the type level. The old failure mode ("sum all outcomes, remember to subtract three buckets") is gone.
3. **One exhaustive classifier, no `case _`.** `StepOutcome.of(error: ProtocolError)` is the single place the ADT becomes a taxonomy class; the wildcard is deliberately absent, so a new `ProtocolError` case warns there rather than being silently filed into whichever bucket it was written beside.

Caveat that could not be closed from inside this track: `commonSettings` has no `-Xfatal-warnings`, so (3) is a warning rather than a hard error. `ErrorTaxonomySpec` lists all seven constructors by name as the backstop; making it fatal is a `build.sbt` change.

## Histogram wire format

```
DriverHistogramReport { version, campaign, driverId, capturedAtEpochMillis, histograms: [ EncodedHistogram ] }
EncodedHistogram      { id: MeasurementId, unit: "microseconds", count, encoding }
```

`encoding` is HdrHistogram's own compressed V2 payload, base64url'd (JSON- and text-column-safe). **Quantiles are never shipped** — only bucket counts, because counts add and quantiles do not. `unit` and `count` are redundant with the payload on purpose: a truncated payload decodes into a plausible histogram of the wrong size, and `decode` rejects that.

The merge arithmetic is checked against an independently stated answer rather than against itself: 100 samples of exactly 1,000 µs from one driver and 100 of exactly 2,000 µs from another, both below 2,048 where 3 significant digits give one-microsecond buckets — so the merged set must have count 200, min 1,000, max 2,000, mean 1,500, median 1,000 (the 100th of 200 ordered samples) and p90 = p95 = p99 = 2,000. Also asserted: merging does not mutate the inputs (the coordinator keeps them for the per-driver view), a `count` disagreeing with its payload is rejected, and an unknown `unit` / non-base64 payload / future `version` are rejected rather than guessed at.

## Verified

`sbt "loadgen/compile" "loadgen/Test/compile" "loadgen/test"` — **51 new tests pass**. Also verified against the other three Phase 1 tracks merged together (#270, #272, #273): 125 loadgen + 19 mockapi tests, no conflicts.

## Integration points — one call each

```scala
DriverHealthSource.from(
  scheduleLagByScenario  = scheduler.scheduleLagByScenario, // track D: UIO[Map[String, Duration]]
  busyUsers              = driver.busyUsers,
  inflightRequests       = driver.inflightRequests,
  storeFlushDroppedTotal = store.flushDroppedTotal,         // track C: UIO[Long]
)
```

- **Track D (#273)** — lag keyed by scenario name (a config-derived label, never a user/session id). More importantly: the scheduler is the only component that knows `intendedStart`, so the work item it hands the driver must carry it. `IntendedLatency.between(intendedStart, completedAt)` is the only constructor besides an explicit `unsafe`, so the coordinated-omission correction cannot be dropped by accident.
- **Track C (#272)** — cumulative dropped rows, monotonic within a process. The reporter treats a decrease as a restart (re-baselines, adds nothing), so a re-created buffer does not invent dropped rows.

## Needs a decision

1. **§11's outcome label list has no bucket for `RefreshRejected`.** Taken literally, refresh rejections would sit outside the taxonomy *and* outside the error budget's denominator — contradicting §7.4, which treats them as the campaign's most important failure. Added as an eighth `loadgen_outcomes_total` value **and** kept the dedicated `loadgen_refresh_rejected_total{reason}` counter. If the intent was the dedicated counter only, this is the line to change.
2. **§11 has no driver-CPU metric, but §15's definition of done asserts "driver CPU < 40%".** Named `loadgen_driver_cpu_utilisation`, a fraction in `[0,1]` of the process's own allocation. The name is invented; review it before dashboards depend on it.
3. **"histogram (native/exponential)" is not available.** `zio-metrics-connectors-prometheus` emits classic bucketed histograms only; used exponential boundaries (1 ms doubling, 17 buckets). Native histograms need a different exporter — a dependency change, so this stopped here.
4. **The design doc's "edge proxy p99 ≤ backend p99 + 15 ms" cannot be evaluated from driver-side data as written.** It needs a campaign-wide p99 for `mockapi`'s own service time, and `mockapi` deliberately ships no `util`-based metrics handoff (#264). Either the driver measures `targets.mockUrl` directly (the config field exists, so this is possible) or `mockapi` needs a minimal handoff — note that track A (#270) *does* now expose `mockapi_delay_seconds`, which may satisfy this via scraping. Implemented as `RelativeLatencyThreshold` with both measurement ids caller-supplied; if the backend measurement never arrives, the report lists the criterion under `notEvaluated` and does **not** pass the campaign.
5. **Thresholds have no configuration home.** `AcceptanceThresholds.designDefaults(…)` encodes §6.7/§15's prose numbers, with measurement ids as parameters because the naming is track E's. **Config fields this track wants but did not add** (`LoadgenConfig` was shared surface while three agents worked in parallel): `metrics.snapshot-interval` (60 s per §11), `metrics.health-publish-interval`, a stable `driver.id` for the report envelope, and a `campaign.acceptance` block.
6. **§11 requires snapshots "written to the emulator DB every 60 s" but names no table.** This track's side ends at the wire format; the table belongs to track C (#272).
7. **`RefreshRejection.Unknown(detail)` carries free text from the SUT's response.** As a label value that would let the SUT dictate this metric's cardinality, so it collapses to `reason="unknown"` and the detail stays in logs. Worth stating in §11's cardinality paragraph, which currently only forbids ids and paths.
8. **A latency above 60 s cannot be recorded**, and clamping it is invisible in the quantiles — so clamped samples are counted in `loadgen_latency_clamped_total` (not in §11). Non-zero means the report's tail is a floor, not a measurement.

## Not verified

- No end-to-end scrape of `/metrics` through `VersolaApp`'s diagnostics port; assertions go against the in-process zio-metrics registry, as `AuthMetricsSpec` and `ObservabilitySpec` already do. Metric names and labels are asserted; the Prometheus text rendering is not.
- `ProcessCpu.utilisation` is only asserted to be `None` or within `[0,1]` — a 1-core build box with three other agents compiling cannot produce a meaningful reading.
- Nothing is wired into `Main.scala` or the driver loop (other tracks' packages), and no config field was added.
- CI still does not compile this module (see #264's `workflow`-scope blocker).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M250N18RAS1VTZXQM135Q2DV&panel=chat)