### PR TITLE
util-postgres: let a caller name the config block its pool reads

### DIFF
--- a/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresHikariDataSource.scala
+++ b/util/implementations/postgres/src/main/scala/versola/util/postgres/PostgresHikariDataSource.scala
@@ -11,15 +11,31 @@ import java.nio.file.{Files, Paths}
 import java.util.concurrent.locks.ReentrantLock
 
 object PostgresHikariDataSource:
+  /** @param configPath
+    *   where this pool's `PostgresConfig` lives in the config file, as nested block names.
+    *   Defaults to the top-level `postgres { }` block every service uses. A process that talks
+    *   to more than one database needs one pool per database and therefore one block per pool:
+    *   `loadgen` has its own bookkeeping store (`store { postgres { } }`) *and*, in its seeder
+    *   role, the system under test's database -- two different hosts, users and pool sizes that
+    *   a single `postgres { }` block cannot express.
+    */
   def transactor(
       serviceName: Option[String],
       migrate: Boolean,
       validateOnMigrate: Boolean = true,
       migrationLocations: Option[Seq[String]] = None,
+      configPath: Seq[String] = Seq("postgres"),
   ): ZLayer[Scope & ConfigProvider, Throwable, TransactorZIO & HikariDataSource & PostgresConfig] =
-    ZLayer(ZIO.serviceWithZIO[ConfigProvider](_.load(Config.Nested("postgres", deriveConfig[PostgresConfig])))) >+>
+    ZLayer(ZIO.serviceWithZIO[ConfigProvider](_.load(nestedConfig(configPath)))) >+>
       layer(serviceName, migrate, validateOnMigrate, migrationLocations) >+>
       TransactorZIO.layer
+
+  /** `Config.Nested` applied right-to-left, so `Seq("store", "postgres")` reads
+    * `store.postgres`. An empty path reads a `PostgresConfig` at the root of the file, which no
+    * caller wants today but is the only sensible reading of "no enclosing blocks".
+    */
+  private[postgres] def nestedConfig(configPath: Seq[String]): Config[PostgresConfig] =
+    configPath.foldRight(deriveConfig[PostgresConfig])((name, inner) => Config.Nested(name, inner))
 
   /** Create a HikariDataSource layer with optional Flyway migration.
     *

--- a/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresConfigSpec.scala
+++ b/util/implementations/postgres/src/test/scala/versola/util/postgres/PostgresConfigSpec.scala
@@ -29,6 +29,11 @@ object PostgresConfigSpec extends ZIOSpecDefault:
       |  leak-detection-threshold = "0 seconds"
       |}""".stripMargin
 
+  private val nestedHocon =
+    s"""store {
+       |${fullHocon.linesIterator.map("  " + _).mkString("\n")}
+       |}""".stripMargin
+
   private val validConfig = PostgresConfig(
     url = "jdbc:postgresql://localhost:5432/auth",
     notificationsUrl = None,
@@ -64,6 +69,20 @@ object PostgresConfigSpec extends ZIOSpecDefault:
             |  password = "1234"
             |}""".stripMargin
         for result <- TypesafeConfigProvider.fromHoconString(incompleteHocon).kebabCase.load(postgresConfig).exit
+        yield assertTrue(result.isFailure)
+      },
+      test("reads the same block from a nested path, for a process with more than one pool") {
+        for config <- TypesafeConfigProvider
+            .fromHoconString(nestedHocon)
+            .kebabCase
+            .load(PostgresHikariDataSource.nestedConfig(Seq("store", "postgres")))
+        yield assertTrue(
+          config.url == "jdbc:postgresql://localhost:5432/auth",
+          config.maximumPoolSize == 15,
+        )
+      },
+      test("does not find a nested block at the default top-level path") {
+        for result <- TypesafeConfigProvider.fromHoconString(nestedHocon).kebabCase.load(postgresConfig).exit
         yield assertTrue(result.isFailure)
       },
       test("does not leak the raw password through toString (regression for #64)") {


### PR DESCRIPTION
Unblocks one of the two blockers on #288 (loadgen track C) — see [that PR's "cannot fix from inside its own scope" section](https://github.com/versolauth/versola/pull/288).

## The problem

`PostgresHikariDataSource.transactor` hardcodes the block it loads:

```scala
ZLayer(ZIO.serviceWithZIO[ConfigProvider](_.load(Config.Nested("postgres", deriveConfig[PostgresConfig]))))
```

That is right for auth/central/edge — one process, one database — and wrong for a process that talks to two. `loadgen` is that process twice over:

- the emulator's own bookkeeping store (`store { }` in dev spec §5), whose `UNLOGGED` tables and pool size have nothing to do with the SUT's;
- in its `seed` role (§10), the **system under test's** Postgres, which it `COPY`s 10–20M users into — a different host, user and pool size.

One unnamed `postgres { }` block cannot name both, and track C had no way to construct a `TransactorZIO` for the emulator's database at all as a result: its `StoreConfig` carried `url` + `maximum-pool-size` and nothing else, because inventing the credentials would have been guessing.

## The change

One parameter:

```scala
configPath: Seq[String] = Seq("postgres")
```

folded right through `Config.Nested`, so `Seq("store", "postgres")` reads `store.postgres`. The default leaves all four existing call sites (auth, central, edge, the `PostgresSpec` test layer) byte-identical — this is additive.

The alternative was for `loadgen` to hand-roll its own `HikariConfig` + Flyway wiring, which would have duplicated `validate` (the pool-tuning guard that exists because HikariCP silently corrects out-of-range values), the `Secret` handling that keeps the password out of `toString`, and the `migrate`-vs-`validate` decision this object documents at length. A parameter is cheaper than a second copy of all that.

## Verified

`sbt compile "tools/compile" "loadgen/compile" "mockapi/compile"` and `util-postgres/testOnly versola.util.postgres.PostgresConfigSpec` — **16 tests pass**, including two new ones: the same block read from `store.postgres`, and a nested block *not* being found at the default top-level path (so the default can't silently start matching more than it did).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M250N18RAS1VTZXQM135Q2DV&panel=chat)