### PR TITLE
loadgen: provisioner — clients, resources, roles, presets, challenge settings (E)

### DIFF
--- a/loadgen/src/main/resources/flows/phone-otp-auth-flow.json
+++ b/loadgen/src/main/resources/flows/phone-otp-auth-flow.json
@@ -1,0 +1,10 @@
+{
+  "primary": {
+    "credentials": ["phone"],
+    "inlinePassword": false,
+    "factors": [{ "type": "otp", "required": true }]
+  },
+  "passkey": null,
+  "equivalents": {},
+  "otpType": "sms"
+}

--- a/loadgen/src/main/resources/flows/phone-otp-password-auth-flow.json
+++ b/loadgen/src/main/resources/flows/phone-otp-password-auth-flow.json
@@ -1,0 +1,10 @@
+{
+  "primary": {
+    "credentials": ["phone"],
+    "inlinePassword": true,
+    "factors": [{ "type": "otp", "required": true }]
+  },
+  "passkey": null,
+  "equivalents": {},
+  "otpType": "sms"
+}

--- a/loadgen/src/main/resources/flows/phone-otp-password-registration-flow.json
+++ b/loadgen/src/main/resources/flows/phone-otp-password-registration-flow.json
@@ -1,0 +1,5 @@
+{
+  "credential": "phone",
+  "steps": [{ "type": "otp" }, { "type": "setPassword" }],
+  "roleIds": ["retail-user"]
+}

--- a/loadgen/src/main/resources/flows/phone-passkey-auth-flow.json
+++ b/loadgen/src/main/resources/flows/phone-passkey-auth-flow.json
@@ -1,0 +1,10 @@
+{
+  "primary": {
+    "credentials": ["phone"],
+    "inlinePassword": false,
+    "factors": [{ "type": "otp", "required": true }]
+  },
+  "passkey": { "factors": [] },
+  "equivalents": {},
+  "otpType": "sms"
+}

--- a/loadgen/src/main/scala/versola/loadgen/Main.scala
+++ b/loadgen/src/main/scala/versola/loadgen/Main.scala
@@ -1,8 +1,11 @@
 package versola.loadgen
 
+import versola.loadgen.config.{LoadgenConfig, LoadgenRole}
+import versola.loadgen.provision.Provisioner
 import versola.util.EnvName
 import versola.util.http.VersolaApp
 import zio.*
+import zio.config.magnolia.deriveConfig
 import zio.http.*
 import zio.telemetry.opentelemetry.tracing.Tracing
 
@@ -10,10 +13,9 @@ import zio.telemetry.opentelemetry.tracing.Tracing
   * §2, §12) -- which one this process plays is a config value (`role = coordinator | driver`),
   * not a build-time or CLI switch, so the same staged jar and image serve both.
   *
-  * This is the skeleton commit only: it wires `loadgen` into the build and proves out
-  * `VersolaApp`'s boot sequence (diagnostics port, `/liveness`, `/readiness`, graceful shutdown)
-  * for the module. Role dispatch, the full `LoadgenConfig` tree, and the real routes land with
-  * the `config`/`protocol`/`coordinator`/`driver` packages.
+  * `role = provision` is the one-shot subcommand of §10: it runs to completion and exits, so it
+  * takes over `run` rather than standing up the servers `VersolaApp` otherwise waits on forever.
+  * The remaining roles still land with the `coordinator`/`driver` packages.
   */
 object Main extends VersolaApp("loadgen"):
   val environmentTag = Tag[Environment]
@@ -24,6 +26,12 @@ object Main extends VersolaApp("loadgen"):
 
   override val dependencies: ZLayer[Scope & EnvName & ConfigProvider & Tracing & Client, Throwable, Dependencies] =
     ZLayer.succeed(())
+
+  override def run: ZIO[Environment & ZIOAppArgs & Scope, Any, Any] =
+    ZIO.serviceWithZIO[ConfigProvider](_.load(deriveConfig[LoadgenConfig])).flatMap: config =>
+      config.role match
+        case LoadgenRole.Provision => Provisioner.provision(config)
+        case _ => super.run
 
   override def routes: Routes[Dependencies & Tracing & EnvName, Throwable] =
     Routes(

--- a/loadgen/src/main/scala/versola/loadgen/config/LoadgenConfig.scala
+++ b/loadgen/src/main/scala/versola/loadgen/config/LoadgenConfig.scala
@@ -24,6 +24,7 @@ case class LoadgenConfig(
     session: SessionConfig,
     campaign: CampaignConfig,
     actions: List[BusinessActionConfig],
+    provision: Option[ProvisionConfig],
 )
 
 /** Which half of the `loadgen` binary this process runs. Same binary and image serve all four --
@@ -154,6 +155,62 @@ case class CampaignConfig(
     diurnal: DiurnalConfig,
     registration: RegistrationConfig,
 )
+
+/** What `loadgen provision` needs beyond [[TargetsConfig]] to write the campaign's configuration
+  * into central (versola-load-emulator-design.md §3). Optional for the same reason [[ShardConfig]]
+  * is: a driver or coordinator process holds no admin credentials and its config file omits the
+  * block entirely, which requiring it here would turn into a decode failure before role dispatch
+  * ever read `role`.
+  *
+  * Only what a deployment actually varies lives here. The campaign's own shape -- which clients
+  * exist, the ten endpoints, the permissions and the two roles -- is fixed by the design doc and
+  * lives in [[versola.loadgen.provision.CampaignBlueprint]], not in HOCON: it is the definition of
+  * the campaign, not a knob.
+  *
+  * @param paymentAmountThreshold the amount above which the payment endpoints' CEL access rule
+  *                               denies, in the minor unit the campaign's bodies carry
+  */
+case class ProvisionConfig(
+    tenantId: String,
+    /** Presented as the HTTP Basic password on central's configuration API -- the same base64url
+      * value e2e's `RESOURCE_SECRET` carries.
+      */
+    centralSecret: Config.Secret,
+    /** Presented as the HTTP Basic password on edge's service API. */
+    edgeSecret: Config.Secret,
+    /** Where the three mobile clients' authorization codes are redirected -- an app scheme, which
+      * central accepts for a native client but not over plain HTTP on a non-loopback host.
+      */
+    mobileRedirectUri: String,
+    resources: ProvisionResourcesConfig,
+    preset: ProvisionPresetConfig,
+    passkey: ProvisionPasskeyConfig,
+    paymentAmountThreshold: Long,
+)
+
+/** The three `mockapi`-backed resources' RFC 8707 identifiers, which are also the base URIs edge
+  * proxies to. One per resource rather than derived from `targets.mock-url`: central requires each
+  * to be absolute and path-less, so three resources on one `mockapi` need three authorities
+  * resolving to it, which only the deployment knows.
+  */
+case class ProvisionResourcesConfig(coreUri: String, payUri: String, notifyUri: String)
+
+/** The one edge login preset, for the `web-otp` client (design doc §2.2). `cookieDomain`/
+  * `cookiePath` scope the `EDGE_SESSION` cookie; both are optional in central, so both are
+  * `Option` here rather than silently defaulted to the whole origin.
+  */
+case class ProvisionPresetConfig(
+    id: String,
+    cookieDomain: Option[String],
+    cookiePath: Option[String],
+    postLogoutRedirectUri: Option[String],
+)
+
+/** WebAuthn relying-party settings for the tenant. `rpId` is a registrable domain suffix of
+  * `targets.origin`, which the authenticator signs against, so it cannot be derived from the
+  * origin URL without guessing where the site's boundary is.
+  */
+case class ProvisionPasskeyConfig(rpId: String, rpName: String, userVerification: String)
 
 /** One of the ten protected-resource actions of versola-load-emulator-design.md §3: a relative
   * weight, the HTTP method/path against edge, and the ACR it requires (`None` for actions with

--- a/loadgen/src/main/scala/versola/loadgen/protocol/AdminClient.scala
+++ b/loadgen/src/main/scala/versola/loadgen/protocol/AdminClient.scala
@@ -1,7 +1,6 @@
 package versola.loadgen.protocol
 
 import zio.Task
-import zio.json.ast.Json
 
 /** Bootstraps and administers the SUT's configuration -- clients, resources, roles,
   * permissions, auth-request presets, challenge settings -- plus the sync/outbox calls a
@@ -9,19 +8,22 @@ import zio.json.ast.Json
   * (§10); never wired into a driver, which is why this lives on its own trait rather than
   * folded into [[AuthClient]].
   *
-  * Request/response shapes are `Json.Obj` placeholders for now, not the ~55 concrete admin
-  * payloads e2e's `OAuthClient`/`Flows.scala` already encode. Track E replaces every one of
-  * these with a typed request built from the shared flow resource files under `flows`
-  * (§3.4) once it ports them; the point of this trait for now is the set of admin operations
-  * a campaign needs, not their exact wire shape.
+  * Every operation is a desired-state apply, not a create: `provision` runs against
+  * environments that are already provisioned at least as often as against empty ones, and one
+  * that failed halfway through has to be re-runnable. The `upsert*` names are the dev spec's
+  * (§4); `registerClient`/`registerResource` keep theirs but behave the same way.
   */
 trait AdminClient:
-  def registerClient(spec: Json.Obj): Task[ClientCreds]
-  def registerResource(spec: Json.Obj): Task[Unit]
-  def upsertRoles(spec: Json.Obj): Task[Unit]
-  def upsertPermissions(spec: Json.Obj): Task[Unit]
-  def upsertAuthRequestPresets(spec: Json.Obj): Task[Unit]
-  def upsertChallengeSettings(spec: Json.Obj): Task[Unit]
+  /** Answers the credentials a driver authenticates with, which for a confidential client means
+    * a secret this call is the only source of -- central hands one back on registration and
+    * never again.
+    */
+  def registerClient(spec: ClientSpec): Task[ClientCreds]
+  def registerResource(spec: ResourceSpec): Task[Unit]
+  def upsertRoles(specs: List[RoleSpec]): Task[Unit]
+  def upsertPermissions(specs: List[PermissionSpec]): Task[Unit]
+  def upsertAuthRequestPresets(spec: AuthRequestPresetsSpec): Task[Unit]
+  def upsertChallengeSettings(spec: ChallengeSettingsSpec): Task[Unit]
   def syncConfiguration(): Task[Unit]
   def syncEdgeConfiguration(): Task[Unit]
   def flushUserOutbox(): Task[Unit]

--- a/loadgen/src/main/scala/versola/loadgen/protocol/AdminSpecs.scala
+++ b/loadgen/src/main/scala/versola/loadgen/protocol/AdminSpecs.scala
@@ -1,0 +1,122 @@
+package versola.loadgen.protocol
+
+import zio.json.ast.Json
+
+import java.util.UUID
+
+// The typed admin requests [[AdminClient]] takes, one per central/edge admin operation a campaign
+// needs (versola-loadgen-dev-spec.md §4). Field-for-field these are central's own create/update
+// DTOs minus what a load campaign never varies: no localized descriptions (one English string),
+// no tenant per call (a campaign provisions one tenant, named once on the client), and no
+// secret-rotation or delete surface.
+//
+// `authFlow`/`registrationFlow` stay `Json`: they are the shared flow documents of §3.4, read
+// verbatim out of `loadgen/src/main/resources/flows/` so that the emulator and the e2e suite
+// cannot drift from central's schema independently. Re-typing that tree here would reintroduce
+// exactly the second definition §3.4 exists to prevent.
+
+/** @param publicClient registers a `native` client -- public, PKCE-only, never issued a secret
+  *                     (design doc §2.2: the three mobile clients). `false` registers a `web`
+  *                     client, which is confidential and gets one.
+  */
+case class ClientSpec(
+    clientId: String,
+    clientName: String,
+    redirectUris: Set[String],
+    allowedScopes: Set[String],
+    accessTokenTtlSeconds: Int,
+    refreshTokenTtlSeconds: Option[Int],
+    publicClient: Boolean,
+    authFlow: Json,
+    registrationFlow: Option[Json],
+    backChannelLogoutUri: Option[String],
+)
+
+/** One protected endpoint of a resource, relative to `/resources/{resourceId}` -- the part edge
+  * appends to the resource's base URI, `{name}` path templates included.
+  *
+  * `id` is what a [[PermissionSpec]] grants, so it must be the same value on every `provision`
+  * run; [[versola.loadgen.provision.CampaignBlueprint]] derives it from the endpoint's identity
+  * rather than drawing a fresh UUID.
+  *
+  * @param allow           CEL access rule, evaluated per request (design doc §3: the writes carry
+  *                        one so `checkRules` is on the measured path rather than a no-op)
+  * @param stepUpCondition CEL predicate deciding whether `stepUpAcr` applies at all
+  * @param stepUpAcr       space-separated ACR values, any one of which satisfies the endpoint
+  * @param maxAgeSeconds   RFC 9470 freshness bound on `auth_time`
+  */
+case class ResourceEndpointSpec(
+    id: UUID,
+    method: String,
+    path: String,
+    fetchUserInfo: Boolean,
+    allow: Option[String],
+    stepUpCondition: Option[String],
+    stepUpAcr: Option[String],
+    maxAgeSeconds: Option[Int],
+)
+
+/** @param resourceUri the resource's RFC 8707 identifier, which is also the base URI edge proxies
+  *                    to -- central requires it to be absolute and path-less
+  * @param audience    the clients allowed to obtain tokens for this resource
+  */
+case class ResourceSpec(
+    resourceId: String,
+    resourceUri: String,
+    audience: List[String],
+    endpoints: List[ResourceEndpointSpec],
+)
+
+case class PermissionSpec(
+    permission: String,
+    description: String,
+    endpointIds: Set[UUID],
+)
+
+case class RoleSpec(
+    roleId: String,
+    description: String,
+    permissions: Set[String],
+)
+
+/** A named, server-side authorization request edge's `/login/{presetId}` starts (§8.4).
+  *
+  * Carries no `acr_values`: [[EdgeClient.login]] passes one per call, and pinning it here would
+  * make every web session start out already satisfying the L2 endpoints, removing the web half of
+  * the step-up load the campaign exists to measure (design doc §2.3).
+  */
+case class AuthRequestPresetSpec(
+    presetId: String,
+    description: String,
+    redirectUri: String,
+    postLoginRedirectUri: String,
+    postLogoutRedirectUri: Option[String],
+    scope: Set[String],
+    responseType: String,
+    cookieDomain: Option[String],
+    cookiePath: Option[String],
+)
+
+/** Central replaces a client's preset set outright, so this is the whole desired set for one
+  * client, not an addition to it.
+  */
+case class AuthRequestPresetsSpec(
+    clientId: String,
+    presets: List[AuthRequestPresetSpec],
+)
+
+/** @param acrVocabulary which authentication factors each ACR value requires -- what makes
+  *                      `acr_values` mean anything to auth, and therefore what makes a step-up
+  *                      resolvable at all (§7.4)
+  */
+case class ChallengeSettingsSpec(
+    allowedPrefixes: List[String],
+    otpLength: Int,
+    otpResendAfterSeconds: Int,
+    passkeyRpId: String,
+    passkeyRpName: String,
+    passkeyOrigins: Set[String],
+    passkeyUserVerification: String,
+    ipHeader: String,
+    acrVocabulary: Map[String, List[String]],
+)

--- a/loadgen/src/main/scala/versola/loadgen/protocol/HttpAdminClient.scala
+++ b/loadgen/src/main/scala/versola/loadgen/protocol/HttpAdminClient.scala
@@ -16,9 +16,9 @@ import java.util.UUID
   * Each `upsert` reads the current state first and then creates or updates, rather than creating
   * and treating the failure as "already there": only `/configuration/clients` reports a duplicate
   * as a `409`, while roles, permissions and resources surface theirs as a unique-violation `500`,
-  * which is indistinguishable from central actually being broken. The client listing is served
-  * from a cache a PostgreSQL notification refreshes, so a stale read can still lose the race --
-  * hence the `409` fallback on the one operation that reports it.
+  * which is indistinguishable from central actually being broken. Every listing is served from a
+  * cache a PostgreSQL notification refreshes, so a stale read can still lose the race -- hence
+  * the `409` fallback on clients, and [[convergeAfterFailedCreate]] on the rest.
   *
   * Not a hot path: this runs once per campaign, so unlike the driver-facing clients (§3.3) it
   * parses whole bodies and builds request objects per call.
@@ -40,12 +40,15 @@ final class HttpAdminClient(
   override def registerClient(spec: ClientSpec): Task[ClientCreds] =
     for
       existing <- listClients
-      creds <-
-        if existing.contains(spec.clientId) then adoptClient(spec)
-        else
+      creds <- existing.get(spec.clientId) match
+        case Some(current) => adoptClient(spec, current)
+        case None =>
           createClient(spec).flatMap:
             case Some(secret) => ZIO.succeed(ClientCreds(spec.clientId, secret))
-            case None => adoptClient(spec)
+            // The listing that said the client was absent was stale, so the state the blueprint
+            // is diffed against has to be read again rather than assumed empty.
+            case None =>
+              listClients.flatMap(fresh => adoptClient(spec, fresh.getOrElse(spec.clientId, ClientState.empty)))
     yield creds
 
   /** Brings a client that already exists up to the blueprint and answers usable credentials.
@@ -56,8 +59,8 @@ final class HttpAdminClient(
     * breaks at the moment of the rotation, and the rotation itself has no in-progress guard --
     * which is what makes a third and fourth `provision` run work the same as the second.
     */
-  private def adoptClient(spec: ClientSpec): Task[ClientCreds] =
-    updateClient(spec) *>
+  private def adoptClient(spec: ClientSpec, current: ClientState): Task[ClientCreds] =
+    updateClient(spec, current) *>
       (if spec.publicClient then ZIO.none else rotateClientSecret(spec.clientId).asSome)
         .map(ClientCreds(spec.clientId, _))
 
@@ -85,13 +88,20 @@ final class HttpAdminClient(
         expectSuccess("registerClient", response)
           *> decode[CreateClientResponseBody]("registerClient", response).map(raw => Some(raw.secret))
 
-  private def updateClient(spec: ClientSpec): Task[Unit] =
+  /** The multi-value fields are patched rather than replaced, so the removal half has to be
+    * computed from what central currently holds: a redirect URI, scope or client permission the
+    * blueprint narrowed away would otherwise stay active on the target, leaving an obsolete
+    * OAuth redirect target or privilege behind every re-run.
+    */
+  private def updateClient(spec: ClientSpec, current: ClientState): Task[Unit] =
     val body = UpdateClientBody(
       clientId = spec.clientId,
       clientName = Map(englishTag -> spec.clientName),
-      redirectUris = PatchSet(add = spec.redirectUris, remove = Set.empty),
-      scope = PatchSet(add = spec.allowedScopes, remove = Set.empty),
-      permissions = PatchSet(add = Set.empty, remove = Set.empty),
+      redirectUris = PatchSet(add = spec.redirectUris, remove = current.redirectUris -- spec.redirectUris),
+      scope = PatchSet(add = spec.allowedScopes, remove = current.scopes -- spec.allowedScopes),
+      // The campaign grants its permissions through roles, so a client that carries one directly
+      // carries it from a configuration nothing names any more.
+      permissions = PatchSet(add = Set.empty, remove = current.permissions),
       accessTokenTtl = Some(spec.accessTokenTtlSeconds.toLong),
       refreshTokenTtl = spec.refreshTokenTtlSeconds.map(_.toLong),
       theme = Some(defaultTheme),
@@ -112,11 +122,13 @@ final class HttpAdminClient(
       expectSuccess("rotateClientSecret", response)
         *> decode[RotateSecretResponseBody]("rotateClientSecret", response).map(_.secret)
 
-  private def listClients: Task[Set[String]] =
+  private def listClients: Task[Map[String, ClientState]] =
     val url = central("configuration", "clients").addQueryParam("tenantId", tenantId)
     send(Method.GET, url, None).flatMap: response =>
       expectSuccess("listClients", response)
-        *> decode[ClientListBody]("listClients", response).map(_.clients.map(_.id).toSet)
+        *> decode[ClientListBody]("listClients", response).map(_.clients.map { entry =>
+          entry.id -> ClientState(entry.redirectUris, entry.scope, entry.permissions)
+        }.toMap)
 
   override def registerResource(spec: ResourceSpec): Task[Unit] =
     listResources.flatMap: existing =>
@@ -136,8 +148,9 @@ final class HttpAdminClient(
       // one hop the campaign is meant to measure end to end.
       internal = false,
     )
-    send(Method.POST, central("configuration", "resources"), Some(body.toJson))
-      .flatMap(expectSuccess("registerResource", _))
+    send(Method.POST, central("configuration", "resources"), Some(body.toJson)).flatMap: response =>
+      convergeAfterFailedCreate("registerResource", response, listResources.map(_.get(spec.resourceId))): endpointIds =>
+        updateResource(spec, endpointIds)
 
   /** Endpoints are replaced by id, and central's update deletes every id it is about to create
     * before creating it, so sending the full desired set is a single atomic desired-state apply:
@@ -166,24 +179,29 @@ final class HttpAdminClient(
   override def upsertPermissions(specs: List[PermissionSpec]): Task[Unit] =
     listPermissions.flatMap: existing =>
       ZIO.foreachDiscard(specs): spec =>
-        if existing.contains(spec.permission) then
-          val body = UpdatePermissionBody(
-            tenantId = tenantId,
-            permission = spec.permission,
-            description = PatchText(add = Map(englishTag -> spec.description), delete = Set.empty),
-            endpointIds = Some(spec.endpointIds),
-          )
-          send(Method.PUT, central("configuration", "permissions"), Some(body.toJson))
-            .flatMap(expectSuccess("upsertPermissions", _))
-        else
-          val body = CreatePermissionBody(
-            tenantId = tenantId,
-            permission = spec.permission,
-            description = Map(englishTag -> spec.description),
-            endpointIds = spec.endpointIds,
-          )
-          send(Method.POST, central("configuration", "permissions"), Some(body.toJson))
-            .flatMap(expectSuccess("upsertPermissions", _))
+        if existing.contains(spec.permission) then updatePermission(spec)
+        else createPermission(spec)
+
+  private def createPermission(spec: PermissionSpec): Task[Unit] =
+    val body = CreatePermissionBody(
+      tenantId = tenantId,
+      permission = spec.permission,
+      description = Map(englishTag -> spec.description),
+      endpointIds = spec.endpointIds,
+    )
+    send(Method.POST, central("configuration", "permissions"), Some(body.toJson)).flatMap: response =>
+      val present = listPermissions.map(existing => Option.when(existing.contains(spec.permission))(()))
+      convergeAfterFailedCreate("upsertPermissions", response, present)(_ => updatePermission(spec))
+
+  private def updatePermission(spec: PermissionSpec): Task[Unit] =
+    val body = UpdatePermissionBody(
+      tenantId = tenantId,
+      permission = spec.permission,
+      description = PatchText(add = Map(englishTag -> spec.description), delete = Set.empty),
+      endpointIds = Some(spec.endpointIds),
+    )
+    send(Method.PUT, central("configuration", "permissions"), Some(body.toJson))
+      .flatMap(expectSuccess("upsertPermissions", _))
 
   private def listPermissions: Task[Set[String]] =
     val url = central("configuration", "permissions").addQueryParam("tenantId", tenantId)
@@ -195,27 +213,33 @@ final class HttpAdminClient(
     listRoles.flatMap: existing =>
       ZIO.foreachDiscard(specs): spec =>
         existing.get(spec.roleId) match
-          case Some(granted) =>
-            // A role's permissions are patched, not replaced, so the revocation half has to be
-            // computed here -- a permission the blueprint moved from `retail-user` to
-            // `retail-basic` would otherwise stay granted on both.
-            val body = UpdateRoleBody(
-              tenantId = tenantId,
-              id = spec.roleId,
-              description = PatchText(add = Map(englishTag -> spec.description), delete = Set.empty),
-              permissions = PatchSet(add = spec.permissions -- granted, remove = granted -- spec.permissions),
-            )
-            send(Method.PUT, central("configuration", "roles"), Some(body.toJson))
-              .flatMap(expectSuccess("upsertRoles", _))
-          case None =>
-            val body = CreateRoleBody(
-              tenantId = tenantId,
-              id = spec.roleId,
-              description = Map(englishTag -> spec.description),
-              permissions = spec.permissions,
-            )
-            send(Method.POST, central("configuration", "roles"), Some(body.toJson))
-              .flatMap(expectSuccess("upsertRoles", _))
+          case Some(granted) => updateRole(spec, granted)
+          case None => createRole(spec)
+
+  private def createRole(spec: RoleSpec): Task[Unit] =
+    val body = CreateRoleBody(
+      tenantId = tenantId,
+      id = spec.roleId,
+      description = Map(englishTag -> spec.description),
+      permissions = spec.permissions,
+    )
+    send(Method.POST, central("configuration", "roles"), Some(body.toJson)).flatMap: response =>
+      convergeAfterFailedCreate("upsertRoles", response, listRoles.map(_.get(spec.roleId))): granted =>
+        updateRole(spec, granted)
+
+  /** A role's permissions are patched, not replaced, so the revocation half has to be computed
+    * here -- a permission the blueprint moved from `retail-user` to `retail-basic` would
+    * otherwise stay granted on both.
+    */
+  private def updateRole(spec: RoleSpec, granted: Set[String]): Task[Unit] =
+    val body = UpdateRoleBody(
+      tenantId = tenantId,
+      id = spec.roleId,
+      description = PatchText(add = Map(englishTag -> spec.description), delete = Set.empty),
+      permissions = PatchSet(add = spec.permissions -- granted, remove = granted -- spec.permissions),
+    )
+    send(Method.PUT, central("configuration", "roles"), Some(body.toJson))
+      .flatMap(expectSuccess("upsertRoles", _))
 
   private def listRoles: Task[Map[String, Set[String]]] =
     val url = central("configuration", "roles").addQueryParam("tenantId", tenantId)
@@ -326,6 +350,24 @@ final class HttpAdminClient(
       client.request(request).flatMap: response =>
         response.body.asString.map(AdminResponse(response.status, _))
 
+  /** Finishes a create central refused, by re-reading and applying the desired-state update when
+    * the id turns out to be there after all.
+    *
+    * The create-or-update choice is made on a cached listing, so a concurrent run -- or the one
+    * that died halfway and is being retried -- can commit the same id between that read and this
+    * write. Central reports it as the unique violation's bare `500`, indistinguishable from being
+    * broken, so what tells the two apart is the fresh read rather than the status: an id that is
+    * there now was committed by someone and the update converges on it, and one that is not
+    * leaves the create's failure to stop the run.
+    */
+  private def convergeAfterFailedCreate[A](
+      operation: String,
+      response: AdminResponse,
+      current: Task[Option[A]],
+  )(update: A => Task[Unit]): Task[Unit] =
+    if response.status.isSuccess then ZIO.unit
+    else current.flatMap(_.fold(expectSuccess(operation, response))(update))
+
   private def expectSuccess(operation: String, response: AdminResponse): Task[Unit] =
     ZIO.unless(response.status.isSuccess)(ZIO.fail(AdminCallFailed(operation, response.status, response.body))).unit
 
@@ -409,7 +451,20 @@ object HttpAdminClient:
 
   private case class RotateSecretResponseBody(secret: String) derives JsonDecoder
 
-  private case class ClientListEntry(id: String) derives JsonDecoder
+  private case class ClientListEntry(
+      id: String,
+      redirectUris: Set[String],
+      scope: Set[String],
+      permissions: Set[String],
+  ) derives JsonDecoder
+
+  /** A client's patched, multi-value state as central's listing reports it -- what a
+    * desired-state update has to diff the blueprint against to know what to remove.
+    */
+  private case class ClientState(redirectUris: Set[String], scopes: Set[String], permissions: Set[String])
+
+  private object ClientState:
+    val empty: ClientState = ClientState(Set.empty, Set.empty, Set.empty)
 
   private case class ClientListBody(clients: List[ClientListEntry]) derives JsonDecoder
 

--- a/loadgen/src/main/scala/versola/loadgen/protocol/HttpAdminClient.scala
+++ b/loadgen/src/main/scala/versola/loadgen/protocol/HttpAdminClient.scala
@@ -1,0 +1,535 @@
+package versola.loadgen.protocol
+
+import versola.loadgen.config.{ProvisionConfig, TargetsConfig}
+import zio.*
+import zio.http.*
+import zio.http.Header.Authorization
+import zio.json.*
+import zio.json.ast.Json
+
+import java.util.UUID
+
+/** [[AdminClient]] over central's and edge's HTTP admin APIs, authenticating with HTTP Basic the
+  * same way e2e's `OAuthClient` does -- the central resource secret for central's configuration
+  * API, the edge internal secret for edge's service API.
+  *
+  * Each `upsert` reads the current state first and then creates or updates, rather than creating
+  * and treating the failure as "already there": only `/configuration/clients` reports a duplicate
+  * as a `409`, while roles, permissions and resources surface theirs as a unique-violation `500`,
+  * which is indistinguishable from central actually being broken. The client listing is served
+  * from a cache a PostgreSQL notification refreshes, so a stale read can still lose the race --
+  * hence the `409` fallback on the one operation that reports it.
+  *
+  * Not a hot path: this runs once per campaign, so unlike the driver-facing clients (§3.3) it
+  * parses whole bodies and builds request objects per call.
+  */
+final class HttpAdminClient(
+    client: Client,
+    centralUrl: URL,
+    edgeUrl: URL,
+    centralSecret: String,
+    edgeSecret: String,
+    tenantId: String,
+) extends AdminClient:
+
+  import HttpAdminClient.*
+
+  private val centralAuthorization = Authorization.Basic("central", centralSecret)
+  private val edgeAuthorization = Authorization.Basic("edge", edgeSecret)
+
+  override def registerClient(spec: ClientSpec): Task[ClientCreds] =
+    for
+      existing <- listClients
+      creds <-
+        if existing.contains(spec.clientId) then adoptClient(spec)
+        else
+          createClient(spec).flatMap:
+            case Some(secret) => ZIO.succeed(ClientCreds(spec.clientId, secret))
+            case None => adoptClient(spec)
+    yield creds
+
+  /** Brings a client that already exists up to the blueprint and answers usable credentials.
+    *
+    * A confidential client's secret is readable exactly once, at registration, so the only way to
+    * hand the campaign one for a client a previous run created is to rotate. Central keeps the
+    * previous secret alive alongside the new one, so nothing authenticating with the old value
+    * breaks at the moment of the rotation, and the rotation itself has no in-progress guard --
+    * which is what makes a third and fourth `provision` run work the same as the second.
+    */
+  private def adoptClient(spec: ClientSpec): Task[ClientCreds] =
+    updateClient(spec) *>
+      (if spec.publicClient then ZIO.none else rotateClientSecret(spec.clientId).asSome)
+        .map(ClientCreds(spec.clientId, _))
+
+  private def createClient(spec: ClientSpec): Task[Option[Option[String]]] =
+    val body = CreateClientBody(
+      tenantId = tenantId,
+      id = spec.clientId,
+      clientName = Map(englishTag -> spec.clientName),
+      redirectUris = spec.redirectUris,
+      allowedScopes = spec.allowedScopes,
+      permissions = Set.empty,
+      accessTokenTtl = spec.accessTokenTtlSeconds,
+      refreshTokenTtl = spec.refreshTokenTtlSeconds,
+      theme = defaultTheme,
+      authFlow = spec.authFlow,
+      registrationFlow = spec.registrationFlow,
+      otpTemplateId = defaultOtpTemplateId,
+      frontChannelLogoutSessionRequired = false,
+      backChannelLogoutUri = spec.backChannelLogoutUri,
+      clientType = if spec.publicClient then nativeClientType else webClientType,
+    )
+    send(Method.POST, central("configuration", "clients"), Some(body.toJson)).flatMap: response =>
+      if response.status == Status.Conflict then ZIO.none
+      else
+        expectSuccess("registerClient", response)
+          *> decode[CreateClientResponseBody]("registerClient", response).map(raw => Some(raw.secret))
+
+  private def updateClient(spec: ClientSpec): Task[Unit] =
+    val body = UpdateClientBody(
+      clientId = spec.clientId,
+      clientName = Map(englishTag -> spec.clientName),
+      redirectUris = PatchSet(add = spec.redirectUris, remove = Set.empty),
+      scope = PatchSet(add = spec.allowedScopes, remove = Set.empty),
+      permissions = PatchSet(add = Set.empty, remove = Set.empty),
+      accessTokenTtl = Some(spec.accessTokenTtlSeconds.toLong),
+      refreshTokenTtl = spec.refreshTokenTtlSeconds.map(_.toLong),
+      theme = Some(defaultTheme),
+      otpTemplateId = Some(defaultOtpTemplateId),
+      authFlow = spec.authFlow,
+      // A patchable field is cleared by an explicit `null` and left alone by omission, so the
+      // blueprint's `None` has to be written rather than dropped -- a client that carried a
+      // registration flow or a logout URI the campaign no longer wants would otherwise keep it.
+      registrationFlow = spec.registrationFlow.getOrElse(Json.Null),
+      backChannelLogoutUri = spec.backChannelLogoutUri.fold(Json.Null)(Json.Str(_)),
+    )
+    send(Method.PUT, central("configuration", "clients"), Some(body.toJson))
+      .flatMap(expectSuccess("updateClient", _))
+
+  private def rotateClientSecret(clientId: String): Task[String] =
+    val url = central("configuration", "clients", "rotate-secret").addQueryParam("clientId", clientId)
+    send(Method.POST, url, None).flatMap: response =>
+      expectSuccess("rotateClientSecret", response)
+        *> decode[RotateSecretResponseBody]("rotateClientSecret", response).map(_.secret)
+
+  private def listClients: Task[Set[String]] =
+    val url = central("configuration", "clients").addQueryParam("tenantId", tenantId)
+    send(Method.GET, url, None).flatMap: response =>
+      expectSuccess("listClients", response)
+        *> decode[ClientListBody]("listClients", response).map(_.clients.map(_.id).toSet)
+
+  override def registerResource(spec: ResourceSpec): Task[Unit] =
+    listResources.flatMap: existing =>
+      existing.get(spec.resourceId) match
+        case None => createResource(spec)
+        case Some(endpointIds) => updateResource(spec, endpointIds)
+
+  private def createResource(spec: ResourceSpec): Task[Unit] =
+    val body = CreateResourceBody(
+      tenantId = tenantId,
+      resourceId = spec.resourceId,
+      resource = spec.resourceUri,
+      audience = spec.audience,
+      endpoints = spec.endpoints.map(endpointBody),
+      // Public rather than internal: an internal resource is proxied with edge's own Basic
+      // credentials and never sees the caller's token, which would take the access token off the
+      // one hop the campaign is meant to measure end to end.
+      internal = false,
+    )
+    send(Method.POST, central("configuration", "resources"), Some(body.toJson))
+      .flatMap(expectSuccess("registerResource", _))
+
+  /** Endpoints are replaced by id, and central's update deletes every id it is about to create
+    * before creating it, so sending the full desired set is a single atomic desired-state apply:
+    * an endpoint whose ACR or CEL rule changed is rewritten, and one the blueprint dropped is
+    * deleted rather than left granting access nothing names any more.
+    */
+  private def updateResource(spec: ResourceSpec, existingEndpointIds: Set[UUID]): Task[Unit] =
+    val desired = spec.endpoints.map(_.id).toSet
+    val body = UpdateResourceBody(
+      resourceId = spec.resourceId,
+      resource = Some(spec.resourceUri),
+      audience = Some(spec.audience),
+      deleteEndpoints = existingEndpointIds -- desired,
+      createEndpoints = spec.endpoints.map(endpointBody),
+    )
+    send(Method.PUT, central("configuration", "resources"), Some(body.toJson))
+      .flatMap(expectSuccess("updateResource", _))
+
+  private def listResources: Task[Map[String, Set[UUID]]] =
+    val url = central("configuration", "resources").addQueryParam("tenantId", tenantId)
+    send(Method.GET, url, None).flatMap: response =>
+      expectSuccess("listResources", response)
+        *> decode[ResourceListBody]("listResources", response)
+          .map(_.resources.map(entry => entry.resourceId -> entry.endpoints.map(_.id).toSet).toMap)
+
+  override def upsertPermissions(specs: List[PermissionSpec]): Task[Unit] =
+    listPermissions.flatMap: existing =>
+      ZIO.foreachDiscard(specs): spec =>
+        if existing.contains(spec.permission) then
+          val body = UpdatePermissionBody(
+            tenantId = tenantId,
+            permission = spec.permission,
+            description = PatchText(add = Map(englishTag -> spec.description), delete = Set.empty),
+            endpointIds = Some(spec.endpointIds),
+          )
+          send(Method.PUT, central("configuration", "permissions"), Some(body.toJson))
+            .flatMap(expectSuccess("upsertPermissions", _))
+        else
+          val body = CreatePermissionBody(
+            tenantId = tenantId,
+            permission = spec.permission,
+            description = Map(englishTag -> spec.description),
+            endpointIds = spec.endpointIds,
+          )
+          send(Method.POST, central("configuration", "permissions"), Some(body.toJson))
+            .flatMap(expectSuccess("upsertPermissions", _))
+
+  private def listPermissions: Task[Set[String]] =
+    val url = central("configuration", "permissions").addQueryParam("tenantId", tenantId)
+    send(Method.GET, url, None).flatMap: response =>
+      expectSuccess("listPermissions", response)
+        *> decode[PermissionListBody]("listPermissions", response).map(_.permissions.map(_.permission).toSet)
+
+  override def upsertRoles(specs: List[RoleSpec]): Task[Unit] =
+    listRoles.flatMap: existing =>
+      ZIO.foreachDiscard(specs): spec =>
+        existing.get(spec.roleId) match
+          case Some(granted) =>
+            // A role's permissions are patched, not replaced, so the revocation half has to be
+            // computed here -- a permission the blueprint moved from `retail-user` to
+            // `retail-basic` would otherwise stay granted on both.
+            val body = UpdateRoleBody(
+              tenantId = tenantId,
+              id = spec.roleId,
+              description = PatchText(add = Map(englishTag -> spec.description), delete = Set.empty),
+              permissions = PatchSet(add = spec.permissions -- granted, remove = granted -- spec.permissions),
+            )
+            send(Method.PUT, central("configuration", "roles"), Some(body.toJson))
+              .flatMap(expectSuccess("upsertRoles", _))
+          case None =>
+            val body = CreateRoleBody(
+              tenantId = tenantId,
+              id = spec.roleId,
+              description = Map(englishTag -> spec.description),
+              permissions = spec.permissions,
+            )
+            send(Method.POST, central("configuration", "roles"), Some(body.toJson))
+              .flatMap(expectSuccess("upsertRoles", _))
+
+  private def listRoles: Task[Map[String, Set[String]]] =
+    val url = central("configuration", "roles").addQueryParam("tenantId", tenantId)
+    send(Method.GET, url, None).flatMap: response =>
+      expectSuccess("listRoles", response)
+        *> decode[RoleListBody]("listRoles", response)
+          .map(_.roles.map(entry => entry.id -> entry.permissions).toMap)
+
+  /** Central stores a client's presets as one set, so this call is idempotent by construction --
+    * no read first, and a re-run cannot accumulate duplicates.
+    */
+  override def upsertAuthRequestPresets(spec: AuthRequestPresetsSpec): Task[Unit] =
+    val body = SavePresetsBody(
+      clientId = spec.clientId,
+      presets = spec.presets.map: preset =>
+        PresetBody(
+          id = preset.presetId,
+          description = preset.description,
+          redirectUri = preset.redirectUri,
+          postLoginRedirectUri = preset.postLoginRedirectUri,
+          postLogoutRedirectUri = preset.postLogoutRedirectUri,
+          scope = preset.scope,
+          responseType = preset.responseType,
+          customParameters = Map.empty,
+          cookieDomain = preset.cookieDomain,
+          cookiePath = preset.cookiePath,
+        ),
+    )
+    send(Method.POST, central("configuration", "auth-request-presets"), Some(body.toJson))
+      .flatMap(expectSuccess("upsertAuthRequestPresets", _))
+
+  /** Central's challenge-settings write is a full replace of the tenant's document, so this sets
+    * every field the campaign depends on rather than only the ACR vocabulary.
+    */
+  override def upsertChallengeSettings(spec: ChallengeSettingsSpec): Task[Unit] =
+    val body = UpsertChallengeSettingsBody(
+      tenantId = tenantId,
+      allowedPrefixes = spec.allowedPrefixes,
+      submissionLimits = SubmissionLimitsBody(
+        otpRequest = Nil,
+        otpSubmit = Nil,
+        passwordSubmit = Nil,
+        passkeyAssertion = Nil,
+        banDurationSeconds = 0,
+      ),
+      otpLength = spec.otpLength,
+      otpResendAfter = spec.otpResendAfterSeconds,
+      passkeySettings = PasskeySettingsBody(
+        rpId = spec.passkeyRpId,
+        rpName = spec.passkeyRpName,
+        origins = spec.passkeyOrigins,
+        userVerification = spec.passkeyUserVerification,
+      ),
+      ipHeader = spec.ipHeader,
+      acrVocabulary = Some(spec.acrVocabulary),
+    )
+    send(Method.PUT, central("configuration", "challenges", "challenge-settings"), Some(body.toJson))
+      .flatMap(expectSuccess("upsertChallengeSettings", _))
+
+  override def syncConfiguration(): Task[Unit] =
+    send(Method.POST, central("service", "configuration", "sync"), None)
+      .flatMap(expectSuccess("syncConfiguration", _))
+
+  /** Retried on a 5xx for the reason e2e's client is: the sync makes edge call central over a
+    * pooled connection, and one central closed while it sat idle surfaces here as a 500 on the
+    * first attempt.
+    */
+  override def syncEdgeConfiguration(): Task[Unit] =
+    val post = send(Method.POST, edge("service", "configuration", "sync"), None, edgeAuthorization)
+    post
+      .repeat(Schedule.spaced(500.millis) *> Schedule.recurUntil[AdminResponse](!_.status.isServerError))
+      .timeout(5.seconds)
+      .someOrElseZIO(post)
+      .withClock(Clock.ClockLive)
+      .flatMap(expectSuccess("syncEdgeConfiguration", _))
+
+  override def flushUserOutbox(): Task[Unit] =
+    send(Method.POST, central("service", "users", "outbox", "flush"), None)
+      .flatMap(expectSuccess("flushUserOutbox", _))
+
+  private def endpointBody(spec: ResourceEndpointSpec): ResourceEndpointBody =
+    ResourceEndpointBody(
+      id = spec.id,
+      path = spec.path,
+      method = spec.method,
+      fetchUserInfo = spec.fetchUserInfo,
+      allow = spec.allow,
+      inject = Nil,
+      stepUpCondition = spec.stepUpCondition,
+      stepUpAcr = spec.stepUpAcr,
+      maxAge = spec.maxAgeSeconds,
+    )
+
+  private def central(segments: String*): URL = centralUrl.addPath(Path(segments.mkString("/", "/", "")))
+
+  private def edge(segments: String*): URL = edgeUrl.addPath(Path(segments.mkString("/", "/", "")))
+
+  private def send(
+      method: Method,
+      url: URL,
+      body: Option[String],
+      authorization: Authorization = centralAuthorization,
+  ): Task[AdminResponse] =
+    val base = Request(method = method, url = url, body = body.fold(Body.empty)(Body.fromString(_)))
+      .addHeader(authorization)
+    val request = body.fold(base)(_ => base.addHeader(Header.ContentType(MediaType.application.json)))
+    ZIO.scoped:
+      client.request(request).flatMap: response =>
+        response.body.asString.map(AdminResponse(response.status, _))
+
+  private def expectSuccess(operation: String, response: AdminResponse): Task[Unit] =
+    ZIO.unless(response.status.isSuccess)(ZIO.fail(AdminCallFailed(operation, response.status, response.body))).unit
+
+  private def decode[A: JsonDecoder](operation: String, response: AdminResponse): Task[A] =
+    ZIO.fromEither(response.body.fromJson[A])
+      .mapError(error => AdminCallFailed(operation, response.status, s"unreadable response: $error"))
+
+object HttpAdminClient:
+  /** Effectful because a target URL that does not parse is a configuration error worth failing
+    * the run on, rather than one that turns every admin call into a request to a relative URL.
+    */
+  def make(client: Client, targets: TargetsConfig, provision: ProvisionConfig): Task[AdminClient] =
+    for
+      central <- parseUrl("central-url", targets.centralUrl)
+      edge <- parseUrl("edge-url", targets.edgeUrl)
+    yield HttpAdminClient(
+      client = client,
+      centralUrl = central,
+      edgeUrl = edge,
+      centralSecret = provision.centralSecret.stringValue,
+      edgeSecret = provision.edgeSecret.stringValue,
+      tenantId = provision.tenantId,
+    )
+
+  private def parseUrl(setting: String, url: String): Task[URL] =
+    ZIO.fromEither(URL.decode(url)).mapError(cause => InvalidAdminUrl(setting, url, cause))
+
+  /** Central's admin API is multilingual; a load campaign is not, so every description this
+    * client writes carries one tag.
+    */
+  private val englishTag = "en"
+  private val defaultTheme = "default"
+  private val defaultOtpTemplateId = "default"
+  private val nativeClientType = "native"
+  private val webClientType = "web"
+
+  private case class AdminResponse(status: Status, body: String)
+
+  // Request/response bodies, field-for-field central's own DTOs. zio-json omits a `None` member,
+  // which is what central's optional-means-absent members expect; the `Json`-typed members are
+  // the patch fields, where an explicit `null` is a deletion and omission is "leave alone".
+
+  private case class PatchSet(add: Set[String], remove: Set[String]) derives JsonEncoder
+
+  private case class PatchText(add: Map[String, String], delete: Set[String]) derives JsonEncoder
+
+  private case class CreateClientBody(
+      tenantId: String,
+      id: String,
+      clientName: Map[String, String],
+      redirectUris: Set[String],
+      allowedScopes: Set[String],
+      permissions: Set[String],
+      accessTokenTtl: Int,
+      refreshTokenTtl: Option[Int],
+      theme: String,
+      authFlow: Json,
+      registrationFlow: Option[Json],
+      otpTemplateId: String,
+      frontChannelLogoutSessionRequired: Boolean,
+      backChannelLogoutUri: Option[String],
+      clientType: String,
+  ) derives JsonEncoder
+
+  private case class UpdateClientBody(
+      clientId: String,
+      clientName: Map[String, String],
+      redirectUris: PatchSet,
+      scope: PatchSet,
+      permissions: PatchSet,
+      accessTokenTtl: Option[Long],
+      refreshTokenTtl: Option[Long],
+      theme: Option[String],
+      otpTemplateId: Option[String],
+      authFlow: Json,
+      registrationFlow: Json,
+      backChannelLogoutUri: Json,
+  ) derives JsonEncoder
+
+  private case class CreateClientResponseBody(secret: Option[String]) derives JsonDecoder
+
+  private case class RotateSecretResponseBody(secret: String) derives JsonDecoder
+
+  private case class ClientListEntry(id: String) derives JsonDecoder
+
+  private case class ClientListBody(clients: List[ClientListEntry]) derives JsonDecoder
+
+  private case class ResourceEndpointBody(
+      id: UUID,
+      path: String,
+      method: String,
+      fetchUserInfo: Boolean,
+      allow: Option[String],
+      inject: List[Json],
+      stepUpCondition: Option[String],
+      stepUpAcr: Option[String],
+      maxAge: Option[Int],
+  ) derives JsonEncoder
+
+  private case class CreateResourceBody(
+      tenantId: String,
+      resourceId: String,
+      resource: String,
+      audience: List[String],
+      endpoints: List[ResourceEndpointBody],
+      internal: Boolean,
+  ) derives JsonEncoder
+
+  private case class UpdateResourceBody(
+      resourceId: String,
+      resource: Option[String],
+      audience: Option[List[String]],
+      deleteEndpoints: Set[UUID],
+      createEndpoints: List[ResourceEndpointBody],
+  ) derives JsonEncoder
+
+  private case class ResourceListEndpoint(id: UUID) derives JsonDecoder
+
+  private case class ResourceListEntry(resourceId: String, endpoints: List[ResourceListEndpoint]) derives JsonDecoder
+
+  private case class ResourceListBody(resources: List[ResourceListEntry]) derives JsonDecoder
+
+  private case class CreatePermissionBody(
+      tenantId: String,
+      permission: String,
+      description: Map[String, String],
+      endpointIds: Set[UUID],
+  ) derives JsonEncoder
+
+  private case class UpdatePermissionBody(
+      tenantId: String,
+      permission: String,
+      description: PatchText,
+      endpointIds: Option[Set[UUID]],
+  ) derives JsonEncoder
+
+  private case class PermissionListEntry(permission: String) derives JsonDecoder
+
+  private case class PermissionListBody(permissions: List[PermissionListEntry]) derives JsonDecoder
+
+  private case class CreateRoleBody(
+      tenantId: String,
+      id: String,
+      description: Map[String, String],
+      permissions: Set[String],
+  ) derives JsonEncoder
+
+  private case class UpdateRoleBody(
+      tenantId: String,
+      id: String,
+      description: PatchText,
+      permissions: PatchSet,
+  ) derives JsonEncoder
+
+  private case class RoleListEntry(id: String, permissions: Set[String]) derives JsonDecoder
+
+  private case class RoleListBody(roles: List[RoleListEntry]) derives JsonDecoder
+
+  private case class PresetBody(
+      id: String,
+      description: String,
+      redirectUri: String,
+      postLoginRedirectUri: String,
+      postLogoutRedirectUri: Option[String],
+      scope: Set[String],
+      responseType: String,
+      customParameters: Map[String, List[String]],
+      cookieDomain: Option[String],
+      cookiePath: Option[String],
+  ) derives JsonEncoder
+
+  private case class SavePresetsBody(clientId: String, presets: List[PresetBody]) derives JsonEncoder
+
+  private case class SubmissionLimitsBody(
+      otpRequest: List[Json],
+      otpSubmit: List[Json],
+      passwordSubmit: List[Json],
+      passkeyAssertion: List[Json],
+      banDurationSeconds: Int,
+  ) derives JsonEncoder
+
+  private case class PasskeySettingsBody(
+      rpId: String,
+      rpName: String,
+      origins: Set[String],
+      userVerification: String,
+  ) derives JsonEncoder
+
+  private case class UpsertChallengeSettingsBody(
+      tenantId: String,
+      allowedPrefixes: List[String],
+      submissionLimits: SubmissionLimitsBody,
+      otpLength: Int,
+      otpResendAfter: Int,
+      passkeySettings: PasskeySettingsBody,
+      ipHeader: String,
+      acrVocabulary: Option[Map[String, List[String]]],
+  ) derives JsonEncoder
+
+final case class InvalidAdminUrl(setting: String, url: String, cause: Throwable)
+    extends RuntimeException(s"targets.$setting is not a valid URL: $url", cause)
+
+/** A central/edge admin call that did not succeed. Carries the operation rather than the URL so
+  * that a `provision` failure names the step to re-run.
+  */
+final case class AdminCallFailed(operation: String, status: Status, body: String)
+    extends RuntimeException(s"$operation failed: status=$status body=$body")

--- a/loadgen/src/main/scala/versola/loadgen/provision/CampaignBlueprint.scala
+++ b/loadgen/src/main/scala/versola/loadgen/provision/CampaignBlueprint.scala
@@ -1,0 +1,408 @@
+package versola.loadgen.provision
+
+import versola.loadgen.config.{ProvisionConfig, TargetsConfig}
+import versola.loadgen.protocol.*
+import zio.json.ast.Json
+
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+
+/** The campaign's desired configuration in central: the four clients of design doc §2.2, the
+  * three `mockapi`-backed resources and ten protected actions of §3, the permissions those
+  * actions need, the `retail-user`/`retail-basic` roles, the one edge login preset and the ACR
+  * vocabulary every step-up resolves through.
+  *
+  * A pure value, computed once from config and the shared flow documents, so that what
+  * `provision` is about to write can be asserted on without a SUT.
+  */
+case class CampaignBlueprint(
+    clients: List[ClientSpec],
+    resources: List[ResourceSpec],
+    permissions: List[PermissionSpec],
+    roles: List[RoleSpec],
+    presets: List[AuthRequestPresetsSpec],
+    challengeSettings: ChallengeSettingsSpec,
+)
+
+object CampaignBlueprint:
+
+  /** The four clients, named as the design doc names them -- also the ids a driver's config picks
+    * a client by, so they are not free to change.
+    */
+  val mobileOtpClientId = "mobile-otp"
+  val mobileOtpPasswordClientId = "mobile-otp-password"
+  val mobilePasskeyClientId = "mobile-passkey"
+  val webOtpClientId = "web-otp"
+
+  val clientIds: List[String] =
+    List(mobileOtpClientId, mobileOtpPasswordClientId, mobilePasskeyClientId, webOtpClientId)
+
+  val coreResourceId = "core"
+  val payResourceId = "pay"
+  val notifyResourceId = "notify"
+
+  /** The full-access role 90% of the population holds, and the read-only one the other 10% does.
+    * The 403s `retail-basic` collects on the write actions are the campaign's only source of a
+    * realistic forbidden rate (design doc §3), which is why it is provisioned rather than
+    * emulated driver-side.
+    */
+  val retailUserRoleId = "retail-user"
+  val retailBasicRoleId = "retail-basic"
+
+  /** Scopes every client requests. `offline_access` is not optional: without it there is no
+    * refresh token, and §2.3's 96.7% refresh path -- the bulk of the campaign's traffic -- cannot
+    * happen at all.
+    */
+  val scopes: Set[String] = Set("openid", "profile", "phone", "offline_access")
+
+  /** Design doc §5's access-token TTL; the session model (§5's `session.access-token-ttl`) reads
+    * the same 15 minutes to decide when a long session needs an extra refresh.
+    */
+  private val accessTokenTtlSeconds = 900
+
+  /** 30 days, per §2.2's "refresh token in the app, rotating, 30 d". */
+  private val refreshTokenTtlSeconds = 2592000
+
+  /** Step-up ACRs, in the two combinations the ten actions require.
+    *
+    * L2 is `otp-level`: an ordinary login requests no `acr_values` and so carries no `acr` at all,
+    * which is what makes the payment actions demand a step-up rather than pass on the factor the
+    * user happened to log in with (§2.3's "if token acr < L2").
+    *
+    * L3 names both the passkey and the password level, and edge treats `stepUpAcr` as a
+    * space-separated set of alternatives -- design doc §3 #10 is "passkey or password re-auth",
+    * and pinning it to the passkey level alone would make the action unreachable for the 75% of
+    * the population that has never enrolled one.
+    */
+  private val level2Acr = Acr.OtpLevel
+  private val level3Acr = s"${Acr.PasskeyLevel} ${Acr.PasswordLevel}"
+
+  /** Design doc §3 #9: `max_age=300` forces a re-authentication on a stale `auth_time`. */
+  private val cardLimitsMaxAgeSeconds = 300
+
+  /** Reads as "required" so that the L2/L3 actions always demand their ACR. The condition exists
+    * because `stepUpAcr` is only consulted when it passes; the variable part of the step-up rate
+    * is the session model's, not the SUT's.
+    */
+  private val stepUpAlways = "true"
+
+  /** One of the ten protected actions of design doc §3. `permission` is the one that unlocks it;
+    * several actions share one, which is what makes the read/write split a role can express.
+    */
+  private case class Action(
+      resourceId: String,
+      method: String,
+      path: String,
+      permission: String,
+      permissionDescription: String,
+      fetchUserInfo: Boolean,
+      allow: Option[String],
+      stepUpAcr: Option[String],
+      maxAgeSeconds: Option[Int],
+  )
+
+  /** The CEL access rule the two payment endpoints carry, so that `checkRules` is evaluated on
+    * the measured path rather than skipped -- an edge benchmarked with no rule at all flatters it
+    * (design doc §3).
+    *
+    * Guarded by `has` and widened with `double`, because a rule that cannot read what it needs is
+    * a 403: the campaign's forbidden rate is supposed to come from `retail-basic` alone, and a
+    * payment body without an `amount`, or with an integral one, must not add to it.
+    */
+  private def amountRule(threshold: Long): String =
+    s"!has(request.body.amount) || double(request.body.amount) <= ${threshold.toDouble}"
+
+  private def actions(threshold: Long): List[Action] = List(
+    Action(
+      resourceId = coreResourceId,
+      method = "GET",
+      path = "/accounts",
+      permission = "accounts:read",
+      permissionDescription = "Read account list and balances",
+      fetchUserInfo = false,
+      allow = None,
+      stepUpAcr = None,
+      maxAgeSeconds = None,
+    ),
+    Action(
+      resourceId = coreResourceId,
+      method = "GET",
+      path = "/accounts/{accountId}/transactions",
+      permission = "transactions:read",
+      permissionDescription = "Read account transactions",
+      fetchUserInfo = false,
+      allow = None,
+      stepUpAcr = None,
+      maxAgeSeconds = None,
+    ),
+    Action(
+      resourceId = coreResourceId,
+      method = "GET",
+      path = "/cards",
+      permission = "cards:read",
+      permissionDescription = "Read card list",
+      fetchUserInfo = false,
+      allow = None,
+      stepUpAcr = None,
+      maxAgeSeconds = None,
+    ),
+    // The only action that asks edge to call `/userinfo`, which is what puts auth's claims path
+    // under load at all (design doc §3 #4).
+    Action(
+      resourceId = coreResourceId,
+      method = "GET",
+      path = "/profile",
+      permission = "profile:read",
+      permissionDescription = "Read own profile",
+      fetchUserInfo = true,
+      allow = None,
+      stepUpAcr = None,
+      maxAgeSeconds = None,
+    ),
+    Action(
+      resourceId = notifyResourceId,
+      method = "GET",
+      path = "/notifications",
+      permission = "notifications:read",
+      permissionDescription = "Read notifications",
+      fetchUserInfo = false,
+      allow = None,
+      stepUpAcr = None,
+      maxAgeSeconds = None,
+    ),
+    Action(
+      resourceId = payResourceId,
+      method = "GET",
+      path = "/templates",
+      permission = "payments:read",
+      permissionDescription = "Read payment templates",
+      fetchUserInfo = false,
+      allow = None,
+      stepUpAcr = None,
+      maxAgeSeconds = None,
+    ),
+    Action(
+      resourceId = payResourceId,
+      method = "POST",
+      path = "/p2p",
+      permission = "payments:write",
+      permissionDescription = "Submit payments",
+      fetchUserInfo = false,
+      allow = Some(amountRule(threshold)),
+      stepUpAcr = Some(level2Acr),
+      maxAgeSeconds = None,
+    ),
+    Action(
+      resourceId = payResourceId,
+      method = "POST",
+      path = "/utility",
+      permission = "payments:write",
+      permissionDescription = "Submit payments",
+      fetchUserInfo = false,
+      allow = Some(amountRule(threshold)),
+      stepUpAcr = Some(level2Acr),
+      maxAgeSeconds = None,
+    ),
+    Action(
+      resourceId = coreResourceId,
+      method = "PUT",
+      path = "/cards/{cardId}/limits",
+      permission = "cards:write",
+      permissionDescription = "Change card limits",
+      fetchUserInfo = false,
+      allow = None,
+      stepUpAcr = Some(level2Acr),
+      maxAgeSeconds = Some(cardLimitsMaxAgeSeconds),
+    ),
+    Action(
+      resourceId = coreResourceId,
+      method = "DELETE",
+      path = "/profile/security/devices/{deviceId}",
+      permission = "profile:write",
+      permissionDescription = "Revoke own devices",
+      fetchUserInfo = false,
+      allow = None,
+      stepUpAcr = Some(level3Acr),
+      maxAgeSeconds = None,
+    ),
+  )
+
+  /** Endpoint ids have to survive a re-`provision`: a permission grants an endpoint by id, so a
+    * fresh UUID per run would leave every permission pointing at an endpoint that no longer
+    * exists and every action 403. Derived from the endpoint's identity -- resource, method and
+    * path -- rather than stored, so the seeder, a re-run and a second driver all compute the same
+    * value with nothing to keep in sync.
+    */
+  private def endpointId(resourceId: String, method: String, path: String): UUID =
+    UUID.nameUUIDFromBytes(s"versola-loadgen/$resourceId/$method$path".getBytes(StandardCharsets.UTF_8))
+
+  def apply(targets: TargetsConfig, provision: ProvisionConfig, flows: CampaignFlows): CampaignBlueprint =
+    val allActions = actions(provision.paymentAmountThreshold)
+
+    // Where a completed edge login sends the browser, and where central posts this client's
+    // back-channel logouts. The first is a redirect URI the browser must reach, so it is built on
+    // the public origin -- central refuses plain HTTP on a non-loopback host anyway; the second is
+    // server-to-server and uses the in-cluster address.
+    val edgeCompleteUri = s"${targets.origin}/complete"
+    val edgeBackChannelLogoutUri = s"${targets.edgeUrl}/logout/backchannel"
+
+    val mobileClients = List(
+      (mobileOtpClientId, "Loadgen mobile OTP", flows.phoneOtpAuthFlow, Some(flows.registrationFlow)),
+      (
+        mobileOtpPasswordClientId,
+        "Loadgen mobile OTP + password",
+        flows.phoneOtpPasswordAuthFlow,
+        Some(flows.registrationFlow),
+      ),
+      // No registration flow: an account is registered from a credential card, and this client's
+      // primary credential is the passkey the new account does not have yet. The passkey cohort
+      // enrols from an already-registered session (§2.3's 0.5%/month enrolment).
+      (mobilePasskeyClientId, "Loadgen mobile passkey", flows.phonePasskeyAuthFlow, None),
+    ).map: (clientId, name, authFlow, registrationFlow) =>
+      ClientSpec(
+        clientId = clientId,
+        clientName = name,
+        redirectUris = Set(provision.mobileRedirectUri),
+        allowedScopes = scopes,
+        accessTokenTtlSeconds = accessTokenTtlSeconds,
+        refreshTokenTtlSeconds = Some(refreshTokenTtlSeconds),
+        publicClient = true,
+        authFlow = authFlow,
+        registrationFlow = registrationFlow,
+        backChannelLogoutUri = None,
+      )
+
+    val webClient = ClientSpec(
+      clientId = webOtpClientId,
+      clientName = "Loadgen web OTP",
+      redirectUris = Set(edgeCompleteUri),
+      allowedScopes = scopes,
+      accessTokenTtlSeconds = accessTokenTtlSeconds,
+      refreshTokenTtlSeconds = Some(refreshTokenTtlSeconds),
+      publicClient = false,
+      authFlow = flows.phoneOtpAuthFlow,
+      registrationFlow = Some(flows.registrationFlow),
+      // Design doc §3 #10 exercises the back-channel logout, which only reaches edge if the
+      // client edge fronts declares where to send it.
+      backChannelLogoutUri = Some(edgeBackChannelLogoutUri),
+    )
+
+    val clients = mobileClients :+ webClient
+
+    // Every client may hold a token for every resource: a session's actions are drawn from all
+    // ten regardless of how it authenticated, so a resource that named only some of the clients
+    // would fail audience validation for the rest.
+    val audience = clientIds
+
+    val resourceUris = Map(
+      coreResourceId -> provision.resources.coreUri,
+      payResourceId -> provision.resources.payUri,
+      notifyResourceId -> provision.resources.notifyUri,
+    )
+
+    val resources = List(coreResourceId, payResourceId, notifyResourceId).map: resourceId =>
+      ResourceSpec(
+        resourceId = resourceId,
+        resourceUri = resourceUris(resourceId),
+        audience = audience,
+        endpoints = allActions.filter(_.resourceId == resourceId).map: action =>
+          ResourceEndpointSpec(
+            id = endpointId(action.resourceId, action.method, action.path),
+            method = action.method,
+            path = action.path,
+            fetchUserInfo = action.fetchUserInfo,
+            allow = action.allow,
+            stepUpCondition = action.stepUpAcr.map(_ => stepUpAlways),
+            stepUpAcr = action.stepUpAcr,
+            maxAgeSeconds = action.maxAgeSeconds,
+          ),
+      )
+
+    val permissions = allActions
+      .groupBy(action => (action.permission, action.permissionDescription))
+      .toList
+      .sortBy(_._1._1)
+      .map: entry =>
+        val ((permission, description), grouped) = entry
+        PermissionSpec(
+          permission = permission,
+          description = description,
+          endpointIds = grouped.map(a => endpointId(a.resourceId, a.method, a.path)).toSet,
+        )
+
+    val readPermissions = permissions.map(_.permission).filter(_.endsWith(":read")).toSet
+
+    val roles = List(
+      RoleSpec(
+        roleId = retailUserRoleId,
+        description = "Retail customer",
+        // Every permission, including the two writes the design doc's summary line leaves out:
+        // with `cards:write`/`profile:write` withheld from this role too, actions #9 and #10
+        // would 403 for the entire population, which would both bury the `retail-basic` signal
+        // and stop the max-age re-auth and back-channel-logout paths from ever running.
+        permissions = permissions.map(_.permission).toSet,
+      ),
+      RoleSpec(
+        roleId = retailBasicRoleId,
+        description = "Retail customer, read-only",
+        permissions = readPermissions,
+      ),
+    )
+
+    val presets = List(
+      AuthRequestPresetsSpec(
+        clientId = webOtpClientId,
+        presets = List(
+          AuthRequestPresetSpec(
+            presetId = provision.preset.id,
+            description = "Loadgen web login",
+            redirectUri = edgeCompleteUri,
+            postLoginRedirectUri = targets.origin,
+            postLogoutRedirectUri = provision.preset.postLogoutRedirectUri,
+            scope = scopes,
+            responseType = "code",
+            cookieDomain = provision.preset.cookieDomain,
+            cookiePath = provision.preset.cookiePath,
+          ),
+        ),
+      ),
+    )
+
+    val challengeSettings = ChallengeSettingsSpec(
+      allowedPrefixes = Nil,
+      otpLength = 6,
+      otpResendAfterSeconds = 60,
+      passkeyRpId = provision.passkey.rpId,
+      passkeyRpName = provision.passkey.rpName,
+      passkeyOrigins = Set(targets.origin),
+      passkeyUserVerification = provision.passkey.userVerification,
+      ipHeader = "X-Forwarded-For",
+      // What makes `acr_values` resolvable: without a vocabulary, auth can neither tell that a
+      // session already satisfies the requested ACR nor work out which factor would achieve it,
+      // so every step-up would come back as `unmet_authentication_requirements` (§7.4).
+      acrVocabulary = Map(
+        Acr.OtpLevel -> List("otp"),
+        Acr.PasswordLevel -> List("password"),
+        Acr.PasskeyLevel -> List("passkey"),
+      ),
+    )
+
+    CampaignBlueprint(
+      clients = clients,
+      resources = resources,
+      permissions = permissions,
+      roles = roles,
+      presets = presets,
+      challengeSettings = challengeSettings,
+    )
+
+/** The `authFlow`/`registrationFlow` documents, read verbatim from the shared resource files of
+  * dev spec §3.4 rather than re-encoded here -- central's schema changes are exactly what this
+  * indirection exists to keep from being discovered twice, once by e2e and once by the emulator.
+  */
+case class CampaignFlows(
+    phoneOtpAuthFlow: Json,
+    phoneOtpPasswordAuthFlow: Json,
+    phonePasskeyAuthFlow: Json,
+    registrationFlow: Json,
+)

--- a/loadgen/src/main/scala/versola/loadgen/provision/FlowResources.scala
+++ b/loadgen/src/main/scala/versola/loadgen/provision/FlowResources.scala
@@ -1,0 +1,53 @@
+package versola.loadgen.provision
+
+import zio.json.ast.Json
+import zio.{Task, ZIO}
+
+import java.nio.charset.StandardCharsets
+
+/** Reads the shared flow documents of dev spec §3.4 off the classpath.
+  *
+  * They are resources rather than Scala values so that e2e can load the same files once
+  * `protocol/` is extracted into its own module (§3.2's post-v1 item): two copies of a client's
+  * `authFlow` drift the moment central's schema changes, and the drift is invisible until a
+  * campaign's logins start failing for a reason the e2e suite says cannot happen.
+  */
+object FlowResources:
+
+  private val directory = "flows"
+
+  val phoneOtpAuthFlowFile = "phone-otp-auth-flow.json"
+  val phoneOtpPasswordAuthFlowFile = "phone-otp-password-auth-flow.json"
+  val phonePasskeyAuthFlowFile = "phone-passkey-auth-flow.json"
+  val registrationFlowFile = "phone-otp-password-registration-flow.json"
+
+  def load: Task[CampaignFlows] =
+    for
+      phoneOtp <- read(phoneOtpAuthFlowFile)
+      phoneOtpPassword <- read(phoneOtpPasswordAuthFlowFile)
+      phonePasskey <- read(phonePasskeyAuthFlowFile)
+      registration <- read(registrationFlowFile)
+    yield CampaignFlows(
+      phoneOtpAuthFlow = phoneOtp,
+      phoneOtpPasswordAuthFlow = phoneOtpPassword,
+      phonePasskeyAuthFlow = phonePasskey,
+      registrationFlow = registration,
+    )
+
+  private def read(name: String): Task[Json] =
+    val path = s"$directory/$name"
+    for
+      bytes <- ZIO
+        .attemptBlocking(Option(getClass.getClassLoader.getResourceAsStream(path)))
+        .someOrFail(MissingFlowResource(path))
+        .flatMap(stream => ZIO.attemptBlocking(stream.readAllBytes()).ensuring(ZIO.succeed(stream.close())))
+      json <- ZIO
+        .fromEither(Json.decoder.decodeJson(String(bytes, StandardCharsets.UTF_8)))
+        .mapError(error => MalformedFlowResource(path, error))
+    yield json
+
+final case class MissingFlowResource(path: String)
+    extends RuntimeException(s"Flow resource '$path' is not on the classpath")
+
+final case class MalformedFlowResource(path: String, detail: String)
+    extends RuntimeException(s"Flow resource '$path' is not valid JSON: $detail")

--- a/loadgen/src/main/scala/versola/loadgen/provision/Provisioner.scala
+++ b/loadgen/src/main/scala/versola/loadgen/provision/Provisioner.scala
@@ -18,17 +18,19 @@ object Provisioner:
 
   /** The order is not cosmetic. Resources come before permissions because a permission grants an
     * endpoint id the resource has to have declared; permissions before roles because a role
-    * grants a permission; clients before presets and resources because a preset is validated
-    * against its client's redirect URIs and a resource's audience names clients. The syncs come
-    * last, and edge's after auth's, because edge reads client and preset state from central.
+    * grants a permission; roles before clients because a client's registration flow grants a
+    * role by id and central rejects the write with a `400` if that role does not exist yet;
+    * clients before presets because a preset is validated against its client's redirect URIs.
+    * The syncs come last, and edge's after auth's, because edge reads client and preset state
+    * from central.
     */
   def run(admin: AdminClient, blueprint: CampaignBlueprint): Task[Map[String, ClientCreds]] =
     for
       _ <- ZIO.logInfo("Provisioning campaign configuration")
-      creds <- ZIO.foreach(blueprint.clients)(spec => admin.registerClient(spec).map(spec.clientId -> _))
       _ <- ZIO.foreachDiscard(blueprint.resources)(admin.registerResource)
       _ <- admin.upsertPermissions(blueprint.permissions)
       _ <- admin.upsertRoles(blueprint.roles)
+      creds <- ZIO.foreach(blueprint.clients)(spec => admin.registerClient(spec).map(spec.clientId -> _))
       _ <- ZIO.foreachDiscard(blueprint.presets)(admin.upsertAuthRequestPresets)
       _ <- admin.upsertChallengeSettings(blueprint.challengeSettings)
       // The outbox carries user writes to auth. Nothing here creates a user, but the seeder (§10)

--- a/loadgen/src/main/scala/versola/loadgen/provision/Provisioner.scala
+++ b/loadgen/src/main/scala/versola/loadgen/provision/Provisioner.scala
@@ -1,0 +1,63 @@
+package versola.loadgen.provision
+
+import versola.loadgen.config.LoadgenConfig
+import versola.loadgen.protocol.{AdminClient, ClientCreds, HttpAdminClient}
+import zio.*
+import zio.http.Client
+
+/** `loadgen provision`: writes the campaign's configuration into central and makes auth and edge
+  * pick it up, then exits. Deliverable D6 of the tracking issue; run once before a campaign, and
+  * again whenever the blueprint changes.
+  *
+  * Re-runnable by construction. Every write is a desired-state apply ([[AdminClient]]), the
+  * endpoint ids are derived rather than drawn, and the order below is the dependency order, so a
+  * run against an already-provisioned environment converges instead of duplicating or failing --
+  * which matters most for the case it was written for: a run that died halfway.
+  */
+object Provisioner:
+
+  /** The order is not cosmetic. Resources come before permissions because a permission grants an
+    * endpoint id the resource has to have declared; permissions before roles because a role
+    * grants a permission; clients before presets and resources because a preset is validated
+    * against its client's redirect URIs and a resource's audience names clients. The syncs come
+    * last, and edge's after auth's, because edge reads client and preset state from central.
+    */
+  def run(admin: AdminClient, blueprint: CampaignBlueprint): Task[Map[String, ClientCreds]] =
+    for
+      _ <- ZIO.logInfo("Provisioning campaign configuration")
+      creds <- ZIO.foreach(blueprint.clients)(spec => admin.registerClient(spec).map(spec.clientId -> _))
+      _ <- ZIO.foreachDiscard(blueprint.resources)(admin.registerResource)
+      _ <- admin.upsertPermissions(blueprint.permissions)
+      _ <- admin.upsertRoles(blueprint.roles)
+      _ <- ZIO.foreachDiscard(blueprint.presets)(admin.upsertAuthRequestPresets)
+      _ <- admin.upsertChallengeSettings(blueprint.challengeSettings)
+      // The outbox carries user writes to auth. Nothing here creates a user, but the seeder (§10)
+      // and a campaign's registration ramp both leave entries behind, and a campaign that starts
+      // with users auth has not heard about yet measures failed logins.
+      _ <- admin.flushUserOutbox()
+      _ <- admin.syncConfiguration()
+      _ <- admin.syncEdgeConfiguration()
+      _ <- ZIO.logInfo(s"Provisioned ${blueprint.clients.size} clients, ${blueprint.resources.size} resources, " +
+        s"${blueprint.permissions.size} permissions, ${blueprint.roles.size} roles")
+    yield creds.toMap
+
+  /** Role dispatch's entry point: resolves what `role = provision` needs out of the config tree
+    * and runs one pass.
+    *
+    * The `provision` block is optional in [[LoadgenConfig]], so its absence is caught here rather
+    * than at decode time -- a driver's config legitimately omits it, and failing the decode for
+    * everyone would stop `role` from being read at all.
+    */
+  def provision(config: LoadgenConfig): RIO[Client, Unit] =
+    for
+      provisionConfig <- ZIO
+        .fromOption(config.provision)
+        .orElseFail(MissingProvisionConfig)
+      flows <- FlowResources.load
+      client <- ZIO.service[Client]
+      admin <- HttpAdminClient.make(client, config.targets, provisionConfig)
+      _ <- run(admin, CampaignBlueprint(config.targets, provisionConfig, flows))
+    yield ()
+
+case object MissingProvisionConfig
+    extends RuntimeException("role = provision requires a 'provision' configuration block")

--- a/loadgen/src/test/scala/versola/loadgen/config/LoadgenConfigSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/config/LoadgenConfigSpec.scala
@@ -17,7 +17,10 @@ object LoadgenConfigSpec extends ZIOSpecDefault:
 
   private val loadgenConfigDescriptor = deriveConfig[LoadgenConfig]
 
-  private val hocon: String =
+  /** Not private: [[versola.loadgen.provision.ProvisionerSpec]] loads role dispatch's input from
+    * the same tree, and a second copy of it would drift the moment a field is added.
+    */
+  val hocon: String =
     """role = driver
       |shard { index = 0, count = 8 }
       |
@@ -75,7 +78,30 @@ object LoadgenConfigSpec extends ZIOSpecDefault:
       |  { name = balance, weight = 0.4, method = GET, path = "/accounts/balance" },
       |  { name = pay,     weight = 0.1, method = POST, path = "/payments", acr = "password-level" },
       |]
+      |
+      |provision {
+      |  tenant-id = default
+      |  central-secret = "central-secret"
+      |  edge-secret = "edge-secret"
+      |  mobile-redirect-uri = "versola://callback"
+      |  resources {
+      |    core-uri   = "http://mockapi-core:8100"
+      |    pay-uri    = "http://mockapi-pay:8100"
+      |    notify-uri = "http://mockapi-notify:8100"
+      |  }
+      |  preset {
+      |    id = web-otp
+      |    cookie-domain = "bank.example.test"
+      |    cookie-path = "/"
+      |    post-logout-redirect-uri = "https://bank.example.test/goodbye"
+      |  }
+      |  passkey { rp-id = "bank.example.test", rp-name = "Versola Bank", user-verification = preferred }
+      |  payment-amount-threshold = 1000000
+      |}
       |""".stripMargin
+
+  /** The provision block dropped, as a driver's or coordinator's config file leaves it. */
+  val hoconWithoutProvision: String = hocon.substring(0, hocon.indexOf("provision {"))
 
   def spec = suite("LoadgenConfig")(
     suite("parsing")(
@@ -99,7 +125,21 @@ object LoadgenConfigSpec extends ZIOSpecDefault:
           config.actions.map(_.name) == List("balance", "pay"),
           config.actions(1).acr == Some("password-level"),
           config.actions(0).acr == None,
+          config.provision.map(_.tenantId) == Some("default"),
+          config.provision.map(_.resources.coreUri) == Some("http://mockapi-core:8100"),
+          config.provision.flatMap(_.preset.cookieDomain) == Some("bank.example.test"),
+          config.provision.map(_.passkey.rpId) == Some("bank.example.test"),
+          config.provision.map(_.paymentAmountThreshold) == Some(1000000L),
         )
+      },
+      // A driver holds no admin credentials, so requiring the block here would fail its decode
+      // before `role` was ever read.
+      test("decodes a config that omits the provision block") {
+        for config <- TypesafeConfigProvider
+            .fromHoconString(hoconWithoutProvision)
+            .kebabCase
+            .load(loadgenConfigDescriptor)
+        yield assertTrue(config.provision == None)
       },
       test("decodes a coordinator config, which owns no shard") {
         for config <- TypesafeConfigProvider

--- a/loadgen/src/test/scala/versola/loadgen/protocol/HttpAdminClientSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/protocol/HttpAdminClientSpec.scala
@@ -25,9 +25,12 @@ object HttpAdminClientSpec extends ZIOSpecDefault:
   private def passkeyClient = blueprint.clients.find(_.clientId == CampaignBlueprint.mobilePasskeyClientId).get
   private def coreResource = blueprint.resources.find(_.resourceId == CampaignBlueprint.coreResourceId).get
 
+  /** Seeds the role the blueprint's registration flows grant: central rejects a client naming a
+    * role that does not exist, and these specs write clients without provisioning first.
+    */
   private def fakeAdmin(staleClientListing: Boolean = false): ZIO[TestClient & Client, Throwable, (AdminClient, FakeCentral)] =
     for
-      fake <- FakeCentral.make(staleClientListing)
+      fake <- FakeCentral.make(staleClientListing).flatMap(_.withRoles(Set(CampaignBlueprint.retailUserRoleId)))
       _ <- TestClient.addRoutes(fake.handler.toRoutes)
       client <- ZIO.service[Client]
       admin <- HttpAdminClient.make(client, ProvisionFixtures.targets, ProvisionFixtures.provision)
@@ -139,6 +142,47 @@ object HttpAdminClientSpec extends ZIOSpecDefault:
           field(update, "backChannelLogoutUri").contains(Json.Null),
         )
       },
+      // The multi-value fields are patched, not replaced, so a redirect URI or scope the
+      // blueprint narrowed away stays active on central unless the update names it -- an
+      // obsolete OAuth redirect target surviving every re-run.
+      test("takes away a redirect URI, scope and permission the blueprint no longer wants") {
+        val widened = webClient.copy(
+          redirectUris = webClient.redirectUris + "https://bank.example.test/stale",
+          allowedScopes = webClient.allowedScopes + "stale:scope",
+        )
+        for
+          (admin, fake) <- fakeAdmin()
+          _ <- admin.registerClient(widened)
+          _ <- fake.grantClientPermissions(webClient.clientId, Set("stale:permission"))
+          _ <- admin.registerClient(webClient)
+          state <- fake.snapshot
+          update = parse(state.callsTo(Method.PUT, "/configuration/clients").head.body)
+          stored = state.clients(webClient.clientId)
+        yield assertTrue(
+          strings(obj(update, "redirectUris"), "remove") == List("https://bank.example.test/stale"),
+          strings(obj(update, "scope"), "remove") == List("stale:scope"),
+          strings(obj(update, "permissions"), "remove") == List("stale:permission"),
+          stored.redirectUris == webClient.redirectUris,
+          stored.scopes == webClient.allowedScopes,
+          stored.permissions.isEmpty,
+        )
+      },
+      // Central validates the roles a registration flow grants while saving the client, so a
+      // pass that wrote the clients before the roles would be rejected outright.
+      test("is refused when the role its registration flow grants does not exist yet") {
+        for
+          fake <- FakeCentral.make()
+          _ <- TestClient.addRoutes(fake.handler.toRoutes)
+          client <- ZIO.service[Client]
+          admin <- HttpAdminClient.make(client, ProvisionFixtures.targets, ProvisionFixtures.provision)
+          error <- admin.registerClient(webClient).flip
+        yield assert(error)(
+          isSubtype[AdminCallFailed](
+            hasField[AdminCallFailed, String]("operation", _.operation, equalTo("registerClient")) &&
+              hasField[AdminCallFailed, Status]("status", _.status, equalTo(Status.BadRequest)),
+          ),
+        )
+      },
       test("sends the blueprint's flow as a patch when the client keeps one") {
         for
           (admin, fake) <- fakeAdmin()
@@ -192,6 +236,21 @@ object HttpAdminClientSpec extends ZIOSpecDefault:
           state.resources(coreResource.resourceId).endpointIds == coreResource.endpoints.map(_.id).toSet,
         )
       },
+      // The listing the create-or-update choice is made on is cached, so a retry after a partial
+      // run can be told the resource is absent and have the create rejected as a duplicate.
+      test("converges on a resource a concurrent run committed behind a stale listing") {
+        for
+          (admin, fake) <- fakeAdmin()
+          _ <- admin.registerResource(coreResource)
+          _ <- fake.staleListings
+          _ <- admin.registerResource(coreResource)
+          state <- fake.snapshot
+        yield assertTrue(
+          state.callsTo(Method.POST, "/configuration/resources").size == 2,
+          state.callsTo(Method.PUT, "/configuration/resources").size == 1,
+          state.resources(coreResource.resourceId).endpointIds == coreResource.endpoints.map(_.id).toSet,
+        )
+      },
     ),
     suite("permissions and roles")(
       test("creates a permission once and updates it thereafter") {
@@ -235,6 +294,29 @@ object HttpAdminClientSpec extends ZIOSpecDefault:
           strings(obj(update, "permissions"), "remove") == List("cards:read"),
           strings(obj(update, "permissions"), "add").isEmpty,
           !state.roles(granted.roleId).contains("cards:read"),
+        )
+      },
+      // Same race as the resources': a unique-violation 500 on a create whose listing was stale
+      // must not fail the pass, because the id it names is already there.
+      test("converges on a permission and a role a concurrent run committed behind a stale listing") {
+        for
+          (admin, fake) <- fakeAdmin()
+          _ <- admin.upsertPermissions(blueprint.permissions)
+          _ <- admin.upsertRoles(blueprint.roles)
+          first <- fake.snapshot
+          _ <- fake.staleListings
+          _ <- admin.upsertPermissions(blueprint.permissions)
+          _ <- admin.upsertRoles(blueprint.roles)
+          second <- fake.snapshot
+        yield assertTrue(
+          // The cold listing sends the second pass down the create branch for everything, and
+          // every one of those creates is refused as a duplicate.
+          second.callsTo(Method.POST, "/configuration/permissions").size ==
+            first.callsTo(Method.POST, "/configuration/permissions").size + blueprint.permissions.size,
+          second.callsTo(Method.POST, "/configuration/roles").size ==
+            first.callsTo(Method.POST, "/configuration/roles").size + blueprint.roles.size,
+          second.permissions == first.permissions,
+          second.roles == first.roles,
         )
       },
     ),

--- a/loadgen/src/test/scala/versola/loadgen/protocol/HttpAdminClientSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/protocol/HttpAdminClientSpec.scala
@@ -1,0 +1,311 @@
+package versola.loadgen.protocol
+
+import versola.loadgen.provision.FakeCentral.*
+import versola.loadgen.provision.{CampaignBlueprint, FakeCentral, ProvisionFixtures}
+import zio.*
+import zio.http.*
+import zio.json.ast.Json
+import zio.test.*
+import zio.test.Assertion.*
+
+import java.util.UUID
+
+/** Asserts the wire shape of every admin call and the create-or-update choice behind it.
+  *
+  * These payloads are hand-built against central's DTOs, so nothing but a test notices when a
+  * field is misspelled: central answers a 200, ignores the member it does not know, and the
+  * campaign fails hours later with a 403 nobody can trace back to provisioning.
+  */
+object HttpAdminClientSpec extends ZIOSpecDefault:
+
+  private val blueprint = ProvisionFixtures.blueprint
+  private val tenantId = ProvisionFixtures.provision.tenantId
+
+  private def webClient = blueprint.clients.find(_.clientId == CampaignBlueprint.webOtpClientId).get
+  private def passkeyClient = blueprint.clients.find(_.clientId == CampaignBlueprint.mobilePasskeyClientId).get
+  private def coreResource = blueprint.resources.find(_.resourceId == CampaignBlueprint.coreResourceId).get
+
+  private def fakeAdmin(staleClientListing: Boolean = false): ZIO[TestClient & Client, Throwable, (AdminClient, FakeCentral)] =
+    for
+      fake <- FakeCentral.make(staleClientListing)
+      _ <- TestClient.addRoutes(fake.handler.toRoutes)
+      client <- ZIO.service[Client]
+      admin <- HttpAdminClient.make(client, ProvisionFixtures.targets, ProvisionFixtures.provision)
+    yield (admin, fake)
+
+  /** Reads succeed with an empty listing, writes fail -- so the operation the failure names is
+    * the write, not the read that preceded it.
+    */
+  private def failingWrites(status: Status): ZIO[TestClient & Client, Throwable, AdminClient] =
+    for
+      _ <- TestClient.addRoutes(
+        Handler
+          .fromFunction[Request]: request =>
+            if request.method == Method.GET then Response.json("""{"clients":[],"resources":[],"permissions":[],"roles":[]}""")
+            else Response.text("boom").status(status)
+          .toRoutes,
+      )
+      client <- ZIO.service[Client]
+      admin <- HttpAdminClient.make(client, ProvisionFixtures.targets, ProvisionFixtures.provision)
+    yield admin
+
+  def spec = suite("HttpAdminClient")(
+    suite("registerClient")(
+      test("creates a client it has not seen, with the tenant, flows and TTLs of the blueprint") {
+        for
+          (admin, fake) <- fakeAdmin()
+          creds <- admin.registerClient(webClient)
+          state <- fake.snapshot
+          body = state.clients(webClient.clientId).spec
+        yield assertTrue(
+          str(body, "tenantId") == tenantId,
+          str(body, "id") == webClient.clientId,
+          str(body, "clientType") == "web",
+          strings(body, "redirectUris").toSet == webClient.redirectUris,
+          strings(body, "allowedScopes").toSet == webClient.allowedScopes,
+          num(body, "accessTokenTtl").contains(BigDecimal(900)),
+          num(body, "refreshTokenTtl").contains(BigDecimal(2592000)),
+          field(body, "authFlow").contains(webClient.authFlow),
+          field(body, "registrationFlow") == webClient.registrationFlow,
+          optionalStr(body, "backChannelLogoutUri") == webClient.backChannelLogoutUri,
+          creds == ClientCreds(webClient.clientId, Some("secret-web-otp-0")),
+        )
+      },
+      test("marks a mobile client native and carries no secret back") {
+        for
+          (admin, fake) <- fakeAdmin()
+          creds <- admin.registerClient(passkeyClient)
+          state <- fake.snapshot
+          body = state.clients(passkeyClient.clientId).spec
+        yield assertTrue(
+          str(body, "clientType") == "native",
+          field(body, "registrationFlow").isEmpty,
+          creds == ClientCreds(passkeyClient.clientId, None),
+        )
+      },
+      // A confidential client's secret is readable exactly once, at registration, so the only way
+      // to hand the campaign one for a client a previous run created is to rotate.
+      test("updates and rotates when the client already exists") {
+        for
+          (admin, fake) <- fakeAdmin()
+          _ <- admin.registerClient(webClient)
+          second <- admin.registerClient(webClient)
+          state <- fake.snapshot
+        yield assertTrue(
+          second == ClientCreds(webClient.clientId, Some("secret-web-otp-1")),
+          state.callsTo(Method.POST, "/configuration/clients").size == 1,
+          state.callsTo(Method.PUT, "/configuration/clients").size == 1,
+          state.callsTo(Method.POST, "/configuration/clients/rotate-secret").size == 1,
+        )
+      },
+      test("does not rotate a public client, which has no secret to rotate") {
+        for
+          (admin, fake) <- fakeAdmin()
+          _ <- admin.registerClient(passkeyClient)
+          second <- admin.registerClient(passkeyClient)
+          state <- fake.snapshot
+        yield assertTrue(
+          second == ClientCreds(passkeyClient.clientId, None),
+          state.callsTo(Method.POST, "/configuration/clients/rotate-secret").isEmpty,
+          state.callsTo(Method.PUT, "/configuration/clients").size == 1,
+        )
+      },
+      // Central's cached client listing can be stale, so a create can still lose the race -- the
+      // 409 has to be a hand-off to the update path and not a failure.
+      test("falls back to update when a concurrent create won the race") {
+        for
+          (admin, fake) <- fakeAdmin(staleClientListing = true)
+          _ <- admin.registerClient(webClient)
+          creds <- admin.registerClient(webClient)
+          state <- fake.snapshot
+        yield assertTrue(
+          // Both runs see an empty listing and try to create; the second is told it lost.
+          state.callsTo(Method.POST, "/configuration/clients").size == 2,
+          state.callsTo(Method.PUT, "/configuration/clients").size == 1,
+          creds == ClientCreds(webClient.clientId, Some("secret-web-otp-1")),
+        )
+      },
+      // A patchable field is cleared by an explicit null and left alone by omission, so a client
+      // that carried a registration flow the campaign no longer wants must be sent one.
+      test("clears a dropped registration flow and logout URI rather than omitting them") {
+        for
+          (admin, fake) <- fakeAdmin()
+          _ <- admin.registerClient(passkeyClient)
+          _ <- admin.registerClient(passkeyClient)
+          state <- fake.snapshot
+          update = parse(state.callsTo(Method.PUT, "/configuration/clients").head.body)
+        yield assertTrue(
+          field(update, "registrationFlow").contains(Json.Null),
+          field(update, "backChannelLogoutUri").contains(Json.Null),
+        )
+      },
+      test("sends the blueprint's flow as a patch when the client keeps one") {
+        for
+          (admin, fake) <- fakeAdmin()
+          _ <- admin.registerClient(webClient)
+          _ <- admin.registerClient(webClient)
+          state <- fake.snapshot
+          update = parse(state.callsTo(Method.PUT, "/configuration/clients").head.body)
+        yield assertTrue(
+          field(update, "registrationFlow") == webClient.registrationFlow,
+          field(update, "authFlow").contains(webClient.authFlow),
+          strings(obj(update, "scope"), "add").toSet == webClient.allowedScopes,
+        )
+      },
+    ),
+    suite("registerResource")(
+      test("creates a resource with its endpoints, and not as an internal one") {
+        for
+          (admin, fake) <- fakeAdmin()
+          _ <- admin.registerResource(coreResource)
+          state <- fake.snapshot
+          body = state.resources(coreResource.resourceId).spec
+          limits = objects(body, "endpoints").find(e => str(e, "path") == "/cards/{cardId}/limits").get
+          expected = coreResource.endpoints.find(_.path == "/cards/{cardId}/limits").get
+        yield assertTrue(
+          str(body, "tenantId") == tenantId,
+          str(body, "resource") == ProvisionFixtures.provision.resources.coreUri,
+          strings(body, "audience") == CampaignBlueprint.clientIds,
+          bool(body, "internal").contains(false),
+          objects(body, "endpoints").size == coreResource.endpoints.size,
+          str(limits, "method") == "PUT",
+          str(limits, "id") == expected.id.toString,
+          optionalStr(limits, "stepUpAcr") == expected.stepUpAcr,
+          optionalStr(limits, "stepUpCondition") == expected.stepUpCondition,
+          num(limits, "maxAge").contains(BigDecimal(300)),
+          bool(limits, "fetchUserInfo").contains(false),
+        )
+      },
+      // Central's update deletes every id it is about to create before creating it, so sending
+      // the full desired set is one atomic desired-state apply.
+      test("re-creates the desired endpoints and deletes only the ones the blueprint dropped") {
+        val stale = UUID.fromString("00000000-0000-0000-0000-0000000000ff")
+        for
+          (admin, fake) <- fakeAdmin()
+          _ <- admin.registerResource(coreResource.copy(endpoints = coreResource.endpoints.map(_.copy(id = stale))))
+          _ <- admin.registerResource(coreResource)
+          state <- fake.snapshot
+          update = parse(state.callsTo(Method.PUT, "/configuration/resources").head.body)
+        yield assertTrue(
+          strings(update, "deleteEndpoints").map(UUID.fromString) == List(stale),
+          objects(update, "createEndpoints").size == coreResource.endpoints.size,
+          state.resources(coreResource.resourceId).endpointIds == coreResource.endpoints.map(_.id).toSet,
+        )
+      },
+    ),
+    suite("permissions and roles")(
+      test("creates a permission once and updates it thereafter") {
+        for
+          (admin, fake) <- fakeAdmin()
+          _ <- admin.upsertPermissions(blueprint.permissions)
+          _ <- admin.upsertPermissions(blueprint.permissions)
+          state <- fake.snapshot
+          created = parse(state.callsTo(Method.POST, "/configuration/permissions").head.body)
+          updated = parse(state.callsTo(Method.PUT, "/configuration/permissions").head.body)
+        yield assertTrue(
+          state.callsTo(Method.POST, "/configuration/permissions").size == blueprint.permissions.size,
+          state.callsTo(Method.PUT, "/configuration/permissions").size == blueprint.permissions.size,
+          str(created, "tenantId") == tenantId,
+          field(created, "description").exists(_.asObject.exists(_.fields.map(_._1) == Chunk("en"))),
+          str(updated, "permission") == blueprint.permissions.head.permission,
+          strings(updated, "endpointIds").map(UUID.fromString).toSet == blueprint.permissions.head.endpointIds,
+        )
+      },
+      test("creates a role with its permissions") {
+        for
+          (admin, fake) <- fakeAdmin()
+          _ <- admin.upsertRoles(blueprint.roles)
+          state <- fake.snapshot
+        yield assertTrue(
+          state.roles(CampaignBlueprint.retailUserRoleId) == blueprint.roles.head.permissions,
+          state.roles(CampaignBlueprint.retailBasicRoleId) == blueprint.roles.last.permissions,
+        )
+      },
+      // A role's permissions are patched, not replaced, so a permission the blueprint moved from
+      // one role to another would otherwise stay granted on both.
+      test("revokes a permission the blueprint took away") {
+        val granted = blueprint.roles.last
+        for
+          (admin, fake) <- fakeAdmin()
+          _ <- admin.upsertRoles(List(granted))
+          _ <- admin.upsertRoles(List(granted.copy(permissions = granted.permissions - "cards:read")))
+          state <- fake.snapshot
+          update = parse(state.callsTo(Method.PUT, "/configuration/roles").head.body)
+        yield assertTrue(
+          strings(obj(update, "permissions"), "remove") == List("cards:read"),
+          strings(obj(update, "permissions"), "add").isEmpty,
+          !state.roles(granted.roleId).contains("cards:read"),
+        )
+      },
+    ),
+    suite("presets and challenge settings")(
+      // Central stores a client's presets as one set, so a re-run cannot accumulate duplicates.
+      test("replaces the client's presets wholesale") {
+        for
+          (admin, fake) <- fakeAdmin()
+          _ <- admin.upsertAuthRequestPresets(blueprint.presets.head)
+          _ <- admin.upsertAuthRequestPresets(blueprint.presets.head)
+          state <- fake.snapshot
+          preset = state.presets(CampaignBlueprint.webOtpClientId).head
+        yield assertTrue(
+          state.presets(CampaignBlueprint.webOtpClientId).size == 1,
+          str(preset, "id") == ProvisionFixtures.provision.preset.id,
+          str(preset, "responseType") == "code",
+          strings(preset, "scope").toSet == CampaignBlueprint.scopes,
+          optionalStr(preset, "cookieDomain") == ProvisionFixtures.provision.preset.cookieDomain,
+          optionalStr(preset, "postLogoutRedirectUri") == ProvisionFixtures.provision.preset.postLogoutRedirectUri,
+        )
+      },
+      test("writes the whole challenge-settings document, vocabulary included") {
+        for
+          (admin, fake) <- fakeAdmin()
+          _ <- admin.upsertChallengeSettings(blueprint.challengeSettings)
+          state <- fake.snapshot
+          body = state.challengeSettings.get
+          passkey = obj(body, "passkeySettings")
+        yield assertTrue(
+          str(body, "tenantId") == tenantId,
+          num(body, "otpLength").contains(BigDecimal(6)),
+          str(body, "ipHeader") == "X-Forwarded-For",
+          str(passkey, "rpId") == ProvisionFixtures.provision.passkey.rpId,
+          strings(passkey, "origins") == List(ProvisionFixtures.targets.origin),
+          strings(obj(body, "acrVocabulary"), versola.loadgen.protocol.Acr.OtpLevel) == List("otp"),
+          field(obj(body, "submissionLimits"), "banDurationSeconds").isDefined,
+        )
+      },
+    ),
+    suite("syncs")(
+      test("tells auth and edge to reload, and flushes the user outbox") {
+        for
+          (admin, fake) <- fakeAdmin()
+          _ <- admin.flushUserOutbox()
+          _ <- admin.syncConfiguration()
+          _ <- admin.syncEdgeConfiguration()
+          state <- fake.snapshot
+        yield assertTrue(state.outboxFlushes == 1, state.authSyncs == 1, state.edgeSyncs == 1)
+      },
+    ),
+    suite("failures")(
+      // A unique violation reaches the caller as a 500, which is indistinguishable from central
+      // being broken -- so a failure has to stop the run and name the step to re-run.
+      test("fails with the operation that broke") {
+        for
+          admin <- failingWrites(Status.InternalServerError)
+          error <- admin.upsertRoles(blueprint.roles).flip
+        yield assert(error)(
+          isSubtype[AdminCallFailed](
+            hasField[AdminCallFailed, String]("operation", _.operation, equalTo("upsertRoles")) &&
+              hasField[AdminCallFailed, Status]("status", _.status, equalTo(Status.InternalServerError)),
+          ),
+        )
+      },
+      test("fails when a client listing cannot be read") {
+        for
+          _ <- TestClient.addRoutes(Handler.fromResponse(Response.json("""{"unexpected":true}""")).toRoutes)
+          client <- ZIO.service[Client]
+          admin <- HttpAdminClient.make(client, ProvisionFixtures.targets, ProvisionFixtures.provision)
+          error <- admin.registerClient(webClient).flip
+        yield assert(error)(isSubtype[AdminCallFailed](hasField("operation", _.operation, Assertion.equalTo("listClients"))))
+      },
+    ),
+  ).provide(TestClient.layer) @@ TestAspect.silentLogging

--- a/loadgen/src/test/scala/versola/loadgen/provision/CampaignBlueprintSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/provision/CampaignBlueprintSpec.scala
@@ -1,0 +1,219 @@
+package versola.loadgen.provision
+
+import versola.loadgen.protocol.Acr
+import zio.json.ast.Json
+import zio.test.*
+import zio.test.Assertion.*
+
+/** Asserts what `provision` is about to write, without a central to write it to.
+  *
+  * The blueprint is where a campaign's meaning lives -- which action needs a step-up, which role
+  * is allowed to write -- and a mistake here does not fail a run, it silently measures the wrong
+  * system: an endpoint with no `stepUpAcr` produces a campaign with no step-ups and a latency
+  * profile that looks better than the real one.
+  */
+object CampaignBlueprintSpec extends ZIOSpecDefault:
+
+  import ProvisionFixtures.blueprint
+
+  private def endpoints = blueprint.resources.flatMap(r => r.endpoints.map(r.resourceId -> _))
+
+  private def endpointFor(method: String, path: String) =
+    endpoints.map(_._2).find(e => e.method == method && e.path == path)
+
+  def spec = suite("CampaignBlueprint")(
+    suite("clients")(
+      test("declares the four clients of design doc §2.2") {
+        assertTrue(blueprint.clients.map(_.clientId) == CampaignBlueprint.clientIds)
+      },
+      test("makes the three mobile clients public and the edge-fronted one confidential") {
+        val public = blueprint.clients.filter(_.publicClient).map(_.clientId)
+        val confidential = blueprint.clients.filterNot(_.publicClient).map(_.clientId)
+        assertTrue(
+          public == List(
+            CampaignBlueprint.mobileOtpClientId,
+            CampaignBlueprint.mobileOtpPasswordClientId,
+            CampaignBlueprint.mobilePasskeyClientId,
+          ),
+          confidential == List(CampaignBlueprint.webOtpClientId),
+        )
+      },
+      test("gives each client the auth flow its cohort authenticates with") {
+        val flows = blueprint.clients.map(c => c.clientId -> c.authFlow).toMap
+        assertTrue(
+          flows(CampaignBlueprint.mobileOtpClientId) == ProvisionFixtures.flows.phoneOtpAuthFlow,
+          flows(CampaignBlueprint.mobileOtpPasswordClientId) == ProvisionFixtures.flows.phoneOtpPasswordAuthFlow,
+          flows(CampaignBlueprint.mobilePasskeyClientId) == ProvisionFixtures.flows.phonePasskeyAuthFlow,
+          flows(CampaignBlueprint.webOtpClientId) == ProvisionFixtures.flows.phoneOtpAuthFlow,
+        )
+      },
+      test("withholds a registration flow from the passkey client only") {
+        val without = blueprint.clients.filter(_.registrationFlow.isEmpty).map(_.clientId)
+        assertTrue(without == List(CampaignBlueprint.mobilePasskeyClientId))
+      },
+      // Without offline_access there is no refresh token, and §2.3's 96.7% refresh path -- most
+      // of the campaign's traffic -- cannot be exercised at all.
+      test("requests offline_access for every client") {
+        assert(blueprint.clients)(forall(hasField("scopes", _.allowedScopes, contains("offline_access"))))
+      },
+      test("redirects the mobile clients to the app scheme and the web client to edge") {
+        val mobile = blueprint.clients.filter(_.publicClient)
+        val web = blueprint.clients.find(_.clientId == CampaignBlueprint.webOtpClientId).get
+        assertTrue(
+          mobile.forall(_.redirectUris == Set(ProvisionFixtures.provision.mobileRedirectUri)),
+          web.redirectUris == Set(s"${ProvisionFixtures.targets.origin}/complete"),
+        )
+      },
+      // §3 #10 exercises the back-channel logout, which only reaches edge if the client edge
+      // fronts declares where central should post it.
+      test("declares a back-channel logout URI for the edge-fronted client only") {
+        val declared = blueprint.clients.filter(_.backChannelLogoutUri.isDefined).map(_.clientId)
+        assertTrue(
+          declared == List(CampaignBlueprint.webOtpClientId),
+          blueprint.clients.last.backChannelLogoutUri.contains(s"${ProvisionFixtures.targets.edgeUrl}/logout/backchannel"),
+        )
+      },
+    ),
+    suite("resources and endpoints")(
+      test("declares the ten protected actions of design doc §3 across three resources") {
+        assertTrue(
+          blueprint.resources.map(_.resourceId) == List(
+            CampaignBlueprint.coreResourceId,
+            CampaignBlueprint.payResourceId,
+            CampaignBlueprint.notifyResourceId,
+          ),
+          endpoints.size == 10,
+        )
+      },
+      test("assigns each endpoint to the resource that serves it") {
+        val byResource = endpoints.groupMap(_._1)(pair => s"${pair._2.method} ${pair._2.path}").view.mapValues(_.toSet).toMap
+        assertTrue(
+          byResource(CampaignBlueprint.coreResourceId) == Set(
+            "GET /accounts",
+            "GET /accounts/{accountId}/transactions",
+            "GET /cards",
+            "GET /profile",
+            "PUT /cards/{cardId}/limits",
+            "DELETE /profile/security/devices/{deviceId}",
+          ),
+          byResource(CampaignBlueprint.payResourceId) == Set("GET /templates", "POST /p2p", "POST /utility"),
+          byResource(CampaignBlueprint.notifyResourceId) == Set("GET /notifications"),
+        )
+      },
+      test("names every client in every resource's audience") {
+        assert(blueprint.resources)(
+          forall(hasField("audience", _.audience, equalTo(CampaignBlueprint.clientIds))),
+        )
+      },
+      // An L2 action must not be satisfiable by the factor the user happened to log in with:
+      // an ordinary login requests no acr_values and so carries no acr at all.
+      test("requires the OTP level on the payment and card-limit actions") {
+        val stepUp = endpoints.map(_._2).filter(_.stepUpAcr.contains(Acr.OtpLevel)).map(e => s"${e.method} ${e.path}")
+        assertTrue(stepUp.toSet == Set("POST /p2p", "POST /utility", "PUT /cards/{cardId}/limits"))
+      },
+      // §3 #10 is "passkey or password re-auth": edge reads stepUpAcr as a space-separated set of
+      // alternatives, and pinning it to the passkey level alone would make the action unreachable
+      // for the 75% of the population that has never enrolled one.
+      test("accepts either passkey or password re-auth on the device-revocation action") {
+        val revoke = endpointFor("DELETE", "/profile/security/devices/{deviceId}").get
+        assertTrue(
+          revoke.stepUpAcr.toList.flatMap(_.split(" ")).toSet == Set(Acr.PasskeyLevel, Acr.PasswordLevel),
+        )
+      },
+      test("pairs every step-up ACR with a condition, and declares neither elsewhere") {
+        assert(endpoints.map(_._2))(
+          forall(assertion("has a condition exactly when it has an ACR")(e => e.stepUpAcr.isDefined == e.stepUpCondition.isDefined)),
+        )
+      },
+      test("forces a re-authentication on a stale auth_time for the card-limit action only") {
+        val withMaxAge = endpoints.map(_._2).filter(_.maxAgeSeconds.isDefined)
+        assertTrue(withMaxAge.map(e => e.path -> e.maxAgeSeconds) == List("/cards/{cardId}/limits" -> Some(300)))
+      },
+      test("only the /profile action asks edge to fetch userinfo") {
+        val fetching = endpoints.map(_._2).filter(_.fetchUserInfo).map(_.path)
+        assertTrue(fetching == List("/profile"))
+      },
+      // A CEL rule exists so that checkRules runs on the measured path; it must not add to the
+      // campaign's forbidden rate on a body that carries no amount.
+      test("guards the payment CEL rule against a missing or integral amount") {
+        val rules = endpoints.map(_._2).flatMap(_.allow)
+        assertTrue(
+          rules.size == 2,
+          rules.forall(_.startsWith("!has(request.body.amount) ||")),
+          rules.forall(_.contains("double(request.body.amount) <= 1000000.0")),
+        )
+      },
+      // A permission grants an endpoint by id, so a fresh UUID per run would leave every
+      // permission pointing at an endpoint that no longer exists and every action 403.
+      test("derives endpoint ids stably across blueprints") {
+        val other = CampaignBlueprint(ProvisionFixtures.targets, ProvisionFixtures.provision, ProvisionFixtures.flows)
+        assertTrue(
+          other.resources.flatMap(_.endpoints.map(_.id)) == blueprint.resources.flatMap(_.endpoints.map(_.id)),
+          endpoints.map(_._2.id).distinct.size == 10,
+        )
+      },
+    ),
+    suite("permissions and roles")(
+      test("covers every endpoint with exactly one permission") {
+        val granted = blueprint.permissions.flatMap(_.endpointIds)
+        assertTrue(
+          granted.distinct.size == 10,
+          granted.toSet == endpoints.map(_._2.id).toSet,
+        )
+      },
+      test("shares one permission between the two payment actions") {
+        val write = blueprint.permissions.find(_.permission == "payments:write").get
+        val paths = endpoints.map(_._2).filter(e => write.endpointIds.contains(e.id)).map(_.path).toSet
+        assertTrue(paths == Set("/p2p", "/utility"))
+      },
+      test("grants the full-access role every permission") {
+        val role = blueprint.roles.find(_.roleId == CampaignBlueprint.retailUserRoleId).get
+        assertTrue(role.permissions == blueprint.permissions.map(_.permission).toSet)
+      },
+      // The 403s this role collects on the write actions are the campaign's only source of a
+      // realistic forbidden rate (§3), so it must hold the reads and none of the writes.
+      test("grants the read-only role the reads and none of the writes") {
+        val role = blueprint.roles.find(_.roleId == CampaignBlueprint.retailBasicRoleId).get
+        assertTrue(
+          role.permissions.forall(_.endsWith(":read")),
+          role.permissions.nonEmpty,
+          blueprint.permissions.map(_.permission).toSet -- role.permissions == Set(
+            "payments:write",
+            "cards:write",
+            "profile:write",
+          ),
+        )
+      },
+    ),
+    suite("presets and challenge settings")(
+      test("declares the one edge login preset against the edge-fronted client") {
+        val preset = blueprint.presets.head
+        assertTrue(
+          blueprint.presets.map(_.clientId) == List(CampaignBlueprint.webOtpClientId),
+          preset.presets.map(_.presetId) == List(ProvisionFixtures.provision.preset.id),
+          preset.presets.head.redirectUri == s"${ProvisionFixtures.targets.origin}/complete",
+          preset.presets.head.scope == CampaignBlueprint.scopes,
+        )
+      },
+      // Without a vocabulary auth cannot tell that a session already satisfies the requested ACR,
+      // nor which factor would achieve it, so every step-up comes back as
+      // unmet_authentication_requirements (§7.4).
+      test("maps every ACR the endpoints request to the factor that satisfies it") {
+        val vocabulary = blueprint.challengeSettings.acrVocabulary
+        val requested = endpoints.flatMap(_._2.stepUpAcr).flatMap(_.split(" ")).toSet
+        assertTrue(
+          requested.subsetOf(vocabulary.keySet),
+          vocabulary(Acr.OtpLevel) == List("otp"),
+          vocabulary(Acr.PasswordLevel) == List("password"),
+          vocabulary(Acr.PasskeyLevel) == List("passkey"),
+        )
+      },
+      test("signs passkeys against the configured relying party and the campaign's origin") {
+        val settings = blueprint.challengeSettings
+        assertTrue(
+          settings.passkeyRpId == ProvisionFixtures.provision.passkey.rpId,
+          settings.passkeyOrigins == Set(ProvisionFixtures.targets.origin),
+        )
+      },
+    ),
+  )

--- a/loadgen/src/test/scala/versola/loadgen/provision/FakeCentral.scala
+++ b/loadgen/src/test/scala/versola/loadgen/provision/FakeCentral.scala
@@ -26,6 +26,31 @@ final class FakeCentral(state: Ref[FakeCentral.State], staleClientListing: Boole
 
   def snapshot: UIO[State] = state.get
 
+  /** Pre-creates roles, for the specs that write a client on its own: central validates the
+    * roles a registration flow grants while saving the client, so a client-only test would
+    * otherwise be rejected the way the provisioner's ordering was.
+    */
+  def withRoles(roleIds: Set[String]): UIO[FakeCentral] =
+    state.update(s => s.copy(roles = s.roles ++ roleIds.map(_ -> Set.empty[String]))).as(this)
+
+  /** Grants a permission directly to a stored client -- something the campaign's blueprint never
+    * asks for, and therefore the only way to test that the desired-state update takes away what
+    * a previous configuration left behind.
+    */
+  def grantClientPermissions(clientId: String, permissions: Set[String]): UIO[Unit] =
+    state.update: s =>
+      s.copy(clients = s.clients.updatedWith(clientId)(_.map(c => c.copy(permissions = c.permissions ++ permissions))))
+
+  /** Puts the listing caches back the way a run that lost a race sees them: the next read of
+    * each configuration listing answers as if nothing were there, though every write is
+    * committed, and catches up on the read after it. The window in which a create-if-missing
+    * check takes the create branch for something that is already there.
+    */
+  def staleListings: UIO[Unit] = state.update(_.copy(coldPaths = coldListingPaths))
+
+  private def cold(path: String): UIO[Boolean] =
+    state.modify(s => (s.coldPaths.contains(path), s.copy(coldPaths = s.coldPaths - path)))
+
   private def respond(request: Request, body: String): UIO[Response] =
     val path = request.url.path.encode
     val record = state.update(s => s.copy(calls = s.calls :+ Call(request.method, path, body)))
@@ -39,27 +64,43 @@ final class FakeCentral(state: Ref[FakeCentral.State], staleClientListing: Boole
         // the listing is served from a cache a PostgreSQL notification refreshes, so a peer's
         // client can be absent from it and still conflict on create.
         state.get.map: s =>
-          val visible = if staleClientListing then Nil else s.clients.keys.toList.sorted
-          json(Json.Obj("clients" -> array(visible.map(idObject))))
+          val visible = if staleClientListing then Nil else s.clients.toList.sortBy(_._1)
+          json(Json.Obj("clients" -> array(visible.map { (clientId, stored) =>
+            Json.Obj(
+              "id" -> Json.Str(clientId),
+              "redirectUris" -> array(stored.redirectUris.toList.sorted.map(Json.Str(_))),
+              "scope" -> array(stored.scopes.toList.sorted.map(Json.Str(_))),
+              "permissions" -> array(stored.permissions.toList.sorted.map(Json.Str(_))),
+            )
+          })))
 
       case (Method.POST, "/configuration/clients") =>
         val spec = parse(body)
         val clientId = str(spec, "id")
-        state.modify: s =>
+        val create = state.modify: s =>
           if s.clients.contains(clientId) then (Response.status(Status.Conflict), s)
           else
             val secret = if str(spec, "clientType") == "web" then Some(s"secret-$clientId-0") else None
             val response = json(Json.Obj(secret.map(v => "secret" -> Json.Str(v)).toList*), Status.Created)
-            (response, s.copy(clients = s.clients.updated(clientId, StoredClient(spec, secret))))
+            val stored = StoredClient(
+              spec = spec,
+              secret = secret,
+              redirectUris = strings(spec, "redirectUris").toSet,
+              scopes = strings(spec, "allowedScopes").toSet,
+              permissions = strings(spec, "permissions").toSet,
+            )
+            (response, s.copy(clients = s.clients.updated(clientId, stored)))
+        unknownRole(spec).someOrElseZIO(create)
 
       case (Method.PUT, "/configuration/clients") =>
         val spec = parse(body)
         val clientId = str(spec, "clientId")
-        state.modify: s =>
+        val update = state.modify: s =>
           s.clients.get(clientId) match
             case None => (Response.status(Status.NoContent), s)
             case Some(stored) =>
               (Response.status(Status.NoContent), s.copy(clients = s.clients.updated(clientId, stored.updated(spec))))
+        unknownRole(spec).someOrElseZIO(update)
 
       case (Method.POST, "/configuration/clients/rotate-secret") =>
         val clientId = request.url.queryParams.queryParam("clientId").getOrElse("")
@@ -74,8 +115,9 @@ final class FakeCentral(state: Ref[FakeCentral.State], staleClientListing: Boole
               )
 
       case (Method.GET, "/configuration/resources") =>
-        state.get.map: s =>
-          json(Json.Obj("resources" -> array(s.resources.toList.sortBy(_._1).map { (resourceId, stored) =>
+        cold(path).zip(state.get).map: (stale, s) =>
+          val visible = if stale then Nil else s.resources.toList.sortBy(_._1)
+          json(Json.Obj("resources" -> array(visible.map { (resourceId, stored) =>
             Json.Obj(
               "resourceId" -> Json.Str(resourceId),
               "endpoints" -> array(stored.endpointIds.toList.sortBy(_.toString).map(idObject)),
@@ -107,8 +149,9 @@ final class FakeCentral(state: Ref[FakeCentral.State], staleClientListing: Boole
               )
 
       case (Method.GET, "/configuration/permissions") =>
-        state.get.map: s =>
-          json(Json.Obj("permissions" -> array(s.permissions.keys.toList.sorted.map: permission =>
+        cold(path).zip(state.get).map: (stale, s) =>
+          val visible = if stale then Nil else s.permissions.keys.toList.sorted
+          json(Json.Obj("permissions" -> array(visible.map: permission =>
             Json.Obj("permission" -> Json.Str(permission)))))
 
       case (Method.POST, "/configuration/permissions") =>
@@ -130,8 +173,9 @@ final class FakeCentral(state: Ref[FakeCentral.State], staleClientListing: Boole
             (Response.status(Status.NoContent), s.copy(permissions = s.permissions.updated(permission, endpointIds)))
 
       case (Method.GET, "/configuration/roles") =>
-        state.get.map: s =>
-          json(Json.Obj("roles" -> array(s.roles.toList.sortBy(_._1).map { (roleId, granted) =>
+        cold(path).zip(state.get).map: (stale, s) =>
+          val visible = if stale then Nil else s.roles.toList.sortBy(_._1)
+          json(Json.Obj("roles" -> array(visible.map { (roleId, granted) =>
             Json.Obj("id" -> Json.Str(roleId), "permissions" -> array(granted.toList.sorted.map(Json.Str(_))))
           })))
 
@@ -177,6 +221,18 @@ final class FakeCentral(state: Ref[FakeCentral.State], staleClientListing: Boole
 
       case _ => ZIO.succeed(Response.status(Status.NotFound)))
 
+  /** Central validates the roles a client's registration flow grants while saving the client and
+    * answers a `400` for one that does not exist yet -- the reason roles are provisioned before
+    * any client that names them.
+    */
+  private def unknownRole(spec: Json.Obj): UIO[Option[Response]] =
+    val granted = field(spec, "registrationFlow").collect { case flow: Json.Obj => strings(flow, "roleIds") }
+      .getOrElse(Nil)
+    state.get.map: s =>
+      granted.find(!s.roles.contains(_)).map: roleId =>
+        Response.text(s"Invalid registration configuration: role '$roleId' does not exist")
+          .status(Status.BadRequest)
+
 object FakeCentral:
 
   case class Call(method: Method, path: String, body: String)
@@ -192,11 +248,38 @@ object FakeCentral:
     "/configuration/roles",
   )
 
-  case class StoredClient(spec: Json.Obj, secret: Option[String], rotations: Int = 0):
-    def updated(spec: Json.Obj): StoredClient = copy(spec = spec)
+  case class StoredClient(
+      spec: Json.Obj,
+      secret: Option[String],
+      redirectUris: Set[String] = Set.empty,
+      scopes: Set[String] = Set.empty,
+      permissions: Set[String] = Set.empty,
+      rotations: Int = 0,
+  ):
+    /** Applies the update's patch sets the way central's repository does, removals before
+      * additions, so a client whose configuration was narrowed really does lose what the
+      * update takes away.
+      */
+    def updated(spec: Json.Obj): StoredClient =
+      copy(
+        spec = spec,
+        redirectUris = patched(redirectUris, obj(spec, "redirectUris")),
+        scopes = patched(scopes, obj(spec, "scope")),
+        permissions = patched(permissions, obj(spec, "permissions")),
+      )
+
     def rotated(secret: String): StoredClient = copy(secret = Some(secret), rotations = rotations + 1)
 
+    private def patched(current: Set[String], patch: Json.Obj): Set[String] =
+      current -- strings(patch, "remove") ++ strings(patch, "add")
+
   case class StoredResource(spec: Json.Obj, endpointIds: Set[UUID])
+
+  /** The listings [[FakeCentral.staleListings]] serves cold. Clients are not among them: their
+    * listing has its own flag, because the provisioner's 409 fallback needs it stale throughout.
+    */
+  val coldListingPaths: Set[String] =
+    Set("/configuration/resources", "/configuration/permissions", "/configuration/roles")
 
   case class State(
       clients: Map[String, StoredClient],
@@ -208,6 +291,7 @@ object FakeCentral:
       authSyncs: Int,
       edgeSyncs: Int,
       outboxFlushes: Int,
+      coldPaths: Set[String],
       calls: Chunk[Call],
   ):
     def callsTo(method: Method, path: String): Chunk[Call] =
@@ -223,6 +307,7 @@ object FakeCentral:
     authSyncs = 0,
     edgeSyncs = 0,
     outboxFlushes = 0,
+    coldPaths = Set.empty,
     calls = Chunk.empty,
   )
 
@@ -314,7 +399,12 @@ object ProvisionFixtures:
     phoneOtpAuthFlow = Json.Obj("primary" -> Json.Str("phone-otp")),
     phoneOtpPasswordAuthFlow = Json.Obj("primary" -> Json.Str("phone-otp-password")),
     phonePasskeyAuthFlow = Json.Obj("primary" -> Json.Str("phone-passkey")),
-    registrationFlow = Json.Obj("credential" -> Json.Str("phone")),
+    // Carries `roleIds` because the real document does: central validates the roles a
+    // registration flow grants while saving the client that names it.
+    registrationFlow = Json.Obj(
+      "credential" -> Json.Str("phone"),
+      "roleIds" -> Json.Arr(Json.Str(CampaignBlueprint.retailUserRoleId)),
+    ),
   )
 
   val blueprint: CampaignBlueprint = CampaignBlueprint(targets, provision, flows)

--- a/loadgen/src/test/scala/versola/loadgen/provision/FakeCentral.scala
+++ b/loadgen/src/test/scala/versola/loadgen/provision/FakeCentral.scala
@@ -1,0 +1,320 @@
+package versola.loadgen.provision
+
+import versola.loadgen.config.*
+import zio.*
+import zio.http.*
+import zio.json.*
+import zio.json.ast.Json
+
+import java.util.UUID
+
+/** In-memory stand-in for central's configuration API and edge's service API, with the two
+  * behaviours the provisioner's idempotency actually turns on: a duplicate client is a `409`,
+  * while a duplicate role, permission or resource is the `500` a unique violation surfaces as.
+  *
+  * Holds real state rather than replaying canned responses, so that "run `provision` twice"
+  * is a test of convergence and not of a script -- the second run reads back what the first
+  * one wrote, exactly as it would against a live central.
+  */
+final class FakeCentral(state: Ref[FakeCentral.State], staleClientListing: Boolean):
+
+  import FakeCentral.*
+
+  def handler: Handler[Any, Nothing, Request, Response] =
+    Handler.fromFunctionZIO[Request]: request =>
+      request.body.asString.orDie.flatMap(body => respond(request, body))
+
+  def snapshot: UIO[State] = state.get
+
+  private def respond(request: Request, body: String): UIO[Response] =
+    val path = request.url.path.encode
+    val record = state.update(s => s.copy(calls = s.calls :+ Call(request.method, path, body)))
+    val fromEdge = request.header(Header.Authorization).exists {
+      case Header.Authorization.Basic(user, _) => user == "edge"
+      case _ => false
+    }
+    record *> ((request.method, path) match
+      case (Method.GET, "/configuration/clients") =>
+        // `staleClientListing` reproduces the one race the provisioner cannot read its way out of:
+        // the listing is served from a cache a PostgreSQL notification refreshes, so a peer's
+        // client can be absent from it and still conflict on create.
+        state.get.map: s =>
+          val visible = if staleClientListing then Nil else s.clients.keys.toList.sorted
+          json(Json.Obj("clients" -> array(visible.map(idObject))))
+
+      case (Method.POST, "/configuration/clients") =>
+        val spec = parse(body)
+        val clientId = str(spec, "id")
+        state.modify: s =>
+          if s.clients.contains(clientId) then (Response.status(Status.Conflict), s)
+          else
+            val secret = if str(spec, "clientType") == "web" then Some(s"secret-$clientId-0") else None
+            val response = json(Json.Obj(secret.map(v => "secret" -> Json.Str(v)).toList*), Status.Created)
+            (response, s.copy(clients = s.clients.updated(clientId, StoredClient(spec, secret))))
+
+      case (Method.PUT, "/configuration/clients") =>
+        val spec = parse(body)
+        val clientId = str(spec, "clientId")
+        state.modify: s =>
+          s.clients.get(clientId) match
+            case None => (Response.status(Status.NoContent), s)
+            case Some(stored) =>
+              (Response.status(Status.NoContent), s.copy(clients = s.clients.updated(clientId, stored.updated(spec))))
+
+      case (Method.POST, "/configuration/clients/rotate-secret") =>
+        val clientId = request.url.queryParams.queryParam("clientId").getOrElse("")
+        state.modify: s =>
+          s.clients.get(clientId) match
+            case None => (Response.status(Status.NotFound), s)
+            case Some(stored) =>
+              val rotated = s"secret-$clientId-${stored.rotations + 1}"
+              (
+                json(Json.Obj("secret" -> Json.Str(rotated))),
+                s.copy(clients = s.clients.updated(clientId, stored.rotated(rotated))),
+              )
+
+      case (Method.GET, "/configuration/resources") =>
+        state.get.map: s =>
+          json(Json.Obj("resources" -> array(s.resources.toList.sortBy(_._1).map { (resourceId, stored) =>
+            Json.Obj(
+              "resourceId" -> Json.Str(resourceId),
+              "endpoints" -> array(stored.endpointIds.toList.sortBy(_.toString).map(idObject)),
+            )
+          })))
+
+      case (Method.POST, "/configuration/resources") =>
+        val spec = parse(body)
+        val resourceId = str(spec, "resourceId")
+        state.modify: s =>
+          if s.resources.contains(resourceId) then (uniqueViolation, s)
+          else
+            val stored = StoredResource(spec, objects(spec, "endpoints").map(endpointIdOf).toSet)
+            (Response.status(Status.Created), s.copy(resources = s.resources.updated(resourceId, stored)))
+
+      case (Method.PUT, "/configuration/resources") =>
+        val spec = parse(body)
+        val resourceId = str(spec, "resourceId")
+        state.modify: s =>
+          s.resources.get(resourceId) match
+            case None => (Response.status(Status.NoContent), s)
+            case Some(stored) =>
+              val deleted = strings(spec, "deleteEndpoints").map(UUID.fromString).toSet
+              val created = objects(spec, "createEndpoints").map(endpointIdOf).toSet
+              val endpoints = (stored.endpointIds -- deleted -- created) ++ created
+              (
+                Response.status(Status.NoContent),
+                s.copy(resources = s.resources.updated(resourceId, StoredResource(spec, endpoints))),
+              )
+
+      case (Method.GET, "/configuration/permissions") =>
+        state.get.map: s =>
+          json(Json.Obj("permissions" -> array(s.permissions.keys.toList.sorted.map: permission =>
+            Json.Obj("permission" -> Json.Str(permission)))))
+
+      case (Method.POST, "/configuration/permissions") =>
+        val spec = parse(body)
+        val permission = str(spec, "permission")
+        state.modify: s =>
+          if s.permissions.contains(permission) then (uniqueViolation, s)
+          else
+            val endpointIds = strings(spec, "endpointIds").map(UUID.fromString).toSet
+            (Response.status(Status.Created), s.copy(permissions = s.permissions.updated(permission, endpointIds)))
+
+      case (Method.PUT, "/configuration/permissions") =>
+        val spec = parse(body)
+        val permission = str(spec, "permission")
+        state.modify: s =>
+          if !s.permissions.contains(permission) then (Response.status(Status.NoContent), s)
+          else
+            val endpointIds = strings(spec, "endpointIds").map(UUID.fromString).toSet
+            (Response.status(Status.NoContent), s.copy(permissions = s.permissions.updated(permission, endpointIds)))
+
+      case (Method.GET, "/configuration/roles") =>
+        state.get.map: s =>
+          json(Json.Obj("roles" -> array(s.roles.toList.sortBy(_._1).map { (roleId, granted) =>
+            Json.Obj("id" -> Json.Str(roleId), "permissions" -> array(granted.toList.sorted.map(Json.Str(_))))
+          })))
+
+      case (Method.POST, "/configuration/roles") =>
+        val spec = parse(body)
+        val roleId = str(spec, "id")
+        state.modify: s =>
+          if s.roles.contains(roleId) then (uniqueViolation, s)
+          else
+            (Response.status(Status.Created), s.copy(roles = s.roles.updated(roleId, strings(spec, "permissions").toSet)))
+
+      case (Method.PUT, "/configuration/roles") =>
+        val spec = parse(body)
+        val roleId = str(spec, "id")
+        state.modify: s =>
+          s.roles.get(roleId) match
+            case None => (Response.status(Status.NoContent), s)
+            case Some(granted) =>
+              val patch = obj(spec, "permissions")
+              val updated = (granted -- strings(patch, "remove").toSet) ++ strings(patch, "add").toSet
+              (Response.status(Status.NoContent), s.copy(roles = s.roles.updated(roleId, updated)))
+
+      case (Method.POST, "/configuration/auth-request-presets") =>
+        val spec = parse(body)
+        state.modify: s =>
+          (
+            Response.status(Status.NoContent),
+            s.copy(presets = s.presets.updated(str(spec, "clientId"), objects(spec, "presets"))),
+          )
+
+      case (Method.PUT, "/configuration/challenges/challenge-settings") =>
+        state.modify(s => (Response.status(Status.NoContent), s.copy(challengeSettings = Some(parse(body)))))
+
+      case (Method.POST, "/service/users/outbox/flush") =>
+        state.modify(s => (Response.status(Status.NoContent), s.copy(outboxFlushes = s.outboxFlushes + 1)))
+
+      // Central and edge expose this on the same path, so which one was called is told apart by
+      // the credential that arrived rather than by the URL -- the test client routes on path only.
+      case (Method.POST, "/service/configuration/sync") =>
+        state.modify: s =>
+          if fromEdge then (Response.status(Status.NoContent), s.copy(edgeSyncs = s.edgeSyncs + 1))
+          else (Response.status(Status.NoContent), s.copy(authSyncs = s.authSyncs + 1))
+
+      case _ => ZIO.succeed(Response.status(Status.NotFound)))
+
+object FakeCentral:
+
+  case class Call(method: Method, path: String, body: String)
+
+  /** The four endpoints where a POST means "create", and a second one for the same id is either a
+    * conflict or a unique violation. The other POSTs -- presets, secret rotation, the syncs -- are
+    * idempotent by construction.
+    */
+  val createPaths: List[String] = List(
+    "/configuration/clients",
+    "/configuration/resources",
+    "/configuration/permissions",
+    "/configuration/roles",
+  )
+
+  case class StoredClient(spec: Json.Obj, secret: Option[String], rotations: Int = 0):
+    def updated(spec: Json.Obj): StoredClient = copy(spec = spec)
+    def rotated(secret: String): StoredClient = copy(secret = Some(secret), rotations = rotations + 1)
+
+  case class StoredResource(spec: Json.Obj, endpointIds: Set[UUID])
+
+  case class State(
+      clients: Map[String, StoredClient],
+      resources: Map[String, StoredResource],
+      permissions: Map[String, Set[UUID]],
+      roles: Map[String, Set[String]],
+      presets: Map[String, List[Json.Obj]],
+      challengeSettings: Option[Json.Obj],
+      authSyncs: Int,
+      edgeSyncs: Int,
+      outboxFlushes: Int,
+      calls: Chunk[Call],
+  ):
+    def callsTo(method: Method, path: String): Chunk[Call] =
+      calls.filter(call => call.method == method && call.path == path)
+
+  val empty: State = State(
+    clients = Map.empty,
+    resources = Map.empty,
+    permissions = Map.empty,
+    roles = Map.empty,
+    presets = Map.empty,
+    challengeSettings = None,
+    authSyncs = 0,
+    edgeSyncs = 0,
+    outboxFlushes = 0,
+    calls = Chunk.empty,
+  )
+
+  def make(staleClientListing: Boolean = false): UIO[FakeCentral] =
+    Ref.make(empty).map(FakeCentral(_, staleClientListing))
+
+  /** A unique-key violation as central reports it: an unhandled repository failure, not a 409.
+    * This is why the provisioner reads before it writes.
+    */
+  private val uniqueViolation: Response =
+    Response.text("ERROR: duplicate key value violates unique constraint").status(Status.InternalServerError)
+
+  private def json(body: Json.Obj, status: Status = Status.Ok): Response =
+    Response.json(body.toJson).status(status)
+
+  private def array(values: List[Json]): Json.Arr = Json.Arr(Chunk.fromIterable(values))
+
+  private def idObject(id: String): Json.Obj = Json.Obj("id" -> Json.Str(id))
+
+  private def idObject(id: UUID): Json.Obj = idObject(id.toString)
+
+  private def endpointIdOf(endpoint: Json.Obj): UUID = UUID.fromString(str(endpoint, "id"))
+
+  def parse(body: String): Json.Obj =
+    Json.decoder.decodeJson(body) match
+      case Right(obj: Json.Obj) => obj
+      case other => throw RuntimeException(s"not a JSON object: $other")
+
+  def field(obj: Json.Obj, name: String): Option[Json] =
+    obj.fields.collectFirst { case (key, value) if key == name => value }
+
+  def str(obj: Json.Obj, name: String): String =
+    field(obj, name).collect { case Json.Str(value) => value }
+      .getOrElse(throw RuntimeException(s"missing string '$name' in $obj"))
+
+  def optionalStr(obj: Json.Obj, name: String): Option[String] =
+    field(obj, name).collect { case Json.Str(value) => value }
+
+  def bool(obj: Json.Obj, name: String): Option[Boolean] =
+    field(obj, name).collect { case Json.Bool(value) => value }
+
+  def num(obj: Json.Obj, name: String): Option[BigDecimal] =
+    field(obj, name).collect { case Json.Num(value) => BigDecimal(value) }
+
+  def obj(parent: Json.Obj, name: String): Json.Obj =
+    field(parent, name).collect { case value: Json.Obj => value }
+      .getOrElse(throw RuntimeException(s"missing object '$name' in $parent"))
+
+  def strings(parent: Json.Obj, name: String): List[String] =
+    field(parent, name).collect { case Json.Arr(values) => values.collect { case Json.Str(v) => v }.toList }
+      .getOrElse(Nil)
+
+  def objects(parent: Json.Obj, name: String): List[Json.Obj] =
+    field(parent, name).collect { case Json.Arr(values) => values.collect { case v: Json.Obj => v }.toList }
+      .getOrElse(Nil)
+
+/** The deployment-specific half of a campaign's provisioning input, shared by the specs below. */
+object ProvisionFixtures:
+
+  val targets: TargetsConfig = TargetsConfig(
+    authUrl = "http://auth:8080",
+    edgeUrl = "http://edge:8095",
+    centralUrl = "http://central:8090",
+    mockUrl = "http://mockapi:8100",
+    origin = "https://bank.example.test",
+  )
+
+  val provision: ProvisionConfig = ProvisionConfig(
+    tenantId = "default",
+    centralSecret = Config.Secret("central-secret"),
+    edgeSecret = Config.Secret("edge-secret"),
+    mobileRedirectUri = "versola://callback",
+    resources = ProvisionResourcesConfig(
+      coreUri = "http://mockapi-core:8100",
+      payUri = "http://mockapi-pay:8100",
+      notifyUri = "http://mockapi-notify:8100",
+    ),
+    preset = ProvisionPresetConfig(
+      id = "web-otp",
+      cookieDomain = Some("bank.example.test"),
+      cookiePath = Some("/"),
+      postLogoutRedirectUri = Some("https://bank.example.test/goodbye"),
+    ),
+    passkey = ProvisionPasskeyConfig(rpId = "bank.example.test", rpName = "Versola Bank", userVerification = "preferred"),
+    paymentAmountThreshold = 1000000L,
+  )
+
+  val flows: CampaignFlows = CampaignFlows(
+    phoneOtpAuthFlow = Json.Obj("primary" -> Json.Str("phone-otp")),
+    phoneOtpPasswordAuthFlow = Json.Obj("primary" -> Json.Str("phone-otp-password")),
+    phonePasskeyAuthFlow = Json.Obj("primary" -> Json.Str("phone-passkey")),
+    registrationFlow = Json.Obj("credential" -> Json.Str("phone")),
+  )
+
+  val blueprint: CampaignBlueprint = CampaignBlueprint(targets, provision, flows)

--- a/loadgen/src/test/scala/versola/loadgen/provision/ProvisionerSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/provision/ProvisionerSpec.scala
@@ -1,0 +1,155 @@
+package versola.loadgen.provision
+
+import versola.loadgen.config.{LoadgenConfig, LoadgenConfigSpec}
+import versola.loadgen.protocol.{AdminCallFailed, AdminClient, HttpAdminClient}
+import zio.*
+import zio.config.magnolia.deriveConfig
+import zio.config.typesafe.TypesafeConfigProvider
+import zio.http.*
+import zio.test.*
+
+/** Asserts that one `provision` pass writes the whole campaign, and that a second pass over the
+  * same environment converges instead of duplicating or failing.
+  *
+  * Re-runnability is the requirement worth a test: the run that needs it most is the one that
+  * died halfway, leaving clients created and roles not, and the operator's only recovery is to
+  * run the same command again.
+  */
+object ProvisionerSpec extends ZIOSpecDefault:
+
+  private val blueprint = ProvisionFixtures.blueprint
+
+  private def fakeAdmin: ZIO[TestClient & Client, Throwable, (AdminClient, FakeCentral)] =
+    for
+      fake <- FakeCentral.make()
+      _ <- TestClient.addRoutes(fake.handler.toRoutes)
+      client <- ZIO.service[Client]
+      admin <- HttpAdminClient.make(client, ProvisionFixtures.targets, ProvisionFixtures.provision)
+    yield (admin, fake)
+
+  private def loadConfig(hocon: String): Task[LoadgenConfig] =
+    TypesafeConfigProvider.fromHoconString(hocon).kebabCase.load(deriveConfig[LoadgenConfig])
+
+  def spec = suite("Provisioner")(
+    test("writes the campaign's clients, resources, permissions, roles, presets and settings") {
+      for
+        (admin, fake) <- fakeAdmin
+        creds <- Provisioner.run(admin, blueprint)
+        state <- fake.snapshot
+      yield assertTrue(
+        creds.keySet == CampaignBlueprint.clientIds.toSet,
+        state.clients.keySet == CampaignBlueprint.clientIds.toSet,
+        state.resources.keySet == Set("core", "pay", "notify"),
+        state.permissions.keySet == blueprint.permissions.map(_.permission).toSet,
+        state.roles.keySet == Set(CampaignBlueprint.retailUserRoleId, CampaignBlueprint.retailBasicRoleId),
+        state.presets.keySet == Set(CampaignBlueprint.webOtpClientId),
+        state.challengeSettings.isDefined,
+      )
+    },
+    // A permission grants an endpoint by id, so provisioning a permission before its resource
+    // declared that endpoint would leave the grant pointing at nothing.
+    test("declares every endpoint a permission grants before granting it") {
+      for
+        (admin, fake) <- fakeAdmin
+        _ <- Provisioner.run(admin, blueprint)
+        state <- fake.snapshot
+        declared = state.resources.values.flatMap(_.endpointIds).toSet
+        granted = state.permissions.values.flatten.toSet
+        firstPermission = state.calls.indexWhere(_.path == "/configuration/permissions")
+        lastResource = state.calls.lastIndexWhere(_.path == "/configuration/resources")
+      yield assertTrue(granted == declared, granted.size == 10, lastResource < firstPermission)
+    },
+    // Edge reads client and preset state from central, so a sync that ran before the writes
+    // leaves edge serving the previous campaign's configuration.
+    test("syncs auth and then edge, after every write") {
+      for
+        (admin, fake) <- fakeAdmin
+        _ <- Provisioner.run(admin, blueprint)
+        state <- fake.snapshot
+        lastWrite = state.calls.lastIndexWhere(!_.path.startsWith("/service"))
+        authSync = state.calls.indexWhere(call => call.path == "/service/configuration/sync")
+        edgeSync = state.calls.lastIndexWhere(call => call.path == "/service/configuration/sync")
+      yield assertTrue(
+        state.authSyncs == 1,
+        state.edgeSyncs == 1,
+        state.outboxFlushes == 1,
+        lastWrite < authSync,
+        authSync < edgeSync,
+      )
+    },
+    test("a second pass creates nothing and changes nothing") {
+      for
+        (admin, fake) <- fakeAdmin
+        _ <- Provisioner.run(admin, blueprint)
+        first <- fake.snapshot
+        _ <- Provisioner.run(admin, blueprint)
+        second <- fake.snapshot
+      yield assertTrue(
+        FakeCentral.createPaths.forall(path =>
+          second.callsTo(Method.POST, path).size == first.callsTo(Method.POST, path).size,
+        ),
+        second.clients.keySet == first.clients.keySet,
+        second.resources.view.mapValues(_.endpointIds).toMap == first.resources.view.mapValues(_.endpointIds).toMap,
+        second.permissions == first.permissions,
+        second.roles == first.roles,
+        second.presets.view.mapValues(_.size).toMap == first.presets.view.mapValues(_.size).toMap,
+        second.challengeSettings == first.challengeSettings,
+      )
+    },
+    // The recovery case: a run that died after the clients were created must be able to finish
+    // the rest on the next attempt rather than tripping over its own leftovers.
+    test("finishes a run that died halfway") {
+      for
+        (admin, fake) <- fakeAdmin
+        _ <- ZIO.foreachDiscard(blueprint.clients)(admin.registerClient)
+        _ <- ZIO.foreachDiscard(blueprint.resources.take(1))(admin.registerResource)
+        _ <- Provisioner.run(admin, blueprint)
+        state <- fake.snapshot
+      yield assertTrue(
+        state.resources.keySet == Set("core", "pay", "notify"),
+        state.permissions.values.flatten.toSet == state.resources.values.flatMap(_.endpointIds).toSet,
+        state.roles(CampaignBlueprint.retailUserRoleId) == blueprint.roles.head.permissions,
+      )
+    },
+    test("hands back usable credentials for every client, secret-bearing only where there is one") {
+      for
+        (admin, _) <- fakeAdmin
+        creds <- Provisioner.run(admin, blueprint)
+      yield assertTrue(
+        creds(CampaignBlueprint.webOtpClientId).clientSecret.isDefined,
+        creds(CampaignBlueprint.mobileOtpClientId).clientSecret.isEmpty,
+        creds(CampaignBlueprint.mobilePasskeyClientId).clientSecret.isEmpty,
+      )
+    },
+    // A half-provisioned environment measures the wrong system, so a failed step stops the run
+    // rather than leaving the rest unwritten and the campaign to discover it.
+    test("stops at the first failed step") {
+      for
+        _ <- TestClient.addRoutes(Handler.fromResponse(Response.status(Status.InternalServerError)).toRoutes)
+        client <- ZIO.service[Client]
+        admin <- HttpAdminClient.make(client, ProvisionFixtures.targets, ProvisionFixtures.provision)
+        error <- Provisioner.run(admin, blueprint).flip
+      yield assert(error)(Assertion.isSubtype[AdminCallFailed](Assertion.anything))
+    },
+    // The block is optional so that a driver's config still decodes, which makes its absence the
+    // provisioner's problem to report rather than the config loader's.
+    test("refuses to run without a provision configuration block") {
+      for
+        config <- loadConfig(LoadgenConfigSpec.hoconWithoutProvision)
+        error <- Provisioner.provision(config).flip
+      yield assertTrue(error == MissingProvisionConfig)
+    },
+    test("provisions from a config file, reading the campaign's flows off the classpath") {
+      for
+        (_, fake) <- fakeAdmin
+        config <- loadConfig(LoadgenConfigSpec.hocon)
+        _ <- Provisioner.provision(config)
+        state <- fake.snapshot
+        flows <- FlowResources.load
+      yield assertTrue(
+        state.clients.keySet == CampaignBlueprint.clientIds.toSet,
+        FakeCentral.field(state.clients(CampaignBlueprint.mobileOtpClientId).spec, "authFlow")
+          .contains(flows.phoneOtpAuthFlow),
+      )
+    },
+  ).provide(TestClient.layer) @@ TestAspect.silentLogging

--- a/loadgen/src/test/scala/versola/loadgen/provision/ProvisionerSpec.scala
+++ b/loadgen/src/test/scala/versola/loadgen/provision/ProvisionerSpec.scala
@@ -59,6 +59,40 @@ object ProvisionerSpec extends ZIOSpecDefault:
         lastResource = state.calls.lastIndexWhere(_.path == "/configuration/resources")
       yield assertTrue(granted == declared, granted.size == 10, lastResource < firstPermission)
     },
+    // A client's registration flow grants a role by id, and central validates that the role
+    // exists while saving the client -- a pass that wrote the clients first would be rejected
+    // with a 400 on the very first one.
+    test("creates the roles a client's registration flow grants before the client") {
+      for
+        (admin, fake) <- fakeAdmin
+        _ <- Provisioner.run(admin, blueprint)
+        state <- fake.snapshot
+        granted = blueprint.clients.flatMap(_.registrationFlow).flatMap(_.asObject)
+          .flatMap(flow => FakeCentral.strings(flow, "roleIds"))
+        lastRole = state.calls.lastIndexWhere(_.path == "/configuration/roles")
+        firstClient = state.calls.indexWhere(_.path == "/configuration/clients")
+      yield assertTrue(
+        granted.toSet == Set(CampaignBlueprint.retailUserRoleId),
+        granted.toSet.subsetOf(state.roles.keySet),
+        lastRole < firstClient,
+      )
+    },
+    // The listings the create-or-update choices are made on are cached, so a pass retried
+    // straight after a partial one can be told that what it just wrote is not there.
+    test("converges when the listings have not caught up with what a previous pass wrote") {
+      for
+        (admin, fake) <- fakeAdmin
+        _ <- Provisioner.run(admin, blueprint)
+        first <- fake.snapshot
+        _ <- fake.staleListings
+        _ <- Provisioner.run(admin, blueprint)
+        second <- fake.snapshot
+      yield assertTrue(
+        second.resources.view.mapValues(_.endpointIds).toMap == first.resources.view.mapValues(_.endpointIds).toMap,
+        second.permissions == first.permissions,
+        second.roles == first.roles,
+      )
+    },
     // Edge reads client and preset state from central, so a sync that ran before the writes
     // leaves edge serving the previous campaign's configuration.
     test("syncs auth and then edge, after every write") {
@@ -101,8 +135,10 @@ object ProvisionerSpec extends ZIOSpecDefault:
     test("finishes a run that died halfway") {
       for
         (admin, fake) <- fakeAdmin
-        _ <- ZIO.foreachDiscard(blueprint.clients)(admin.registerClient)
-        _ <- ZIO.foreachDiscard(blueprint.resources.take(1))(admin.registerResource)
+        _ <- ZIO.foreachDiscard(blueprint.resources)(admin.registerResource)
+        _ <- admin.upsertPermissions(blueprint.permissions)
+        _ <- admin.upsertRoles(blueprint.roles)
+        _ <- ZIO.foreachDiscard(blueprint.clients.take(1))(admin.registerClient)
         _ <- Provisioner.run(admin, blueprint)
         state <- fake.snapshot
       yield assertTrue(


### PR DESCRIPTION
Closes #274. Part of #267 (track E, deliverable D6).

`role = provision` writes the campaign's configuration into central, makes auth and edge pick it up, and exits.

## What is here

- **`CampaignBlueprint`** — the campaign's desired state as a pure value: the four clients of design doc §2.2, the three `mockapi`-backed resources and ten protected actions of §3, their permissions, the `retail-user`/`retail-basic` roles, the one edge login preset and the ACR vocabulary every step-up resolves through. Only what a deployment varies (tenant, admin secrets, resource URIs, relying party, payment threshold) is HOCON; the campaign's shape is not a knob.
- **`HttpAdminClient`** — replaces W1's `Json.Obj` placeholders with typed requests, field-for-field against central's create/update DTOs.
- **`Provisioner`** — dependency-ordered single pass, wired into `Main` as role dispatch.
- **Flow resources** — the `authFlow`/`registrationFlow` documents as classpath JSON (dev spec §3.4), so e2e can load the same files once `protocol/` is extracted.

## Idempotency

Every write is a desired-state apply, and the client reads current state before writing: only `/configuration/clients` reports a duplicate as a `409`, while roles, permissions and resources surface theirs as a unique-violation `500` that is indistinguishable from central actually being broken. The `409` fallback is kept on the one operation that reports it, because the client listing is cache-backed and a stale read can still lose the race.

Endpoint ids are derived from the endpoint's identity (resource, method, path) rather than drawn, so a re-run does not leave every permission granting an endpoint that no longer exists. A confidential client's secret is rotated on adoption — registration is the only other time central hands one out — and the edge sync that follows propagates it.

## Tests

57 tests: each admin operation's payload shape against an in-memory central that holds real state, the create-vs-update choice including the stale-listing race, a second `provision` pass over an already-provisioned environment, a run that died halfway, role revocation, and failure propagation.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M2B8J5009S4K9NS1NE7BN711&panel=chat)